### PR TITLE
Improve core/domain/enums and tests

### DIFF
--- a/core/domain/enums/admin-state.go
+++ b/core/domain/enums/admin-state.go
@@ -29,13 +29,20 @@ type AdminStateType uint8
 const (
 	LOCKED AdminStateType = iota
 	UNLOCKED
-)
 
-var adminStateStringArray = [...]string{"LOCKED", "UNLOCKED"} // Used for String function
+	lockedStr   = "LOCKED"
+	unlockedStr = "UNLOCKED"
+)
 
 /*
 String() func for formatting
 */
 func (a AdminStateType) String() string {
-	return adminStateStringArray[a]
+	switch a {
+	case LOCKED:
+		return lockedStr
+	case UNLOCKED:
+		return unlockedStr
+	}
+	return invalidStr
 }

--- a/core/domain/enums/admin-state_test.go
+++ b/core/domain/enums/admin-state_test.go
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2018
+// Cavium
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+package enums
+
+import (
+	"testing"
+)
+
+func TestStringAdminState(t *testing.T) {
+	tests := []struct {
+		name string
+		as   AdminStateType
+	}{
+		{"locked", LOCKED},
+		{"unlocked", UNLOCKED},
+		{"invalid", UNLOCKED + 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.as.String() == "" {
+				t.Errorf("String should not be empty")
+			}
+		})
+	}
+}

--- a/core/domain/enums/database.go
+++ b/core/domain/enums/database.go
@@ -19,32 +19,37 @@ package enums
 
 import (
 	"errors"
-	"strings"
 )
 
 type DATABASE int
 
 const (
-	INVALID DATABASE = -1
-	MONGODB DATABASE = iota
+	INVALID DATABASE = iota
+	MONGODB
 	MYSQL
 )
 
-var MONGODBSTR = "mongodb"
-var MYSQLSTR string = "mysql"
+const (
+	invalidStr = "invalid"
+	mongoStr   = "mongodb"
+	mysqlStr   = "mysql"
+)
 
 // DATABASEArr : Add in order declared in Struct for string value
-var DATABASEArr = [...]string{MONGODBSTR, MYSQLSTR}
+var databaseArr = [...]string{invalidStr, mongoStr, mysqlStr}
 
 func (db DATABASE) String() string {
-	return DATABASEArr[db]
+	if db >= INVALID && db <= MYSQL {
+		return databaseArr[db]
+	}
+	return invalidStr
 }
 
 // GetDatabaseType : Return enum valude of the Database Type
 func GetDatabaseType(db string) (DATABASE, error) {
-	if strings.Compare(MONGODBSTR, db) == 0 {
+	if mongoStr == db {
 		return MONGODB, nil
-	} else if strings.Compare(MYSQLSTR, db) == 0 {
+	} else if mysqlStr == db {
 		return MYSQL, nil
 	} else {
 		return INVALID, errors.New("Undefined Database Type")

--- a/core/domain/enums/database_test.go
+++ b/core/domain/enums/database_test.go
@@ -18,33 +18,49 @@
 package enums
 
 import (
-	"reflect"
 	"testing"
 )
 
 func TestGetDatabaseType(t *testing.T) {
-	type args struct {
-		db string
-	}
 	tests := []struct {
 		name    string
-		args    args
+		args    string
 		want    DATABASE
 		wantErr bool
 	}{
-		{"type is mongo", args{"mongodb"}, MONGODB, false},
-		{"type is mysql", args{"mysql"}, MYSQL, false},
-		{"type is unknown", args{"foo"}, INVALID, true},
+		{"type is mongo", "mongodb", MONGODB, false},
+		{"type is mysql", "mysql", MYSQL, false},
+		{"type is unknown", "foo", INVALID, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetDatabaseType(tt.args.db)
+			got, err := GetDatabaseType(tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDatabaseType() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if got != tt.want {
 				t.Errorf("GetDatabaseType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringDatabaseType(t *testing.T) {
+	tests := []struct {
+		name string
+		db   DATABASE
+	}{
+		{"mongo", MONGODB},
+		{"mysql", MYSQL},
+		{"unknown", INVALID},
+		{"invalid1", INVALID - 1},
+		{"invalid2", MYSQL + 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.db.String() == "" {
+				t.Errorf("String should not be empty")
 			}
 		})
 	}

--- a/core/domain/enums/operating-state.go
+++ b/core/domain/enums/operating-state.go
@@ -28,13 +28,20 @@ type OperatingStateType uint8
 const (
 	ENABLED OperatingStateType = iota
 	DISABLED
-)
 
-var operatingStateStringArray = [...]string{"ENABLED", "DISABLED"} // Used for String() function
+	enabledStr  = "ENABLED"
+	disabledStr = "DISABLED"
+)
 
 /*
 String function for formatting
 */
 func (o OperatingStateType) String() string {
-	return operatingStateStringArray[o]
+	switch o {
+	case ENABLED:
+		return enabledStr
+	case DISABLED:
+		return disabledStr
+	}
+	return invalidStr
 }

--- a/core/domain/enums/operating-state_test.go
+++ b/core/domain/enums/operating-state_test.go
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2018
+// Cavium
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+package enums
+
+import (
+	"testing"
+)
+
+func TestStringOperatingState(t *testing.T) {
+	tests := []struct {
+		name string
+		os   OperatingStateType
+	}{
+		{"enabled", ENABLED},
+		{"disabled", DISABLED},
+		{"invalid", DISABLED + 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.os.String() == "" {
+				t.Errorf("String should not be empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
There was a panic if trying to convert to string some invalid values.
Added tests to AdminState and OperatingState
protocol.go is not used anywhere, should be removed
database.go is only used by metadata, should be moved to core/metadata/