### PR TITLE
Addressing panic from issue #223

### DIFF
--- a/core/domain/models/command.go
+++ b/core/domain/models/command.go
@@ -70,6 +70,27 @@ func (c Command) String() string {
 	return string(out)
 }
 
+func(c *Command) UnmarshalJSON(b []byte) error {
+	type Alias Command
+	alias := &struct {
+		*Alias
+	} {
+		Alias: (*Alias)(c),
+	}
+
+	if err := json.Unmarshal(b, &alias); err != nil {
+		return err
+	}
+	c = (*Command)(alias.Alias)
+	if c.Get == nil {
+		c.Get = &Get{}
+	}
+	if c.Put == nil {
+		c.Put = &Put{}
+	}
+	return nil
+}
+
 // Append all the associated value descriptors to the list
 // Associated by PUT command parameters and PUT/GET command return values
 func (c *Command) AllAssociatedValueDescriptors(vdNames *map[string]string) {


### PR DESCRIPTION
The approach here was to utilize UnmarshalJSON() on the Command domain
model in order to ensure that both Get and Put are initialized. The
bug was caused because the sample request did not have a GET so when
Mongo tried to call Get.String() it panicked due to NIL reference.

I wanted a solution that would NOT entail adding nil checks throughout the code base. We should be able to rely on whether or not a given property is initialized when deserializing.

#223 
Signed-off-by: Trevor Conn <trevor_conn@dell.com>