### PR TITLE
Don't override export-distro hostname if env set

### DIFF
--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -145,16 +145,10 @@ func loadConfig() (*config, *client.Config) {
 		MongoSocketTimeout:  defMongoSocketTimeout,
 		ConsulHost:          env(envConsulHost, defConsulHost),
 		ConsulPort:          defConsulPort,
+		Hostname:            env(envClientHost, defHostname),
 	}
-
-	hostname, err := os.Hostname()
-	if err == nil {
-		cfg.Hostname = hostname
-	}
-	cfg.Hostname = env(envClientHost, cfg.Hostname)
 
 	portStr := env(envConsulPort, strconv.Itoa(cfg.ConsulPort))
-
 	port, err := strconv.Atoi(portStr)
 	if err == nil {
 		cfg.ConsulPort = port

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -121,10 +121,6 @@ func loadConfig() (distro.Config, config) {
 		ConsulPort: defConsulPort,
 		Hostname:   env(envDistroHost, defHostname),
 	}
-	hostname, err := os.Hostname()
-	if err == nil {
-		cfg.Hostname = hostname
-	}
 
 	portStr := env(envConsulPort, strconv.Itoa(cfg.ConsulPort))
 	port, err := strconv.Atoi(portStr)


### PR DESCRIPTION
Fix issue where os.hostname overrides the hostname set thru ENV.