### PR TITLE
Fixed service health check registration in Consul

### DIFF
--- a/support/consul-client/consul.go
+++ b/support/consul-client/consul.go
@@ -45,7 +45,7 @@ func ConsulInit(config ConsulConfig) error {
 	var err error // Declare error to be used throughout function
 
 	// Connect to the Consul Agent
-	defaultConfig := consulapi.DefaultConfig()
+	defaultConfig := &consulapi.Config{}
 	defaultConfig.Address = config.ConsulAddress + ":" + strconv.Itoa(config.ConsulPort)
 	consul, err = consulapi.NewClient(defaultConfig)
 	if err != nil {
@@ -64,7 +64,7 @@ func ConsulInit(config ConsulConfig) error {
 
 	// Register the Health Check
 	err = consul.Agent().CheckRegister(&consulapi.AgentCheckRegistration{
-		Name:      "Health Check",
+		Name:      "Health Check: " + config.ServiceName,
 		Notes:     "Check the health of the API",
 		ServiceID: config.ServiceName,
 		AgentServiceCheck: consulapi.AgentServiceCheck{


### PR DESCRIPTION
1.) Removed redundant call to obtain DefaultConfig() from consulapi. Empty properties are
     populated within the NewClient() call in the exact same manner, so no need for this.
2.) All health checks on a given agent must be uniquely named, so added service name.

Issue https://github.com/edgexfoundry/edgex-go/issues/170

Signed-off-by: Trevor Conn <trevor_conn@dell.com>