### PR TITLE
add a ignore item to filter mac os x system hidden file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 vendor
 *.exe
 glide.lock
+*.DS_Store
 
 # binary files
 cmd/core-command/core-command


### PR DESCRIPTION
Signed-off-by: yanghua <yanghua1127@gmail.com>

The `.DS_Store` always exists in any dir in mac os x as a system hidden file to store the dir's metadata. If we create a new dir in project (and in it's sub dir), it would be created. So we'd better filter it.