### PR TITLE
Switch mirrors for alpine image apk update

### DIFF
--- a/docker/Dockerfile.core-command
+++ b/docker/Dockerfile.core-command
@@ -8,6 +8,12 @@
 
 FROM golang:1.9-alpine AS builder
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
+
+# The main mirrors are giving us timeout issues on builds periodically.
+# So we can try these.
+RUN echo http://nl.alpinelinux.org/alpine/v3.6/main > /etc/apk/repositories; \
+    echo http://nl.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories
+
 RUN apk update && apk add make
 COPY . .
 RUN make cmd/core-command/core-command

--- a/docker/Dockerfile.core-data
+++ b/docker/Dockerfile.core-data
@@ -9,6 +9,13 @@
 # Docker image for Golang Core Data micro service 
 FROM golang:1.9-alpine AS builder
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
+
+# The main mirrors are giving us timeout issues on builds periodically.
+# So we can try these.
+RUN echo http://nl.alpinelinux.org/alpine/v3.6/main > /etc/apk/repositories; \
+    echo http://nl.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories
+
+
 RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base
 COPY . .
 RUN make cmd/core-data/core-data

--- a/docker/Dockerfile.core-metadata
+++ b/docker/Dockerfile.core-metadata
@@ -8,6 +8,13 @@
 
 FROM golang:1.9-alpine AS builder
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
+
+# The main mirrors are giving us timeout issues on builds periodically.
+# So we can try these.
+RUN echo http://nl.alpinelinux.org/alpine/v3.6/main > /etc/apk/repositories; \
+    echo http://nl.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories
+
+
 RUN apk update && apk add make
 COPY . .
 RUN make cmd/core-metadata/core-metadata

--- a/docker/Dockerfile.export-client
+++ b/docker/Dockerfile.export-client
@@ -8,6 +8,13 @@
 
 FROM golang:1.9-alpine AS builder
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
+
+# The main mirrors are giving us timeout issues on builds periodically.
+# So we can try these.
+RUN echo http://nl.alpinelinux.org/alpine/v3.6/main > /etc/apk/repositories; \
+    echo http://nl.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories
+
+
 RUN apk update && apk add make
 COPY . .
 RUN make cmd/export-client/export-client

--- a/docker/Dockerfile.export-distro
+++ b/docker/Dockerfile.export-distro
@@ -8,6 +8,13 @@
 
 FROM golang:1.9-alpine AS builder
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
+
+# The main mirrors are giving us timeout issues on builds periodically.
+# So we can try these.
+RUN echo http://nl.alpinelinux.org/alpine/v3.6/main > /etc/apk/repositories; \
+    echo http://nl.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories
+
+
 RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base
 COPY . .
 RUN make cmd/export-distro/export-distro

--- a/docker/Dockerfile.support-logging
+++ b/docker/Dockerfile.support-logging
@@ -7,6 +7,13 @@
 
 FROM golang:1.9-alpine AS builder
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
+
+# The main mirrors are giving us timeout issues on builds periodically.
+# So we can try these.
+RUN echo http://nl.alpinelinux.org/alpine/v3.6/main > /etc/apk/repositories; \
+    echo http://nl.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories
+
+
 RUN apk update && apk add make
 COPY . .
 RUN make cmd/support-logging/support-logging


### PR DESCRIPTION
The default mirrors are not responsive and are
timing out the builds periodically.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>