### PR TITLE
Fixes test of data client

### DIFF
--- a/core/data/clients/memory-database_test.go
+++ b/core/data/clients/memory-database_test.go
@@ -224,7 +224,7 @@ func testDBReadings(t *testing.T, db DBClient) {
 	if len(readings) != 110 {
 		t.Fatalf("There should be 110 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByCreationTime(beforeTime, beforeTime+10, 100)
+	readings, err = db.ReadingsByCreationTime(beforeTime, afterTime+10, 100)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByCreationTime: %v", err)
 	}


### PR DESCRIPTION
In slow-ish environments, this leads to the test's failure. On top of that, the fix aligns the test with its apparent purpose (test the limit arg).

Signed-off-by: Itamar Haber <itamar@redislabs.com>