### PR TITLE
Modified delete methods in core-metadata

### DIFF
--- a/core/db/memory/metadata.go
+++ b/core/db/memory/metadata.go
@@ -152,9 +152,9 @@ func (m *MemDB) GetScheduleEventsByServiceName(ses *[]models.ScheduleEvent, n st
 	return nil
 }
 
-func (m *MemDB) DeleteScheduleEvent(se models.ScheduleEvent) error {
+func (m *MemDB) DeleteScheduleEventById(id string) error {
 	for i, s := range m.scheduleEvents {
-		if s.Id == se.Id {
+		if s.Id.Hex() == id {
 			m.scheduleEvents = append(m.scheduleEvents[:i], m.scheduleEvents[i+1:]...)
 			return nil
 		}
@@ -218,9 +218,9 @@ func (m *MemDB) GetScheduleById(s *models.Schedule, id string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) DeleteSchedule(s models.Schedule) error {
+func (m *MemDB) DeleteScheduleById(id string) error {
 	for i, ss := range m.schedules {
-		if ss.Id.Hex() == s.Id.Hex() {
+		if ss.Id.Hex() == id {
 			m.schedules = append(m.schedules[:i], m.schedules[i+1:]...)
 			return nil
 		}
@@ -304,9 +304,9 @@ func (m *MemDB) GetDeviceReportsByScheduleEventName(drs *[]models.DeviceReport, 
 	return nil
 }
 
-func (m *MemDB) DeleteDeviceReport(dr models.DeviceReport) error {
+func (m *MemDB) DeleteDeviceReportById(id string) error {
 	for i, c := range m.deviceReports {
-		if c.Id == dr.Id {
+		if c.Id.Hex() == id {
 			m.deviceReports = append(m.deviceReports[:i], m.deviceReports[i+1:]...)
 			return nil
 		}
@@ -455,9 +455,9 @@ func (m *MemDB) AddDevice(d *models.Device) error {
 	return nil
 }
 
-func (m *MemDB) DeleteDevice(d models.Device) error {
+func (m *MemDB) DeleteDeviceById(id string) error {
 	for i, dd := range m.devices {
-		if dd.Id.Hex() == d.Id.Hex() {
+		if dd.Id.Hex() == id {
 			m.devices = append(m.devices[:i], m.devices[i+1:]...)
 			return nil
 		}
@@ -508,9 +508,9 @@ func (m *MemDB) GetDeviceProfileById(d *models.DeviceProfile, id string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) DeleteDeviceProfile(dp models.DeviceProfile) error {
+func (m *MemDB) DeleteDeviceProfileById(id string) error {
 	for i, d := range m.deviceProfiles {
-		if d.Id == dp.Id {
+		if d.Id.Hex() == id {
 			m.deviceProfiles = append(m.deviceProfiles[:i], m.deviceProfiles[i+1:]...)
 			return nil
 		}
@@ -706,9 +706,9 @@ func (m *MemDB) GetAddressables(d *[]models.Addressable) error {
 	return nil
 }
 
-func (m *MemDB) DeleteAddressable(a models.Addressable) error {
+func (m *MemDB) DeleteAddressableById(id string) error {
 	for i, aa := range m.addressables {
-		if aa.Id.Hex() == a.Id.Hex() {
+		if aa.Id.Hex() == id {
 			m.addressables = append(m.addressables[:i], m.addressables[i+1:]...)
 			return nil
 		}
@@ -836,9 +836,9 @@ func (m *MemDB) AddDeviceService(ds *models.DeviceService) error {
 	return nil
 }
 
-func (m *MemDB) DeleteDeviceService(ds models.DeviceService) error {
+func (m *MemDB) DeleteDeviceServiceById(id string) error {
 	for i, d := range m.deviceServices {
-		if d.Id == ds.Id {
+		if d.Id.Hex() == id {
 			m.deviceServices = append(m.deviceServices[:i], m.deviceServices[i+1:]...)
 			return nil
 		}
@@ -1005,9 +1005,9 @@ func (m *MemDB) UpdateProvisionWatcher(pw models.ProvisionWatcher) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) DeleteProvisionWatcher(pw models.ProvisionWatcher) error {
+func (m *MemDB) DeleteProvisionWatcherById(id string) error {
 	for i, p := range m.provisionWatchers {
-		if p.Id.Hex() == pw.Id.Hex() {
+		if p.Id.Hex() == id {
 			m.provisionWatchers = append(m.provisionWatchers[:i], m.provisionWatchers[i+1:]...)
 			return nil
 		}

--- a/core/db/mongo/metadata.go
+++ b/core/db/mongo/metadata.go
@@ -129,8 +129,8 @@ func (m *MongoClient) GetScheduleEvents(se *[]models.ScheduleEvent, q bson.M) er
 	return nil
 }
 
-func (m *MongoClient) DeleteScheduleEvent(se models.ScheduleEvent) error {
-	return m.deleteById(db.ScheduleEvent, se.Id.Hex())
+func (m *MongoClient) DeleteScheduleEventById(id string) error {
+	return m.deleteById(db.ScheduleEvent, id)
 }
 
 //  --------------------------Schedule ---------------------------*/
@@ -183,8 +183,8 @@ func (m *MongoClient) UpdateSchedule(sch models.Schedule) error {
 	return nil
 }
 
-func (m *MongoClient) DeleteSchedule(s models.Schedule) error {
-	return m.deleteById(db.Schedule, s.Id.Hex())
+func (m *MongoClient) DeleteScheduleById(id string) error {
+	return m.deleteById(db.Schedule, id)
 }
 
 func (m *MongoClient) GetSchedule(sch *models.Schedule, q bson.M) error {
@@ -265,8 +265,8 @@ func (m *MongoClient) UpdateDeviceReport(dr *models.DeviceReport) error {
 	return col.UpdateId(dr.Id, dr)
 }
 
-func (m *MongoClient) DeleteDeviceReport(dr models.DeviceReport) error {
-	return m.deleteById(db.DeviceReport, dr.Id.Hex())
+func (m *MongoClient) DeleteDeviceReportById(id string) error {
+	return m.deleteById(db.DeviceReport, id)
 }
 
 /* ----------------------------- Device ---------------------------------- */
@@ -305,8 +305,8 @@ func (m *MongoClient) UpdateDevice(rd models.Device) error {
 	return c.UpdateId(rd.Id, md)
 }
 
-func (m *MongoClient) DeleteDevice(d models.Device) error {
-	return m.deleteById(db.Device, d.Id.Hex())
+func (m *MongoClient) DeleteDeviceById(id string) error {
+	return m.deleteById(db.Device, id)
 }
 
 func (m *MongoClient) GetAllDevices(d *[]models.Device) error {
@@ -508,8 +508,8 @@ func (m *MongoClient) GetDeviceProfilesUsingCommand(dp *[]models.DeviceProfile, 
 	return m.GetDeviceProfiles(dp, query)
 }
 
-func (m *MongoClient) DeleteDeviceProfile(dp models.DeviceProfile) error {
-	return m.deleteById(db.DeviceProfile, dp.Id.Hex())
+func (m *MongoClient) DeleteDeviceProfileById(id string) error {
+	return m.deleteById(db.DeviceProfile, id)
 }
 
 //  -----------------------------------Addressable --------------------------*/
@@ -631,8 +631,8 @@ func (m *MongoClient) GetAddressable(d *models.Addressable, q bson.M) error {
 	return nil
 }
 
-func (m *MongoClient) DeleteAddressable(a models.Addressable) error {
-	return m.deleteById(db.Addressable, a.Id.Hex())
+func (m *MongoClient) DeleteAddressableById(id string) error {
+	return m.deleteById(db.Addressable, id)
 }
 
 /* ----------------------------- Device Service ----------------------------------*/
@@ -727,8 +727,8 @@ func (m *MongoClient) UpdateDeviceService(deviceService models.DeviceService) er
 	return c.UpdateId(deviceService.Id, mds)
 }
 
-func (m *MongoClient) DeleteDeviceService(ds models.DeviceService) error {
-	return m.deleteById(db.DeviceService, ds.Id.Hex())
+func (m *MongoClient) DeleteDeviceServiceById(id string) error {
+	return m.deleteById(db.DeviceService, id)
 }
 
 //  ----------------------Provision Watcher -----------------------------*/
@@ -867,8 +867,8 @@ func (m *MongoClient) UpdateProvisionWatcher(pw models.ProvisionWatcher) error {
 	return c.UpdateId(mpw.Id, mpw)
 }
 
-func (m *MongoClient) DeleteProvisionWatcher(pw models.ProvisionWatcher) error {
-	return m.deleteById(db.ProvisionWatcher, pw.Id.Hex())
+func (m *MongoClient) DeleteProvisionWatcherById(id string) error {
+	return m.deleteById(db.ProvisionWatcher, id)
 }
 
 //  ------------------------Command -------------------------------------*/

--- a/core/db/test/db_metadata.go
+++ b/core/db/test/db_metadata.go
@@ -307,7 +307,7 @@ func clearAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error getting addressables %v", err)
 	}
 	for _, a := range addrs {
-		if err = db.DeleteAddressable(a); err != nil {
+		if err = db.DeleteAddressableById(a.Id.Hex()); err != nil {
 			t.Fatalf("Error removing addressable %v: %v", a, err)
 		}
 	}
@@ -320,7 +320,7 @@ func clearDevices(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error getting devices %v", err)
 	}
 	for _, d := range ds {
-		if err = db.DeleteDevice(d); err != nil {
+		if err = db.DeleteDeviceById(d.Id.Hex()); err != nil {
 			t.Fatalf("Error removing device %v: %v", d, err)
 		}
 	}
@@ -333,7 +333,7 @@ func clearSchedules(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error getting schedule %v", err)
 	}
 	for _, s := range ss {
-		if err = db.DeleteSchedule(s); err != nil {
+		if err = db.DeleteScheduleById(s.Id.Hex()); err != nil {
 			t.Fatalf("Error removing schedule %v: %v", s, err)
 		}
 	}
@@ -346,7 +346,7 @@ func clearScheduleEvents(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error getting schedule %v", err)
 	}
 	for _, s := range ss {
-		if err = db.DeleteScheduleEvent(s); err != nil {
+		if err = db.DeleteScheduleEventById(s.Id.Hex()); err != nil {
 			t.Fatalf("Error removing schedule %v: %v", s, err)
 		}
 	}
@@ -359,7 +359,7 @@ func clearDeviceServices(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error getting deviceServices %v", err)
 	}
 	for _, ds := range dss {
-		if err = db.DeleteDeviceService(ds); err != nil {
+		if err = db.DeleteDeviceServiceById(ds.Id.Hex()); err != nil {
 			t.Fatalf("Error removing deviceService %v: %v", ds, err)
 		}
 	}
@@ -372,7 +372,7 @@ func clearDeviceReports(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error getting deviceReports %v", err)
 	}
 	for _, ds := range drs {
-		if err = db.DeleteDeviceReport(ds); err != nil {
+		if err = db.DeleteDeviceReportById(ds.Id.Hex()); err != nil {
 			t.Fatalf("Error removing deviceReport %v: %v", ds, err)
 		}
 	}
@@ -386,7 +386,7 @@ func clearDeviceProfiles(t *testing.T, db interfaces.DBClient) {
 	}
 
 	for _, ds := range dps {
-		if err = db.DeleteDeviceProfile(ds); err != nil {
+		if err = db.DeleteDeviceProfileById(ds.Id.Hex()); err != nil {
 			t.Fatalf("Error removing deviceProfile %v: %v", ds, err)
 		}
 	}
@@ -536,7 +536,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 
 	a.Id = "INVALID"
 	a.Name = "INVALID"
-	err = db.DeleteAddressable(a)
+	err = db.DeleteAddressableById(a.Id.Hex())
 	if err == nil {
 		t.Fatalf("Addressable should not be deleted")
 	}
@@ -545,7 +545,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 	if err != nil {
 		t.Fatalf("Error getting addressable")
 	}
-	err = db.DeleteAddressable(a)
+	err = db.DeleteAddressableById(a.Id.Hex())
 	if err != nil {
 		t.Fatalf("Addressable should be deleted: %v", err)
 	}
@@ -722,13 +722,13 @@ func testDBDeviceService(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteDeviceService(ds)
+	err = db.DeleteDeviceServiceById(ds.Id.Hex())
 	if err == nil {
 		t.Fatalf("DeviceService should not be deleted")
 	}
 
 	ds.Id = id
-	err = db.DeleteDeviceService(ds)
+	err = db.DeleteDeviceServiceById(ds.Id.Hex())
 	if err != nil {
 		t.Fatalf("DeviceService should be deleted: %v", err)
 	}
@@ -798,13 +798,13 @@ func testDBSchedule(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteSchedule(e2)
+	err = db.DeleteScheduleById(e2.Id.Hex())
 	if err == nil {
 		t.Fatalf("Schedule should not be deleted")
 	}
 
 	e2.Id = id
-	err = db.DeleteSchedule(e2)
+	err = db.DeleteScheduleById(e2.Id.Hex())
 	if err != nil {
 		t.Fatalf("Schedule should be deleted: %v", err)
 	}
@@ -905,13 +905,13 @@ func testDBDeviceReport(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteDeviceReport(e2)
+	err = db.DeleteDeviceReportById(e2.Id.Hex())
 	if err == nil {
 		t.Fatalf("DeviceReport should not be deleted")
 	}
 
 	e2.Id = id
-	err = db.DeleteDeviceReport(e2)
+	err = db.DeleteDeviceReportById(e2.Id.Hex())
 	if err != nil {
 		t.Fatalf("DeviceReport should be deleted: %v", err)
 	}
@@ -1033,13 +1033,13 @@ func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteScheduleEvent(e)
+	err = db.DeleteScheduleEventById(e.Id.Hex())
 	if err == nil {
 		t.Fatalf("ScheduleEvent should not be deleted")
 	}
 
 	e.Id = id
-	err = db.DeleteScheduleEvent(e)
+	err = db.DeleteScheduleEventById(e.Id.Hex())
 	if err != nil {
 		t.Fatalf("ScheduleEvent should be deleted: %v", err)
 	}
@@ -1192,13 +1192,13 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteDeviceProfile(d2)
+	err = db.DeleteDeviceProfileById(d2.Id.Hex())
 	if err == nil {
 		t.Fatalf("DeviceProfile should not be deleted")
 	}
 
 	d2.Id = id
-	err = db.DeleteDeviceProfile(d2)
+	err = db.DeleteDeviceProfileById(d2.Id.Hex())
 	if err != nil {
 		t.Fatalf("DeviceProfile should be deleted: %v", err)
 	}
@@ -1334,13 +1334,13 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteDevice(d)
+	err = db.DeleteDeviceById(d.Id.Hex())
 	if err == nil {
 		t.Fatalf("Device should not be deleted")
 	}
 
 	d.Id = id
-	err = db.DeleteDevice(d)
+	err = db.DeleteDeviceById(d.Id.Hex())
 	if err != nil {
 		t.Fatalf("Device should be deleted: %v", err)
 	}
@@ -1456,13 +1456,13 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Should return error")
 	}
 
-	err = db.DeleteProvisionWatcher(pw)
+	err = db.DeleteProvisionWatcherById(pw.Id.Hex())
 	if err == nil {
 		t.Fatalf("ProvisionWatcher should not be deleted")
 	}
 
 	pw.Id = id
-	err = db.DeleteProvisionWatcher(pw)
+	err = db.DeleteProvisionWatcherById(pw.Id.Hex())
 	if err != nil {
 		t.Fatalf("ProvisionWatcher should be deleted: %v", err)
 	}

--- a/core/metadata/interfaces/db.go
+++ b/core/metadata/interfaces/db.go
@@ -32,7 +32,7 @@ type DBClient interface {
 	GetScheduleEventsByScheduleName(se *[]models.ScheduleEvent, n string) error
 	GetScheduleEventsByAddressableId(se *[]models.ScheduleEvent, id string) error
 	GetScheduleEventsByServiceName(se *[]models.ScheduleEvent, n string) error
-	DeleteScheduleEvent(se models.ScheduleEvent) error
+	DeleteScheduleEventById(id string) error
 
 	// Schedule
 	GetAllSchedules(s *[]models.Schedule) error
@@ -40,7 +40,7 @@ type DBClient interface {
 	GetScheduleByName(s *models.Schedule, n string) error
 	UpdateSchedule(s models.Schedule) error
 	GetScheduleById(s *models.Schedule, id string) error
-	DeleteSchedule(s models.Schedule) error
+	DeleteScheduleById(id string) error
 
 	// Device Report
 	GetAllDeviceReports(dr *[]models.DeviceReport) error
@@ -50,7 +50,7 @@ type DBClient interface {
 	AddDeviceReport(dr *models.DeviceReport) error
 	UpdateDeviceReport(dr *models.DeviceReport) error
 	GetDeviceReportsByScheduleEventName(dr *[]models.DeviceReport, n string) error
-	DeleteDeviceReport(dr models.DeviceReport) error
+	DeleteDeviceReportById(id string) error
 
 	// Device
 	UpdateDevice(d models.Device) error
@@ -62,12 +62,12 @@ type DBClient interface {
 	GetDevicesByAddressableId(d *[]models.Device, aid string) error
 	GetDevicesWithLabel(d *[]models.Device, l string) error
 	AddDevice(d *models.Device) error
-	DeleteDevice(d models.Device) error
+	DeleteDeviceById(id string) error
 	UpdateDeviceProfile(dp *models.DeviceProfile) error
 	AddDeviceProfile(d *models.DeviceProfile) error
 	GetAllDeviceProfiles(d *[]models.DeviceProfile) error
 	GetDeviceProfileById(d *models.DeviceProfile, id string) error
-	DeleteDeviceProfile(dp models.DeviceProfile) error
+	DeleteDeviceProfileById(id string) error
 	GetDeviceProfilesByModel(dp *[]models.DeviceProfile, m string) error
 	GetDeviceProfilesWithLabel(dp *[]models.DeviceProfile, l string) error
 	GetDeviceProfilesByManufacturerModel(dp *[]models.DeviceProfile, man string, mod string) error
@@ -85,7 +85,7 @@ type DBClient interface {
 	GetAddressablesByPublisher(a *[]models.Addressable, p string) error
 	GetAddressablesByAddress(a *[]models.Addressable, add string) error
 	GetAddressables(d *[]models.Addressable) error
-	DeleteAddressable(a models.Addressable) error
+	DeleteAddressableById(id string) error
 
 	// Device service
 	UpdateDeviceService(ds models.DeviceService) error
@@ -95,7 +95,7 @@ type DBClient interface {
 	GetDeviceServiceByName(d *models.DeviceService, n string) error
 	GetAllDeviceServices(d *[]models.DeviceService) error
 	AddDeviceService(ds *models.DeviceService) error
-	DeleteDeviceService(ds models.DeviceService) error
+	DeleteDeviceServiceById(id string) error
 
 	// Provision watcher
 	GetProvisionWatcherById(pw *models.ProvisionWatcher, id string) error
@@ -106,7 +106,7 @@ type DBClient interface {
 	GetProvisionWatchersByIdentifier(pw *[]models.ProvisionWatcher, k string, v string) error
 	AddProvisionWatcher(pw *models.ProvisionWatcher) error
 	UpdateProvisionWatcher(pw models.ProvisionWatcher) error
-	DeleteProvisionWatcher(pw models.ProvisionWatcher) error
+	DeleteProvisionWatcherById(id string) error
 
 	// Command
 	GetCommandById(c *models.Command, id string) error

--- a/core/metadata/rest_addressable.go
+++ b/core/metadata/rest_addressable.go
@@ -187,7 +187,7 @@ func restDeleteAddressableById(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = dbClient.DeleteAddressable(a)
+	err = dbClient.DeleteAddressableById(a.Id.Hex())
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			loggingClient.Error(err.Error(), "")
@@ -237,7 +237,7 @@ func restDeleteAddressableByName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := dbClient.DeleteAddressable(a); err != nil {
+	if err := dbClient.DeleteAddressableById(a.Id.Hex()); err != nil {
 		loggingClient.Error(err.Error(), "")
 		if err == mgo.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)

--- a/core/metadata/rest_device.go
+++ b/core/metadata/rest_device.go
@@ -791,7 +791,7 @@ func deleteDevice(d models.Device, w http.ResponseWriter) error {
 		return err
 	}
 
-	if err := dbClient.DeleteDevice(d); err != nil {
+	if err := dbClient.DeleteDeviceById(d.Id.Hex()); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}
@@ -816,7 +816,7 @@ func deleteAssociatedReportsForDevice(d models.Device, w http.ResponseWriter) er
 
 	// Delete the associated reports
 	for _, report := range reports {
-		if err := dbClient.DeleteDeviceReport(report); err != nil {
+		if err := dbClient.DeleteDeviceReportById(report.Id.Hex()); err != nil {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			loggingClient.Error(err.Error(), "")
 			return err

--- a/core/metadata/rest_deviceprofile.go
+++ b/core/metadata/rest_deviceprofile.go
@@ -353,7 +353,7 @@ func deleteDeviceProfile(dp models.DeviceProfile, w http.ResponseWriter) error {
 	}
 
 	// Delete the profile
-	if err := dbClient.DeleteDeviceProfile(dp); err != nil {
+	if err := dbClient.DeleteDeviceProfileById(dp.Id.Hex()); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}

--- a/core/metadata/rest_devicereport.go
+++ b/core/metadata/rest_devicereport.go
@@ -355,7 +355,7 @@ func restDeleteReportByName(w http.ResponseWriter, r *http.Request) {
 }
 
 func deleteDeviceReport(dr models.DeviceReport, w http.ResponseWriter) error {
-	if err := dbClient.DeleteDeviceReport(dr); err != nil {
+	if err := dbClient.DeleteDeviceReportById(dr.Id.Hex()); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}

--- a/core/metadata/rest_deviceservice.go
+++ b/core/metadata/rest_deviceservice.go
@@ -509,7 +509,7 @@ func deleteDeviceService(ds models.DeviceService, w http.ResponseWriter) error {
 	}
 
 	// Delete the device service
-	if err := dbClient.DeleteDeviceService(ds); err != nil {
+	if err := dbClient.DeleteDeviceServiceById(ds.Id.Hex()); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}

--- a/core/metadata/rest_provisionwatcher.go
+++ b/core/metadata/rest_provisionwatcher.go
@@ -100,7 +100,7 @@ func restDeleteProvisionWatcherByName(w http.ResponseWriter, r *http.Request) {
 
 // Delete the provision watcher
 func deleteProvisionWatcher(pw models.ProvisionWatcher, w http.ResponseWriter) error {
-	if err := dbClient.DeleteProvisionWatcher(pw); err != nil {
+	if err := dbClient.DeleteProvisionWatcherById(pw.Id.Hex()); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}

--- a/core/metadata/rest_scheduleevent.go
+++ b/core/metadata/rest_scheduleevent.go
@@ -407,7 +407,7 @@ func deleteScheduleEvent(se models.ScheduleEvent, w http.ResponseWriter) error {
 		return err
 	}
 
-	if err := dbClient.DeleteScheduleEvent(se); err != nil {
+	if err := dbClient.DeleteScheduleEventById(se.Id.Hex()); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}
@@ -858,7 +858,7 @@ func deleteSchedule(s models.Schedule, w http.ResponseWriter) error {
 		return err
 	}
 
-	if err := dbClient.DeleteSchedule(s); err != nil {
+	if err := dbClient.DeleteScheduleById(s.Id.Hex()); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}


### PR DESCRIPTION
Data base delete methods have been modified in core-metadata in order to work in the same way as in core-data.

Signed-off-by: Joan Duran <jduran@circutor.com>