### PR TITLE
Created scheduler-client interface + implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ cmd/support-logging/support-logging
 cmd/core-command/logs/
 cmd/core-data/logs/
 cmd/core-metadata/logs/
+cmd/support-logging/logs/
 cmd/export-client/logs/
 cmd/export-distro/logs/

--- a/support/notifications-client/client.go
+++ b/support/notifications-client/client.go
@@ -65,7 +65,8 @@ type NotificationsClient interface {
 	SendNotification(n Notification) error
 }
 
-type NotificationsHttpClient struct {
+//Named HttpClient instead of RestClient on purpose since there is only one POST method
+type notificationsHttpClient struct {
 
 }
 
@@ -87,13 +88,13 @@ type Notification struct {
 var notificationsClient NotificationsClient
 func GetNotificationsClient() NotificationsClient {
 	if notificationsClient == nil {
-		notificationsClient = &NotificationsHttpClient{}
+		notificationsClient = &notificationsHttpClient{}
 	}
 	return notificationsClient
 }
 
 // Send a notification to the notifications service
-func (nc *NotificationsHttpClient) SendNotification(n Notification) error {
+func (nc *notificationsHttpClient) SendNotification(n Notification) error {
 	client := &http.Client{}
 
 	// Get the JSON request body

--- a/support/scheduler-client/client_config.go
+++ b/support/scheduler-client/client_config.go
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @microservice: support-notifications-client-go library
+ * @author: Trevor Conn, Dell
+ * @version: 0.5.0
+ *******************************************************************************/
+package scheduler_client
+
+type schedulerConfig struct {
+	serviceHost string
+	servicePort int
+}
+
+var clientConfig schedulerConfig
+func SetConfiguration(host string, port int) {
+	clientConfig = schedulerConfig{serviceHost:host, servicePort:port}
+}

--- a/support/scheduler-client/client_test.go
+++ b/support/scheduler-client/client_test.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package scheduler
+package scheduler_client
 
 import (
 	"encoding/json"
@@ -106,11 +106,7 @@ func TestAddSchedule(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
-		SchedulerServiceHost: h[0],
-		SchedulerServicePort: intPort,
-		OwningService:        "notifications",
-	}
+	SetConfiguration(h[0], intPort)
 
 	schedule := models.Schedule{
 		Name:      TestScheduleName,
@@ -121,7 +117,7 @@ func TestAddSchedule(t *testing.T) {
 		RunOnce:   TestScheduleRunOnce,
 	}
 
-	error := scheduleClient.AddSchedule(schedule)
+	error := GetSchedulerClient().AddSchedule(schedule)
 	if error != nil {
 		t.Error(error)
 	}
@@ -180,13 +176,9 @@ func TestQuerySchedule(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
-		SchedulerServiceHost: h[0],
-		SchedulerServicePort: intPort,
-		OwningService:        "notifications",
-	}
+	SetConfiguration(h[0], intPort)
 
-	receivedSchedule, err := scheduleClient.QuerySchedule(TestScheduleId)
+	receivedSchedule, err := GetSchedulerClient().QuerySchedule(TestScheduleId)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -269,13 +261,9 @@ func TestQueryScheduleWithName(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
-		SchedulerServiceHost: h[0],
-		SchedulerServicePort: intPort,
-		OwningService:        "notifications",
-	}
+	SetConfiguration(h[0], intPort)
 
-	receivedSchedule, err := scheduleClient.QueryScheduleWithName(TestScheduleName)
+	receivedSchedule, err := GetSchedulerClient().QueryScheduleWithName(TestScheduleName)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -363,11 +351,7 @@ func TestUpdateSchedule(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
-		SchedulerServiceHost: h[0],
-		SchedulerServicePort: intPort,
-		OwningService:        "notifications",
-	}
+	SetConfiguration(h[0], intPort)
 
 	schedule := models.Schedule{
 		Name:      TestScheduleName,
@@ -378,7 +362,7 @@ func TestUpdateSchedule(t *testing.T) {
 		RunOnce:   TestScheduleRunOnce,
 	}
 
-	error := scheduleClient.UpdateSchedule(schedule)
+	error := GetSchedulerClient().UpdateSchedule(schedule)
 	if error != nil {
 		t.Error(error)
 	}
@@ -416,13 +400,9 @@ func TestRemoveSchedule(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
-		SchedulerServiceHost: h[0],
-		SchedulerServicePort: intPort,
-		OwningService:        "notifications",
-	}
+	SetConfiguration(h[0], intPort)
 
-	error := scheduleClient.RemoveSchedule(TestScheduleIdForTest)
+	error := GetSchedulerClient().RemoveSchedule(TestScheduleIdForTest)
 	if error != nil {
 		t.Error(error)
 	}
@@ -486,11 +466,7 @@ func TestAddScheduleEvent(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
-		SchedulerServiceHost: h[0],
-		SchedulerServicePort: intPort,
-		OwningService:        "notifications",
-	}
+	SetConfiguration(h[0], intPort)
 
 	scheduleEvent := models.ScheduleEvent{
 		Name:       TestScheduleEventName,
@@ -503,7 +479,7 @@ func TestAddScheduleEvent(t *testing.T) {
 		},
 	}
 
-	error := scheduleClient.AddScheduleEvent(scheduleEvent)
+	error := GetSchedulerClient().AddScheduleEvent(scheduleEvent)
 	if error != nil {
 		t.Error(error)
 	}
@@ -561,13 +537,9 @@ func TestQueryScheduleEvent(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
-		SchedulerServiceHost: h[0],
-		SchedulerServicePort: intPort,
-		OwningService:        "notifications",
-	}
+	SetConfiguration(h[0], intPort)
 
-	receivedScheduleEvent, error := scheduleClient.QueryScheduleEvent(TestScheduleEventId)
+	receivedScheduleEvent, error := GetSchedulerClient().QueryScheduleEvent(TestScheduleEventId)
 	if error != nil {
 		t.Error(error)
 	}
@@ -656,11 +628,7 @@ func TestUpdateScheduleEvent(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
-		SchedulerServiceHost: h[0],
-		SchedulerServicePort: intPort,
-		OwningService:        "notifications",
-	}
+	SetConfiguration(h[0], intPort)
 
 	scheduleEvent := models.ScheduleEvent{
 		Name:       TestScheduleEventName,
@@ -673,7 +641,7 @@ func TestUpdateScheduleEvent(t *testing.T) {
 		},
 	}
 
-	error := scheduleClient.UpdateScheduleEvent(scheduleEvent)
+	error := GetSchedulerClient().UpdateScheduleEvent(scheduleEvent)
 	if error != nil {
 		t.Error(error)
 	}
@@ -711,13 +679,9 @@ func TestRemoveScheduleEvent(t *testing.T) {
 		t.Error(e)
 	}
 
-	scheduleClient := SchedulerClient{
-		SchedulerServiceHost: h[0],
-		SchedulerServicePort: intPort,
-		OwningService:        "notifications",
-	}
+	SetConfiguration(h[0], intPort)
 
-	error := scheduleClient.RemoveScheduleEvent(TestScheduleEventId)
+	error := GetSchedulerClient().RemoveScheduleEvent(TestScheduleEventId)
 	if error != nil {
 		t.Error(error)
 	}


### PR DESCRIPTION
1.) New interface for scheduler-client, following pattern
    of notifications-client. Implementation conforms to
    this interface.
2.) Changed name of implementing notifications-client type
    so that it was lower-cased, preserving encapsulation.
    This needs to be done elsewhere, I notice -- like
    metadataclients
3.) Reworked scheduler-client tests.

Issue https://github.com/edgexfoundry/edgex-go/issues/164

Signed-off-by: Trevor Conn <trevor_conn@dell.com>