### PR TITLE
Refactoring core-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 vendor
 *.exe

--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/edgexfoundry/edgex-go"
@@ -46,7 +47,7 @@ func main() {
 	logTarget := setLoggingTarget(*configuration)
 	var loggingClient = logger.NewClient(configuration.ApplicationName, configuration.EnableRemoteLogging, logTarget)
 
-	loggingClient.Info("Starting core-command " + edgex.Version)
+	loggingClient.Info(fmt.Sprintf("Starting %s %s ", command.COMMANDSERVICENAME, edgex.Version))
 
 	command.Start(*configuration, loggingClient)
 }

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -19,6 +19,8 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -29,40 +31,89 @@ import (
 	"github.com/edgexfoundry/edgex-go/support/logging-client"
 )
 
-const (
-	configFile string = "./res/configuration.json"
-)
-
 var loggingClient logger.LoggingClient
 
 func main() {
 	start := time.Now()
+	var (
+		useConsul = flag.String("consul", "", "Should the service use consul?")
+		useProfile = flag.String("profile", "default", "Specify a profile other than default.")
+	)
+	flag.Parse()
 
-	// Load configuration data
+	// Load configuration data from file.
+	// Right now, we always do this first because it contains the Consul endpoint host/port
+	configFile := determineConfigFile(*useProfile)
 	configuration, err := readConfigurationFile(configFile)
 	if err != nil {
-		loggingClient = logger.NewClient(data.COREDATASERVICENAME, false, "")
-		loggingClient.Error("Could not load configuration (" + configFile + "): " + err.Error())
+		logBeforeTermination(fmt.Errorf("could not load configuration file (%s): %v", configFile, err.Error()))
 		return
+	}
+
+	//Determine if configuration should be overridden from Consul
+	var consulMsg string
+	if *useConsul == "y" {
+		consulMsg = "Loading configuration from Consul..."
+		err := data.ConnectToConsul(*configuration)
+		if err != nil {
+			logBeforeTermination(err)
+			return //end program since user explicitly told us to use Consul.
+		}
+	} else {
+		consulMsg = "Bypassing Consul configuration..."
 	}
 
 	logTarget := setLoggingTarget(*configuration)
 	// Create Logger (Default Parameters)
 	loggingClient = logger.NewClient(configuration.Applicationname, configuration.EnableRemoteLogging, logTarget)
 
-	loggingClient.Info("Starting core-data " + edgex.Version)
+	loggingClient.Info(consulMsg)
+	loggingClient.Info(fmt.Sprintf("Starting %s %s ", data.COREDATASERVICENAME, edgex.Version))
 
-	data.Init(*configuration, loggingClient)
+	err = data.Init(*configuration, loggingClient)
+	if err != nil {
+		loggingClient.Error(fmt.Sprintf("call to init() failed: %v", err.Error()))
+		return
+	}
 
 	r := data.LoadRestRoutes()
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(5000), "Request timed out")
 	loggingClient.Info(configuration.Appopenmsg, "")
 
+	startHeartbeat(configuration.Heartbeatmsg, configuration.Heartbeattime)
 	// Time it took to start service
 	loggingClient.Info("Service started in: "+time.Since(start).String(), "")
 	loggingClient.Info("Listening on port: " + strconv.Itoa(configuration.Serverport))
-
 	loggingClient.Error(http.ListenAndServe(":"+strconv.Itoa(configuration.Serverport), r).Error())
+}
+
+func startHeartbeat(msg string, interval int) {
+	chBeats := make(chan string)
+	go data.Heartbeat(msg, interval, chBeats)
+	go func() {
+		for {
+			msg, ok := <-chBeats
+			if !ok {
+				break
+			}
+			loggingClient.Info(msg)
+		}
+		close(chBeats)
+	}()
+}
+
+func logBeforeTermination(err error) {
+	loggingClient = logger.NewClient(data.COREDATASERVICENAME, false, "")
+	loggingClient.Error(err.Error())
+}
+
+func determineConfigFile(profile string) string {
+	switch profile {
+		case "docker":
+			return "./res/configuration-docker.json"
+	    default:
+		    return "./res/configuration.json"
+	}
 }
 
 // Read the configuration file and update configuration struct

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/edgexfoundry/edgex-go"
@@ -45,6 +46,8 @@ func main() {
 	// Create Logger (Default Parameters)
 	loggingClient = logger.NewClient(configuration.ApplicationName, configuration.EnableRemoteLogging, logTarget)
 	loggingClient.Info("Starting core-metadata " + edgex.Version)
+
+	loggingClient.Info(fmt.Sprintf("Starting %s %s ", metadata.METADATASERVICENAME, edgex.Version))
 
 	metadata.Start(*configuration, loggingClient)
 }


### PR DESCRIPTION
 Service cleanup -- restructuring of core-data initialization, including cmd line flag for Consul(Y/N) and Profile (default vs Docker). Also used service name constants in log init message instead of hard-coded strings.