### PR TITLE
add some ignore items to filter built binary and log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,15 @@
 vendor
 *.exe
 glide.lock
+
+# binary files
+cmd/core-command/core-command
+cmd/core-data/core-data
+cmd/core-metadata/core-metadata
+cmd/export-client/export-client
+cmd/export-distro/export-distro
+
+# log dirs
+cmd/core-command/logs/
+cmd/core-data/logs/
+cmd/core-metadata/logs/


### PR DESCRIPTION
current if user build and the project will create some binary and log files we should filter them.

Signed-off-by: vinoyang <vinoyang@tencent.com>