### PR TITLE
snap/snapcraft.yaml: upgrade go to v1.10.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
     stage-packages:
       - curl
   go:
-    source-tag: go1.9.2
+    source-tag: go1.10.2
     source-depth: 1
   glide:
     plugin: shell

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,7 +93,7 @@ parts:
   consul:
     plugin: shell
     source: https://github.com/hashicorp/consul.git
-    source-tag: v1.2.0
+    source-tag: v1.1.0
     shell: bash
     shell-flags: ['-eux', '-o', 'pipefail']
     shell-command: |


### PR DESCRIPTION
This should fix builds such as https://jenkins.edgexfoundry.org/view/Snap/job/edgex-go-snap-master-stage-snap/5/consoleFull

See specifically:

```
15:41:44 ==> Building Consul - OSes: linux, Architectures: amd64
15:41:44 tput: No value for $TERM and no -T specified
15:41:44 tput: No value for $TERM and no -T specified
15:41:44 tput: No value for $TERM and no -T specified
15:41:44 Using gox for concurrent compilation
15:41:44 tput: No value for $TERM and no -T specified
15:41:45 Number of parallel builds: 3
15:41:45 
15:41:45 -->     linux/amd64: github.com/hashicorp/consul
15:42:13 
15:42:13 1 errors occurred:
15:42:13 --> linux/amd64 error: exit status 2
15:42:13 Stderr: # github.com/hashicorp/consul/vendor/google.golang.org/grpc/encoding/proto
15:42:13 vendor/google.golang.org/grpc/encoding/proto/proto.go:35:2: undefined: encoding.RegisterCodec
15:42:13 # github.com/hashicorp/consul/agent/connect
15:42:13 agent/connect/csr.go:16:7: unknown field 'URIs' in struct literal of type x509.CertificateRequest
15:42:13 agent/connect/testing_ca.go:58:7: unknown field 'URIs' in struct literal of type x509.Certificate
15:42:13 agent/connect/testing_ca.go:167:7: unknown field 'URIs' in struct literal of type x509.Certificate
15:42:13 agent/connect/testing_ca.go:203:7: unknown field 'URIs' in struct literal of type x509.CertificateRequest
15:42:13 
15:42:13 tput: No value for $TERM and no -T specified
15:42:13 tput: No value for $TERM and no -T specified
15:42:13 ERROR: Failed to build Consul
15:42:13 tput: No value for $TERM and no -T specified
15:42:13 GNUmakefile:106: recipe for target 'dev-build' failed
15:42:13 make: *** [dev-build] Error 1
```

Which results because `crypto/x509` added a few fields to the CertificateRequest struct for go1.10.