### PR TITLE
Fix typos in URLs for core-metadata's docker toml

### DIFF
--- a/cmd/core-metadata/res/configuration-docker.toml
+++ b/cmd/core-metadata/res/configuration-docker.toml
@@ -17,12 +17,12 @@ HeartBeatMsg = 'Core Metadata heart beat'
 AppOpenMsg = 'This is the EdgeX Core Metadata MicroService'
 ConsulHost = 'edgex-core-consul'
 ConsulProfilesActive = 'docker;go'
-ConsulCheckAddress = 'http://edgex-core-metadata=48081/api/v1/ping'
+ConsulCheckAddress = 'http://edgex-core-metadata:48081/api/v1/ping'
 CheckInterval = '10s'
 ConsulPort = 8500
 EnableRemoteLogging = true
 LoggingFile = './logs/edgex-core-metadata.log'
-LoggingRemoteURL = 'http://edgex-support-logging=48061/api/v1/logs'
+LoggingRemoteURL = 'http://edgex-support-logging:48061/api/v1/logs'
 NotificationPostDeviceChanges = true
 NotificationsSlug = 'device-change-'
 NotificationContent = 'Device update: '


### PR DESCRIPTION
Replace equals sign with colon to correct consul and logging URLs.

Signed-off-by: Justin Scott <justin.a.scott@intel.com>