### PR TITLE
Use sleep instead of busy-wait

### DIFF
--- a/core/clients/types/endpoint.go
+++ b/core/clients/types/endpoint.go
@@ -11,16 +11,13 @@ import (
 type Endpoint struct{}
 
 func (e Endpoint) Monitor(params EndpointParams, ch chan string) {
-	check := time.Now()
 	for {
-		if time.Now().After(check) {
-			data, err := consulclient.GetServiceEndpoint(params.ServiceKey)
-			if err != nil {
-				fmt.Fprintln(os.Stdout, err.Error())
-			}
-			url := fmt.Sprintf("http://%s:%v%s", data.Address, data.Port, params.Path)
-			ch <- url
-			check = time.Now().Add(time.Second * time.Duration(15))
+		data, err := consulclient.GetServiceEndpoint(params.ServiceKey)
+		if err != nil {
+			fmt.Fprintln(os.Stdout, err.Error())
 		}
+		url := fmt.Sprintf("http://%s:%v%s", data.Address, data.Port, params.Path)
+		ch <- url
+		time.Sleep(time.Second * time.Duration(15))
 	}
 }


### PR DESCRIPTION
I observed 200% CPU utilization by core-command and core-data processes.
Profiler showed that culprit is time.Now().After() buzy-loop in
Endpoint.Monitor.
It truly spins for 15 seconds after each "ch" consumption.
Depending on consumption rate it might spin "infinitely"

$ go tool pprof core-command core-command.prof
File: core-command
Type: cpu
Time: Jul 10, 2018 at 3:24pm (PDT)
Duration: 14.52s, Total samples = 28.48s (196.11%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10 -cum
Showing nodes accounting for 28430ms, 99.82% of 28480ms total
Dropped 51 nodes (cum <= 142.40ms)
   flat  flat%   sum%        cum   cum%
      0     0%     0%    21840ms 76.69%  runtime._System /usr/lib/golang/src/runtime/proc.go
20430ms 71.73% 71.73%    20430ms 71.73%  runtime._ExternalCode /usr/lib/golang/src/runtime/proc.go
      0     0% 71.73%     6600ms 23.17%  github.com/edgexfoundry/edgex-go/core/clients/types.(*Endpoint).Monitor <autogenerated>
 1230ms  4.32% 76.05%     6600ms 23.17%  github.com/edgexfoundry/edgex-go/core/clients/types.Endpoint.Monitor /usr/share/gocode/src/github.com/edgexfoundry/edgex-go/core/clients/types/endpoint.go
 1440ms  5.06% 81.11%     4850ms 17.03%  time.Now /usr/lib/golang/src/time/time.go
 2030ms  7.13% 88.24%     3410ms 11.97%  time.now /usr/lib/golang/src/runtime/timestub.go
 1890ms  6.64% 94.87%     1890ms  6.64%  runtime.walltime /usr/lib/golang/src/runtime/sys_linux_amd64.s
  900ms  3.16% 98.03%      900ms  3.16%  runtime.nanotime /usr/lib/golang/src/runtime/sys_linux_amd64.s
  510ms  1.79% 99.82%      510ms  1.79%  time.Time.After /usr/lib/golang/src/time/time.go

Using time.Sleep() fixed the problem and CPU utilization back to normal.

Signed-off-by: Alexey Makhalov <amakhalov@vmware.com>