### PR TITLE
XMPP export connector

### DIFF
--- a/export/distro/registrations.go
+++ b/export/distro/registrations.go
@@ -88,6 +88,9 @@ func (reg *registrationInfo) update(newReg export.Registration) bool {
 		// TODO reg.sender = distro.NewAzureSender("TODO URL")
 	case export.DestRest:
 		reg.sender = NewHTTPSender(newReg.Addressable)
+	case export.DestXMPP:
+		reg.sender = NewXmppSender(newReg.Addressable)
+
 	default:
 		logger.Warn("Destination not supported: ", zap.String("destination", newReg.Destination))
 		return false

--- a/export/distro/registrations.go
+++ b/export/distro/registrations.go
@@ -89,7 +89,7 @@ func (reg *registrationInfo) update(newReg export.Registration) bool {
 	case export.DestRest:
 		reg.sender = NewHTTPSender(newReg.Addressable)
 	case export.DestXMPP:
-		reg.sender = NewXmppSender(newReg.Addressable)
+		reg.sender = NewXMPPSender(newReg.Addressable)
 
 	default:
 		logger.Warn("Destination not supported: ", zap.String("destination", newReg.Destination))

--- a/export/distro/xmpp.go
+++ b/export/distro/xmpp.go
@@ -8,7 +8,6 @@ package distro
 
 import (
 	"crypto/tls"
-	"fmt"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/mattn/go-xmpp"
 	"strings"
@@ -46,7 +45,7 @@ func NewXmppSender(addr models.Addressable) Sender {
 
 	xmppClient, err := options.NewClient()
 	if err != nil {
-		fmt.Errorf(err.Error())
+		logger.Error(err.Error())
 	}
 
 	sender := &xmppSender{

--- a/export/distro/xmpp.go
+++ b/export/distro/xmpp.go
@@ -24,7 +24,7 @@ type xmppSender struct {
 	stamp   time.Time
 }
 
-func NewXmppSender(addr models.Addressable) Sender {
+func NewXMPPSender(addr models.Addressable) Sender {
 	protocol := strings.ToLower(addr.Protocol)
 
 	if protocol == "tls" {

--- a/export/distro/xmpp.go
+++ b/export/distro/xmpp.go
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2018 Tencent
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package distro
+
+import (
+	"crypto/tls"
+	"fmt"
+	"github.com/edgexfoundry/edgex-go/core/domain/models"
+	"github.com/mattn/go-xmpp"
+	"strings"
+	"time"
+)
+
+type xmppSender struct {
+	client  *xmpp.Client
+	remote  string
+	msgType string
+	subject string
+	thread  string
+	other   []string
+	stamp   time.Time
+}
+
+func NewXmppSender(addr models.Addressable) Sender {
+	protocol := strings.ToLower(addr.Protocol)
+
+	if protocol == "tls" {
+		xmpp.DefaultConfig = tls.Config{
+			ServerName:         serverName(addr.Address),
+			InsecureSkipVerify: false,
+		}
+	}
+
+	options := xmpp.Options{
+		Host:     addr.Address,
+		User:     addr.User,
+		Password: addr.Password,
+		NoTLS:    protocol == "tls",
+		Debug:    false,
+		Session:  false,
+	}
+
+	xmppClient, err := options.NewClient()
+	if err != nil {
+		fmt.Errorf(err.Error())
+	}
+
+	sender := &xmppSender{
+		client: xmppClient,
+	}
+
+	return sender
+}
+
+func (sender *xmppSender) Send(data []byte) {
+	stringData := string(data)
+
+	sender.client.Send(xmpp.Chat{
+		Text:    stringData,
+		Remote:  sender.remote,
+		Subject: sender.subject,
+		Thread:  sender.thread,
+		Other:   sender.other,
+		Stamp:   sender.stamp,
+	})
+}
+
+func serverName(host string) string {
+	return strings.Split(host, ":")[0]
+}

--- a/export/distro/xmpp_test.go
+++ b/export/distro/xmpp_test.go
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2018 Tencent
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package distro
+
+import (
+	"crypto/tls"
+	"flag"
+	"github.com/mattn/go-xmpp"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	TestMessage = "hello world"
+)
+
+var server = flag.String("server", "talk.google.com:443", "server")
+//your gmail account, eg: xxx@gmail.com
+var username = flag.String("username", "", "username")
+//your Gmail password
+var password = flag.String("password", "", "password")
+var status = flag.String("status", "xa", "status")
+var statusMessage = flag.String("status-msg", "I for one welcome our new codebot overlords.", "status message")
+var notls = flag.Bool("notls", false, "No TLS")
+var debug = flag.Bool("debug", false, "debug output")
+var session = flag.Bool("session", false, "use server session")
+
+//if you want to test, replace this value with `true`
+var testFlag = false
+
+func getServerName(host string) string {
+	return strings.Split(host, ":")[0]
+}
+
+func TestXmppSend(t *testing.T) {
+	if testFlag {
+		if !*notls {
+			xmpp.DefaultConfig = tls.Config{
+				ServerName:         getServerName(*server),
+				InsecureSkipVerify: false,
+			}
+		}
+
+		var talk *xmpp.Client
+		var err error
+		options := xmpp.Options{Host: *server,
+			User:          *username,
+			Password:      *password,
+			NoTLS:         *notls,
+			Debug:         *debug,
+			Session:       *session,
+			Status:        *status,
+			StatusMessage: *statusMessage,
+		}
+
+		talk, err = options.NewClient()
+
+		if err != nil {
+			t.Error(err.Error())
+		}
+
+		go func() {
+			for {
+				chat, err := talk.Recv()
+				if err != nil {
+					log.Fatal(err)
+				}
+				switch v := chat.(type) {
+				case xmpp.Chat:
+					if v.Text != TestMessage {
+						t.Errorf("Expected received message : %s, actual received message : %s", TestMessage, v.Text)
+					}
+				case xmpp.Presence:
+				}
+			}
+		}()
+
+		line := strings.TrimRight(*username+" "+TestMessage, "\n")
+
+		tokens := strings.SplitN(line, " ", 2)
+		if len(tokens) == 2 {
+			talk.Send(xmpp.Chat{Remote: tokens[0], Type: "chat", Text: tokens[1]})
+		}
+
+		//waiting for receiving go routine
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/export/registration.go
+++ b/export/registration.go
@@ -39,6 +39,7 @@ const (
 	DestIotCoreMQTT = "IOTCORE_TOPIC"
 	DestAzureMQTT   = "AZURE_TOPIC"
 	DestRest        = "REST_ENDPOINT"
+	DestXMPP 		= "XMPP_TOPIC"
 )
 
 // Registration - Defines the registration details

--- a/export/registration.go
+++ b/export/registration.go
@@ -39,7 +39,7 @@ const (
 	DestIotCoreMQTT = "IOTCORE_TOPIC"
 	DestAzureMQTT   = "AZURE_TOPIC"
 	DestRest        = "REST_ENDPOINT"
-	DestXMPP 		= "XMPP_TOPIC"
+	DestXMPP        = "XMPP_TOPIC"
 )
 
 // Registration - Defines the registration details

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,3 +14,4 @@ import:
   subpackages:
   - bson
 - package: gopkg.in/yaml.v2
+- package: github.com/mattn/go-xmpp


### PR DESCRIPTION
Signed-off-by: yanghua <yanghua1127@gmail.com>

cc @janko-isidorovic @drasko and @jpwhitemn 

hi all, 
I have implemented a XMPP export connector and tested it with [hangouts](https://hangouts.google.com/).

there are some statement list below: 

* test code based on the [go-xmpp](https://github.com/mattn/go-xmpp)'s [example code](https://github.com/mattn/go-xmpp/blob/master/_example/example.go)
* there is not a suitable XMPP public server, I have tried to find some servers but there are a few problem, so I used [hangouts](https://hangouts.google.com/), it can be connected with a XMPP protocol.
* someone who want to test it, just fill two config item in `xmpp_test.go` file (I have given the comment) and open a switch variable `testFlag`, more details about XMPP configuration please see [XMPP with Google Hangouts](https://github.com/linuxcsuf/linuxcsuf/wiki/XMPP-with-Google-Hangouts#basics)

any questions, please let me know, thanks!