### PR TITLE
improve README document about installing pkgconfig on mac os x

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ For example, in the case of Debian Linux system you can:
 sudo apt-get install libzmq3-dev
 ```
 
+And if you want to build project from source code, make sure that you have installed "pkg-config" tool before you build project.
+
+For Mac os x, you could use [Homebrew](https://docs.brew.sh/) to install it:
+
+```
+brew install pkgconfig
+```
+
 To fetch the code and compile the microservices execute:
 
 ```


### PR DESCRIPTION
add some supplementary for the README document about installing `pkgconfig`, if we don't install it, the `make build` command would occur a error.