### PR TITLE
snap build: use govendor install instead of sync

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -109,7 +109,7 @@ parts:
       cp -r ./* $GOIMPORTPATH
       cd $GOIMPORTPATH
       go get -u github.com/kardianos/govendor
-      govendor sync
+      govendor install
       make
 
       # install the consul binary


### PR DESCRIPTION
This is a duplicate of #345 but for california