### PR TITLE
Core/Support service naming per design standard

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -69,10 +69,10 @@ func main() {
 
 	// Setup Logging
 	logTarget := setLoggingTarget(*configuration)
-	var loggingClient= logger.NewClient(configuration.ApplicationName, configuration.EnableRemoteLogging, logTarget)
+	var loggingClient= logger.NewClient(internal.CoreCommandServiceKey, configuration.EnableRemoteLogging, logTarget)
 
 	loggingClient.Info(consulMsg)
-	loggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.CommandServiceKey, edgex.Version))
+	loggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.CoreCommandServiceKey, edgex.Version))
 
 	command.Init(*configuration, loggingClient, useConsul)
 
@@ -92,7 +92,7 @@ func main() {
 }
 
 func logBeforeTermination(err error) {
-	loggingClient = logger.NewClient(internal.CommandServiceKey, false, "")
+	loggingClient = logger.NewClient(internal.CoreCommandServiceKey, false, "")
 	loggingClient.Error(err.Error())
 }
 

--- a/cmd/core-command/res/configuration-docker.toml
+++ b/cmd/core-command/res/configuration-docker.toml
@@ -1,11 +1,9 @@
-ApplicationName = 'edgex-core-command'
 ConsulProfilesActive = 'docker;go'
 ReadLimit = 100
 HeartBeatTime = 300000
 ConsulPort = 8500
 ServiceTimeout = 5000
 CheckInterval = '10s'
-ServiceName = 'edgex-core-command'
 ServiceAddress = 'edgex-core-command'
 ServicePort = 48082
 DeviceServiceProtocol = 'http'

--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -1,11 +1,9 @@
-ApplicationName = 'core-command'
 ConsulProfilesActive = 'go'
 ReadLimit = 100
 HeartBeatTime = 300000
 ConsulPort = 8500
 ServiceTimeout = 5000
 CheckInterval = '10s'
-ServiceName = 'core-command'
 ServiceAddress = 'localhost'
 ServicePort = 48082
 DeviceServiceProtocol = 'http'

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	// Setup Logging
 	logTarget := setLoggingTarget(*configuration)
-	loggingClient = logger.NewClient(configuration.ApplicationName, configuration.EnableRemoteLogging, logTarget)
+	loggingClient = logger.NewClient(internal.CoreDataServiceKey, configuration.EnableRemoteLogging, logTarget)
 
 	loggingClient.Info(consulMsg)
 	loggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.CoreDataServiceKey, edgex.Version))

--- a/cmd/core-data/res/configuration-docker.toml
+++ b/cmd/core-data/res/configuration-docker.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'edgex-core-data'
 ConsulProfilesActive = 'docker;go'
 ReadMaxLimit = 100
 MetaDataCheck = false
@@ -13,7 +12,6 @@ MsgPubType = 'zero'
 ServicePort = 48080
 ServiceTimeout = 5000
 ServiceAddress = 'edgex-core-data'
-ServiceName = 'edgex-core-data'
 DeviceUpdateLastConnected = false
 ServiceUpdateLastConnected = false
 MongoDBUserName = 'core'

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'core-data'
 ConsulProfilesActive = 'go'
 ReadMaxLimit = 100
 MetaDataCheck = false
@@ -13,7 +12,6 @@ MsgPubType = 'zero'
 ServicePort = 48080
 ServiceTimeout = 5000
 ServiceAddress = 'localhost'
-ServiceName = 'core-data'
 DeviceUpdateLastConnected = false
 ServiceUpdateLastConnected = false
 MongoDBUserName = 'core'

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -69,10 +69,10 @@ func main() {
 
 	// Setup Logging
 	logTarget := setLoggingTarget(*configuration)
-	loggingClient = logger.NewClient(configuration.ApplicationName, configuration.EnableRemoteLogging, logTarget)
+	loggingClient = logger.NewClient(internal.CoreMetaDataServiceKey, configuration.EnableRemoteLogging, logTarget)
 
 	loggingClient.Info(consulMsg)
-	loggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.MetaDataServiceKey, edgex.Version))
+	loggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.CoreMetaDataServiceKey, edgex.Version))
 
 	err = metadata.Init(*configuration, loggingClient)
 	if err != nil {
@@ -98,7 +98,7 @@ func main() {
 }
 
 func logBeforeTermination(err error) {
-	loggingClient = logger.NewClient(internal.MetaDataServiceKey, false, "")
+	loggingClient = logger.NewClient(internal.CoreMetaDataServiceKey, false, "")
 	loggingClient.Error(err.Error())
 }
 

--- a/cmd/core-metadata/res/configuration-docker.toml
+++ b/cmd/core-metadata/res/configuration-docker.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'edgex-core-metadata'
 DBType = 'mongodb'
 MongoDatabaseName = 'metadata'
 MongoDBUserName = 'meta'
@@ -8,7 +7,6 @@ MongoDBPort = 27017
 MongoDBConnectTimeout = 5000
 ReadMaxLimit = 100
 Protocol = 'http'
-ServiceName = 'edgex-core-metadata'
 ServiceAddress = 'edgex-core-metadata'
 ServicePort = 48081
 ServiceTimeout = 5000

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'core-metadata'
 DBType = 'mongodb'
 MongoDatabaseName = 'metadata'
 MongoDBUserName = ''
@@ -8,7 +7,6 @@ MongoDBPort = 27017
 MongoDBConnectTimeout = 5000
 ReadMaxLimit = 100
 Protocol = 'http'
-ServiceName = 'core-metadata'
 ServiceAddress = 'localhost'
 ServicePort = 48081
 ServiceTimeout = 5000

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/export/client"
+	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"go.uber.org/zap"
@@ -28,7 +29,7 @@ func main() {
 	logger, _ = zap.NewProduction()
 	defer logger.Sync()
 
-	logger.Info(fmt.Sprintf("Starting %s %s", client.ExportClient, edgex.Version))
+	logger.Info(fmt.Sprintf("Starting %s %s", internal.ExportClientServiceKey, edgex.Version))
 
 	var (
 		useConsul  bool

--- a/cmd/export-client/res/configuration-docker.toml
+++ b/cmd/export-client/res/configuration-docker.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'edgex-export-client'
 Hostname = 'edgex-export-client'
 Port = 48071
 DBType = 'mongodb'

--- a/cmd/export-client/res/configuration.toml
+++ b/cmd/export-client/res/configuration.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'export-client'
 Hostname = '127.0.0.1'
 Port = 48071
 DBType = 'mongodb'

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/edgexfoundry/edgex-go/export/distro"
+	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 
@@ -30,7 +31,7 @@ func main() {
 	logger, _ = zap.NewProduction()
 	defer logger.Sync()
 
-	logger.Info("Starting edgex export distro", zap.String("version", edgex.Version))
+	logger.Info("Starting " + internal.ExportDistroServiceKey, zap.String("version", edgex.Version))
 
 	var (
 		useConsul  bool

--- a/cmd/export-distro/res/configuration-docker.toml
+++ b/cmd/export-distro/res/configuration-docker.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'edgex-export-distro'
 Hostname = 'edgex-export-distro'
 Port = 48070
 DistroHost = 'edgex-export-distro'

--- a/cmd/export-distro/res/configuration.toml
+++ b/cmd/export-distro/res/configuration.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'export-distro'
 Hostname = '127.0.0.1'
 Port = 48070
 DistroHost = '127.0.0.1'

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -59,7 +59,7 @@ func main() {
 		consulMsg = "Bypassing Consul configuration..."
 	}
 
-	loggingClient = logger.NewClient(configuration.ApplicationName, false, configuration.LoggingFile)
+	loggingClient = logger.NewClient(internal.SupportLoggingServiceKey, false, configuration.LoggingFile)
 	loggingClient.Info(consulMsg)
 	loggingClient.Info(fmt.Sprintf("Starting %s %s", internal.SupportLoggingServiceKey, edgex.Version))
 

--- a/cmd/support-logging/res/configuration-docker.toml
+++ b/cmd/support-logging/res/configuration-docker.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'edgex-support-logging'
 Hostname = 'edgex-support-logging'
 Port = 48061
 Persistence = 'mongodb'

--- a/cmd/support-logging/res/configuration.toml
+++ b/cmd/support-logging/res/configuration.toml
@@ -1,4 +1,3 @@
-ApplicationName = 'support-logging'
 Hostname = 'localhost'
 Port = 48061
 Persistence = 'mongodb'

--- a/core/clients/metadata/device_test.go
+++ b/core/clients/metadata/device_test.go
@@ -66,7 +66,7 @@ func TestAddDevice(t *testing.T) {
 	url := ts.URL + deviceUriPath
 
 	params := types.EndpointParams{
-		ServiceKey:internal.MetaDataServiceKey,
+		ServiceKey:internal.CoreMetaDataServiceKey,
 		Path:deviceUriPath,
 		UseRegistry:false,
 		Url:url}
@@ -86,7 +86,7 @@ func TestAddDevice(t *testing.T) {
 func TestNewDeviceClientWithConsul(t *testing.T) {
 	deviceUrl := "http://localhost:48081" + deviceUriPath
 	params := types.EndpointParams{
-		ServiceKey:internal.MetaDataServiceKey,
+		ServiceKey:internal.CoreMetaDataServiceKey,
 		Path:deviceUriPath,
 		UseRegistry:true,
 		Url:deviceUrl}
@@ -114,7 +114,7 @@ type MockEndpoint struct {
 
 func(e MockEndpoint) Monitor(params types.EndpointParams, ch chan string) {
 	switch (params.ServiceKey) {
-	case "core-metadata":
+	case internal.CoreMetaDataServiceKey:
 		url := fmt.Sprintf("http://%s:%v%s", "localhost", 48081, params.Path)
 		ch <- url
 		break

--- a/core/clients/metadata/metadata-clients.go
+++ b/core/clients/metadata/metadata-clients.go
@@ -21,20 +21,16 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 
 	"github.com/edgexfoundry/edgex-go/core/clients"
 	"github.com/edgexfoundry/edgex-go/core/clients/types"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
-	"github.com/edgexfoundry/edgex-go/support/logging-client"
 )
 
 var (
 	ErrResponseNil error = errors.New("Problem connecting to metadata - reponse was nil")
 	ErrNotFound    error = errors.New("Item not found")
-	MetaData             = "metadata"
-	loggingClient        = logger.NewClient(MetaData, false, "")
 )
 
 /*
@@ -148,7 +144,6 @@ func(d *DeviceRestClient) init(params types.EndpointParams) {
 			for true {
 				select {
 				case url := <- ch:
-					fmt.Fprintln(os.Stdout,"endpoint loaded: " + url)
 					d.url = url
 				}
 			}
@@ -187,21 +182,14 @@ func NewDeviceProfileClient(metaDbDeviceProfileUrl string) DeviceProfileClient {
 func makeRequest(req *http.Request) (*http.Response, error) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	if err != nil {
-		loggingClient.Error(err.Error())
-	}
 	return resp, err
 }
 
 // Helper method to get the body from the response after making the request
 func getBody(resp *http.Response) ([]byte, error) {
 	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		loggingClient.Error(err.Error())
-		return []byte{}, err
-	}
 
-	return body, nil
+	return body, err
 }
 
 // ***************** ADDRESSABLE CLIENT METHODS ***********************
@@ -212,18 +200,15 @@ func (a *AddressableRestClient) Add(addr *models.Addressable) (string, error) {
 	// Marshal the addressable to JSON
 	jsonStr, err := json.Marshal(addr)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 
 	client := &http.Client{}
 	resp, err := client.Post(a.url, "application/json", bytes.NewReader(jsonStr))
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return "", ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -231,7 +216,6 @@ func (a *AddressableRestClient) Add(addr *models.Addressable) (string, error) {
 	// Get the response body
 	bodyBytes, err := getBody(resp)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	bodyString := string(bodyBytes)
@@ -250,7 +234,7 @@ func (d *AddressableRestClient) decodeAddressable(resp *http.Response) (models.A
 
 	err := dec.Decode(&addr)
 	if err != nil {
-		loggingClient.Error(err.Error())
+		return models.Addressable{}, err
 	}
 
 	return addr, err
@@ -263,7 +247,6 @@ func (d *AddressableRestClient) decodeAddressable(resp *http.Response) (models.A
 func (a *AddressableRestClient) AddressableForName(name string) (models.Addressable, error) {
 	req, err := http.NewRequest(http.MethodGet, a.url+"/name/"+url.QueryEscape(name), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return models.Addressable{}, err
 	}
 
@@ -271,7 +254,6 @@ func (a *AddressableRestClient) AddressableForName(name string) (models.Addressa
 
 	// Check response
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return models.Addressable{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -284,12 +266,10 @@ func (a *AddressableRestClient) AddressableForName(name string) (models.Addressa
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return models.Addressable{}, err
 		}
 		bodyString := string(bodyBytes)
 
-		loggingClient.Debug(bodyString)
 		return models.Addressable{}, errors.New(bodyString)
 	}
 
@@ -304,7 +284,7 @@ func (d *DeviceRestClient) decodeDeviceSlice(resp *http.Response) ([]models.Devi
 
 	err := dec.Decode(&dSlice)
 	if err != nil {
-		loggingClient.Error(err.Error())
+		return []models.Device{}, err
 	}
 
 	return dSlice, err
@@ -317,7 +297,7 @@ func (d *DeviceRestClient) decodeDevice(resp *http.Response) (models.Device, err
 
 	err := dec.Decode(&dev)
 	if err != nil {
-		loggingClient.Error(err.Error())
+		return models.Device{}, err
 	}
 
 	return dev, err
@@ -367,18 +347,15 @@ func (d *DeviceRestClient) CheckForDevice(token string) (models.Device, error) {
 func (d *DeviceRestClient) Device(id string) (models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url+"/"+id, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -387,7 +364,6 @@ func (d *DeviceRestClient) Device(id string) (models.Device, error) {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -402,18 +378,15 @@ func (d *DeviceRestClient) Device(id string) (models.Device, error) {
 func (d *DeviceRestClient) Devices() ([]models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -422,7 +395,6 @@ func (d *DeviceRestClient) Devices() ([]models.Device, error) {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -436,18 +408,15 @@ func (d *DeviceRestClient) Devices() ([]models.Device, error) {
 func (d *DeviceRestClient) DeviceForName(name string) (models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url+"/name/"+url.QueryEscape(name), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -456,7 +425,6 @@ func (d *DeviceRestClient) DeviceForName(name string) (models.Device, error) {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -470,18 +438,15 @@ func (d *DeviceRestClient) DeviceForName(name string) (models.Device, error) {
 func (d *DeviceRestClient) DevicesByLabel(label string) ([]models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url+"/label/"+url.QueryEscape(label), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -490,7 +455,6 @@ func (d *DeviceRestClient) DevicesByLabel(label string) ([]models.Device, error)
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -504,18 +468,15 @@ func (d *DeviceRestClient) DevicesByLabel(label string) ([]models.Device, error)
 func (d *DeviceRestClient) DevicesForService(serviceId string) ([]models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url+"/service/"+serviceId, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -524,7 +485,6 @@ func (d *DeviceRestClient) DevicesForService(serviceId string) ([]models.Device,
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -538,18 +498,15 @@ func (d *DeviceRestClient) DevicesForService(serviceId string) ([]models.Device,
 func (d *DeviceRestClient) DevicesForServiceByName(serviceName string) ([]models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url+"/servicename/"+url.QueryEscape(serviceName), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -558,7 +515,6 @@ func (d *DeviceRestClient) DevicesForServiceByName(serviceName string) ([]models
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -572,18 +528,15 @@ func (d *DeviceRestClient) DevicesForServiceByName(serviceName string) ([]models
 func (d *DeviceRestClient) DevicesForProfile(profileId string) ([]models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url+"/profile/"+profileId, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -592,7 +545,6 @@ func (d *DeviceRestClient) DevicesForProfile(profileId string) ([]models.Device,
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -606,18 +558,15 @@ func (d *DeviceRestClient) DevicesForProfile(profileId string) ([]models.Device,
 func (d *DeviceRestClient) DevicesForProfileByName(profileName string) ([]models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url+"/profilename/"+url.QueryEscape(profileName), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -626,7 +575,6 @@ func (d *DeviceRestClient) DevicesForProfileByName(profileName string) ([]models
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -640,18 +588,15 @@ func (d *DeviceRestClient) DevicesForProfileByName(profileName string) ([]models
 func (d *DeviceRestClient) DevicesForAddressable(addressableId string) ([]models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url+"/addressable/"+addressableId, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -660,7 +605,6 @@ func (d *DeviceRestClient) DevicesForAddressable(addressableId string) ([]models
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -675,18 +619,15 @@ func (d *DeviceRestClient) DevicesForAddressable(addressableId string) ([]models
 func (d *DeviceRestClient) DevicesForAddressableByName(addressableName string) ([]models.Device, error) {
 	req, err := http.NewRequest(http.MethodGet, d.url+"/addressablename/"+url.QueryEscape(addressableName), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 
 	// Make the request and get response
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Device{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Device{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -695,7 +636,6 @@ func (d *DeviceRestClient) DevicesForAddressableByName(addressableName string) (
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Device{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -710,23 +650,19 @@ func (d *DeviceRestClient) DevicesForAddressableByName(addressableName string) (
 func (d *DeviceRestClient) Add(dev *models.Device) (string, error) {
 	jsonStr, err := json.Marshal(dev)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 
 	req, err := http.NewRequest(http.MethodPost, d.url, bytes.NewReader(jsonStr))
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return "", ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -734,13 +670,11 @@ func (d *DeviceRestClient) Add(dev *models.Device) (string, error) {
 	// Get the body
 	bodyBytes, err := getBody(resp)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	bodyString := string(bodyBytes)
 
 	if resp.StatusCode != 200 {
-		loggingClient.Debug(bodyString)
 		return "", errors.New(bodyString)
 	}
 
@@ -751,23 +685,19 @@ func (d *DeviceRestClient) Add(dev *models.Device) (string, error) {
 func (d *DeviceRestClient) Update(dev models.Device) error {
 	jsonStr, err := json.Marshal(&dev)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	req, err := http.NewRequest(http.MethodPut, d.url, bytes.NewReader(jsonStr))
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -776,7 +706,6 @@ func (d *DeviceRestClient) Update(dev models.Device) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -791,17 +720,14 @@ func (d *DeviceRestClient) Update(dev models.Device) error {
 func (d *DeviceRestClient) UpdateLastConnected(id string, time int64) error {
 	req, err := http.NewRequest(http.MethodPut, d.url+"/"+id+"/lastconnected/"+strconv.FormatInt(time, 10), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -810,7 +736,6 @@ func (d *DeviceRestClient) UpdateLastConnected(id string, time int64) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -825,17 +750,14 @@ func (d *DeviceRestClient) UpdateLastConnected(id string, time int64) error {
 func (d *DeviceRestClient) UpdateLastConnectedByName(name string, time int64) error {
 	req, err := http.NewRequest(http.MethodPut, d.url+"/name/"+url.QueryEscape(name)+"/lastconnected/"+strconv.FormatInt(time, 10), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -844,7 +766,6 @@ func (d *DeviceRestClient) UpdateLastConnectedByName(name string, time int64) er
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -859,17 +780,14 @@ func (d *DeviceRestClient) UpdateLastConnectedByName(name string, time int64) er
 func (d *DeviceRestClient) UpdateLastReported(id string, time int64) error {
 	req, err := http.NewRequest(http.MethodPut, d.url+"/"+id+"/lastreported/"+strconv.FormatInt(time, 10), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -878,7 +796,6 @@ func (d *DeviceRestClient) UpdateLastReported(id string, time int64) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -893,17 +810,14 @@ func (d *DeviceRestClient) UpdateLastReported(id string, time int64) error {
 func (d *DeviceRestClient) UpdateLastReportedByName(name string, time int64) error {
 	req, err := http.NewRequest(http.MethodPut, d.url+"/name/"+url.QueryEscape(name)+"/lastreported/"+strconv.FormatInt(time, 10), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -912,7 +826,6 @@ func (d *DeviceRestClient) UpdateLastReportedByName(name string, time int64) err
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -927,17 +840,14 @@ func (d *DeviceRestClient) UpdateLastReportedByName(name string, time int64) err
 func (d *DeviceRestClient) UpdateOpState(id string, opState string) error {
 	req, err := http.NewRequest(http.MethodPut, d.url+"/"+id+"/opstate/"+opState, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -946,7 +856,6 @@ func (d *DeviceRestClient) UpdateOpState(id string, opState string) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -961,17 +870,14 @@ func (d *DeviceRestClient) UpdateOpState(id string, opState string) error {
 func (d *DeviceRestClient) UpdateOpStateByName(name string, opState string) error {
 	req, err := http.NewRequest(http.MethodPut, d.url+"/name/"+url.QueryEscape(name)+"/opstate/"+opState, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -980,7 +886,6 @@ func (d *DeviceRestClient) UpdateOpStateByName(name string, opState string) erro
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -995,17 +900,14 @@ func (d *DeviceRestClient) UpdateOpStateByName(name string, opState string) erro
 func (d *DeviceRestClient) UpdateAdminState(id string, adminState string) error {
 	req, err := http.NewRequest(http.MethodPut, d.url+"/"+id+"/adminstate/"+adminState, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 
@@ -1015,7 +917,6 @@ func (d *DeviceRestClient) UpdateAdminState(id string, adminState string) error 
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -1030,17 +931,14 @@ func (d *DeviceRestClient) UpdateAdminState(id string, adminState string) error 
 func (d *DeviceRestClient) UpdateAdminStateByName(name string, adminState string) error {
 	req, err := http.NewRequest(http.MethodPut, d.url+"/name/"+url.QueryEscape(name)+"/adminstate/"+adminState, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1049,7 +947,6 @@ func (d *DeviceRestClient) UpdateAdminStateByName(name string, adminState string
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -1064,17 +961,14 @@ func (d *DeviceRestClient) UpdateAdminStateByName(name string, adminState string
 func (d *DeviceRestClient) Delete(id string) error {
 	req, err := http.NewRequest(http.MethodDelete, d.url+"/id/"+id, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1083,7 +977,6 @@ func (d *DeviceRestClient) Delete(id string) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -1098,17 +991,14 @@ func (d *DeviceRestClient) Delete(id string) error {
 func (d *DeviceRestClient) DeleteByName(name string) error {
 	req, err := http.NewRequest(http.MethodDelete, d.url+"/name/"+url.QueryEscape(name), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1117,7 +1007,6 @@ func (d *DeviceRestClient) DeleteByName(name string) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -1136,7 +1025,7 @@ func (c *CommandRestClient) decodeCommand(resp *http.Response) (models.Command, 
 	com := models.Command{}
 	err := dec.Decode(&com)
 	if err != nil {
-		loggingClient.Error(err.Error())
+		return models.Command{}, err
 	}
 
 	return com, err
@@ -1148,7 +1037,7 @@ func (c *CommandRestClient) decodeCommandSlice(resp *http.Response) ([]models.Co
 	comSlice := []models.Command{}
 	err := dec.Decode(&comSlice)
 	if err != nil {
-		loggingClient.Error(err.Error())
+		return []models.Command{}, err
 	}
 
 	return comSlice, err
@@ -1158,17 +1047,14 @@ func (c *CommandRestClient) decodeCommandSlice(resp *http.Response) ([]models.Co
 func (c *CommandRestClient) Command(id string) (models.Command, error) {
 	req, err := http.NewRequest(http.MethodGet, c.url+"/"+id, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return models.Command{}, err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return models.Command{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return models.Command{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1177,7 +1063,6 @@ func (c *CommandRestClient) Command(id string) (models.Command, error) {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return models.Command{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -1192,17 +1077,14 @@ func (c *CommandRestClient) Command(id string) (models.Command, error) {
 func (c *CommandRestClient) Commands() ([]models.Command, error) {
 	req, err := http.NewRequest(http.MethodGet, c.url, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Command{}, err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Command{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Command{}, ErrResponseNil
 	}
 
@@ -1210,7 +1092,6 @@ func (c *CommandRestClient) Commands() ([]models.Command, error) {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Command{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -1225,17 +1106,14 @@ func (c *CommandRestClient) Commands() ([]models.Command, error) {
 func (c *CommandRestClient) CommandsForName(name string) ([]models.Command, error) {
 	req, err := http.NewRequest(http.MethodGet, c.url+"/name/"+name, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Command{}, err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return []models.Command{}, err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return []models.Command{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1244,7 +1122,6 @@ func (c *CommandRestClient) CommandsForName(name string) ([]models.Command, erro
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return []models.Command{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -1259,23 +1136,19 @@ func (c *CommandRestClient) CommandsForName(name string) ([]models.Command, erro
 func (c *CommandRestClient) Add(com *models.Command) (string, error) {
 	jsonStr, err := json.Marshal(com)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 
 	req, err := http.NewRequest(http.MethodPost, c.url, bytes.NewReader(jsonStr))
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return "", ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1283,7 +1156,6 @@ func (c *CommandRestClient) Add(com *models.Command) (string, error) {
 	// Get the response body
 	bodyBytes, err := getBody(resp)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	bodyString := string(bodyBytes)
@@ -1299,23 +1171,19 @@ func (c *CommandRestClient) Add(com *models.Command) (string, error) {
 func (c *CommandRestClient) Update(com models.Command) error {
 	jsonStr, err := json.Marshal(&com)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	req, err := http.NewRequest(http.MethodPut, c.url, bytes.NewReader(jsonStr))
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1324,7 +1192,6 @@ func (c *CommandRestClient) Update(com models.Command) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -1339,17 +1206,14 @@ func (c *CommandRestClient) Update(com models.Command) error {
 func (c *CommandRestClient) Delete(id string) error {
 	req, err := http.NewRequest(http.MethodDelete, c.url+"/id/"+id, nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1358,7 +1222,6 @@ func (c *CommandRestClient) Delete(id string) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -1376,7 +1239,7 @@ func (s *ServiceRestClient) decodeDeviceService(resp *http.Response) (models.Dev
 	ds := models.DeviceService{}
 	err := dec.Decode(&ds)
 	if err != nil {
-		loggingClient.Error(err.Error())
+		return models.DeviceService{}, err
 	}
 
 	return ds, err
@@ -1386,17 +1249,14 @@ func (s *ServiceRestClient) decodeDeviceService(resp *http.Response) (models.Dev
 func (s *ServiceRestClient) UpdateLastConnected(id string, time int64) error {
 	req, err := http.NewRequest(http.MethodPut, s.url+"/"+id+"/lastconnected/"+strconv.FormatInt(time, 10), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1405,7 +1265,6 @@ func (s *ServiceRestClient) UpdateLastConnected(id string, time int64) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -1420,17 +1279,14 @@ func (s *ServiceRestClient) UpdateLastConnected(id string, time int64) error {
 func (s *ServiceRestClient) UpdateLastReported(id string, time int64) error {
 	req, err := http.NewRequest(http.MethodPut, s.url+"/"+id+"/lastreported/"+strconv.FormatInt(time, 10), nil)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 
 	resp, err := makeRequest(req)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1439,7 +1295,6 @@ func (s *ServiceRestClient) UpdateLastReported(id string, time int64) error {
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return err
 		}
 		bodyString := string(bodyBytes)
@@ -1454,18 +1309,15 @@ func (s *ServiceRestClient) UpdateLastReported(id string, time int64) error {
 func (s *ServiceRestClient) Add(ds *models.DeviceService) (string, error) {
 	jsonStr, err := json.Marshal(ds)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 
 	client := &http.Client{}
 	resp, err := client.Post(s.url, "application/json", bytes.NewReader(jsonStr))
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return "", ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1473,13 +1325,11 @@ func (s *ServiceRestClient) Add(ds *models.DeviceService) (string, error) {
 	// Get the response body
 	bodyBytes, err := getBody(resp)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	bodyString := string(bodyBytes)
 
 	if resp.StatusCode != 200 {
-		loggingClient.Debug(bodyString)
 		return "", errors.New(bodyString)
 	}
 
@@ -1496,7 +1346,6 @@ func (s *ServiceRestClient) DeviceServiceForName(name string) (models.DeviceServ
 
 	resp, err := makeRequest(req)
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return models.DeviceService{}, ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1509,7 +1358,6 @@ func (s *ServiceRestClient) DeviceServiceForName(name string) (models.DeviceServ
 		// Get the response body
 		bodyBytes, err := getBody(resp)
 		if err != nil {
-			loggingClient.Error(err.Error())
 			return models.DeviceService{}, err
 		}
 		bodyString := string(bodyBytes)
@@ -1526,18 +1374,15 @@ func (s *ServiceRestClient) DeviceServiceForName(name string) (models.DeviceServ
 func (dpc *DeviceProfileRestClient) Add(dp *models.DeviceProfile) (string, error) {
 	jsonStr, err := json.Marshal(dp)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 
 	client := &http.Client{}
 	resp, err := client.Post(dpc.url, "application/json", bytes.NewReader(jsonStr))
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	if resp == nil {
-		loggingClient.Error(ErrResponseNil.Error())
 		return "", ErrResponseNil
 	}
 	defer resp.Body.Close()
@@ -1545,14 +1390,12 @@ func (dpc *DeviceProfileRestClient) Add(dp *models.DeviceProfile) (string, error
 	// Get the response
 	bodyBytes, err := getBody(resp)
 	if err != nil {
-		loggingClient.Error(err.Error())
 		return "", err
 	}
 	bodyString := string(bodyBytes)
 
 	// Check the response code
 	if resp.StatusCode != 200 {
-		loggingClient.Debug(bodyString)
 		return "", errors.New(bodyString)
 	}
 

--- a/core/command/const.go
+++ b/core/command/const.go
@@ -15,7 +15,6 @@ package command
 
 // ConfigurationStruct : Struct used to pase the JSON configuration file
 type ConfigurationStruct struct {
-	ApplicationName            string
 	ConsulProfilesActive       string
 	ReadMaxLimit               int
 	ServicePort                int
@@ -24,7 +23,6 @@ type ConfigurationStruct struct {
 	ServiceTimeout             int
 	CheckInterval              string
 	ServiceAddress             string
-	ServiceName                string
 	DeviceServiceProtocol      string
 	HeartBeatMsg               string
 	AppOpenMsg                 string

--- a/core/command/init.go
+++ b/core/command/init.go
@@ -31,7 +31,7 @@ func ConnectToConsul(conf ConfigurationStruct) error {
 
 	// Initialize service on Consul
 	err := consulclient.ConsulInit(consulclient.ConsulConfig{
-		ServiceName:    conf.ServiceName,
+		ServiceName:    internal.CoreCommandServiceKey,
 		ServicePort:    conf.ServicePort,
 		ServiceAddress: conf.ServiceAddress,
 		CheckAddress:   conf.ConsulCheckAddress,
@@ -44,7 +44,7 @@ func ConnectToConsul(conf ConfigurationStruct) error {
 		return fmt.Errorf("connection to Consul could not be made: %v", err.Error())
 	} else {
 		// Update configuration data from Consul
-		if err := consulclient.CheckKeyValuePairs(&conf, conf.ApplicationName, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
+		if err := consulclient.CheckKeyValuePairs(&conf, internal.CoreCommandServiceKey, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
 			return fmt.Errorf("error getting key/values from Consul: %v", err.Error())
 		}
 	}
@@ -58,7 +58,7 @@ func Init(conf ConfigurationStruct, l logger.LoggingClient, useConsul bool) {
 
 	// Create metadata clients
 	params := types.EndpointParams{
-		ServiceKey:internal.MetaDataServiceKey,
+		ServiceKey:internal.CoreMetaDataServiceKey,
 		Path:conf.MetaDevicePath,
 		UseRegistry:useConsul,
 		Url:conf.MetaDeviceURL}

--- a/core/data/const.go
+++ b/core/data/const.go
@@ -14,7 +14,6 @@
 package data
 
 type ConfigurationStruct struct {
-	ApplicationName            string
 	ConsulProfilesActive       string
 	ReadMaxLimit               int
 	MetaDataCheck              bool
@@ -29,7 +28,6 @@ type ConfigurationStruct struct {
 	ServicePort                int
 	ServiceTimeout             int
 	ServiceAddress             string
-	ServiceName                string
 	DeviceUpdateLastConnected  bool
 	ServiceUpdateLastConnected bool
 	MongoDBUserName            string

--- a/core/data/init.go
+++ b/core/data/init.go
@@ -37,7 +37,7 @@ func ConnectToConsul(conf ConfigurationStruct) error {
 
 	// Initialize service on Consul
 	err := consulclient.ConsulInit(consulclient.ConsulConfig{
-		ServiceName:    conf.ServiceName,
+		ServiceName:    internal.CoreDataServiceKey,
 		ServicePort:    conf.ServicePort,
 		ServiceAddress: conf.ServiceAddress,
 		CheckAddress:   conf.ConsulCheckAddress,
@@ -50,7 +50,7 @@ func ConnectToConsul(conf ConfigurationStruct) error {
 		return fmt.Errorf("connection to Consul could not be made: %v", err.Error())
 	} else {
 		// Update configuration data from Consul
-		if err := consulclient.CheckKeyValuePairs(&conf, conf.ServiceName, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
+		if err := consulclient.CheckKeyValuePairs(&conf, internal.CoreDataServiceKey, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
 			return fmt.Errorf("error getting key/values from Consul: %v", err.Error())
 		}
 	}
@@ -80,7 +80,7 @@ func Init(conf ConfigurationStruct, l logger.LoggingClient, useConsul bool) erro
 
 	// Create metadata clients
 	params := types.EndpointParams{
-						ServiceKey:internal.MetaDataServiceKey,
+						ServiceKey:internal.CoreMetaDataServiceKey,
 						Path:conf.MetaDevicePath,
 						UseRegistry:useConsul,
 						Url:conf.MetaDeviceURL}

--- a/core/metadata/const.go
+++ b/core/metadata/const.go
@@ -21,7 +21,6 @@ import (
 
 // Struct used to pase the JSON configuration file
 type ConfigurationStruct struct {
-	ApplicationName                     string
 	DBType                              string
 	MongoDatabaseName                   string
 	MongoDBUserName                     string
@@ -31,7 +30,6 @@ type ConfigurationStruct struct {
 	MongoDBConnectTimeout               int
 	ReadMaxLimit                        int
 	Protocol                            string
-	ServiceName                         string
 	ServiceAddress                      string
 	ServicePort                         int
 	ServiceTimeout                      int

--- a/core/metadata/init.go
+++ b/core/metadata/init.go
@@ -22,6 +22,7 @@ import (
 	consulclient "github.com/edgexfoundry/edgex-go/support/consul-client"
 	logger "github.com/edgexfoundry/edgex-go/support/logging-client"
 	notifications "github.com/edgexfoundry/edgex-go/support/notifications-client"
+	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 // DS : DataStore to retrieve data from database.
@@ -31,7 +32,7 @@ var loggingClient logger.LoggingClient
 func ConnectToConsul(conf ConfigurationStruct) error {
 	// Initialize service on Consul
 	err := consulclient.ConsulInit(consulclient.ConsulConfig{
-		ServiceName:    conf.ServiceName,
+		ServiceName:    internal.CoreMetaDataServiceKey,
 		ServicePort:    conf.ServicePort,
 		ServiceAddress: conf.ServiceAddress,
 		CheckAddress:   conf.ConsulCheckAddress,
@@ -43,7 +44,7 @@ func ConnectToConsul(conf ConfigurationStruct) error {
 		return fmt.Errorf("connection to Consul could not be made: %v", err.Error())
 	} else {
 		// Update configuration data from Consul
-		if err := consulclient.CheckKeyValuePairs(&conf, conf.ApplicationName, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
+		if err := consulclient.CheckKeyValuePairs(&conf, internal.CoreMetaDataServiceKey, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
 			return fmt.Errorf("error getting key/values from Consul: %v", err.Error())
 		}
 	}

--- a/export/client/const.go
+++ b/export/client/const.go
@@ -7,7 +7,6 @@
 package client
 
 type ConfigurationStruct struct {
-	ApplicationName      string
 	Hostname             string
 	Port                 int
 	DBType               string
@@ -28,6 +27,3 @@ type ConfigurationStruct struct {
 
 var configuration ConfigurationStruct = ConfigurationStruct{} // Needs to be initialized before used
 
-var (
-	ExportClient = "export-client"
-)

--- a/export/client/init.go
+++ b/export/client/init.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/export/client/clients"
 	"github.com/edgexfoundry/edgex-go/support/consul-client"
+	"github.com/edgexfoundry/edgex-go/internal"
 	"go.uber.org/zap"
 )
 
@@ -27,7 +28,7 @@ var logger *zap.Logger
 func ConnectToConsul(conf ConfigurationStruct) error {
 	// Initialize service on Consul
 	err := consulclient.ConsulInit(consulclient.ConsulConfig{
-		ServiceName:    conf.ApplicationName,
+		ServiceName:    internal.ExportClientServiceKey,
 		ServicePort:    conf.Port,
 		ServiceAddress: conf.Hostname,
 		CheckAddress:   "http://" + conf.Hostname + ":" + strconv.Itoa(conf.Port) + PingApiPath,
@@ -40,7 +41,7 @@ func ConnectToConsul(conf ConfigurationStruct) error {
 		return fmt.Errorf("connection to Consul could not be made: %v", err.Error())
 	} else {
 		// Update configuration data from Consul
-		if err := consulclient.CheckKeyValuePairs(&conf, conf.ApplicationName, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
+		if err := consulclient.CheckKeyValuePairs(&conf, internal.ExportClientServiceKey, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
 			return fmt.Errorf("error getting key/values from Consul: %v", err.Error())
 		}
 	}

--- a/export/distro/const.go
+++ b/export/distro/const.go
@@ -7,7 +7,6 @@
 package distro
 
 type ConfigurationStruct struct {
-	ApplicationName      string
 	Hostname             string
 	Port                 int
 	DistroHost           string

--- a/export/distro/init.go
+++ b/export/distro/init.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 	"strconv"
 	"strings"
+	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 const (
@@ -23,7 +24,7 @@ var logger *zap.Logger
 func ConnectToConsul(conf ConfigurationStruct) error {
 	// Initialize service on Consul
 	err := consulclient.ConsulInit(consulclient.ConsulConfig{
-		ServiceName:    conf.ApplicationName,
+		ServiceName:    internal.ExportDistroServiceKey,
 		ServicePort:    conf.ConsulPort,
 		ServiceAddress: conf.ConsulHost,
 		CheckAddress:   "http://" + conf.Hostname + ":" + strconv.Itoa(conf.Port) + PingApiPath,
@@ -36,7 +37,7 @@ func ConnectToConsul(conf ConfigurationStruct) error {
 		return fmt.Errorf("connection to Consul could not be made: %v", err.Error())
 	} else {
 		// Update configuration data from Consul
-		if err := consulclient.CheckKeyValuePairs(&conf, conf.ApplicationName, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
+		if err := consulclient.CheckKeyValuePairs(&conf, internal.ExportDistroServiceKey, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
 			return fmt.Errorf("error getting key/values from Consul: %v", err.Error())
 		}
 	}

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -14,7 +14,9 @@
 package internal
 
 
-const CommandServiceKey            = "core-command"
-const CoreDataServiceKey           = "core-data"
-const MetaDataServiceKey           = "core-metadata"
-const SupportLoggingServiceKey     = "support-logging"
+const CoreCommandServiceKey        = "edgex-core-command"
+const CoreDataServiceKey           = "edgex-core-data"
+const CoreMetaDataServiceKey       = "edgex-core-metadata"
+const ExportClientServiceKey       = "edgex-export-client"
+const ExportDistroServiceKey       = "edgex-export-distro"
+const SupportLoggingServiceKey     = "edgex-support-logging"

--- a/support/logging/const.go
+++ b/support/logging/const.go
@@ -7,7 +7,6 @@
 package logging
 
 type ConfigurationStruct struct {
-	ApplicationName      string
 	Hostname             string
 	Port                 int
 	Persistence          string

--- a/support/logging/init.go
+++ b/support/logging/init.go
@@ -8,9 +8,11 @@ package logging
 
 import (
 	"fmt"
-	"github.com/edgexfoundry/edgex-go/support/consul-client"
 	"strconv"
 	"strings"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/support/consul-client"
 )
 
 const (
@@ -20,7 +22,7 @@ const (
 func ConnectToConsul(conf ConfigurationStruct) error {
 	// Initialize service on Consul
 	err := consulclient.ConsulInit(consulclient.ConsulConfig{
-		ServiceName:    conf.ApplicationName,
+		ServiceName:    internal.SupportLoggingServiceKey,
 		ServicePort:    conf.Port,
 		ServiceAddress: conf.Hostname,
 		CheckAddress:   "http://" + conf.Hostname + ":" + strconv.Itoa(conf.Port) + PingApiPath,
@@ -33,7 +35,7 @@ func ConnectToConsul(conf ConfigurationStruct) error {
 		return fmt.Errorf("connection to Consul could not be made: %v", err.Error())
 	} else {
 		// Update configuration data from Consul
-		if err := consulclient.CheckKeyValuePairs(&conf, conf.ApplicationName, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
+		if err := consulclient.CheckKeyValuePairs(&conf, internal.SupportLoggingServiceKey, strings.Split(conf.ConsulProfilesActive, ";")); err != nil {
 			return fmt.Errorf("error getting key/values from Consul: %v", err.Error())
 		}
 	}


### PR DESCRIPTION
#245

In addition, the introduction of the LoggingClient to the metadata client has been removed. This is because the manner in which it was implemented resulted in loss of visibility during logging as to which service was using the client, and also prevented any kind of remote logging since parameters were set inline without recourse to configuration. In any case, logging of errors should be done by functions that utilize the service clients, not the service clients themselves. Subsequent PRs will address further removal of the LoggingClient from service client packages.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>