### PR TITLE
snap/snapcraft.yaml: use govendor install instead of sync

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -109,7 +109,7 @@ parts:
       cp -r ./* $GOIMPORTPATH
       cd $GOIMPORTPATH
       go get -u github.com/kardianos/govendor
-      govendor sync
+      govendor install
       make
 
       # install the consul binary


### PR DESCRIPTION
Consul uses govendor for their vendor dependency management and currently we are doing `govendor sync`, which only will update with locally available commits, etc. that are already in the vendor folder, when we really need to do `govendor install`, which will download/install from external places all necessary vendor dependencies. This should fix builds such as : https://jenkins.edgexfoundry.org/view/Snap/job/edgex-go-snap-master-stage-snap/14/console