### PR TITLE
Build in docker

### DIFF
--- a/docker/Dockerfile.core-command
+++ b/docker/Dockerfile.core-command
@@ -7,9 +7,15 @@
 #
 
 FROM golang:1.9-alpine AS builder
-WORKDIR /go/src/github.com/edgexfoundry/edgex-go
-RUN apk update && apk add make
+RUN apk --update add \
+    make \
+    git \
+    glide \
+    zeromq-dev \
+    build-base
+WORKDIR $GOPATH/src/github.com/edgexfoundry/edgex-go
 COPY . .
+RUN glide install
 RUN make cmd/core-command/core-command
 
 FROM scratch

--- a/docker/Dockerfile.core-data
+++ b/docker/Dockerfile.core-data
@@ -6,11 +6,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Docker image for Golang Core Data micro service 
 FROM golang:1.9-alpine AS builder
-WORKDIR /go/src/github.com/edgexfoundry/edgex-go
-RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk --update add \
+    make \
+    git \
+    glide \
+    zeromq-dev \
+    build-base
+WORKDIR $GOPATH/src/github.com/edgexfoundry/edgex-go
 COPY . .
+RUN glide install
 RUN make cmd/core-data/core-data
 
 #Next image - Copy built Go binary into new workspace

--- a/docker/Dockerfile.core-metadata
+++ b/docker/Dockerfile.core-metadata
@@ -7,9 +7,15 @@
 #
 
 FROM golang:1.9-alpine AS builder
-WORKDIR /go/src/github.com/edgexfoundry/edgex-go
-RUN apk update && apk add make
+RUN apk --update add \
+    make \
+    git \
+    glide \
+    zeromq-dev \
+    build-base
+WORKDIR $GOPATH/src/github.com/edgexfoundry/edgex-go
 COPY . .
+RUN glide install
 RUN make cmd/core-metadata/core-metadata
 
 FROM scratch

--- a/docker/Dockerfile.export-client
+++ b/docker/Dockerfile.export-client
@@ -7,9 +7,15 @@
 #
 
 FROM golang:1.9-alpine AS builder
-WORKDIR /go/src/github.com/edgexfoundry/edgex-go
-RUN apk update && apk add make
+RUN apk --update add \
+    make \
+    git \
+    glide \
+    zeromq-dev \
+    build-base
+WORKDIR $GOPATH/src/github.com/edgexfoundry/edgex-go
 COPY . .
+RUN glide install
 RUN make cmd/export-client/export-client
 
 FROM scratch

--- a/docker/Dockerfile.export-distro
+++ b/docker/Dockerfile.export-distro
@@ -7,9 +7,15 @@
 #
 
 FROM golang:1.9-alpine AS builder
-WORKDIR /go/src/github.com/edgexfoundry/edgex-go
-RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk --update add \
+    make \
+    git \
+    glide \
+    zeromq-dev \
+    build-base
+WORKDIR $GOPATH/src/github.com/edgexfoundry/edgex-go
 COPY . .
+RUN glide install
 RUN make cmd/export-distro/export-distro
 
 FROM alpine:3.7

--- a/docker/Dockerfile.support-logging
+++ b/docker/Dockerfile.support-logging
@@ -6,9 +6,15 @@
 #
 
 FROM golang:1.9-alpine AS builder
-WORKDIR /go/src/github.com/edgexfoundry/edgex-go
-RUN apk update && apk add make
+RUN apk --update add \
+    make \
+    git \
+    glide \
+    zeromq-dev \
+    build-base
+WORKDIR $GOPATH/src/github.com/edgexfoundry/edgex-go
 COPY . .
+RUN glide install
 RUN make cmd/support-logging/support-logging
 
 FROM scratch


### PR DESCRIPTION
This pull request does 3 things
- adds the logging microservice to the DOCKERS targets in the Makefile
- makes end image more reproducible by putting all of the builder dependencies within the Dockerfiles, limiting the risk that a build system artifact ends up in the resulting docker image.  This also makes it more straightforward when I am building for another architecture, i.e. aarch64
- sets all Dockerfiles to build with the same builder container (all except the final build artifacts).  This speeds up image rebuilds on slower architectures / systems and establishes a 'builder' container that we may want to optimize/isolate in the future.