### PR TITLE
Added core-data database benchmark

### DIFF
--- a/core/data/clients/mongo-client.go
+++ b/core/data/clients/mongo-client.go
@@ -110,22 +110,24 @@ func (mc *MongoClient) AddEvent(e *models.Event) (bson.ObjectId, error) {
 
 	// Insert readings
 	var ui []interface{}
-	for i := range e.Readings {
-		e.Readings[i].Id = bson.NewObjectId()
-		e.Readings[i].Created = e.Created
-		e.Readings[i].Device = e.Device
-		ui = append(ui, e.Readings[i])
-	}
-	err := s.DB(mc.Database.Name).C(READINGS_COLLECTION).Insert(ui...)
-	if err != nil {
-		return e.ID, err
+	if len(e.Readings) != 0 {
+		for i := range e.Readings {
+			e.Readings[i].Id = bson.NewObjectId()
+			e.Readings[i].Created = e.Created
+			e.Readings[i].Device = e.Device
+			ui = append(ui, e.Readings[i])
+		}
+		err := s.DB(mc.Database.Name).C(READINGS_COLLECTION).Insert(ui...)
+		if err != nil {
+			return e.ID, err
+		}
 	}
 
 	// Handle DBRefs
 	me := MongoEvent{Event: *e}
 
 	// Add the event
-	err = s.DB(mc.Database.Name).C(EVENTS_COLLECTION).Insert(me)
+	err := s.DB(mc.Database.Name).C(EVENTS_COLLECTION).Insert(me)
 	if err != nil {
 		return e.ID, err
 	}

--- a/core/data/clients/mongo-client_test.go
+++ b/core/data/clients/mongo-client_test.go
@@ -35,3 +35,18 @@ func TestMongoDB(t *testing.T) {
 
 	testDB(t, mongo)
 }
+
+func BenchmarkMongoDB(b *testing.B) {
+
+	b.Log("This benchmark needs to have a running mongo on localhost")
+
+	config := DBConfiguration{
+		DbType:       MONGO,
+		Host:         "0.0.0.0",
+		Port:         27017,
+		DatabaseName: "coredata",
+		Timeout:      1000,
+	}
+
+	benchmarkDB(b, config)
+}


### PR DESCRIPTION
Added core-data database benchmark for events and readings. This are the results using MemoryDB:

```
BenchmarkMemoryDB/AddReading-4         	 2000000	       932 ns/op
BenchmarkMemoryDB/Readings-4           	1000000000	         2.49 ns/op
BenchmarkMemoryDB/ReadingCount-4       	2000000000	         1.96 ns/op
BenchmarkMemoryDB/ReadingById-4        	   10000	    452221 ns/op
BenchmarkMemoryDB/ReadingsByDevice-4   	   10000	   6302543 ns/op
BenchmarkMemoryDB/AddEvent-4           	  500000	      2478 ns/op
BenchmarkMemoryDB/Events-4             	1000000000	         2.49 ns/op
BenchmarkMemoryDB/EventCount-4         	2000000000	         1.97 ns/op
BenchmarkMemoryDB/EventById-4          	   10000	    445389 ns/op
BenchmarkMemoryDB/EventsForDevice-4    	     300	   5457085 ns/op
```

Using MongoDB:

```
BenchmarkMongoDB/AddReading-4         	   20000	     71763 ns/op
BenchmarkMongoDB/Readings-4           	      20	  87182137 ns/op
BenchmarkMongoDB/ReadingCount-4       	   30000	     45202 ns/op
BenchmarkMongoDB/ReadingById-4        	   30000	     49845 ns/op
BenchmarkMongoDB/ReadingsByDevice-4   	     500	   5840177 ns/op
BenchmarkMongoDB/AddEvent-4           	   10000	    175462 ns/op
BenchmarkMongoDB/Events-4             	       1	2444354706 ns/op
BenchmarkMongoDB/EventCount-4         	   30000	     42597 ns/op
BenchmarkMongoDB/EventById-4          	    5000	    277984 ns/op
BenchmarkMongoDB/EventsForDevice-4    	      50	  25948797 ns/op
```

And using InfluxDB:

```
BenchmarkInfluxDB/AddReading-4         	    1000	   3655253 ns/op
BenchmarkInfluxDB/Readings-4           	      50	  20668168 ns/op
BenchmarkInfluxDB/ReadingCount-4       	     100	  17444028 ns/op
BenchmarkInfluxDB/ReadingById-4        	    1101	    532633 ns/op
BenchmarkInfluxDB/ReadingsByDevice-4   	     110	    589713 ns/op
BenchmarkInfluxDB/AddEvent-4           	     500	   4195042 ns/op
BenchmarkInfluxDB/Events-4             	       1	2510077616 ns/op
BenchmarkInfluxDB/EventCount-4         	     100	  14889074 ns/op
BenchmarkInfluxDB/EventById-4          	     500	   3185022 ns/op
BenchmarkInfluxDB/EventsForDevice-4    	       3	 356720149 ns/op
```

This results are obtained using an Ubuntu 16.04 in a Intel® Core™ i7-7500U CPU @ 2.70GHz × 4 with 16GB RAM and 256GB SSD.

Also fixed an issue found in MongoDB when adding an event without readings.

Signed-off-by: Joan Duran <jduran@circutor.com>