### PR TITLE
Adding command line params to docker entrypoints

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -36,10 +36,11 @@ var loggingClient logger.LoggingClient
 
 func main() {
 	start := time.Now()
-	var useConsul, useProfile string
+	var useConsul bool
+	var useProfile string
 
-	flag.StringVar(&useConsul, "consul", "n", "Should the service use consul?")
-	flag.StringVar(&useConsul, "c", "n", "Should the service use consul?")
+	flag.BoolVar(&useConsul, "consul", false, "Indicates the service should use consul.")
+	flag.BoolVar(&useConsul, "c", false, "Indicates the service should use consul.")
 	flag.StringVar(&useProfile, "profile", "default", "Specify a profile other than default.")
 	flag.StringVar(&useProfile, "p", "default", "Specify a profile other than default.")
 	flag.Usage = usage.HelpCallback
@@ -55,7 +56,7 @@ func main() {
 
 	//Determine if configuration should be overridden from Consul
 	var consulMsg string
-	if useConsul == "y" {
+	if useConsul {
 		consulMsg = "Loading configuration from Consul..."
 		err := command.ConnectToConsul(*configuration)
 		if err != nil {

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -36,10 +36,11 @@ var loggingClient logger.LoggingClient
 
 func main() {
 	start := time.Now()
-	var useConsul, useProfile string
+	var useConsul bool
+	var useProfile string
 
-	flag.StringVar(&useConsul, "consul", "n", "Should the service use consul?")
-	flag.StringVar(&useConsul, "c", "n", "Should the service use consul?")
+	flag.BoolVar(&useConsul, "consul", false, "Indicates the service should use consul.")
+	flag.BoolVar(&useConsul, "c", false, "Indicates the service should use consul.")
 	flag.StringVar(&useProfile, "profile", "default", "Specify a profile other than default.")
 	flag.StringVar(&useProfile, "p", "default", "Specify a profile other than default.")
 	flag.Usage = usage.HelpCallback
@@ -55,7 +56,7 @@ func main() {
 
 	//Determine if configuration should be overridden from Consul
 	var consulMsg string
-	if useConsul == "y" {
+	if useConsul {
 		consulMsg = "Loading configuration from Consul..."
 		err := data.ConnectToConsul(*configuration)
 		if err != nil {

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -36,10 +36,11 @@ var loggingClient logger.LoggingClient
 
 func main() {
 	start := time.Now()
-	var useConsul, useProfile string
+	var useConsul bool
+	var useProfile string
 
-	flag.StringVar(&useConsul, "consul", "n", "Should the service use consul?")
-	flag.StringVar(&useConsul, "c", "n", "Should the service use consul?")
+	flag.BoolVar(&useConsul, "consul", false, "Indicates the service should use consul.")
+	flag.BoolVar(&useConsul, "c", false, "Indicates the service should use consul.")
 	flag.StringVar(&useProfile, "profile", "default", "Specify a profile other than default.")
 	flag.StringVar(&useProfile, "p", "default", "Specify a profile other than default.")
 	flag.Usage = usage.HelpCallback
@@ -55,7 +56,7 @@ func main() {
 
 	//Determine if configuration should be overridden from Consul
 	var consulMsg string
-	if useConsul == "y" {
+	if useConsul {
 		consulMsg = "Loading configuration from Consul..."
 		err := metadata.ConnectToConsul(*configuration)
 		if err != nil {

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -25,14 +25,14 @@ import (
 var loggingClient logger.LoggingClient
 
 func main() {
-	var useConsul, useProfile string
+	var useConsul bool
+	var useProfile string
 
-	flag.StringVar(&useConsul, "consul", "n", "Should the service use consul?")
-	flag.StringVar(&useConsul, "c", "n", "Should the service use consul?")
+	flag.BoolVar(&useConsul, "consul", false, "Indicates the service should use consul.")
+	flag.BoolVar(&useConsul, "c", false, "Indicates the service should use consul.")
 	flag.StringVar(&useProfile, "profile", "default", "Specify a profile other than default.")
 	flag.StringVar(&useProfile, "p", "default", "Specify a profile other than default.")
 	flag.Usage = usage.HelpCallback
-	flag.Parse()
 	flag.Parse()
 
 	configuration := &logging.ConfigurationStruct{}
@@ -44,7 +44,7 @@ func main() {
 
 	//Determine if configuration should be overridden from Consul
 	var consulMsg string
-	if useConsul == "y" {
+	if useConsul {
 		consulMsg = "Loading configuration from Consul..."
 		err := logging.ConnectToConsul(*configuration)
 		if err != nil {

--- a/docker/Dockerfile.core-command
+++ b/docker/Dockerfile.core-command
@@ -26,5 +26,5 @@ EXPOSE $APP_PORT
 
 WORKDIR /
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-command/core-command /
-COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-command/res/configuration-docker.toml /res/configuration.toml
-ENTRYPOINT ["/core-command"]
+COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-command/res/configuration-docker.toml /res/configuration-docker.toml
+ENTRYPOINT ["/core-command","--consul","--profile=docker","--confdir=/res"]

--- a/docker/Dockerfile.core-data
+++ b/docker/Dockerfile.core-data
@@ -30,6 +30,6 @@ RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
 
 RUN apk --no-cache add zeromq
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-data/core-data /
-COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-data/res/configuration-docker.toml /res/configuration.toml
+COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-data/res/configuration-docker.toml /res/configuration-docker.toml
 
-ENTRYPOINT ["/core-data"]
+ENTRYPOINT ["/core-data","--consul","--profile=docker","--confdir=/res"]

--- a/docker/Dockerfile.core-metadata
+++ b/docker/Dockerfile.core-metadata
@@ -27,5 +27,5 @@ EXPOSE $APP_PORT
 
 WORKDIR /
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-metadata/core-metadata /
-COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-metadata/res/configuration-docker.toml /res/configuration.toml
-ENTRYPOINT ["/core-metadata"]
+COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-metadata/res/configuration-docker.toml /res/configuration-docker.toml
+ENTRYPOINT ["/core-metadata","--consul","--profile=docker","--confdir=/res"]

--- a/docker/Dockerfile.support-logging
+++ b/docker/Dockerfile.support-logging
@@ -20,4 +20,5 @@ RUN make cmd/support-logging/support-logging
 
 FROM scratch
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/support-logging/support-logging /
-ENTRYPOINT ["/support-logging"]
+COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/support-logging/res/configuration-docker.toml /res/configuration-docker.toml
+ENTRYPOINT ["/support-logging","--consul","--profile=docker","--confdir=/res"]

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -24,7 +24,7 @@ import (
 var usageStr = `
 Usage: %s [options]
 Server Options:
-    -c, --consul y                  "y" indicates service should use Consul
+    -c, --consul                    Indicates service should use Consul
     -p, --profile <name>            Indicate configuration profile other than default
 Common Options:
     -h, --help                      Show this message


### PR DESCRIPTION
1.) Integrated supported cmd line params into docker files for
    core-command, core-data, core-metadata, support-logging.
2.) Modified handling of --consul cmds line param. Since it is
    effectively a boolean, removed necessity to specify --consul=y
3.) In docker files, configuration-docker.toml cannot be renamed
    to configuration.toml or else the file will not be found.
    This is due to the --profile cmd line value handling.

Issue https://github.com/edgexfoundry/edgex-go/issues/160

Signed-off-by: Trevor Conn <trevor_conn@dell.com>