### PR TITLE
Add GIT_SHA to a docker tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ VERSION=$(shell cat ./VERSION)
 
 GOFLAGS=-ldflags "-X github.com/edgexfoundry/edgex-go.Version=$(VERSION)"
 
+GIT_SHA=$(shell git rev-parse --short HEAD)
+
 build: $(MICROSERVICES)
 	go build ./...
 
@@ -64,6 +66,7 @@ docker_core_metadata:
 	docker build \
 		-f docker/Dockerfile.core-metadata \
 		-t edgexfoundry/docker-core-metadata-go:latest \
+		-t edgexfoundry/docker-core-metadata-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-core-metadata-go:$(VERSION) \
 		-t edgexfoundry/docker-core-metadata-go:$(VERSION)-dev \
 		.
@@ -72,6 +75,7 @@ docker_core_data:
 	docker build \
 		-f docker/Dockerfile.core-data \
 		-t edgexfoundry/docker-core-data-go:latest \
+		-t edgexfoundry/docker-core-data-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-core-data-go:$(VERSION) \
 		-t edgexfoundry/docker-core-data-go:$(VERSION)-dev \
 		.
@@ -80,6 +84,7 @@ docker_core_command:
 	docker build \
 		-f docker/Dockerfile.core-command \
 		-t edgexfoundry/docker-core-command-go:latest \
+		-t edgexfoundry/docker-core-command-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-core-command-go:$(VERSION) \
 		-t edgexfoundry/docker-core-command-go:$(VERSION)-dev \
 		.
@@ -88,6 +93,7 @@ docker_export_client:
 	docker build \
 		-f docker/Dockerfile.export-client \
 		-t edgexfoundry/docker-export-client-go:latest \
+		-t edgexfoundry/docker-export-client-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-export-client-go:$(VERSION) \
 		-t edgexfoundry/docker-export-client-go:$(VERSION)-dev \
 		.
@@ -96,6 +102,7 @@ docker_export_distro:
 	docker build \
 		-f docker/Dockerfile.export-distro \
 		-t edgexfoundry/docker-export-distro-go:latest \
+		-t edgexfoundry/docker-export-distro-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-export-distro-go:$(VERSION) \
 		-t edgexfoundry/docker-export-distro-go:$(VERSION)-dev \
 		.
@@ -104,6 +111,7 @@ docker_support_logging:
 	docker build \
 		-f docker/Dockerfile.support-logging \
 		-t edgexfoundry/docker-support-logging-go:latest \
+		-t edgexfoundry/docker-support-logging-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-support-logging-go:$(VERSION) \
 		-t edgexfoundry/docker-support-logging-go:$(VERSION)-dev \
 		.


### PR DESCRIPTION
This will help me try out my publish scripts.
The issue this solves happens on the Cavium
build machine and can potentially have several docker
builds happening at one time.  This way I can query for
a specific builds generated docker images in an easy way.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>