### PR TITLE
export-client: Fix getting no registrations from memorydb

### DIFF
--- a/export/client/clients/database-client.go
+++ b/export/client/clients/database-client.go
@@ -115,7 +115,7 @@ func NewDBClient(config DBConfiguration) (DBClient, error) {
 		// Create the mongo client
 		return newMongoClient(config)
 	case MEMORY:
-		return &memDB{}, nil
+		return newMemoryClient(), nil
 	default:
 		return nil, ErrUnsupportedDatabase
 	}

--- a/export/client/clients/memory-database.go
+++ b/export/client/clients/memory-database.go
@@ -26,6 +26,12 @@ type memDB struct {
 	regs []export.Registration
 }
 
+func newMemoryClient() *memDB {
+	return &memDB{
+		regs: make([]export.Registration, 0),
+	}
+}
+
 func (mc *memDB) Registrations() ([]export.Registration, error) {
 	return mc.regs, nil
 }

--- a/export/client/clients/memory-database_test.go
+++ b/export/client/clients/memory-database_test.go
@@ -13,15 +13,25 @@ import (
 )
 
 func testDB(t *testing.T, db DBClient) {
+	regs, err := db.Registrations()
+	if err != nil {
+		t.Fatalf("Error getting registrations %v", err)
+	}
+	if regs == nil {
+		t.Fatalf("Should return an empty array")
+	}
+	if len(regs) != 0 {
+		t.Fatalf("There should not be no registrations instead of %d", len(regs))
+	}
+
 	r := export.Registration{}
 	r.Name = "name"
-
 	id, err := db.AddRegistration(&r)
 	if err != nil {
 		t.Fatalf("Error adding registration %v: %v", r, err)
 	}
 
-	regs, err := db.Registrations()
+	regs, err = db.Registrations()
 	if err != nil {
 		t.Fatalf("Error getting registrations %v", err)
 	}
@@ -92,6 +102,6 @@ func testDB(t *testing.T, db DBClient) {
 }
 
 func TestMemoryDB(t *testing.T) {
-	memory := &memDB{}
+	memory := newMemoryClient()
 	testDB(t, memory)
 }

--- a/internal/pkg/db/memory/data.go
+++ b/internal/pkg/db/memory/data.go
@@ -31,7 +31,9 @@ func (m *MemDB) AddReading(r models.Reading) (bson.ObjectId, error) {
 }
 
 func (m *MemDB) Events() ([]models.Event, error) {
-	return m.events, nil
+	cpy := make([]models.Event, len(m.events))
+	copy(cpy, m.events)
+	return cpy, nil
 }
 
 func (m *MemDB) AddEvent(e *models.Event) (bson.ObjectId, error) {
@@ -180,7 +182,9 @@ func (m *MemDB) ScrubAllEvents() error {
 }
 
 func (m *MemDB) Readings() ([]models.Reading, error) {
-	return m.readings, nil
+	cpy := make([]models.Reading, len(m.readings))
+	copy(cpy, m.readings)
+	return cpy, nil
 }
 
 func (m *MemDB) UpdateReading(reading models.Reading) error {
@@ -294,7 +298,9 @@ func (m *MemDB) AddValueDescriptor(value models.ValueDescriptor) (bson.ObjectId,
 }
 
 func (m *MemDB) ValueDescriptors() ([]models.ValueDescriptor, error) {
-	return m.vDescriptors, nil
+	cpy := make([]models.ValueDescriptor, len(m.vDescriptors))
+	copy(cpy, m.vDescriptors)
+	return cpy, nil
 }
 
 func (m *MemDB) UpdateValueDescriptor(value models.ValueDescriptor) error {

--- a/internal/pkg/db/test/db_data.go
+++ b/internal/pkg/db/test/db_data.go
@@ -76,6 +76,17 @@ func testDBReadings(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error removing all readings")
 	}
 
+	readings, err := db.Readings()
+	if err != nil {
+		t.Fatalf("Error getting readings %v", err)
+	}
+	if readings == nil {
+		t.Fatalf("Should return an empty array")
+	}
+	if len(readings) != 0 {
+		t.Fatalf("There should be 0 readings instead of %d", len(readings))
+	}
+
 	beforeTime := dbp.MakeTimestamp()
 	id, err := populateDbReadings(db, 100)
 	if err != nil {
@@ -97,7 +108,7 @@ func testDBReadings(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 110 readings instead of %d", count)
 	}
 
-	readings, err := db.Readings()
+	readings, err = db.Readings()
 	if err != nil {
 		t.Fatalf("Error getting readings %v", err)
 	}
@@ -270,6 +281,17 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error removing all events")
 	}
 
+	events, err := db.Events()
+	if err != nil {
+		t.Fatalf("Error getting events %v", err)
+	}
+	if events == nil {
+		t.Fatalf("Should return an empty array")
+	}
+	if len(events) != 0 {
+		t.Fatalf("There should be 0 events instead of %d", len(events))
+	}
+
 	beforeTime := dbp.MakeTimestamp()
 	id, err := populateDbEvents(db, 100, 0)
 	if err != nil {
@@ -315,7 +337,7 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 events instead of %d", count)
 	}
 
-	events, err := db.Events()
+	events, err = db.Events()
 	if err != nil {
 		t.Fatalf("Error getting events %v", err)
 	}
@@ -473,6 +495,17 @@ func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error removing all value descriptors")
 	}
 
+	values, err := db.ValueDescriptors()
+	if err != nil {
+		t.Fatalf("Error getting events %v", err)
+	}
+	if values == nil {
+		t.Fatalf("Should return an empty array")
+	}
+	if len(values) != 0 {
+		t.Fatalf("There should be 0 values instead of %d", len(values))
+	}
+
 	id, err := populateDbValues(db, 110)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
@@ -483,7 +516,7 @@ func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Should be an error adding a new ValueDescriptor with the same name\n")
 	}
 
-	values, err := db.ValueDescriptors()
+	values, err = db.ValueDescriptors()
 	if err != nil {
 		t.Fatalf("Error getting Values %v", err)
 	}


### PR DESCRIPTION
It was returning null instead of empty array when a registration was never added.