### PR TITLE
Bugfix core-data "get event by deviceId" api return no data

### DIFF
--- a/core/db/mongo/data.go
+++ b/core/db/mongo/data.go
@@ -194,17 +194,25 @@ func (mc *MongoClient) getEventsLimit(q bson.M, limit int) ([]models.Event, erro
 	defer s.Close()
 
 	// Handle DBRefs
-	var events []models.Event
+	var me []mongoEvent
+	events := []models.Event{}
 
 	// Check if limit is 0
 	if limit == 0 {
 		return events, nil
 	}
 
+	err := s.DB(mc.database.Name).C(db.EventsCollection).Find(q).Limit(limit).All(&me)
+	if err != nil {
+		return events, err
+	}
 
-	err := s.DB(mc.database.Name).C(db.EventsCollection).Find(q).Limit(limit).All(&events)
+	// Append all the events
+	for _, e := range me {
+		events = append(events, e.Event)
+	}
 
-	return events, err
+	return events, nil
 }
 
 // Get a single event for the passed query


### PR DESCRIPTION
API:   http://localhost:48080/api/v1/event/device/:deviceId/:limit
Error: no data returned:
Reason: As mongoEvent not match mongodb's structure(models.Event)