### PR TITLE
snap/snapcraft.yaml: upgrade consul version to v1.2.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,7 +93,7 @@ parts:
   consul:
     plugin: shell
     source: https://github.com/hashicorp/consul.git
-    source-tag: v0.7.3
+    source-tag: v1.2.0
     shell: bash
     shell-flags: ['-eux', '-o', 'pipefail']
     shell-command: |


### PR DESCRIPTION
This upgrades the version of consul that is used in the snap.