### PR TITLE
core-metadata: mongo error was used instead of core/db error

### DIFF
--- a/core/db/test/db_data.go
+++ b/core/db/test/db_data.go
@@ -12,12 +12,12 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/core/data/interfaces"
-	dbp "github.com/edgexfoundry/edgex-go/core/db"
+	"github.com/edgexfoundry/edgex-go/core/db"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"gopkg.in/mgo.v2/bson"
 )
 
-func populateDbReadings(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateDbReadings(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
 		name := fmt.Sprintf("name%d", i)
@@ -26,7 +26,7 @@ func populateDbReadings(db interfaces.DBClient, count int) (bson.ObjectId, error
 		r.Device = name
 		r.Value = name
 		var err error
-		id, err = db.AddReading(r)
+		id, err = dbClient.AddReading(r)
 		if err != nil {
 			return id, err
 		}
@@ -34,7 +34,7 @@ func populateDbReadings(db interfaces.DBClient, count int) (bson.ObjectId, error
 	return id, nil
 }
 
-func populateDbValues(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateDbValues(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
 		name := fmt.Sprintf("name%d", i)
@@ -45,7 +45,7 @@ func populateDbValues(db interfaces.DBClient, count int) (bson.ObjectId, error) 
 		v.UomLabel = name
 		v.Labels = []string{name, "LABEL"}
 		var err error
-		id, err = db.AddValueDescriptor(v)
+		id, err = dbClient.AddValueDescriptor(v)
 		if err != nil {
 			return id, err
 		}
@@ -53,7 +53,7 @@ func populateDbValues(db interfaces.DBClient, count int) (bson.ObjectId, error) 
 	return id, nil
 }
 
-func populateDbEvents(db interfaces.DBClient, count int, pushed int64) (bson.ObjectId, error) {
+func populateDbEvents(dbClient interfaces.DBClient, count int, pushed int64) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
 		name := fmt.Sprintf("name%d", i)
@@ -62,7 +62,7 @@ func populateDbEvents(db interfaces.DBClient, count int, pushed int64) (bson.Obj
 		e.Event = name
 		e.Pushed = pushed
 		var err error
-		id, err = db.AddEvent(&e)
+		id, err = dbClient.AddEvent(&e)
 		if err != nil {
 			return id, err
 		}
@@ -70,26 +70,26 @@ func populateDbEvents(db interfaces.DBClient, count int, pushed int64) (bson.Obj
 	return id, nil
 }
 
-func testDBReadings(t *testing.T, db interfaces.DBClient) {
-	err := db.ScrubAllEvents()
+func testDBReadings(t *testing.T, dbClient interfaces.DBClient) {
+	err := dbClient.ScrubAllEvents()
 	if err != nil {
 		t.Fatalf("Error removing all readings")
 	}
 
-	beforeTime := dbp.MakeTimestamp()
-	id, err := populateDbReadings(db, 100)
+	beforeTime := db.MakeTimestamp()
+	id, err := populateDbReadings(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	// To have two readings with the same name
-	id, err = populateDbReadings(db, 10)
+	id, err = populateDbReadings(dbClient, 10)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
-	afterTime := dbp.MakeTimestamp()
+	afterTime := db.MakeTimestamp()
 
-	count, err := db.ReadingCount()
+	count, err := dbClient.ReadingCount()
 	if err != nil {
 		t.Fatalf("Error getting readings count:  %v", err)
 	}
@@ -97,40 +97,43 @@ func testDBReadings(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 110 readings instead of %d", count)
 	}
 
-	readings, err := db.Readings()
+	readings, err := dbClient.Readings()
 	if err != nil {
 		t.Fatalf("Error getting readings %v", err)
 	}
 	if len(readings) != 110 {
 		t.Fatalf("There should be 110 readings instead of %d", len(readings))
 	}
-	r3, err := db.ReadingById(id.Hex())
+	r3, err := dbClient.ReadingById(id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting reading by id %v", err)
 	}
 	if r3.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", r3.Id, id)
 	}
-	_, err = db.ReadingById("INVALID")
+	_, err = dbClient.ReadingById("INVALID")
 	if err == nil {
 		t.Fatalf("Reading should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	readings, err = db.ReadingsByDeviceAndValueDescriptor("name1", "name1", 10)
+	readings, err = dbClient.ReadingsByDeviceAndValueDescriptor("name1", "name1", 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByDeviceAndValueDescriptor: %v", err)
 	}
 	if len(readings) != 2 {
 		t.Fatalf("There should be 2 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByDeviceAndValueDescriptor("name1", "name1", 1)
+	readings, err = dbClient.ReadingsByDeviceAndValueDescriptor("name1", "name1", 1)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByDeviceAndValueDescriptor: %v", err)
 	}
 	if len(readings) != 1 {
 		t.Fatalf("There should be 1 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByDeviceAndValueDescriptor("name20", "name20", 10)
+	readings, err = dbClient.ReadingsByDeviceAndValueDescriptor("name20", "name20", 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByDeviceAndValueDescriptor: %v", err)
 	}
@@ -138,21 +141,21 @@ func testDBReadings(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 readings, not %d", len(readings))
 	}
 
-	readings, err = db.ReadingsByDevice("name1", 10)
+	readings, err = dbClient.ReadingsByDevice("name1", 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByDevice: %v", err)
 	}
 	if len(readings) != 2 {
 		t.Fatalf("There should be 2 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByDevice("name1", 1)
+	readings, err = dbClient.ReadingsByDevice("name1", 1)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByDevice: %v", err)
 	}
 	if len(readings) != 1 {
 		t.Fatalf("There should be 1 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByDevice("name20", 10)
+	readings, err = dbClient.ReadingsByDevice("name20", 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByDevice: %v", err)
 	}
@@ -160,28 +163,28 @@ func testDBReadings(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 readings, not %d", len(readings))
 	}
 
-	readings, err = db.ReadingsByValueDescriptor("name1", 10)
+	readings, err = dbClient.ReadingsByValueDescriptor("name1", 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByValueDescriptor: %v", err)
 	}
 	if len(readings) != 2 {
 		t.Fatalf("There should be 2 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByValueDescriptor("name1", 1)
+	readings, err = dbClient.ReadingsByValueDescriptor("name1", 1)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByValueDescriptor: %v", err)
 	}
 	if len(readings) != 1 {
 		t.Fatalf("There should be 1 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByValueDescriptor("name20", 10)
+	readings, err = dbClient.ReadingsByValueDescriptor("name20", 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByValueDescriptor: %v", err)
 	}
 	if len(readings) != 1 {
 		t.Fatalf("There should be 1 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByValueDescriptor("name", 10)
+	readings, err = dbClient.ReadingsByValueDescriptor("name", 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByValueDescriptor: %v", err)
 	}
@@ -189,28 +192,28 @@ func testDBReadings(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 readings, not %d", len(readings))
 	}
 
-	readings, err = db.ReadingsByValueDescriptorNames([]string{"name1", "name2"}, 10)
+	readings, err = dbClient.ReadingsByValueDescriptorNames([]string{"name1", "name2"}, 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByValueDescriptorNames: %v", err)
 	}
 	if len(readings) != 4 {
 		t.Fatalf("There should be 4 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByValueDescriptorNames([]string{"name1", "name2"}, 1)
+	readings, err = dbClient.ReadingsByValueDescriptorNames([]string{"name1", "name2"}, 1)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByValueDescriptorNames: %v", err)
 	}
 	if len(readings) != 1 {
 		t.Fatalf("There should be 1 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByValueDescriptorNames([]string{"name", "noname"}, 10)
+	readings, err = dbClient.ReadingsByValueDescriptorNames([]string{"name", "noname"}, 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByValueDescriptorNames: %v", err)
 	}
 	if len(readings) != 0 {
 		t.Fatalf("There should be 0 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByValueDescriptorNames([]string{"name20"}, 10)
+	readings, err = dbClient.ReadingsByValueDescriptorNames([]string{"name20"}, 10)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByValueDescriptorNames: %v", err)
 	}
@@ -218,14 +221,14 @@ func testDBReadings(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 readings, not %d", len(readings))
 	}
 
-	readings, err = db.ReadingsByCreationTime(beforeTime, afterTime+10, 200)
+	readings, err = dbClient.ReadingsByCreationTime(beforeTime, afterTime+10, 200)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByCreationTime: %v", err)
 	}
 	if len(readings) != 110 {
 		t.Fatalf("There should be 110 readings, not %d", len(readings))
 	}
-	readings, err = db.ReadingsByCreationTime(beforeTime, beforeTime+30, 100)
+	readings, err = dbClient.ReadingsByCreationTime(beforeTime, beforeTime+30, 100)
 	if err != nil {
 		t.Fatalf("Error getting ReadingsByCreationTime: %v", err)
 	}
@@ -236,11 +239,11 @@ func testDBReadings(t *testing.T, db interfaces.DBClient) {
 	r := models.Reading{}
 	r.Id = id
 	r.Name = "name"
-	err = db.UpdateReading(r)
+	err = dbClient.UpdateReading(r)
 	if err != nil {
 		t.Fatalf("Error updating reading %v", err)
 	}
-	r2, err := db.ReadingById(r.Id.Hex())
+	r2, err := dbClient.ReadingById(r.Id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting reading by id %v", err)
 	}
@@ -248,42 +251,45 @@ func testDBReadings(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Did not update reading correctly: %s %s", r.Name, r2.Name)
 	}
 
-	err = db.DeleteReadingById("INVALID")
+	err = dbClient.DeleteReadingById("INVALID")
 	if err == nil {
 		t.Fatalf("Reading should not be deleted")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.DeleteReadingById(id.Hex())
+	err = dbClient.DeleteReadingById(id.Hex())
 	if err != nil {
 		t.Fatalf("Reading should be deleted: %v", err)
 	}
 
-	err = db.UpdateReading(r)
+	err = dbClient.UpdateReading(r)
 	if err == nil {
 		t.Fatalf("Update should return error")
 	}
 }
 
-func testDBEvents(t *testing.T, db interfaces.DBClient) {
-	err := db.ScrubAllEvents()
+func testDBEvents(t *testing.T, dbClient interfaces.DBClient) {
+	err := dbClient.ScrubAllEvents()
 	if err != nil {
 		t.Fatalf("Error removing all events")
 	}
 
-	beforeTime := dbp.MakeTimestamp()
-	id, err := populateDbEvents(db, 100, 0)
+	beforeTime := db.MakeTimestamp()
+	id, err := populateDbEvents(dbClient, 100, 0)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	// To have two events with the same name
-	id, err = populateDbEvents(db, 10, 1)
+	id, err = populateDbEvents(dbClient, 10, 1)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
-	afterTime := dbp.MakeTimestamp()
+	afterTime := db.MakeTimestamp()
 
-	count, err := db.EventCount()
+	count, err := dbClient.EventCount()
 	if err != nil {
 		t.Fatalf("Error getting events count:  %v", err)
 	}
@@ -291,7 +297,7 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 110 events instead of %d", count)
 	}
 
-	count, err = db.EventCountByDeviceId("name1")
+	count, err = dbClient.EventCountByDeviceId("name1")
 	if err != nil {
 		t.Fatalf("Error getting events count:  %v", err)
 	}
@@ -299,7 +305,7 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 2 events instead of %d", count)
 	}
 
-	count, err = db.EventCountByDeviceId("name20")
+	count, err = dbClient.EventCountByDeviceId("name20")
 	if err != nil {
 		t.Fatalf("Error getting events count:  %v", err)
 	}
@@ -307,7 +313,7 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 events instead of %d", count)
 	}
 
-	count, err = db.EventCountByDeviceId("name")
+	count, err = dbClient.EventCountByDeviceId("name")
 	if err != nil {
 		t.Fatalf("Error getting events count:  %v", err)
 	}
@@ -315,47 +321,50 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 events instead of %d", count)
 	}
 
-	events, err := db.Events()
+	events, err := dbClient.Events()
 	if err != nil {
 		t.Fatalf("Error getting events %v", err)
 	}
 	if len(events) != 110 {
 		t.Fatalf("There should be 110 events instead of %d", len(events))
 	}
-	e3, err := db.EventById(id.Hex())
+	e3, err := dbClient.EventById(id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting event by id %v", err)
 	}
 	if e3.ID.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", e3.ID, id)
 	}
-	_, err = db.EventById("INVALID")
+	_, err = dbClient.EventById("INVALID")
 	if err == nil {
 		t.Fatalf("Event should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	events, err = db.EventsForDeviceLimit("name1", 10)
+	events, err = dbClient.EventsForDeviceLimit("name1", 10)
 	if err != nil {
 		t.Fatalf("Error getting EventsForDeviceLimit: %v", err)
 	}
 	if len(events) != 2 {
 		t.Fatalf("There should be 2 events, not %d", len(events))
 	}
-	events, err = db.EventsForDeviceLimit("name1", 1)
+	events, err = dbClient.EventsForDeviceLimit("name1", 1)
 	if err != nil {
 		t.Fatalf("Error getting EventsForDeviceLimit: %v", err)
 	}
 	if len(events) != 1 {
 		t.Fatalf("There should be 1 events, not %d", len(events))
 	}
-	events, err = db.EventsForDeviceLimit("name20", 10)
+	events, err = dbClient.EventsForDeviceLimit("name20", 10)
 	if err != nil {
 		t.Fatalf("Error getting EventsForDeviceLimit: %v", err)
 	}
 	if len(events) != 1 {
 		t.Fatalf("There should be 1 events, not %d", len(events))
 	}
-	events, err = db.EventsForDeviceLimit("name", 10)
+	events, err = dbClient.EventsForDeviceLimit("name", 10)
 	if err != nil {
 		t.Fatalf("Error getting EventsForDeviceLimit: %v", err)
 	}
@@ -363,21 +372,21 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 events, not %d", len(events))
 	}
 
-	events, err = db.EventsForDevice("name1")
+	events, err = dbClient.EventsForDevice("name1")
 	if err != nil {
 		t.Fatalf("Error getting EventsForDevice: %v", err)
 	}
 	if len(events) != 2 {
 		t.Fatalf("There should be 2 events, not %d", len(events))
 	}
-	events, err = db.EventsForDevice("name20")
+	events, err = dbClient.EventsForDevice("name20")
 	if err != nil {
 		t.Fatalf("Error getting EventsForDevice: %v", err)
 	}
 	if len(events) != 1 {
 		t.Fatalf("There should be 1 events, not %d", len(events))
 	}
-	events, err = db.EventsForDevice("name")
+	events, err = dbClient.EventsForDevice("name")
 	if err != nil {
 		t.Fatalf("Error getting EventsForDevice: %v", err)
 	}
@@ -385,14 +394,14 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 events, not %d", len(events))
 	}
 
-	events, err = db.EventsByCreationTime(beforeTime, afterTime+10, 200)
+	events, err = dbClient.EventsByCreationTime(beforeTime, afterTime+10, 200)
 	if err != nil {
 		t.Fatalf("Error getting EventsByCreationTime: %v", err)
 	}
 	if len(events) != 110 {
 		t.Fatalf("There should be 110 events, not %d", len(events))
 	}
-	events, err = db.EventsByCreationTime(beforeTime, afterTime+10, 100)
+	events, err = dbClient.EventsByCreationTime(beforeTime, afterTime+10, 100)
 	if err != nil {
 		t.Fatalf("Error getting EventsByCreationTime: %v", err)
 	}
@@ -400,14 +409,14 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 events, not %d", len(events))
 	}
 
-	events, err = db.EventsOlderThanAge(0)
+	events, err = dbClient.EventsOlderThanAge(0)
 	if err != nil {
 		t.Fatalf("Error getting EventsOlderThanAge: %v", err)
 	}
 	if len(events) != 110 {
 		t.Fatalf("There should be 110 events, not %d", len(events))
 	}
-	events, err = db.EventsOlderThanAge(1000000)
+	events, err = dbClient.EventsOlderThanAge(1000000)
 	if err != nil {
 		t.Fatalf("Error getting EventsOlderThanAge: %v", err)
 	}
@@ -415,7 +424,7 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 events, not %d", len(events))
 	}
 
-	events, err = db.EventsPushed()
+	events, err = dbClient.EventsPushed()
 	if err != nil {
 		t.Fatalf("Error getting EventsOlderThanAge: %v", err)
 	}
@@ -426,11 +435,11 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 	e := models.Event{}
 	e.ID = id
 	e.Device = "name"
-	err = db.UpdateEvent(e)
+	err = dbClient.UpdateEvent(e)
 	if err != nil {
 		t.Fatalf("Error updating event %v", err)
 	}
-	e2, err := db.EventById(e.ID.Hex())
+	e2, err := dbClient.EventById(e.ID.Hex())
 	if err != nil {
 		t.Fatalf("Error getting event by id %v", err)
 	}
@@ -438,27 +447,30 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Did not update event correctly: %s %s", e.Device, e2.Device)
 	}
 
-	err = db.DeleteEventById("INVALID")
+	err = dbClient.DeleteEventById("INVALID")
 	if err == nil {
 		t.Fatalf("Event should not be deleted")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.DeleteEventById(id.Hex())
+	err = dbClient.DeleteEventById(id.Hex())
 	if err != nil {
 		t.Fatalf("Event should be deleted: %v", err)
 	}
 
-	err = db.UpdateEvent(e)
+	err = dbClient.UpdateEvent(e)
 	if err == nil {
 		t.Fatalf("Update should return error")
 	}
 
-	err = db.ScrubAllEvents()
+	err = dbClient.ScrubAllEvents()
 	if err != nil {
 		t.Fatalf("Error removing all events")
 	}
 
-	events, err = db.Events()
+	events, err = dbClient.Events()
 	if err != nil {
 		t.Fatalf("Error getting events %v", err)
 	}
@@ -467,23 +479,23 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 	}
 }
 
-func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
-	err := db.ScrubAllValueDescriptors()
+func testDBValueDescriptors(t *testing.T, dbClient interfaces.DBClient) {
+	err := dbClient.ScrubAllValueDescriptors()
 	if err != nil {
 		t.Fatalf("Error removing all value descriptors")
 	}
 
-	id, err := populateDbValues(db, 110)
+	id, err := populateDbValues(dbClient, 110)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
-	_, err = populateDbValues(db, 110)
+	_, err = populateDbValues(dbClient, 110)
 	if err == nil {
 		t.Fatalf("Should be an error adding a new ValueDescriptor with the same name\n")
 	}
 
-	values, err := db.ValueDescriptors()
+	values, err := dbClient.ValueDescriptors()
 	if err != nil {
 		t.Fatalf("Error getting Values %v", err)
 	}
@@ -491,45 +503,51 @@ func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 110 Values instead of %d", len(values))
 	}
 
-	v3, err := db.ValueDescriptorById(id.Hex())
+	v3, err := dbClient.ValueDescriptorById(id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting Value by id %v", err)
 	}
 	if v3.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", v3.Id, id)
 	}
-	_, err = db.ValueDescriptorById("INVALID")
+	_, err = dbClient.ValueDescriptorById("INVALID")
 	if err == nil {
 		t.Fatalf("Value should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	v3, err = db.ValueDescriptorByName("name1")
+	v3, err = dbClient.ValueDescriptorByName("name1")
 	if err != nil {
 		t.Fatalf("Error getting Value by id %v", err)
 	}
 	if v3.Name != "name1" {
 		t.Fatalf("Name does not match %s - name1", v3.Name)
 	}
-	_, err = db.ValueDescriptorByName("INVALID")
+	_, err = dbClient.ValueDescriptorByName("INVALID")
 	if err == nil {
 		t.Fatalf("Value should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	values, err = db.ValueDescriptorsByName([]string{"name1", "name2"})
+	values, err = dbClient.ValueDescriptorsByName([]string{"name1", "name2"})
 	if err != nil {
 		t.Fatalf("Error getting ValuesByValueDescriptorNames: %v", err)
 	}
 	if len(values) != 2 {
 		t.Fatalf("There should be 2 Values, not %d", len(values))
 	}
-	values, err = db.ValueDescriptorsByName([]string{"name1", "name"})
+	values, err = dbClient.ValueDescriptorsByName([]string{"name1", "name"})
 	if err != nil {
 		t.Fatalf("Error getting ValuesByValueDescriptorNames: %v", err)
 	}
 	if len(values) != 1 {
 		t.Fatalf("There should be 1 Values, not %d", len(values))
 	}
-	values, err = db.ValueDescriptorsByName([]string{"name", "INVALID"})
+	values, err = dbClient.ValueDescriptorsByName([]string{"name", "INVALID"})
 	if err != nil {
 		t.Fatalf("Error getting ValuesByValueDescriptorNames: %v", err)
 	}
@@ -537,14 +555,14 @@ func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 Values, not %d", len(values))
 	}
 
-	values, err = db.ValueDescriptorsByUomLabel("name1")
+	values, err = dbClient.ValueDescriptorsByUomLabel("name1")
 	if err != nil {
 		t.Fatalf("Error getting ValuesByValueDescriptorNames: %v", err)
 	}
 	if len(values) != 1 {
 		t.Fatalf("There should be 1 Values, not %d", len(values))
 	}
-	values, err = db.ValueDescriptorsByUomLabel("INVALID")
+	values, err = dbClient.ValueDescriptorsByUomLabel("INVALID")
 	if err != nil {
 		t.Fatalf("Error getting ValuesByValueDescriptorNames: %v", err)
 	}
@@ -552,14 +570,14 @@ func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 Values, not %d", len(values))
 	}
 
-	values, err = db.ValueDescriptorsByLabel("name1")
+	values, err = dbClient.ValueDescriptorsByLabel("name1")
 	if err != nil {
 		t.Fatalf("Error getting ValuesByValueDescriptorNames: %v", err)
 	}
 	if len(values) != 1 {
 		t.Fatalf("There should be 1 Values, not %d", len(values))
 	}
-	values, err = db.ValueDescriptorsByLabel("INVALID")
+	values, err = dbClient.ValueDescriptorsByLabel("INVALID")
 	if err != nil {
 		t.Fatalf("Error getting ValuesByValueDescriptorNames: %v", err)
 	}
@@ -567,14 +585,14 @@ func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 Values, not %d", len(values))
 	}
 
-	values, err = db.ValueDescriptorsByType("name1")
+	values, err = dbClient.ValueDescriptorsByType("name1")
 	if err != nil {
 		t.Fatalf("Error getting ValuesByValueDescriptorNames: %v", err)
 	}
 	if len(values) != 1 {
 		t.Fatalf("There should be 1 Values, not %d", len(values))
 	}
-	values, err = db.ValueDescriptorsByType("INVALID")
+	values, err = dbClient.ValueDescriptorsByType("INVALID")
 	if err != nil {
 		t.Fatalf("Error getting ValuesByValueDescriptorNames: %v", err)
 	}
@@ -585,11 +603,11 @@ func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
 	v := models.ValueDescriptor{}
 	v.Id = id
 	v.Name = "name"
-	err = db.UpdateValueDescriptor(v)
+	err = dbClient.UpdateValueDescriptor(v)
 	if err != nil {
 		t.Fatalf("Error updating Value %v", err)
 	}
-	v2, err := db.ValueDescriptorById(v.Id.Hex())
+	v2, err := dbClient.ValueDescriptorById(v.Id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting Value by id %v", err)
 	}
@@ -597,55 +615,55 @@ func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Did not update Value correctly: %s %s", v.Name, v2.Name)
 	}
 
-	err = db.DeleteValueDescriptorById("INVALID")
+	err = dbClient.DeleteValueDescriptorById("INVALID")
 	if err == nil {
 		t.Fatalf("Value should not be deleted")
 	}
 
-	err = db.DeleteValueDescriptorById(id.Hex())
+	err = dbClient.DeleteValueDescriptorById(id.Hex())
 	if err != nil {
 		t.Fatalf("Value should be deleted: %v", err)
 	}
 
-	err = db.UpdateValueDescriptor(v)
+	err = dbClient.UpdateValueDescriptor(v)
 	if err == nil {
 		t.Fatalf("Update should return error")
 	}
 
-	err = db.ScrubAllValueDescriptors()
+	err = dbClient.ScrubAllValueDescriptors()
 	if err != nil {
 		t.Fatalf("Error removing all value descriptors")
 	}
 }
 
-func TestDataDB(t *testing.T, db interfaces.DBClient) {
+func TestDataDB(t *testing.T, dbClient interfaces.DBClient) {
 
-	err := db.Connect()
+	err := dbClient.Connect()
 	if err != nil {
 		t.Fatalf("Could not connect with mongodb: %v", err)
 	}
 
-	testDBReadings(t, db)
-	testDBEvents(t, db)
-	testDBValueDescriptors(t, db)
+	testDBReadings(t, dbClient)
+	testDBEvents(t, dbClient)
+	testDBValueDescriptors(t, dbClient)
 
-	db.CloseSession()
+	dbClient.CloseSession()
 	// Calling CloseSession twice to test that there is no panic when closing an
 	// already closed db
-	db.CloseSession()
+	dbClient.CloseSession()
 }
 
-func BenchmarkDB(b *testing.B, db interfaces.DBClient) {
+func BenchmarkDB(b *testing.B, dbClient interfaces.DBClient) {
 
-	benchmarkReadings(b, db)
-	benchmarkEvents(b, db)
-	db.CloseSession()
+	benchmarkReadings(b, dbClient)
+	benchmarkEvents(b, dbClient)
+	dbClient.CloseSession()
 }
 
-func benchmarkReadings(b *testing.B, db interfaces.DBClient) {
+func benchmarkReadings(b *testing.B, dbClient interfaces.DBClient) {
 
 	// Remove previous events and readings
-	db.ScrubAllEvents()
+	dbClient.ScrubAllEvents()
 
 	var readings []string
 
@@ -654,7 +672,7 @@ func benchmarkReadings(b *testing.B, db interfaces.DBClient) {
 		for i := 0; i < b.N; i++ {
 			reading.Name = "test" + strconv.Itoa(i)
 			reading.Device = "device" + strconv.Itoa(i/100)
-			id, err := db.AddReading(reading)
+			id, err := dbClient.AddReading(reading)
 			if err != nil {
 				b.Fatalf("Error add reading: %v", err)
 			}
@@ -664,7 +682,7 @@ func benchmarkReadings(b *testing.B, db interfaces.DBClient) {
 
 	b.Run("Readings", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, err := db.Readings()
+			_, err := dbClient.Readings()
 			if err != nil {
 				b.Fatalf("Error readings: %v", err)
 			}
@@ -673,7 +691,7 @@ func benchmarkReadings(b *testing.B, db interfaces.DBClient) {
 
 	b.Run("ReadingCount", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, err := db.ReadingCount()
+			_, err := dbClient.ReadingCount()
 			if err != nil {
 				b.Fatalf("Error reading count: %v", err)
 			}
@@ -685,7 +703,7 @@ func benchmarkReadings(b *testing.B, db interfaces.DBClient) {
 			b.N = len(readings)
 		}
 		for i := 0; i < b.N; i++ {
-			_, err := db.ReadingById(readings[i])
+			_, err := dbClient.ReadingById(readings[i])
 			if err != nil {
 				b.Fatalf("Error reading by ID: %v", err)
 			}
@@ -698,7 +716,7 @@ func benchmarkReadings(b *testing.B, db interfaces.DBClient) {
 		}
 		for i := 0; i < b.N; i++ {
 			device := "device" + strconv.Itoa(i)
-			_, err := db.ReadingsByDevice(device, 100)
+			_, err := dbClient.ReadingsByDevice(device, 100)
 			if err != nil {
 				b.Fatalf("Error reading by device: %v", err)
 			}
@@ -706,10 +724,10 @@ func benchmarkReadings(b *testing.B, db interfaces.DBClient) {
 	})
 }
 
-func benchmarkEvents(b *testing.B, db interfaces.DBClient) {
+func benchmarkEvents(b *testing.B, dbClient interfaces.DBClient) {
 
 	// Remove previous events and readings
-	db.ScrubAllEvents()
+	dbClient.ScrubAllEvents()
 
 	var events []string
 
@@ -723,7 +741,7 @@ func benchmarkEvents(b *testing.B, db interfaces.DBClient) {
 		event.Readings = append(event.Readings, reading)
 		for i := 0; i < b.N; i++ {
 			event.Device = "device" + strconv.Itoa(i/100)
-			id, err := db.AddEvent(&event)
+			id, err := dbClient.AddEvent(&event)
 			if err != nil {
 				b.Fatalf("Error add event: %v", err)
 			}
@@ -733,7 +751,7 @@ func benchmarkEvents(b *testing.B, db interfaces.DBClient) {
 
 	b.Run("Events", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, err := db.Events()
+			_, err := dbClient.Events()
 			if err != nil {
 				b.Fatalf("Error events: %v", err)
 			}
@@ -742,7 +760,7 @@ func benchmarkEvents(b *testing.B, db interfaces.DBClient) {
 
 	b.Run("EventCount", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, err := db.EventCount()
+			_, err := dbClient.EventCount()
 			if err != nil {
 				b.Fatalf("Error event count: %v", err)
 			}
@@ -754,7 +772,7 @@ func benchmarkEvents(b *testing.B, db interfaces.DBClient) {
 			b.N = len(events)
 		}
 		for i := 0; i < b.N; i++ {
-			_, err := db.EventById(events[i])
+			_, err := dbClient.EventById(events[i])
 			if err != nil {
 				b.Fatalf("Error event by ID: %v", err)
 			}
@@ -767,7 +785,7 @@ func benchmarkEvents(b *testing.B, db interfaces.DBClient) {
 		}
 		for i := 0; i < b.N; i++ {
 			device := "device" + strconv.Itoa(i)
-			_, err := db.EventsForDevice(device)
+			_, err := dbClient.EventsForDevice(device)
 			if err != nil {
 				b.Fatalf("Error events for device: %v", err)
 			}

--- a/core/db/test/db_metadata.go
+++ b/core/db/test/db_metadata.go
@@ -10,27 +10,28 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/edgexfoundry/edgex-go/core/db"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/edgexfoundry/edgex-go/core/metadata/interfaces"
 	"gopkg.in/mgo.v2/bson"
 )
 
-func TestMetadataDB(t *testing.T, db interfaces.DBClient) {
+func TestMetadataDB(t *testing.T, dbClient interfaces.DBClient) {
 
-	testDBAddressables(t, db)
-	testDBCommand(t, db)
-	testDBDeviceService(t, db)
-	testDBSchedule(t, db)
-	testDBDeviceReport(t, db)
-	testDBScheduleEvent(t, db)
-	testDBDeviceProfile(t, db)
-	testDBDevice(t, db)
-	testDBProvisionWatcher(t, db)
+	testDBAddressables(t, dbClient)
+	testDBCommand(t, dbClient)
+	testDBDeviceService(t, dbClient)
+	testDBSchedule(t, dbClient)
+	testDBDeviceReport(t, dbClient)
+	testDBScheduleEvent(t, dbClient)
+	testDBDeviceProfile(t, dbClient)
+	testDBDevice(t, dbClient)
+	testDBProvisionWatcher(t, dbClient)
 
-	db.CloseSession()
+	dbClient.CloseSession()
 	// Calling CloseSession twice to test that there is no panic when closing an
 	// already closed db
-	db.CloseSession()
+	dbClient.CloseSession()
 }
 
 func getAddressable(i int, prefix string) models.Addressable {
@@ -49,7 +50,7 @@ func getAddressable(i int, prefix string) models.Addressable {
 	return a
 }
 
-func getDeviceService(db interfaces.DBClient, i int) (models.DeviceService, error) {
+func getDeviceService(dbClient interfaces.DBClient, i int) (models.DeviceService, error) {
 	name := fmt.Sprintf("name%d", i)
 	ds := models.DeviceService{}
 	ds.Name = name
@@ -61,14 +62,14 @@ func getDeviceService(db interfaces.DBClient, i int) (models.DeviceService, erro
 	ds.LastReported = 5
 	ds.Description = name
 	var err error
-	_, err = db.AddAddressable(&ds.Addressable)
+	_, err = dbClient.AddAddressable(&ds.Addressable)
 	if err != nil {
 		return ds, fmt.Errorf("Error creating addressable: %v", err)
 	}
 	return ds, nil
 }
 
-func getCommand(db interfaces.DBClient, i int) models.Command {
+func getCommand(dbClient interfaces.DBClient, i int) models.Command {
 	name := fmt.Sprintf("name%d", i)
 	c := models.Command{}
 	c.Name = name
@@ -77,7 +78,7 @@ func getCommand(db interfaces.DBClient, i int) models.Command {
 	return c
 }
 
-func getDeviceProfile(db interfaces.DBClient, i int) (models.DeviceProfile, error) {
+func getDeviceProfile(dbClient interfaces.DBClient, i int) (models.DeviceProfile, error) {
 	name := fmt.Sprintf("name%d", i)
 	dp := models.DeviceProfile{}
 	dp.Name = name
@@ -88,8 +89,8 @@ func getDeviceProfile(db interfaces.DBClient, i int) (models.DeviceProfile, erro
 	// TODO
 	// dp.DeviceResources = append(dp.DeviceResources, name)
 	// dp.Resources = append(dp.Resources, name)
-	c := getCommand(db, i)
-	err := db.AddCommand(&c)
+	c := getCommand(dbClient, i)
+	err := dbClient.AddCommand(&c)
 	if err != nil {
 		return dp, err
 	}
@@ -97,12 +98,12 @@ func getDeviceProfile(db interfaces.DBClient, i int) (models.DeviceProfile, erro
 	return dp, nil
 }
 
-func populateAddressable(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateAddressable(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
 		var err error
 		a := getAddressable(i, "")
-		id, err = db.AddAddressable(&a)
+		id, err = dbClient.AddAddressable(&a)
 		if err != nil {
 			return id, err
 		}
@@ -110,11 +111,11 @@ func populateAddressable(db interfaces.DBClient, count int) (bson.ObjectId, erro
 	return id, nil
 }
 
-func populateCommand(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateCommand(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
-		c := getCommand(db, i)
-		err := db.AddCommand(&c)
+		c := getCommand(dbClient, i)
+		err := dbClient.AddCommand(&c)
 		if err != nil {
 			return id, err
 		}
@@ -123,15 +124,15 @@ func populateCommand(db interfaces.DBClient, count int) (bson.ObjectId, error) {
 	return id, nil
 }
 
-func populateDeviceService(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateDeviceService(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 
 	for i := 0; i < count; i++ {
-		ds, err := getDeviceService(db, i)
+		ds, err := getDeviceService(dbClient, i)
 		if err != nil {
 			return id, nil
 		}
-		err = db.AddDeviceService(&ds)
+		err = dbClient.AddDeviceService(&ds)
 		id = ds.Id
 		if err != nil {
 			return id, fmt.Errorf("Error creating device service: %v", err)
@@ -140,7 +141,7 @@ func populateDeviceService(db interfaces.DBClient, count int) (bson.ObjectId, er
 	return id, nil
 }
 
-func populateSchedule(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateSchedule(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
 		var err error
@@ -152,7 +153,7 @@ func populateSchedule(db interfaces.DBClient, count int) (bson.ObjectId, error) 
 		s.Frequency = name
 		s.Cron = name
 		s.RunOnce = false
-		err = db.AddSchedule(&s)
+		err = dbClient.AddSchedule(&s)
 		if err != nil {
 			return id, err
 		}
@@ -161,7 +162,7 @@ func populateSchedule(db interfaces.DBClient, count int) (bson.ObjectId, error) 
 	return id, nil
 }
 
-func populateDeviceReport(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateDeviceReport(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
 		var err error
@@ -171,7 +172,7 @@ func populateDeviceReport(db interfaces.DBClient, count int) (bson.ObjectId, err
 		dr.Device = name
 		dr.Event = name
 		dr.Expected = append(dr.Expected, name)
-		err = db.AddDeviceReport(&dr)
+		err = dbClient.AddDeviceReport(&dr)
 		if err != nil {
 			return id, err
 		}
@@ -180,7 +181,7 @@ func populateDeviceReport(db interfaces.DBClient, count int) (bson.ObjectId, err
 	return id, nil
 }
 
-func populateScheduleEvent(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateScheduleEvent(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
 		var err error
@@ -191,11 +192,11 @@ func populateScheduleEvent(db interfaces.DBClient, count int) (bson.ObjectId, er
 		se.Parameters = name
 		se.Service = name
 		se.Addressable = getAddressable(i, "se_")
-		_, err = db.AddAddressable(&se.Addressable)
+		_, err = dbClient.AddAddressable(&se.Addressable)
 		if err != nil {
 			return id, fmt.Errorf("Error creating addressable: %v", err)
 		}
-		err = db.AddScheduleEvent(&se)
+		err = dbClient.AddScheduleEvent(&se)
 		if err != nil {
 			return id, err
 		}
@@ -204,7 +205,7 @@ func populateScheduleEvent(db interfaces.DBClient, count int) (bson.ObjectId, er
 	return id, nil
 }
 
-func populateDevice(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateDevice(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
 		var err error
@@ -218,28 +219,28 @@ func populateDevice(db interfaces.DBClient, count int) (bson.ObjectId, error) {
 		d.Labels = append(d.Labels, name)
 
 		d.Addressable = getAddressable(i, "device")
-		_, err = db.AddAddressable(&d.Addressable)
+		_, err = dbClient.AddAddressable(&d.Addressable)
 		if err != nil {
 			return id, fmt.Errorf("Error creating addressable: %v", err)
 		}
 
-		d.Service, err = getDeviceService(db, i)
+		d.Service, err = getDeviceService(dbClient, i)
 		if err != nil {
 			return id, nil
 		}
-		err = db.AddDeviceService(&d.Service)
+		err = dbClient.AddDeviceService(&d.Service)
 		if err != nil {
 			return id, fmt.Errorf("Error creating DeviceService: %v", err)
 		}
-		d.Profile, err = getDeviceProfile(db, i)
+		d.Profile, err = getDeviceProfile(dbClient, i)
 		if err != nil {
 			return id, fmt.Errorf("Error getting DeviceProfile: %v", err)
 		}
-		err = db.AddDeviceProfile(&d.Profile)
+		err = dbClient.AddDeviceProfile(&d.Profile)
 		if err != nil {
 			return id, fmt.Errorf("Error creating DeviceProfile: %v", err)
 		}
-		err = db.AddDevice(&d)
+		err = dbClient.AddDevice(&d)
 		if err != nil {
 			return id, err
 		}
@@ -248,14 +249,14 @@ func populateDevice(db interfaces.DBClient, count int) (bson.ObjectId, error) {
 	return id, nil
 }
 
-func populateDeviceProfile(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateDeviceProfile(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
-		dp, err := getDeviceProfile(db, i)
+		dp, err := getDeviceProfile(dbClient, i)
 		if err != nil {
 			return id, fmt.Errorf("Error getting DeviceProfile: %v", err)
 		}
-		err = db.AddDeviceProfile(&dp)
+		err = dbClient.AddDeviceProfile(&dp)
 		if err != nil {
 			return id, err
 		}
@@ -264,7 +265,7 @@ func populateDeviceProfile(db interfaces.DBClient, count int) (bson.ObjectId, er
 	return id, nil
 }
 
-func populateProvisionWatcher(db interfaces.DBClient, count int) (bson.ObjectId, error) {
+func populateProvisionWatcher(dbClient interfaces.DBClient, count int) (bson.ObjectId, error) {
 	var id bson.ObjectId
 	for i := 0; i < count; i++ {
 		var err error
@@ -275,23 +276,23 @@ func populateProvisionWatcher(db interfaces.DBClient, count int) (bson.ObjectId,
 		d.Identifiers = make(map[string]string)
 		d.Identifiers["name"] = name
 
-		d.Service, err = getDeviceService(db, i)
+		d.Service, err = getDeviceService(dbClient, i)
 		if err != nil {
 			return id, err
 		}
-		err = db.AddDeviceService(&d.Service)
+		err = dbClient.AddDeviceService(&d.Service)
 		if err != nil {
 			return id, fmt.Errorf("Error creating DeviceService: %v", err)
 		}
-		d.Profile, err = getDeviceProfile(db, i)
+		d.Profile, err = getDeviceProfile(dbClient, i)
 		if err != nil {
 			return id, fmt.Errorf("Error getting DeviceProfile: %v", err)
 		}
-		err = db.AddDeviceProfile(&d.Profile)
+		err = dbClient.AddDeviceProfile(&d.Profile)
 		if err != nil {
 			return id, fmt.Errorf("Error creating DeviceProfile: %v", err)
 		}
-		err = db.AddProvisionWatcher(&d)
+		err = dbClient.AddProvisionWatcher(&d)
 		if err != nil {
 			return id, err
 		}
@@ -300,115 +301,115 @@ func populateProvisionWatcher(db interfaces.DBClient, count int) (bson.ObjectId,
 	return id, nil
 }
 
-func clearAddressables(t *testing.T, db interfaces.DBClient) {
+func clearAddressables(t *testing.T, dbClient interfaces.DBClient) {
 	var addrs []models.Addressable
-	err := db.GetAddressables(&addrs)
+	err := dbClient.GetAddressables(&addrs)
 	if err != nil {
 		t.Fatalf("Error getting addressables %v", err)
 	}
 	for _, a := range addrs {
-		if err = db.DeleteAddressable(a); err != nil {
+		if err = dbClient.DeleteAddressable(a); err != nil {
 			t.Fatalf("Error removing addressable %v: %v", a, err)
 		}
 	}
 }
 
-func clearDevices(t *testing.T, db interfaces.DBClient) {
+func clearDevices(t *testing.T, dbClient interfaces.DBClient) {
 	var ds []models.Device
-	err := db.GetAllDevices(&ds)
+	err := dbClient.GetAllDevices(&ds)
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
 	for _, d := range ds {
-		if err = db.DeleteDevice(d); err != nil {
+		if err = dbClient.DeleteDevice(d); err != nil {
 			t.Fatalf("Error removing device %v: %v", d, err)
 		}
 	}
 }
 
-func clearSchedules(t *testing.T, db interfaces.DBClient) {
+func clearSchedules(t *testing.T, dbClient interfaces.DBClient) {
 	var ss []models.Schedule
-	err := db.GetAllSchedules(&ss)
+	err := dbClient.GetAllSchedules(&ss)
 	if err != nil {
 		t.Fatalf("Error getting schedule %v", err)
 	}
 	for _, s := range ss {
-		if err = db.DeleteSchedule(s); err != nil {
+		if err = dbClient.DeleteSchedule(s); err != nil {
 			t.Fatalf("Error removing schedule %v: %v", s, err)
 		}
 	}
 }
 
-func clearScheduleEvents(t *testing.T, db interfaces.DBClient) {
+func clearScheduleEvents(t *testing.T, dbClient interfaces.DBClient) {
 	var ss []models.ScheduleEvent
-	err := db.GetAllScheduleEvents(&ss)
+	err := dbClient.GetAllScheduleEvents(&ss)
 	if err != nil {
 		t.Fatalf("Error getting schedule %v", err)
 	}
 	for _, s := range ss {
-		if err = db.DeleteScheduleEvent(s); err != nil {
+		if err = dbClient.DeleteScheduleEvent(s); err != nil {
 			t.Fatalf("Error removing schedule %v: %v", s, err)
 		}
 	}
 }
 
-func clearDeviceServices(t *testing.T, db interfaces.DBClient) {
+func clearDeviceServices(t *testing.T, dbClient interfaces.DBClient) {
 	var dss []models.DeviceService
-	err := db.GetAllDeviceServices(&dss)
+	err := dbClient.GetAllDeviceServices(&dss)
 	if err != nil {
 		t.Fatalf("Error getting deviceServices %v", err)
 	}
 	for _, ds := range dss {
-		if err = db.DeleteDeviceService(ds); err != nil {
+		if err = dbClient.DeleteDeviceService(ds); err != nil {
 			t.Fatalf("Error removing deviceService %v: %v", ds, err)
 		}
 	}
 }
 
-func clearDeviceReports(t *testing.T, db interfaces.DBClient) {
+func clearDeviceReports(t *testing.T, dbClient interfaces.DBClient) {
 	var drs []models.DeviceReport
-	err := db.GetAllDeviceReports(&drs)
+	err := dbClient.GetAllDeviceReports(&drs)
 	if err != nil {
 		t.Fatalf("Error getting deviceReports %v", err)
 	}
 	for _, ds := range drs {
-		if err = db.DeleteDeviceReport(ds); err != nil {
+		if err = dbClient.DeleteDeviceReport(ds); err != nil {
 			t.Fatalf("Error removing deviceReport %v: %v", ds, err)
 		}
 	}
 }
 
-func clearDeviceProfiles(t *testing.T, db interfaces.DBClient) {
+func clearDeviceProfiles(t *testing.T, dbClient interfaces.DBClient) {
 	var dps []models.DeviceProfile
-	err := db.GetAllDeviceProfiles(&dps)
+	err := dbClient.GetAllDeviceProfiles(&dps)
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
 
 	for _, ds := range dps {
-		if err = db.DeleteDeviceProfile(ds); err != nil {
+		if err = dbClient.DeleteDeviceProfile(ds); err != nil {
 			t.Fatalf("Error removing deviceProfile %v: %v", ds, err)
 		}
 	}
 }
 
-func testDBAddressables(t *testing.T, db interfaces.DBClient) {
+func testDBAddressables(t *testing.T, dbClient interfaces.DBClient) {
 	var addrs []models.Addressable
 
-	clearAddressables(t, db)
+	clearAddressables(t, dbClient)
 
-	id, err := populateAddressable(db, 100)
+	id, err := populateAddressable(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	// Error to have an Addressable with the same name
-	_, err = populateAddressable(db, 1)
+	_, err = populateAddressable(dbClient, 1)
 	if err == nil {
 		t.Fatalf("Should not be able to add a duplicated addressable\n")
 	}
 
-	err = db.GetAddressables(&addrs)
+	err = dbClient.GetAddressables(&addrs)
 	if err != nil {
 		t.Fatalf("Error getting addressables %v", err)
 	}
@@ -416,30 +417,36 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 addressables instead of %d", len(addrs))
 	}
 	a := models.Addressable{}
-	err = db.GetAddressableById(&a, id.Hex())
+	err = dbClient.GetAddressableById(&a, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting addressable by id %v", err)
 	}
 	if a.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", a.Id, id)
 	}
-	err = db.GetAddressableById(&a, "INVALID")
+	err = dbClient.GetAddressableById(&a, "INVALID")
 	if err == nil {
 		t.Fatalf("Addressable should not be found")
 	}
-	err = db.GetAddressableByName(&a, "name1")
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
+	err = dbClient.GetAddressableByName(&a, "name1")
 	if err != nil {
 		t.Fatalf("Error getting addressable by name %v", err)
 	}
 	if a.Name != "name1" {
 		t.Fatalf("name does not match %s - %s", a.Name, "name1")
 	}
-	err = db.GetAddressableByName(&a, "INVALID")
+	err = dbClient.GetAddressableByName(&a, "INVALID")
 	if err == nil {
 		t.Fatalf("Addressable should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetAddressablesByTopic(&addrs, "name1")
+	err = dbClient.GetAddressablesByTopic(&addrs, "name1")
 	if err != nil {
 		t.Fatalf("Error getting addressables by topic: %v", err)
 	}
@@ -447,7 +454,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 addressable, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByTopic(&addrs, "INVALID")
+	err = dbClient.GetAddressablesByTopic(&addrs, "INVALID")
 	if err != nil {
 		t.Fatalf("Error getting addressables by topic: %v", err)
 	}
@@ -455,7 +462,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be no addressables, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByPort(&addrs, 2)
+	err = dbClient.GetAddressablesByPort(&addrs, 2)
 	if err != nil {
 		t.Fatalf("Error getting addressables by port: %v", err)
 	}
@@ -463,7 +470,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 addressable, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByPort(&addrs, -1)
+	err = dbClient.GetAddressablesByPort(&addrs, -1)
 	if err != nil {
 		t.Fatalf("Error getting addressables by port: %v", err)
 	}
@@ -471,7 +478,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be no addressables, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByPublisher(&addrs, "name1")
+	err = dbClient.GetAddressablesByPublisher(&addrs, "name1")
 	if err != nil {
 		t.Fatalf("Error getting addressables by publisher: %v", err)
 	}
@@ -479,7 +486,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 addressable, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByPublisher(&addrs, "INVALID")
+	err = dbClient.GetAddressablesByPublisher(&addrs, "INVALID")
 	if err != nil {
 		t.Fatalf("Error getting addressables by publisher: %v", err)
 	}
@@ -487,7 +494,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be no addressables, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByAddress(&addrs, "name1")
+	err = dbClient.GetAddressablesByAddress(&addrs, "name1")
 	if err != nil {
 		t.Fatalf("Error getting addressables by Address: %v", err)
 	}
@@ -495,7 +502,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 addressable, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByAddress(&addrs, "INVALID")
+	err = dbClient.GetAddressablesByAddress(&addrs, "INVALID")
 	if err != nil {
 		t.Fatalf("Error getting addressables by Address: %v", err)
 	}
@@ -503,11 +510,11 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be no addressables, not %d", len(addrs))
 	}
 
-	err = db.GetAddressableById(&a, id.Hex())
+	err = dbClient.GetAddressableById(&a, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting addressable %v", err)
 	}
-	err = db.GetAddressableByName(&a, "name1")
+	err = dbClient.GetAddressableByName(&a, "name1")
 	if err != nil {
 		t.Fatalf("Error getting addressable %v", err)
 	}
@@ -515,62 +522,62 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 	aa := models.Addressable{}
 	aa.Id = id
 	aa.Name = "name"
-	err = db.UpdateAddressable(&aa, &a)
+	err = dbClient.UpdateAddressable(&aa, &a)
 	if err != nil {
 		t.Fatalf("Error updating Addressable %v", err)
 	}
-	err = db.GetAddressableByName(&a, "name1")
+	err = dbClient.GetAddressableByName(&a, "name1")
 	if err == nil {
 		t.Fatalf("Addresable name1 should be renamed")
 	}
-	err = db.GetAddressableByName(&a, "name")
+	err = dbClient.GetAddressableByName(&a, "name")
 	if err != nil {
 		t.Fatalf("Addresable name should be renamed")
 	}
 
 	// aa.Name = "name2"
-	// err = db.UpdateAddressable(&aa, &a)
+	// err = dbClient.UpdateAddressable(&aa, &a)
 	// if err == nil {
 	// 	t.Fatalf("Error updating Addressable %v", err)
 	// }
 
 	a.Id = "INVALID"
 	a.Name = "INVALID"
-	err = db.DeleteAddressable(a)
+	err = dbClient.DeleteAddressable(a)
 	if err == nil {
 		t.Fatalf("Addressable should not be deleted")
 	}
 
-	err = db.GetAddressableByName(&a, "name")
+	err = dbClient.GetAddressableByName(&a, "name")
 	if err != nil {
 		t.Fatalf("Error getting addressable")
 	}
-	err = db.DeleteAddressable(a)
+	err = dbClient.DeleteAddressable(a)
 	if err != nil {
 		t.Fatalf("Addressable should be deleted: %v", err)
 	}
 
-	clearAddressables(t, db)
+	clearAddressables(t, dbClient)
 }
 
-func testDBCommand(t *testing.T, db interfaces.DBClient) {
+func testDBCommand(t *testing.T, dbClient interfaces.DBClient) {
 	var commands []models.Command
-	err := db.GetAllCommands(&commands)
+	err := dbClient.GetAllCommands(&commands)
 	if err != nil {
 		t.Fatalf("Error getting commands %v", err)
 	}
 	for _, c := range commands {
-		if err = db.DeleteCommandById(c.Id.Hex()); err != nil {
+		if err = dbClient.DeleteCommandById(c.Id.Hex()); err != nil {
 			t.Fatalf("Error removing command %v", err)
 		}
 	}
 
-	id, err := populateCommand(db, 100)
+	id, err := populateCommand(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
-	err = db.GetAllCommands(&commands)
+	err = dbClient.GetAllCommands(&commands)
 	if err != nil {
 		t.Fatalf("Error getting commands %v", err)
 	}
@@ -578,19 +585,22 @@ func testDBCommand(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 commands instead of %d", len(commands))
 	}
 	c := models.Command{}
-	err = db.GetCommandById(&c, id.Hex())
+	err = dbClient.GetCommandById(&c, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting command by id %v", err)
 	}
 	if c.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", c.Id, id)
 	}
-	err = db.GetCommandById(&c, "INVALID")
+	err = dbClient.GetCommandById(&c, "INVALID")
 	if err == nil {
 		t.Fatalf("Command should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetCommandByName(&commands, "name1")
+	err = dbClient.GetCommandByName(&commands, "name1")
 	if err != nil {
 		t.Fatalf("Error getting commands by name %v", err)
 	}
@@ -598,7 +608,7 @@ func testDBCommand(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 commands instead of %d", len(commands))
 	}
 
-	err = db.GetCommandByName(&commands, "INVALID")
+	err = dbClient.GetCommandByName(&commands, "INVALID")
 	if err != nil {
 		t.Fatalf("Error getting commands by name %v", err)
 	}
@@ -611,45 +621,45 @@ func testDBCommand(t *testing.T, db interfaces.DBClient) {
 	cc.Get = &models.Get{}
 	cc.Put = &models.Put{}
 	cc.Name = "name"
-	err = db.UpdateCommand(&cc, &c)
+	err = dbClient.UpdateCommand(&cc, &c)
 	if err != nil {
 		t.Fatalf("Error updating Command %v", err)
 	}
 
 	c.Id = "INVALID"
-	err = db.UpdateCommand(&cc, &c)
+	err = dbClient.UpdateCommand(&cc, &c)
 	if err == nil {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteCommandById("INVALID")
+	err = dbClient.DeleteCommandById("INVALID")
 	if err == nil {
 		t.Fatalf("Command should not be deleted")
 	}
 
-	err = db.DeleteCommandById(id.Hex())
+	err = dbClient.DeleteCommandById(id.Hex())
 	if err != nil {
 		t.Fatalf("Command should be deleted: %v", err)
 	}
 }
 
-func testDBDeviceService(t *testing.T, db interfaces.DBClient) {
+func testDBDeviceService(t *testing.T, dbClient interfaces.DBClient) {
 	var deviceServices []models.DeviceService
 
-	clearDeviceServices(t, db)
-	id, err := populateDeviceService(db, 100)
+	clearDeviceServices(t, dbClient)
+	id, err := populateDeviceService(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	ds2 := models.DeviceService{}
 	ds2.Name = "name1"
-	err = db.AddDeviceService(&ds2)
+	err = dbClient.AddDeviceService(&ds2)
 	if err == nil {
 		t.Fatalf("Should be an error adding an existing name")
 	}
 
-	err = db.GetAllDeviceServices(&deviceServices)
+	err = dbClient.GetAllDeviceServices(&deviceServices)
 	if err != nil {
 		t.Fatalf("Error getting deviceServices %v", err)
 	}
@@ -657,19 +667,22 @@ func testDBDeviceService(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 deviceServices instead of %d", len(deviceServices))
 	}
 	ds := models.DeviceService{}
-	err = db.GetDeviceServiceById(&ds, id.Hex())
+	err = dbClient.GetDeviceServiceById(&ds, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting deviceService by id %v", err)
 	}
 	if ds.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", ds.Id, id)
 	}
-	err = db.GetDeviceServiceById(&ds, "INVALID")
+	err = dbClient.GetDeviceServiceById(&ds, "INVALID")
 	if err == nil {
 		t.Fatalf("DeviceService should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetDeviceServiceByName(&ds, "name1")
+	err = dbClient.GetDeviceServiceByName(&ds, "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceServices by name %v", err)
 	}
@@ -677,31 +690,34 @@ func testDBDeviceService(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("The ds should be named name1 instead of %s", ds.Name)
 	}
 
-	err = db.GetDeviceServiceByName(&ds, "INVALID")
+	err = dbClient.GetDeviceServiceByName(&ds, "INVALID")
 	if err == nil {
 		t.Fatalf("There should be a not found error")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetDeviceServicesByAddressableId(&deviceServices, ds.Addressable.Id.Hex())
+	err = dbClient.GetDeviceServicesByAddressableId(&deviceServices, ds.Addressable.Id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting deviceServices by addressable id %v", err)
 	}
 	if len(deviceServices) != 1 {
 		t.Fatalf("There should be 1 deviceServices instead of %d", len(deviceServices))
 	}
-	err = db.GetDeviceServicesByAddressableId(&deviceServices, bson.NewObjectId().Hex())
+	err = dbClient.GetDeviceServicesByAddressableId(&deviceServices, bson.NewObjectId().Hex())
 	if err != nil {
 		t.Fatalf("Error getting deviceServices by addressable id")
 	}
 
-	err = db.GetDeviceServicesWithLabel(&deviceServices, "name3")
+	err = dbClient.GetDeviceServicesWithLabel(&deviceServices, "name3")
 	if err != nil {
 		t.Fatalf("Error getting deviceServices by addressable id %v", err)
 	}
 	if len(deviceServices) != 1 {
 		t.Fatalf("There should be 1 deviceServices instead of %d", len(deviceServices))
 	}
-	err = db.GetDeviceServicesWithLabel(&deviceServices, "INVALID")
+	err = dbClient.GetDeviceServicesWithLabel(&deviceServices, "INVALID")
 	if err != nil {
 		t.Fatalf("Error getting deviceServices by addressable id %v", err)
 	}
@@ -711,48 +727,48 @@ func testDBDeviceService(t *testing.T, db interfaces.DBClient) {
 
 	ds.Id = id
 	ds.Name = "name"
-	err = db.UpdateDeviceService(ds)
+	err = dbClient.UpdateDeviceService(ds)
 	if err != nil {
 		t.Fatalf("Error updating DeviceService %v", err)
 	}
 
 	ds.Id = "INVALID"
-	err = db.UpdateDeviceService(ds)
+	err = dbClient.UpdateDeviceService(ds)
 	if err == nil {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteDeviceService(ds)
+	err = dbClient.DeleteDeviceService(ds)
 	if err == nil {
 		t.Fatalf("DeviceService should not be deleted")
 	}
 
 	ds.Id = id
-	err = db.DeleteDeviceService(ds)
+	err = dbClient.DeleteDeviceService(ds)
 	if err != nil {
 		t.Fatalf("DeviceService should be deleted: %v", err)
 	}
 
-	clearDeviceServices(t, db)
+	clearDeviceServices(t, dbClient)
 }
 
-func testDBSchedule(t *testing.T, db interfaces.DBClient) {
+func testDBSchedule(t *testing.T, dbClient interfaces.DBClient) {
 	var schedules []models.Schedule
 
-	clearSchedules(t, db)
-	id, err := populateSchedule(db, 100)
+	clearSchedules(t, dbClient)
+	id, err := populateSchedule(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	e := models.Schedule{}
 	e.Name = "name1"
-	err = db.AddSchedule(&e)
+	err = dbClient.AddSchedule(&e)
 	if err == nil {
 		t.Fatalf("Should be an error adding an existing name")
 	}
 
-	err = db.GetAllSchedules(&schedules)
+	err = dbClient.GetAllSchedules(&schedules)
 	if err != nil {
 		t.Fatalf("Error getting schedules %v", err)
 	}
@@ -760,74 +776,80 @@ func testDBSchedule(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 schedules instead of %d", len(schedules))
 	}
 
-	err = db.GetScheduleById(&e, id.Hex())
+	err = dbClient.GetScheduleById(&e, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting schedule by id %v", err)
 	}
 	if e.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", e.Id, id)
 	}
-	err = db.GetScheduleById(&e, "INVALID")
+	err = dbClient.GetScheduleById(&e, "INVALID")
 	if err == nil {
 		t.Fatalf("Schedule should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetScheduleByName(&e, "name1")
+	err = dbClient.GetScheduleByName(&e, "name1")
 	if err != nil {
 		t.Fatalf("Error getting schedule by id %v", err)
 	}
 	if e.Name != "name1" {
 		t.Fatalf("Id does not match %s - %s", e.Id, id)
 	}
-	err = db.GetScheduleByName(&e, "INVALID")
+	err = dbClient.GetScheduleByName(&e, "INVALID")
 	if err == nil {
 		t.Fatalf("Schedule should not be found")
+	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
 	}
 
 	e2 := models.Schedule{}
 	e2.Id = id
 	e2.Name = "name"
-	err = db.UpdateSchedule(e2)
+	err = dbClient.UpdateSchedule(e2)
 	if err != nil {
 		t.Fatalf("Error updating Schedule %v", err)
 	}
 
 	e2.Id = "INVALID"
-	err = db.UpdateSchedule(e2)
+	err = dbClient.UpdateSchedule(e2)
 	if err == nil {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteSchedule(e2)
+	err = dbClient.DeleteSchedule(e2)
 	if err == nil {
 		t.Fatalf("Schedule should not be deleted")
 	}
 
 	e2.Id = id
-	err = db.DeleteSchedule(e2)
+	err = dbClient.DeleteSchedule(e2)
 	if err != nil {
 		t.Fatalf("Schedule should be deleted: %v", err)
 	}
 }
 
-func testDBDeviceReport(t *testing.T, db interfaces.DBClient) {
+func testDBDeviceReport(t *testing.T, dbClient interfaces.DBClient) {
 	var deviceReports []models.DeviceReport
 
-	clearDeviceReports(t, db)
+	clearDeviceReports(t, dbClient)
 
-	id, err := populateDeviceReport(db, 100)
+	id, err := populateDeviceReport(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	e := models.DeviceReport{}
 	e.Name = "name1"
-	err = db.AddDeviceReport(&e)
+	err = dbClient.AddDeviceReport(&e)
 	if err == nil {
 		t.Fatalf("Should be an error adding an existing name")
 	}
 
-	err = db.GetAllDeviceReports(&deviceReports)
+	err = dbClient.GetAllDeviceReports(&deviceReports)
 	if err != nil {
 		t.Fatalf("Error getting deviceReports %v", err)
 	}
@@ -835,31 +857,37 @@ func testDBDeviceReport(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 deviceReports instead of %d", len(deviceReports))
 	}
 
-	err = db.GetDeviceReportById(&e, id.Hex())
+	err = dbClient.GetDeviceReportById(&e, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting deviceReport by id %v", err)
 	}
 	if e.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", e.Id, id)
 	}
-	err = db.GetDeviceReportById(&e, "INVALID")
+	err = dbClient.GetDeviceReportById(&e, "INVALID")
 	if err == nil {
 		t.Fatalf("DeviceReport should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetDeviceReportByName(&e, "name1")
+	err = dbClient.GetDeviceReportByName(&e, "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceReport by id %v", err)
 	}
 	if e.Name != "name1" {
 		t.Fatalf("Id does not match %s - %s", e.Id, id)
 	}
-	err = db.GetDeviceReportByName(&e, "INVALID")
+	err = dbClient.GetDeviceReportByName(&e, "INVALID")
 	if err == nil {
 		t.Fatalf("DeviceReport should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetDeviceReportByDeviceName(&deviceReports, "name1")
+	err = dbClient.GetDeviceReportByDeviceName(&deviceReports, "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceReports %v", err)
 	}
@@ -867,7 +895,7 @@ func testDBDeviceReport(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 deviceReports instead of %d", len(deviceReports))
 	}
 
-	err = db.GetDeviceReportByDeviceName(&deviceReports, "name")
+	err = dbClient.GetDeviceReportByDeviceName(&deviceReports, "name")
 	if err != nil {
 		t.Fatalf("Error getting deviceReports %v", err)
 	}
@@ -875,7 +903,7 @@ func testDBDeviceReport(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 deviceReports instead of %d", len(deviceReports))
 	}
 
-	err = db.GetDeviceReportsByScheduleEventName(&deviceReports, "name1")
+	err = dbClient.GetDeviceReportsByScheduleEventName(&deviceReports, "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceReports %v", err)
 	}
@@ -883,7 +911,7 @@ func testDBDeviceReport(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 deviceReports instead of %d", len(deviceReports))
 	}
 
-	err = db.GetDeviceReportsByScheduleEventName(&deviceReports, "name")
+	err = dbClient.GetDeviceReportsByScheduleEventName(&deviceReports, "name")
 	if err != nil {
 		t.Fatalf("Error getting deviceReports %v", err)
 	}
@@ -894,53 +922,53 @@ func testDBDeviceReport(t *testing.T, db interfaces.DBClient) {
 	e2 := models.DeviceReport{}
 	e2.Id = id
 	e2.Name = "name"
-	err = db.UpdateDeviceReport(&e2)
+	err = dbClient.UpdateDeviceReport(&e2)
 	if err != nil {
 		t.Fatalf("Error updating DeviceReport %v", err)
 	}
 
 	e2.Id = "INVALID"
-	err = db.UpdateDeviceReport(&e2)
+	err = dbClient.UpdateDeviceReport(&e2)
 	if err == nil {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteDeviceReport(e2)
+	err = dbClient.DeleteDeviceReport(e2)
 	if err == nil {
 		t.Fatalf("DeviceReport should not be deleted")
 	}
 
 	e2.Id = id
-	err = db.DeleteDeviceReport(e2)
+	err = dbClient.DeleteDeviceReport(e2)
 	if err != nil {
 		t.Fatalf("DeviceReport should be deleted: %v", err)
 	}
 }
 
-func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
+func testDBScheduleEvent(t *testing.T, dbClient interfaces.DBClient) {
 	var scheduleEvents []models.ScheduleEvent
 
-	clearScheduleEvents(t, db)
-	clearAddressables(t, db)
-	id, err := populateScheduleEvent(db, 100)
+	clearScheduleEvents(t, dbClient)
+	clearAddressables(t, dbClient)
+	id, err := populateScheduleEvent(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	e := models.ScheduleEvent{}
 	e.Name = "name1"
-	err = db.AddScheduleEvent(&e)
+	err = dbClient.AddScheduleEvent(&e)
 	if err == nil {
 		t.Fatalf("Should be an error adding an existing name")
 	}
 	e.Name = "name_not_used"
 	e.Addressable.Name = "unused"
-	err = db.AddScheduleEvent(&e)
+	err = dbClient.AddScheduleEvent(&e)
 	if err == nil {
 		t.Fatalf("Should be an error adding an event with not existing addressable")
 	}
 
-	err = db.GetAllScheduleEvents(&scheduleEvents)
+	err = dbClient.GetAllScheduleEvents(&scheduleEvents)
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvents %v", err)
 	}
@@ -948,31 +976,37 @@ func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 ScheduleEvents instead of %d", len(scheduleEvents))
 	}
 
-	err = db.GetScheduleEventById(&e, id.Hex())
+	err = dbClient.GetScheduleEventById(&e, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvent by id %v", err)
 	}
 	if e.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", e.Id, id)
 	}
-	err = db.GetScheduleEventById(&e, "INVALID")
+	err = dbClient.GetScheduleEventById(&e, "INVALID")
 	if err == nil {
 		t.Fatalf("ScheduleEvent should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetScheduleEventByName(&e, "name1")
+	err = dbClient.GetScheduleEventByName(&e, "name1")
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvent by id %v", err)
 	}
 	if e.Name != "name1" {
 		t.Fatalf("Id does not match %s - %s", e.Id, id)
 	}
-	err = db.GetScheduleEventByName(&e, "INVALID")
+	err = dbClient.GetScheduleEventByName(&e, "INVALID")
 	if err == nil {
 		t.Fatalf("ScheduleEvent should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetScheduleEventsByScheduleName(&scheduleEvents, "name1")
+	err = dbClient.GetScheduleEventsByScheduleName(&scheduleEvents, "name1")
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvents %v", err)
 	}
@@ -980,7 +1014,7 @@ func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 ScheduleEvents instead of %d", len(scheduleEvents))
 	}
 
-	err = db.GetScheduleEventsByScheduleName(&scheduleEvents, "name")
+	err = dbClient.GetScheduleEventsByScheduleName(&scheduleEvents, "name")
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvents %v", err)
 	}
@@ -988,7 +1022,7 @@ func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 ScheduleEvents instead of %d", len(scheduleEvents))
 	}
 
-	err = db.GetScheduleEventsByAddressableId(&scheduleEvents, e.Addressable.Id.Hex())
+	err = dbClient.GetScheduleEventsByAddressableId(&scheduleEvents, e.Addressable.Id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvents %v", err)
 	}
@@ -996,7 +1030,7 @@ func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 ScheduleEvents instead of %d", len(scheduleEvents))
 	}
 
-	err = db.GetScheduleEventsByAddressableId(&scheduleEvents, bson.NewObjectId().Hex())
+	err = dbClient.GetScheduleEventsByAddressableId(&scheduleEvents, bson.NewObjectId().Hex())
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvents %v", err)
 	}
@@ -1004,7 +1038,7 @@ func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 ScheduleEvents instead of %d", len(scheduleEvents))
 	}
 
-	err = db.GetScheduleEventsByServiceName(&scheduleEvents, "name1")
+	err = dbClient.GetScheduleEventsByServiceName(&scheduleEvents, "name1")
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvents %v", err)
 	}
@@ -1012,7 +1046,7 @@ func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 ScheduleEvents instead of %d", len(scheduleEvents))
 	}
 
-	err = db.GetScheduleEventsByServiceName(&scheduleEvents, "name")
+	err = dbClient.GetScheduleEventsByServiceName(&scheduleEvents, "name")
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvents %v", err)
 	}
@@ -1022,47 +1056,47 @@ func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
 
 	e.Id = id
 	e.Name = "name"
-	err = db.UpdateScheduleEvent(e)
+	err = dbClient.UpdateScheduleEvent(e)
 	if err != nil {
 		t.Fatalf("Error updating ScheduleEvent %v", err)
 	}
 
 	e.Id = "INVALID"
-	err = db.UpdateScheduleEvent(e)
+	err = dbClient.UpdateScheduleEvent(e)
 	if err == nil {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteScheduleEvent(e)
+	err = dbClient.DeleteScheduleEvent(e)
 	if err == nil {
 		t.Fatalf("ScheduleEvent should not be deleted")
 	}
 
 	e.Id = id
-	err = db.DeleteScheduleEvent(e)
+	err = dbClient.DeleteScheduleEvent(e)
 	if err != nil {
 		t.Fatalf("ScheduleEvent should be deleted: %v", err)
 	}
 }
 
-func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
+func testDBDeviceProfile(t *testing.T, dbClient interfaces.DBClient) {
 	var deviceProfiles []models.DeviceProfile
 
-	clearAddressables(t, db)
-	clearDeviceProfiles(t, db)
-	id, err := populateDeviceProfile(db, 100)
+	clearAddressables(t, dbClient)
+	clearDeviceProfiles(t, dbClient)
+	id, err := populateDeviceProfile(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	dp := models.DeviceProfile{}
 	dp.Name = "name1"
-	err = db.AddDeviceProfile(&dp)
+	err = dbClient.AddDeviceProfile(&dp)
 	if err == nil {
 		t.Fatalf("Should be an error adding an existing name")
 	}
 
-	err = db.GetAllDeviceProfiles(&deviceProfiles)
+	err = dbClient.GetAllDeviceProfiles(&deviceProfiles)
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1070,31 +1104,37 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	err = db.GetDeviceProfileById(&dp, id.Hex())
+	err = dbClient.GetDeviceProfileById(&dp, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting deviceProfile by id %v", err)
 	}
 	if dp.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", dp.Id, id)
 	}
-	err = db.GetDeviceProfileById(&dp, "INVALID")
+	err = dbClient.GetDeviceProfileById(&dp, "INVALID")
 	if err == nil {
 		t.Fatalf("DeviceProfile should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetDeviceProfileByName(&dp, "name1")
+	err = dbClient.GetDeviceProfileByName(&dp, "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceProfile by id %v", err)
 	}
 	if dp.Name != "name1" {
 		t.Fatalf("Id does not match %s - %s", dp.Id, id)
 	}
-	err = db.GetDeviceProfileByName(&dp, "INVALID")
+	err = dbClient.GetDeviceProfileByName(&dp, "INVALID")
 	if err == nil {
 		t.Fatalf("DeviceProfile should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetDeviceProfilesByModel(&deviceProfiles, "name1")
+	err = dbClient.GetDeviceProfilesByModel(&deviceProfiles, "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1102,7 +1142,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	err = db.GetDeviceProfilesByModel(&deviceProfiles, "name")
+	err = dbClient.GetDeviceProfilesByModel(&deviceProfiles, "name")
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1110,7 +1150,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	err = db.GetDeviceProfilesByManufacturer(&deviceProfiles, "name1")
+	err = dbClient.GetDeviceProfilesByManufacturer(&deviceProfiles, "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1118,7 +1158,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	err = db.GetDeviceProfilesByManufacturer(&deviceProfiles, "name")
+	err = dbClient.GetDeviceProfilesByManufacturer(&deviceProfiles, "name")
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1126,7 +1166,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	err = db.GetDeviceProfilesByManufacturerModel(&deviceProfiles, "name1", "name1")
+	err = dbClient.GetDeviceProfilesByManufacturerModel(&deviceProfiles, "name1", "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1134,7 +1174,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	err = db.GetDeviceProfilesByManufacturerModel(&deviceProfiles, "name", "name1")
+	err = dbClient.GetDeviceProfilesByManufacturerModel(&deviceProfiles, "name", "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1142,7 +1182,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	err = db.GetDeviceProfilesWithLabel(&deviceProfiles, "name1")
+	err = dbClient.GetDeviceProfilesWithLabel(&deviceProfiles, "name1")
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1150,7 +1190,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	err = db.GetDeviceProfilesWithLabel(&deviceProfiles, "name")
+	err = dbClient.GetDeviceProfilesWithLabel(&deviceProfiles, "name")
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1161,7 +1201,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 	c := models.Command{}
 	c.Id = dp.Commands[0].Id
 
-	err = db.GetDeviceProfilesUsingCommand(&deviceProfiles, c)
+	err = dbClient.GetDeviceProfilesUsingCommand(&deviceProfiles, c)
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1170,7 +1210,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 	}
 
 	c.Id = bson.NewObjectId()
-	err = db.GetDeviceProfilesUsingCommand(&deviceProfiles, c)
+	err = dbClient.GetDeviceProfilesUsingCommand(&deviceProfiles, c)
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1181,51 +1221,51 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 	d2 := models.DeviceProfile{}
 	d2.Id = id
 	d2.Name = "name"
-	err = db.UpdateDeviceProfile(&d2)
+	err = dbClient.UpdateDeviceProfile(&d2)
 	if err != nil {
 		t.Fatalf("Error updating DeviceProfile %v", err)
 	}
 
 	d2.Id = "INVALID"
-	err = db.UpdateDeviceProfile(&d2)
+	err = dbClient.UpdateDeviceProfile(&d2)
 	if err == nil {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteDeviceProfile(d2)
+	err = dbClient.DeleteDeviceProfile(d2)
 	if err == nil {
 		t.Fatalf("DeviceProfile should not be deleted")
 	}
 
 	d2.Id = id
-	err = db.DeleteDeviceProfile(d2)
+	err = dbClient.DeleteDeviceProfile(d2)
 	if err != nil {
 		t.Fatalf("DeviceProfile should be deleted: %v", err)
 	}
 
-	clearDeviceProfiles(t, db)
+	clearDeviceProfiles(t, dbClient)
 }
 
-func testDBDevice(t *testing.T, db interfaces.DBClient) {
+func testDBDevice(t *testing.T, dbClient interfaces.DBClient) {
 	var devices []models.Device
 
-	clearDeviceProfiles(t, db)
-	clearDeviceServices(t, db)
-	clearAddressables(t, db)
-	clearDevices(t, db)
-	id, err := populateDevice(db, 100)
+	clearDeviceProfiles(t, dbClient)
+	clearDeviceServices(t, dbClient)
+	clearAddressables(t, dbClient)
+	clearDevices(t, dbClient)
+	id, err := populateDevice(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	d := models.Device{}
 	d.Name = "name1"
-	err = db.AddDevice(&d)
+	err = dbClient.AddDevice(&d)
 	if err == nil {
 		t.Fatalf("Should be an error adding an existing name")
 	}
 
-	err = db.GetAllDevices(&devices)
+	err = dbClient.GetAllDevices(&devices)
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
@@ -1233,31 +1273,37 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 devices instead of %d", len(devices))
 	}
 
-	err = db.GetDeviceById(&d, id.Hex())
+	err = dbClient.GetDeviceById(&d, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting device by id %v", err)
 	}
 	if d.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", d.Id, id)
 	}
-	err = db.GetDeviceById(&d, "INVALID")
+	err = dbClient.GetDeviceById(&d, "INVALID")
 	if err == nil {
 		t.Fatalf("Device should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetDeviceByName(&d, "name1")
+	err = dbClient.GetDeviceByName(&d, "name1")
 	if err != nil {
 		t.Fatalf("Error getting device by id %v", err)
 	}
 	if d.Name != "name1" {
 		t.Fatalf("Id does not match %s - %s", d.Id, id)
 	}
-	err = db.GetDeviceByName(&d, "INVALID")
+	err = dbClient.GetDeviceByName(&d, "INVALID")
 	if err == nil {
 		t.Fatalf("Device should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetDevicesByProfileId(&devices, d.Profile.Id.Hex())
+	err = dbClient.GetDevicesByProfileId(&devices, d.Profile.Id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
@@ -1265,7 +1311,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 devices instead of %d", len(devices))
 	}
 
-	err = db.GetDevicesByProfileId(&devices, bson.NewObjectId().Hex())
+	err = dbClient.GetDevicesByProfileId(&devices, bson.NewObjectId().Hex())
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
@@ -1273,7 +1319,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 devices instead of %d", len(devices))
 	}
 
-	err = db.GetDevicesByServiceId(&devices, d.Service.Id.Hex())
+	err = dbClient.GetDevicesByServiceId(&devices, d.Service.Id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
@@ -1281,7 +1327,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 devices instead of %d", len(devices))
 	}
 
-	err = db.GetDevicesByServiceId(&devices, bson.NewObjectId().Hex())
+	err = dbClient.GetDevicesByServiceId(&devices, bson.NewObjectId().Hex())
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
@@ -1289,7 +1335,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 devices instead of %d", len(devices))
 	}
 
-	err = db.GetDevicesByAddressableId(&devices, d.Addressable.Id.Hex())
+	err = dbClient.GetDevicesByAddressableId(&devices, d.Addressable.Id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
@@ -1297,7 +1343,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 devices instead of %d", len(devices))
 	}
 
-	err = db.GetDevicesByAddressableId(&devices, bson.NewObjectId().Hex())
+	err = dbClient.GetDevicesByAddressableId(&devices, bson.NewObjectId().Hex())
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
@@ -1305,7 +1351,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 devices instead of %d", len(devices))
 	}
 
-	err = db.GetDevicesWithLabel(&devices, "name1")
+	err = dbClient.GetDevicesWithLabel(&devices, "name1")
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
@@ -1313,7 +1359,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 devices instead of %d", len(devices))
 	}
 
-	err = db.GetDevicesWithLabel(&devices, "name")
+	err = dbClient.GetDevicesWithLabel(&devices, "name")
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}
@@ -1323,48 +1369,48 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 
 	d.Id = id
 	d.Name = "name"
-	err = db.UpdateDevice(d)
+	err = dbClient.UpdateDevice(d)
 	if err != nil {
 		t.Fatalf("Error updating Device %v", err)
 	}
 
 	d.Id = "INVALID"
-	err = db.UpdateDevice(d)
+	err = dbClient.UpdateDevice(d)
 	if err == nil {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteDevice(d)
+	err = dbClient.DeleteDevice(d)
 	if err == nil {
 		t.Fatalf("Device should not be deleted")
 	}
 
 	d.Id = id
-	err = db.DeleteDevice(d)
+	err = dbClient.DeleteDevice(d)
 	if err != nil {
 		t.Fatalf("Device should be deleted: %v", err)
 	}
 }
 
-func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
+func testDBProvisionWatcher(t *testing.T, dbClient interfaces.DBClient) {
 	var provisionWatchers []models.ProvisionWatcher
 
-	clearDeviceProfiles(t, db)
-	clearDeviceServices(t, db)
-	clearAddressables(t, db)
-	id, err := populateProvisionWatcher(db, 100)
+	clearDeviceProfiles(t, dbClient)
+	clearDeviceServices(t, dbClient)
+	clearAddressables(t, dbClient)
+	id, err := populateProvisionWatcher(dbClient, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 
 	pw := models.ProvisionWatcher{}
 	pw.Name = "name1"
-	err = db.AddProvisionWatcher(&pw)
+	err = dbClient.AddProvisionWatcher(&pw)
 	if err == nil {
 		t.Fatalf("Should be an error adding an existing name")
 	}
 
-	err = db.GetAllProvisionWatchers(&provisionWatchers)
+	err = dbClient.GetAllProvisionWatchers(&provisionWatchers)
 	if err != nil {
 		t.Fatalf("Error getting provisionWatchers %v", err)
 	}
@@ -1372,31 +1418,37 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 provisionWatchers instead of %d", len(provisionWatchers))
 	}
 
-	err = db.GetProvisionWatcherById(&pw, id.Hex())
+	err = dbClient.GetProvisionWatcherById(&pw, id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting provisionWatcher by id %v", err)
 	}
 	if pw.Id.Hex() != id.Hex() {
 		t.Fatalf("Id does not match %s - %s", pw.Id, id)
 	}
-	err = db.GetProvisionWatcherById(&pw, "INVALID")
+	err = dbClient.GetProvisionWatcherById(&pw, "INVALID")
 	if err == nil {
 		t.Fatalf("ProvisionWatcher should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetProvisionWatcherByName(&pw, "name1")
+	err = dbClient.GetProvisionWatcherByName(&pw, "name1")
 	if err != nil {
 		t.Fatalf("Error getting provisionWatcher by id %v", err)
 	}
 	if pw.Name != "name1" {
 		t.Fatalf("Id does not match %s - %s", pw.Id, id)
 	}
-	err = db.GetProvisionWatcherByName(&pw, "INVALID")
+	err = dbClient.GetProvisionWatcherByName(&pw, "INVALID")
 	if err == nil {
 		t.Fatalf("ProvisionWatcher should not be found")
 	}
+	if err != db.ErrNotFound {
+		t.Fatalf("Error is not db.ErrNotFound: %v", err)
+	}
 
-	err = db.GetProvisionWatchersByServiceId(&provisionWatchers, pw.Service.Id.Hex())
+	err = dbClient.GetProvisionWatchersByServiceId(&provisionWatchers, pw.Service.Id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting provisionWatchers %v", err)
 	}
@@ -1404,7 +1456,7 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 provisionWatchers instead of %d", len(provisionWatchers))
 	}
 
-	err = db.GetProvisionWatchersByServiceId(&provisionWatchers, bson.NewObjectId().Hex())
+	err = dbClient.GetProvisionWatchersByServiceId(&provisionWatchers, bson.NewObjectId().Hex())
 	if err != nil {
 		t.Fatalf("Error getting provisionWatchers %v", err)
 	}
@@ -1412,7 +1464,7 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 provisionWatchers instead of %d", len(provisionWatchers))
 	}
 
-	err = db.GetProvisionWatchersByProfileId(&provisionWatchers, pw.Profile.Id.Hex())
+	err = dbClient.GetProvisionWatchersByProfileId(&provisionWatchers, pw.Profile.Id.Hex())
 	if err != nil {
 		t.Fatalf("Error getting provisionWatchers %v", err)
 	}
@@ -1420,7 +1472,7 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 provisionWatchers instead of %d", len(provisionWatchers))
 	}
 
-	err = db.GetProvisionWatchersByProfileId(&provisionWatchers, bson.NewObjectId().Hex())
+	err = dbClient.GetProvisionWatchersByProfileId(&provisionWatchers, bson.NewObjectId().Hex())
 	if err != nil {
 		t.Fatalf("Error getting provisionWatchers %v", err)
 	}
@@ -1428,7 +1480,7 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 provisionWatchers instead of %d", len(provisionWatchers))
 	}
 
-	err = db.GetProvisionWatchersByIdentifier(&provisionWatchers, "name", "name1")
+	err = dbClient.GetProvisionWatchersByIdentifier(&provisionWatchers, "name", "name1")
 	if err != nil {
 		t.Fatalf("Error getting provisionWatchers %v", err)
 	}
@@ -1436,7 +1488,7 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 provisionWatchers instead of %d", len(provisionWatchers))
 	}
 
-	err = db.GetProvisionWatchersByIdentifier(&provisionWatchers, "name", "invalid")
+	err = dbClient.GetProvisionWatchersByIdentifier(&provisionWatchers, "name", "invalid")
 	if err != nil {
 		t.Fatalf("Error getting provisionWatchers %v", err)
 	}
@@ -1445,24 +1497,24 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 	}
 
 	pw.Name = "name"
-	err = db.UpdateProvisionWatcher(pw)
+	err = dbClient.UpdateProvisionWatcher(pw)
 	if err != nil {
 		t.Fatalf("Error updating ProvisionWatcher %v", err)
 	}
 
 	pw.Id = "INVALID"
-	err = db.UpdateProvisionWatcher(pw)
+	err = dbClient.UpdateProvisionWatcher(pw)
 	if err == nil {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteProvisionWatcher(pw)
+	err = dbClient.DeleteProvisionWatcher(pw)
 	if err == nil {
 		t.Fatalf("ProvisionWatcher should not be deleted")
 	}
 
 	pw.Id = id
-	err = db.DeleteProvisionWatcher(pw)
+	err = dbClient.DeleteProvisionWatcher(pw)
 	if err != nil {
 		t.Fatalf("ProvisionWatcher should be deleted: %v", err)
 	}

--- a/core/metadata/rest_addressable.go
+++ b/core/metadata/rest_addressable.go
@@ -23,7 +23,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/core/db"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/gorilla/mux"
-	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -101,7 +100,7 @@ func restUpdateAddressable(w http.ResponseWriter, r *http.Request) {
 			err = dbClient.GetAddressableByName(&res, ra.Name)
 		}
 		if err != nil {
-			if err == mgo.ErrNotFound {
+			if err == db.ErrNotFound {
 				http.Error(w, err.Error(), http.StatusNotFound)
 			} else {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -129,7 +128,7 @@ func restUpdateAddressable(w http.ResponseWriter, r *http.Request) {
 
 	if err := dbClient.UpdateAddressable(&ra, &res); err != nil {
 		loggingClient.Error(err.Error(), "")
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -149,7 +148,7 @@ func restGetAddressableById(w http.ResponseWriter, r *http.Request) {
 	var id string = vars["id"]
 	var result models.Addressable
 	if err := dbClient.GetAddressableById(&result, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			loggingClient.Error(err.Error(), "")
@@ -189,7 +188,7 @@ func restDeleteAddressableById(w http.ResponseWriter, r *http.Request) {
 
 	err = dbClient.DeleteAddressable(a)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			loggingClient.Error(err.Error(), "")
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
@@ -239,7 +238,7 @@ func restDeleteAddressableByName(w http.ResponseWriter, r *http.Request) {
 
 	if err := dbClient.DeleteAddressable(a); err != nil {
 		loggingClient.Error(err.Error(), "")
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -289,7 +288,7 @@ func restGetAddressableByName(w http.ResponseWriter, r *http.Request) {
 	var result models.Addressable
 	if err := dbClient.GetAddressableByName(&result, dn); err != nil {
 		loggingClient.Error(err.Error(), "")
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -314,7 +313,7 @@ func restGetAddressableByTopic(w http.ResponseWriter, r *http.Request) {
 	err = dbClient.GetAddressablesByTopic(&res, t)
 	if err != nil {
 		loggingClient.Error(err.Error(), "")
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)

--- a/core/metadata/rest_command.go
+++ b/core/metadata/rest_command.go
@@ -22,7 +22,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/core/db"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/gorilla/mux"
-	"gopkg.in/mgo.v2"
 )
 
 func restGetAllCommands(w http.ResponseWriter, _ *http.Request) {
@@ -186,7 +185,7 @@ func restDeleteCommandById(w http.ResponseWriter, r *http.Request) {
 
 	if err := dbClient.DeleteCommandById(id); err != nil {
 		loggingClient.Error(err.Error(), "")
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else if err == db.ErrCommandStillInUse {
 			http.Error(w, err.Error(), http.StatusConflict)

--- a/core/metadata/rest_device.go
+++ b/core/metadata/rest_device.go
@@ -26,7 +26,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	notifications "github.com/edgexfoundry/edgex-go/support/notifications-client"
 	"github.com/gorilla/mux"
-	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -257,14 +256,14 @@ func updateDeviceFields(from models.Device, to *models.Device) error {
 		err := dbClient.GetDeviceByName(&checkD, from.Name)
 		if err != nil {
 			// A problem occurred accessing database
-			if err != mgo.ErrNotFound {
+			if err != db.ErrNotFound {
 				loggingClient.Error(err.Error(), "")
 				return err
 			}
 		}
 
 		// Found a device, make sure its the one we're trying to update
-		if err != mgo.ErrNotFound {
+		if err != db.ErrNotFound {
 			// Different IDs -> Name is not unique
 			if checkD.Id != to.Id {
 				err = errors.New("Duplicate name for Device")
@@ -306,7 +305,7 @@ func restGetDeviceByProfileId(w http.ResponseWriter, r *http.Request) {
 	var dp models.DeviceProfile
 	err := dbClient.GetDeviceProfileById(&dp, pid)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -336,7 +335,7 @@ func restGetDeviceByServiceId(w http.ResponseWriter, r *http.Request) {
 	var ds models.DeviceService
 	err := dbClient.GetDeviceServiceById(&ds, sid)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -370,7 +369,7 @@ func restGetDeviceByServiceName(w http.ResponseWriter, r *http.Request) {
 	var ds models.DeviceService
 	err = dbClient.GetDeviceServiceByName(&ds, sn)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -406,7 +405,7 @@ func restGetDeviceByAddressableName(w http.ResponseWriter, r *http.Request) {
 	var a models.Addressable
 	err = dbClient.GetAddressableByName(&a, an)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -442,7 +441,7 @@ func restGetDeviceByProfileName(w http.ResponseWriter, r *http.Request) {
 	var dp models.DeviceProfile
 	err = dbClient.GetDeviceProfileByName(&dp, pn)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -473,7 +472,7 @@ func restGetDeviceByAddressableId(w http.ResponseWriter, r *http.Request) {
 	var a models.Addressable
 	err := dbClient.GetAddressableById(&a, aid)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -500,7 +499,7 @@ func restGetDeviceById(w http.ResponseWriter, r *http.Request) {
 	var res models.Device
 	if err := dbClient.GetDeviceById(&res, did); err != nil {
 		loggingClient.Error(err.Error(), "")
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -518,7 +517,7 @@ func restCheckForDevice(w http.ResponseWriter, r *http.Request) {
 	dev := models.Device{}
 	//Check for name first since we're using that meaning by default.
 	if err := dbClient.GetDeviceByName(&dev, token); err != nil {
-		if err != mgo.ErrNotFound {
+		if err != db.ErrNotFound {
 			loggingClient.Error(err.Error(), "restCheckForDevice")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -531,7 +530,7 @@ func restCheckForDevice(w http.ResponseWriter, r *http.Request) {
 		if bson.IsObjectIdHex(token) {
 			if err := dbClient.GetDeviceById(&dev, token); err != nil {
 				loggingClient.Error(err.Error(), "restCheckForDevice")
-				if err == mgo.ErrNotFound {
+				if err == db.ErrNotFound {
 					http.Error(w, err.Error(), http.StatusNotFound)
 				} else {
 					http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -564,7 +563,7 @@ func restSetDeviceOpStateById(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	err := dbClient.GetDeviceById(&d, did)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -614,7 +613,7 @@ func restSetDeviceOpStateByName(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	err = dbClient.GetDeviceByName(&d, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -654,7 +653,7 @@ func restSetDeviceAdminStateById(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	err := dbClient.GetDeviceById(&d, did)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -704,7 +703,7 @@ func restSetDeviceAdminStateByName(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	err = dbClient.GetDeviceByName(&d, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -740,7 +739,7 @@ func restDeleteDeviceById(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	//err := getDeviceById(&d, did)
 	if err := dbClient.GetDeviceById(&d, did); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -842,7 +841,7 @@ func restSetDeviceLastConnectedById(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	err = dbClient.GetDeviceById(&d, did)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -882,7 +881,7 @@ func restSetLastConnectedByIdNotify(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	err = dbClient.GetDeviceById(&d, did)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -920,7 +919,7 @@ func restSetDeviceLastConnectedByName(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	err = dbClient.GetDeviceByName(&d, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -964,7 +963,7 @@ func restSetDeviceLastConnectedByNameNotify(w http.ResponseWriter, r *http.Reque
 	var d models.Device
 	err = dbClient.GetDeviceByName(&d, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -1013,7 +1012,7 @@ func restSetDeviceLastReportedById(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	err = dbClient.GetDeviceById(&d, did)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -1052,7 +1051,7 @@ func restSetDeviceLastReportedByIdNotify(w http.ResponseWriter, r *http.Request)
 	var d models.Device
 	err = dbClient.GetDeviceById(&d, did)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -1090,7 +1089,7 @@ func restSetDeviceLastReportedByName(w http.ResponseWriter, r *http.Request) {
 	var d models.Device
 	err = dbClient.GetDeviceByName(&d, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -1134,7 +1133,7 @@ func restSetDeviceLastReportedByNameNotify(w http.ResponseWriter, r *http.Reques
 	var d models.Device
 	err = dbClient.GetDeviceByName(&d, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -1179,7 +1178,7 @@ func restGetDeviceByName(w http.ResponseWriter, r *http.Request) {
 	var res models.Device
 	err = dbClient.GetDeviceByName(&res, dn)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)

--- a/core/metadata/rest_deviceprofile.go
+++ b/core/metadata/rest_deviceprofile.go
@@ -23,7 +23,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/core/db"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/gorilla/mux"
-	"gopkg.in/mgo.v2"
 	"gopkg.in/yaml.v2"
 )
 
@@ -254,7 +253,7 @@ func restGetProfileByProfileId(w http.ResponseWriter, r *http.Request) {
 	var did string = vars["id"]
 	var res models.DeviceProfile
 	if err := dbClient.GetDeviceProfileById(&res, did); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -273,7 +272,7 @@ func restDeleteProfileByProfileId(w http.ResponseWriter, r *http.Request) {
 	// Check if the device profile exists
 	var dp models.DeviceProfile
 	if err := dbClient.GetDeviceProfileById(&dp, did); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -305,7 +304,7 @@ func restDeleteProfileByName(w http.ResponseWriter, r *http.Request) {
 	// Check if the device profile exists
 	var dp models.DeviceProfile
 	if err = dbClient.GetDeviceProfileByName(&dp, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -544,7 +543,7 @@ func restGetProfileByName(w http.ResponseWriter, r *http.Request) {
 	// Get the device
 	var res models.DeviceProfile
 	if err := dbClient.GetDeviceProfileByName(&res, dn); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -571,7 +570,7 @@ func restGetYamlProfileByName(w http.ResponseWriter, r *http.Request) {
 	err = dbClient.GetDeviceProfileByName(&dp, name)
 	if err != nil {
 		// Not found, return nil
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -608,7 +607,7 @@ func restGetYamlProfileById(w http.ResponseWriter, r *http.Request) {
 	var dp models.DeviceProfile
 	err := dbClient.GetDeviceProfileById(&dp, id)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(nil))
 			return

--- a/core/metadata/rest_devicereport.go
+++ b/core/metadata/rest_devicereport.go
@@ -22,7 +22,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/core/db"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/gorilla/mux"
-	mgo "gopkg.in/mgo.v2"
 )
 
 func restGetAllDeviceReports(w http.ResponseWriter, _ *http.Request) {
@@ -61,7 +60,7 @@ func restAddDeviceReport(w http.ResponseWriter, r *http.Request) {
 	// Check if the device exists
 	var d models.Device
 	if err := dbClient.GetDeviceByName(&d, dr.Device); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device referenced by Device Report doesn't exist", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -73,7 +72,7 @@ func restAddDeviceReport(w http.ResponseWriter, r *http.Request) {
 	// Check if the Schedule Event exists
 	var se models.ScheduleEvent
 	if err := dbClient.GetScheduleEventByName(&se, dr.Event); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Schedule Event referenced by Device Report doesn't exist", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -117,7 +116,7 @@ func restUpdateDeviceReport(w http.ResponseWriter, r *http.Request) {
 	if err := dbClient.GetDeviceReportById(&to, from.Id.Hex()); err != nil {
 		// Try by name
 		if err = dbClient.GetDeviceReportByName(&to, from.Name); err != nil {
-			if err == mgo.ErrNotFound {
+			if err == db.ErrNotFound {
 				http.Error(w, err.Error(), http.StatusNotFound)
 			} else {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -179,7 +178,7 @@ func updateDeviceReportFields(from models.DeviceReport, to *models.DeviceReport,
 func validateDevice(d string, w http.ResponseWriter) error {
 	var device models.Device
 	if err := dbClient.GetDeviceByName(&device, d); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device was not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -194,7 +193,7 @@ func validateDevice(d string, w http.ResponseWriter) error {
 func validateEvent(e string, w http.ResponseWriter) error {
 	var event models.ScheduleEvent
 	if err := dbClient.GetScheduleEventByName(&event, e); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Event was not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -211,7 +210,7 @@ func restGetReportById(w http.ResponseWriter, r *http.Request) {
 	var res models.DeviceReport
 	err := dbClient.GetDeviceReportById(&res, did)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -236,7 +235,7 @@ func restGetReportByName(w http.ResponseWriter, r *http.Request) {
 	var res models.DeviceReport
 	err = dbClient.GetDeviceReportByName(&res, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -306,7 +305,7 @@ func restDeleteReportById(w http.ResponseWriter, r *http.Request) {
 	// Check if the device report exists
 	var dr models.DeviceReport
 	if err := dbClient.GetDeviceReportById(&dr, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -336,7 +335,7 @@ func restDeleteReportByName(w http.ResponseWriter, r *http.Request) {
 	// Check if the device report exists
 	var dr models.DeviceReport
 	if err = dbClient.GetDeviceReportByName(&dr, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)

--- a/core/metadata/rest_deviceservice.go
+++ b/core/metadata/rest_deviceservice.go
@@ -24,7 +24,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/core/db"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/gorilla/mux"
-	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -37,7 +36,7 @@ func getAddressableByIdOrName(a *models.Addressable, w http.ResponseWriter) erro
 	if err := dbClient.GetAddressableById(a, id.Hex()); err != nil {
 		// Try by name
 		if err = dbClient.GetAddressableByName(a, name); err != nil {
-			if err == mgo.ErrNotFound {
+			if err == db.ErrNotFound {
 				http.Error(w, "Addressable not found", http.StatusServiceUnavailable)
 			} else {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -92,7 +91,7 @@ func restAddDeviceService(w http.ResponseWriter, r *http.Request) {
 	// First try by name
 	err = dbClient.GetAddressableByName(&ds.Service.Addressable, ds.Service.Addressable.Name)
 	if err != nil {
-		if err != mgo.ErrNotFound {
+		if err != db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			loggingClient.Error(err.Error(), "")
 		}
@@ -135,7 +134,7 @@ func restGetAddressablesForAssociatedDevicesById(w http.ResponseWriter, r *http.
 
 	// Check if the device service exists
 	if err := dbClient.GetDeviceServiceById(&ds, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -169,7 +168,7 @@ func restGetAddressablesForAssociatedDevicesByName(w http.ResponseWriter, r *htt
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -288,14 +287,14 @@ func updateDeviceServiceFields(from models.DeviceService, to *models.DeviceServi
 		err := dbClient.GetDeviceServiceByName(&checkDS, from.Service.Name)
 		if err != nil {
 			// A problem occurred accessing database
-			if err != mgo.ErrNotFound {
+			if err != db.ErrNotFound {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return err
 			}
 		}
 
 		// Found a device service, make sure its the one we're trying to update
-		if err != mgo.ErrNotFound {
+		if err != db.ErrNotFound {
 			// Different IDs -> Name is not unique
 			if checkDS.Service.Id != to.Service.Id {
 				err = errors.New("Duplicate name for Device Service")
@@ -334,7 +333,7 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 	// Check if the addressable exists
 	var a models.Addressable
 	if err = dbClient.GetAddressableByName(&a, an); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Addressable not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -361,7 +360,7 @@ func restGetServiceByAddressableId(w http.ResponseWriter, r *http.Request) {
 	// Check if the Addressable exists
 	var a models.Addressable
 	if err := dbClient.GetAddressableById(&a, sid); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Addressable not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -412,7 +411,7 @@ func restGetServiceByName(w http.ResponseWriter, r *http.Request) {
 	var res models.DeviceService
 	err = dbClient.GetDeviceServiceByName(&res, dn)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -432,7 +431,7 @@ func restDeleteServiceById(w http.ResponseWriter, r *http.Request) {
 	// Check if the device service exists and get it
 	var ds models.DeviceService
 	if err := dbClient.GetDeviceServiceById(&ds, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -461,7 +460,7 @@ func restDeleteServiceByName(w http.ResponseWriter, r *http.Request) {
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -531,7 +530,7 @@ func restUpdateServiceLastConnectedById(w http.ResponseWriter, r *http.Request) 
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceById(&ds, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -568,7 +567,7 @@ func restUpdateServiceLastConnectedByName(w http.ResponseWriter, r *http.Request
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -605,7 +604,7 @@ func restGetServiceById(w http.ResponseWriter, r *http.Request) {
 	var res models.DeviceService
 
 	if err := dbClient.GetDeviceServiceById(&res, did); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -635,7 +634,7 @@ func restUpdateServiceOpStateById(w http.ResponseWriter, r *http.Request) {
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err := dbClient.GetDeviceServiceById(&ds, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -675,7 +674,7 @@ func restUpdateServiceOpStateByName(w http.ResponseWriter, r *http.Request) {
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -721,7 +720,7 @@ func restUpdateServiceAdminStateById(w http.ResponseWriter, r *http.Request) {
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err := dbClient.GetDeviceServiceById(&ds, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -762,7 +761,7 @@ func restUpdateServiceAdminStateByName(w http.ResponseWriter, r *http.Request) {
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -806,7 +805,7 @@ func restUpdateServiceLastReportedById(w http.ResponseWriter, r *http.Request) {
 	// Check if the devicde service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceById(&ds, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -843,7 +842,7 @@ func restUpdateServiceLastReportedByName(w http.ResponseWriter, r *http.Request)
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)

--- a/core/metadata/rest_provisionwatcher.go
+++ b/core/metadata/rest_provisionwatcher.go
@@ -22,7 +22,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/core/db"
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/gorilla/mux"
-	"gopkg.in/mgo.v2"
 )
 
 func restGetProvisionWatchers(w http.ResponseWriter, _ *http.Request) {
@@ -78,7 +77,7 @@ func restDeleteProvisionWatcherByName(w http.ResponseWriter, r *http.Request) {
 	// Check if the provision watcher exists
 	var pw models.ProvisionWatcher
 	if err = dbClient.GetProvisionWatcherByName(&pw, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			errMessage := "Provision watcher not found: " + err.Error()
 			http.Error(w, errMessage, http.StatusNotFound)
 			loggingClient.Error(errMessage, "")
@@ -118,7 +117,7 @@ func restGetProvisionWatcherById(w http.ResponseWriter, r *http.Request) {
 	var res models.ProvisionWatcher
 
 	if err := dbClient.GetProvisionWatcherById(&res, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			errMessage := "Problem getting provision watcher by ID: " + err.Error()
 			loggingClient.Error(errMessage, "")
 			http.Error(w, errMessage, http.StatusNotFound)
@@ -145,7 +144,7 @@ func restGetProvisionWatcherByName(w http.ResponseWriter, r *http.Request) {
 
 	err = dbClient.GetProvisionWatcherByName(&res, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			loggingClient.Error("Provision watcher not found: "+err.Error(), "")
 		} else {
@@ -193,7 +192,7 @@ func restGetProvisionWatchersByProfileName(w http.ResponseWriter, r *http.Reques
 	// Check if the device profile exists
 	var dp models.DeviceProfile
 	if err = dbClient.GetDeviceProfileByName(&dp, pn); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device profile not found", http.StatusNotFound)
 			loggingClient.Error("Device profile not found: "+err.Error(), "")
 		} else {
@@ -249,7 +248,7 @@ func restGetProvisionWatchersByServiceName(w http.ResponseWriter, r *http.Reques
 	// Check if the device service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceByName(&ds, sn); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 			loggingClient.Error("Device service not found: "+err.Error(), "")
 		} else {
@@ -318,7 +317,7 @@ func restAddProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	if err := dbClient.GetDeviceProfileById(&pw.Profile, pw.Profile.Id.Hex()); err != nil {
 		// Try by name
 		if err = dbClient.GetDeviceProfileByName(&pw.Profile, pw.Profile.Name); err != nil {
-			if err == mgo.ErrNotFound {
+			if err == db.ErrNotFound {
 				loggingClient.Error("Device profile not found for provision watcher: "+err.Error(), "")
 				http.Error(w, "Device profile not found for provision watcher", http.StatusConflict)
 			} else {
@@ -334,7 +333,7 @@ func restAddProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	if err := dbClient.GetDeviceServiceById(&pw.Service, pw.Service.Service.Id.Hex()); err != nil {
 		// Try by name
 		if err = dbClient.GetDeviceServiceByName(&pw.Service, pw.Service.Service.Name); err != nil {
-			if err == mgo.ErrNotFound {
+			if err == db.ErrNotFound {
 				http.Error(w, "Device service not found for provision watcher", http.StatusConflict)
 				loggingClient.Error("Device service not found for provision watcher: "+err.Error(), "")
 			} else {
@@ -383,7 +382,7 @@ func restUpdateProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	if err := dbClient.GetProvisionWatcherById(&to, from.Id.Hex()); err != nil {
 		// Try by name
 		if err = dbClient.GetProvisionWatcherByName(&to, from.Name); err != nil {
-			if err == mgo.ErrNotFound {
+			if err == db.ErrNotFound {
 				http.Error(w, "Provision watcher not found", http.StatusNotFound)
 				loggingClient.Error("Provision watcher not found: "+err.Error(), "")
 			} else {
@@ -427,13 +426,13 @@ func updateProvisionWatcherFields(from models.ProvisionWatcher, to *models.Provi
 		var checkPW models.ProvisionWatcher
 		err := dbClient.GetProvisionWatcherByName(&checkPW, from.Name)
 		if err != nil {
-			if err != mgo.ErrNotFound {
+			if err != db.ErrNotFound {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return err
 			}
 		}
 		// Found one, compare the IDs to see if its another provision watcher
-		if err != mgo.ErrNotFound {
+		if err != db.ErrNotFound {
 			if checkPW.Id != to.Id {
 				err = errors.New("Duplicate name for the provision watcher")
 				http.Error(w, err.Error(), http.StatusConflict)

--- a/core/metadata/rest_scheduleevent.go
+++ b/core/metadata/rest_scheduleevent.go
@@ -25,7 +25,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/core/domain/models"
 	"github.com/gorilla/mux"
 	"github.com/robfig/cron"
-	"gopkg.in/mgo.v2"
 )
 
 func isIntervalValid(frequency string) bool {
@@ -83,7 +82,7 @@ func restAddScheduleEvent(w http.ResponseWriter, r *http.Request) {
 	}
 	var s models.Schedule
 	if err := dbClient.GetScheduleByName(&s, se.Schedule); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Schedule not found for schedule event", http.StatusNotFound)
 			loggingClient.Error("Schedule not found for schedule event: "+err.Error(), "")
 		} else {
@@ -198,7 +197,7 @@ func getScheduleEventByIdOrName(from models.ScheduleEvent, w http.ResponseWriter
 	if err := dbClient.GetScheduleEventById(&se, from.Id.Hex()); err != nil {
 		// Try by Name
 		if err = dbClient.GetScheduleEventByName(&se, from.Name); err != nil {
-			if err == mgo.ErrNotFound {
+			if err == db.ErrNotFound {
 				http.Error(w, "Schedule Event not found", http.StatusNotFound)
 				loggingClient.Error(err.Error(), "")
 			} else {
@@ -225,7 +224,7 @@ func updateScheduleEventFields(from models.ScheduleEvent, to *models.ScheduleEve
 		if err := dbClient.GetAddressableById(&from.Addressable, from.Addressable.Id.Hex()); err != nil {
 			// Try by name
 			if err = dbClient.GetAddressableByName(&from.Addressable, from.Addressable.Name); err != nil {
-				if err == mgo.ErrNotFound {
+				if err == db.ErrNotFound {
 					http.Error(w, "Addressable not found for schedule event", http.StatusNotFound)
 				} else {
 					http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -242,7 +241,7 @@ func updateScheduleEventFields(from models.ScheduleEvent, to *models.ScheduleEve
 			// Verify that the new service exists
 			var checkDS models.DeviceService
 			if err := dbClient.GetDeviceServiceByName(&checkDS, from.Service); err != nil {
-				if err == mgo.ErrNotFound {
+				if err == db.ErrNotFound {
 					http.Error(w, "Device Service not found for schedule event", http.StatusNotFound)
 				} else {
 					http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -259,7 +258,7 @@ func updateScheduleEventFields(from models.ScheduleEvent, to *models.ScheduleEve
 			// Verify that the new schedule exists
 			var checkS models.Schedule
 			if err := dbClient.GetScheduleByName(&checkS, from.Schedule); err != nil {
-				if err == mgo.ErrNotFound {
+				if err == db.ErrNotFound {
 					http.Error(w, "Schedule not found for schedule event", http.StatusNotFound)
 				} else {
 					http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -323,7 +322,7 @@ func restGetScheduleEventByName(w http.ResponseWriter, r *http.Request) {
 	var res models.ScheduleEvent
 	err = dbClient.GetScheduleEventByName(&res, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Schedule event not found", http.StatusNotFound)
 			loggingClient.Error("Schedule event not found: "+err.Error(), "")
 		} else {
@@ -372,7 +371,7 @@ func restDeleteScheduleEventByName(w http.ResponseWriter, r *http.Request) {
 	// Check if the schedule event exists
 	var se models.ScheduleEvent
 	if err := dbClient.GetScheduleEventByName(&se, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Schedule event not found", http.StatusNotFound)
 			loggingClient.Error("Schedule event not found: "+err.Error(), "")
 		} else {
@@ -426,7 +425,7 @@ func restGetScheduleEventById(w http.ResponseWriter, r *http.Request) {
 	var res models.ScheduleEvent
 	err := dbClient.GetScheduleEventById(&res, did)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Schedule event not found", http.StatusNotFound)
 			loggingClient.Error("Schedule event not found: "+err.Error(), "")
 		} else {
@@ -449,7 +448,7 @@ func restGetScheduleEventByAddressableId(w http.ResponseWriter, r *http.Request)
 	// Check if the addressable exists
 	var a models.Addressable
 	if err := dbClient.GetAddressableById(&a, aid); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Addressable not found for schedule event", http.StatusNotFound)
 			loggingClient.Error("Addressable not found for schedule event: "+err.Error(), "")
 		} else {
@@ -485,7 +484,7 @@ func restGetScheduleEventByAddressableName(w http.ResponseWriter, r *http.Reques
 	// Check if the addressable exists
 	var a models.Addressable
 	if err = dbClient.GetAddressableByName(&a, an); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			loggingClient.Error("Addressable not found for schedule event: "+err.Error(), "")
 			http.Error(w, "Addressable not found for schedule event", http.StatusNotFound)
 		} else {
@@ -521,7 +520,7 @@ func restGetScheduleEventsByServiceName(w http.ResponseWriter, r *http.Request) 
 	// Check if the service exists
 	var ds models.DeviceService
 	if err = dbClient.GetDeviceServiceByName(&ds, sn); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Service not found for schedule event", http.StatusNotFound)
 			loggingClient.Error("Device service not found for schedule event: "+err.Error(), "")
 		} else {
@@ -577,7 +576,7 @@ func restAddSchedule(w http.ResponseWriter, r *http.Request) {
 	// Check if the name is unique
 	var checkS models.Schedule
 	if err := dbClient.GetScheduleByName(&checkS, s.Name); err != nil {
-		if err != mgo.ErrNotFound {
+		if err != db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			loggingClient.Error("Schedule not found: "+err.Error(), "")
 			return
@@ -711,7 +710,7 @@ func updateScheduleFields(from models.Schedule, to *models.Schedule, w http.Resp
 		// Check if new name is unique
 		var checkS models.Schedule
 		if err := dbClient.GetScheduleByName(&checkS, from.Name); err != nil {
-			if err != mgo.ErrNotFound {
+			if err != db.ErrNotFound {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			}
 		} else {
@@ -747,7 +746,7 @@ func restGetScheduleById(w http.ResponseWriter, r *http.Request) {
 	var res models.Schedule
 	err := dbClient.GetScheduleById(&res, sid)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Schedule not found", http.StatusNotFound)
 			loggingClient.Error("Schedule not found: "+err.Error(), "")
 		} else {
@@ -773,7 +772,7 @@ func restGetScheduleByName(w http.ResponseWriter, r *http.Request) {
 	var res models.Schedule
 	err = dbClient.GetScheduleByName(&res, n)
 	if err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Schedule not found", http.StatusNotFound)
 			loggingClient.Error("Schedule not found: "+err.Error(), "")
 		} else {
@@ -794,7 +793,7 @@ func restDeleteScheduleById(w http.ResponseWriter, r *http.Request) {
 	// Check if the schedule exists
 	var s models.Schedule
 	if err := dbClient.GetScheduleById(&s, id); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			http.Error(w, "Schedule not found", http.StatusNotFound)
 			loggingClient.Error("Schedule not found: "+err.Error(), "")
 		} else {
@@ -825,7 +824,7 @@ func restDeleteScheduleByName(w http.ResponseWriter, r *http.Request) {
 	// Check if the schedule exists
 	var s models.Schedule
 	if err = dbClient.GetScheduleByName(&s, n); err != nil {
-		if err == mgo.ErrNotFound {
+		if err == db.ErrNotFound {
 			loggingClient.Error("Schedule not found: "+err.Error(), "")
 			http.Error(w, "Schedule not found", http.StatusNotFound)
 		} else {


### PR DESCRIPTION
Fixing issue added in #298
Metadata is checking if the error is ErrNotFound using the mongo error instead of the error defined in core/db which is returned.
Also added tests to verify that db.ErrNotFound is returned.