### PR TITLE
Relocated constants for service naming/keys

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -25,11 +25,11 @@ import (
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/core/command"
+	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/heartbeat"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/support/logging-client"
-	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 var loggingClient logger.LoggingClient

--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/heartbeat"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/support/logging-client"
+	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 var loggingClient logger.LoggingClient
@@ -71,7 +72,7 @@ func main() {
 	var loggingClient= logger.NewClient(configuration.ApplicationName, configuration.EnableRemoteLogging, logTarget)
 
 	loggingClient.Info(consulMsg)
-	loggingClient.Info(fmt.Sprintf("Starting %s %s ", command.COMMANDSERVICENAME, edgex.Version))
+	loggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.CommandServiceKey, edgex.Version))
 
 	command.Init(*configuration, loggingClient)
 
@@ -91,7 +92,7 @@ func main() {
 }
 
 func logBeforeTermination(err error) {
-	loggingClient = logger.NewClient(command.COMMANDSERVICENAME, false, "")
+	loggingClient = logger.NewClient(internal.CommandServiceKey, false, "")
 	loggingClient.Error(err.Error())
 }
 

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -25,11 +25,11 @@ import (
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/core/data"
+	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/heartbeat"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/support/logging-client"
-	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 var loggingClient logger.LoggingClient

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/heartbeat"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/support/logging-client"
+	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 var loggingClient logger.LoggingClient
@@ -71,7 +72,7 @@ func main() {
 	loggingClient = logger.NewClient(configuration.ApplicationName, configuration.EnableRemoteLogging, logTarget)
 
 	loggingClient.Info(consulMsg)
-	loggingClient.Info(fmt.Sprintf("Starting %s %s ", data.COREDATASERVICENAME, edgex.Version))
+	loggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.CoreDataServiceKey, edgex.Version))
 
 	err = data.Init(*configuration, loggingClient)
 	if err != nil {
@@ -97,7 +98,7 @@ func main() {
 }
 
 func logBeforeTermination(err error) {
-	loggingClient = logger.NewClient(data.COREDATASERVICENAME, false, "")
+	loggingClient = logger.NewClient(internal.CoreDataServiceKey, false, "")
 	loggingClient.Error(err.Error())
 }
 

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -25,11 +25,11 @@ import (
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/core/metadata"
+	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/heartbeat"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/support/logging-client"
-	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 var loggingClient logger.LoggingClient

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/heartbeat"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/support/logging-client"
+	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 var loggingClient logger.LoggingClient
@@ -71,7 +72,7 @@ func main() {
 	loggingClient = logger.NewClient(configuration.ApplicationName, configuration.EnableRemoteLogging, logTarget)
 
 	loggingClient.Info(consulMsg)
-	loggingClient.Info(fmt.Sprintf("Starting %s %s ", metadata.METADATASERVICENAME, edgex.Version))
+	loggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.MetaDataServiceKey, edgex.Version))
 
 	err = metadata.Init(*configuration, loggingClient)
 	if err != nil {
@@ -97,7 +98,7 @@ func main() {
 }
 
 func logBeforeTermination(err error) {
-	loggingClient = logger.NewClient(metadata.METADATASERVICENAME, false, "")
+	loggingClient = logger.NewClient(internal.MetaDataServiceKey, false, "")
 	loggingClient.Error(err.Error())
 }
 

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/support/logging"
 	"github.com/edgexfoundry/edgex-go/support/logging-client"
+	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 var loggingClient logger.LoggingClient
@@ -60,7 +61,7 @@ func main() {
 
 	loggingClient = logger.NewClient(configuration.ApplicationName, false, configuration.LoggingFile)
 	loggingClient.Info(consulMsg)
-	loggingClient.Info(fmt.Sprintf("Starting %s %s", logging.SUPPORTLOGGINGSERVICENAME, edgex.Version))
+	loggingClient.Info(fmt.Sprintf("Starting %s %s", internal.SupportLoggingServiceKey, edgex.Version))
 
 	logging.Init(*configuration)
 	heartbeat.Start(configuration.HeartBeatMsg, configuration.HeartBeatTime, loggingClient)
@@ -82,6 +83,6 @@ func main() {
 }
 
 func logBeforeTermination(err error) {
-	loggingClient = logger.NewClient(logging.SUPPORTLOGGINGSERVICENAME, false, "")
+	loggingClient = logger.NewClient(internal.SupportLoggingServiceKey, false, "")
 	loggingClient.Error(err.Error())
 }

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -17,12 +17,12 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/heartbeat"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/support/logging"
 	"github.com/edgexfoundry/edgex-go/support/logging-client"
-	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 var loggingClient logger.LoggingClient

--- a/core/command/const.go
+++ b/core/command/const.go
@@ -51,7 +51,6 @@ var configuration ConfigurationStruct = ConfigurationStruct{}
 
 const (
 	/* -------------- Constants for Command -------------------- */
-	COMMANDSERVICENAME       string = "core-command"
 	REST_HTTP                string = "http://"
 	ID                       string = "id"
 	_ID                      string = "_id"

--- a/core/data/const.go
+++ b/core/data/const.go
@@ -63,6 +63,3 @@ type ConfigurationStruct struct {
 
 var configuration ConfigurationStruct = ConfigurationStruct{} //  Needs to be initialized before used
 
-var (
-	COREDATASERVICENAME = "core-data"
-)

--- a/core/metadata/const.go
+++ b/core/metadata/const.go
@@ -71,7 +71,6 @@ var (
 	DBUSER              = "meta"
 	DBPASS              = "password"
 	MONGODATABASE       = "metadata"
-	METADATASERVICENAME = "core-metadata"
 
 	MAX_LIMIT int = 1000
 

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package internal
+
+var (
+	CommandServiceKey            = "core-command"
+	CoreDataServiceKey 		     = "core-data"
+	MetaDataServiceKey           = "core-metadata"
+	SupportLoggingServiceKey     = "support-logging"
+)

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -13,9 +13,8 @@
  *******************************************************************************/
 package internal
 
-var (
-	CommandServiceKey            = "core-command"
-	CoreDataServiceKey 		     = "core-data"
-	MetaDataServiceKey           = "core-metadata"
-	SupportLoggingServiceKey     = "support-logging"
-)
+
+const CommandServiceKey            = "core-command"
+const CoreDataServiceKey           = "core-data"
+const MetaDataServiceKey           = "core-metadata"
+const SupportLoggingServiceKey     = "support-logging"

--- a/support/logging/const.go
+++ b/support/logging/const.go
@@ -31,6 +31,3 @@ type ConfigurationStruct struct {
 // Configuration data for the support logging service
 var configuration ConfigurationStruct = ConfigurationStruct{}
 
-var (
-	SUPPORTLOGGINGSERVICENAME = "support-logging"
-)


### PR DESCRIPTION
Partially related to #173.

This will be used in the work for #182. Some global location holding the keys to services registered in Consul has to be available for all services. Instead of having the URL in a config file, the key will be in Consul and a dependent service has to know what to ask for. In other words, core-data needs to know core-metadata's key without referencing /core/metadata.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>