### PR TITLE
Config File Location via Command Line Support

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+	"flag"
 )
 
 const (
@@ -31,6 +32,8 @@ const (
 	configDocker = "configuration-docker.toml"
 	configUnitTest = "configuration-test.toml"
 )
+
+var confDir = flag.String("confdir", "", "Specify local configuration directory")
 
 func LoadFromFile(profile string, configuration interface{}) error {
 	path := determinePath()
@@ -61,9 +64,15 @@ func determineConfigFile(profile string) string {
 }
 
 func determinePath() string {
-	//Assumption: one service per container means only one var is needed, set accordingly for each deployment.
-	//For local dev, do not set this variable since configs are all named the same.
-	path := os.Getenv("EDGEX_CONF_DIR")
+	flag.Parse()
+
+	path := *confDir
+
+	if len(path) == 0 { //No cmd line param passed
+		//Assumption: one service per container means only one var is needed, set accordingly for each deployment.
+		//For local dev, do not set this variable since configs are all named the same.
+		path = os.Getenv("EDGEX_CONF_DIR")
+	}
 
 	if len(path) == 0 { //Var is not set
 		path = configDirectory

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,11 +19,11 @@ package config
 
 import (
 	"io/ioutil"
+	"flag"
 	"fmt"
 	"os"
 
 	"github.com/BurntSushi/toml"
-	"flag"
 )
 
 const (

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -40,7 +40,7 @@ func TestLoadFromDefault(t *testing.T) {
 
 func TestLoadFromEnvironment(t *testing.T) {
 	configuration := &TestConfigurationStruct{}
-	os.Setenv("EDGEX_CONF_DIR", "./res")
+	os.Setenv("EDGEX_CONF_DIR", configDirectory)
 	err := LoadFromFile("unit-test", configuration)
 	if err != nil {
 		t.Error(err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,14 +19,28 @@ package config
 
 import (
 	"testing"
+	"os"
 )
 
 type TestConfigurationStruct struct {
 	ApplicationName	string
 }
 
-func TestLoadFromFile(t *testing.T) {
+func TestLoadFromDefault(t *testing.T) {
 	configuration := &TestConfigurationStruct{}
+	err := LoadFromFile("unit-test", configuration)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(configuration.ApplicationName) == 0 {
+		t.Errorf("configuration.ApplicationName is zero length.")
+	}
+}
+
+func TestLoadFromEnvironment(t *testing.T) {
+	configuration := &TestConfigurationStruct{}
+	os.Setenv("EDGEX_CONF_DIR", "./res")
 	err := LoadFromFile("unit-test", configuration)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Order of precedence:
1.) Command line
2.) Environment variable
3.) Hard-coded default path

Pertains to isse https://github.com/edgexfoundry/edgex-go/issues/26