### PR TITLE
[snap] Fix consul build failure

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -109,7 +109,7 @@ parts:
       cp -r ./* $GOIMPORTPATH
       cd $GOIMPORTPATH
       go get -u github.com/kardianos/govendor
-      govendor sync
+      govendor init
       make
 
       # install the consul binary


### PR DESCRIPTION
Use 'govendor init' instead of 'govendor sync'.