### PR TITLE
Fix export-client when there is no db connection

### DIFF
--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -66,6 +66,10 @@ func main() {
 	logger.Info(consulMsg, zap.String("version", edgex.Version))
 
 	err = client.Init(*configuration, logger)
+	if err != nil {
+		logger.Error("Could not initialize export client", zap.Error(err))
+		return
+	}
 
 	errs := make(chan error, 2)
 

--- a/export/client/clients/database-client.go
+++ b/export/client/clients/database-client.go
@@ -15,7 +15,6 @@ package clients
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/edgexfoundry/edgex-go/export"
 	"gopkg.in/mgo.v2/bson"
@@ -114,11 +113,7 @@ func NewDBClient(config DBConfiguration) (DBClient, error) {
 	switch config.DbType {
 	case MONGO:
 		// Create the mongo client
-		mc, err := newMongoClient(config)
-		if err != nil {
-			return nil, fmt.Errorf("Error creating the mongo client: " + err.Error())
-		}
-		return mc, nil
+		return newMongoClient(config)
 	case MEMORY:
 		return &memDB{}, nil
 	default:


### PR DESCRIPTION
Making export-client exit when there no connection to the database