### PR TITLE
Fix missing comma (parse error) core/command/config-docker

### DIFF
--- a/cmd/core-command/res/configuration-docker.json
+++ b/cmd/core-command/res/configuration-docker.json
@@ -18,7 +18,7 @@
 	"ConsulCheckAddress" : "http://edgex-core-command:48082/api/v1/ping",
 	"EnableRemoteLogging" : true,
 	"LogFile" : "./logs/edgex-core-command.log",
-	"LoggingRemoteURL" : "http://edgex-support-logging:48061/api/v1/logs"
+	"LoggingRemoteURL" : "http://edgex-support-logging:48061/api/v1/logs",
 	"Metadbaddressableurl" : "http://edgex-core-metadata:48081/api/v1/addressable",
 	"Metadbdeviceserviceurl" : "http://edgex-core-metadata:48081/api/v1/deviceservice",
 	"Metadbdeviceprofileurl" : "http://edgex-core-metadata:48081/api/v1/deviceprofile",


### PR DESCRIPTION
Replacement for PR #38 which was blocked due to sign-off missing.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>