### PR TITLE
[snap] Limit consul build to native OS/arch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,6 +105,8 @@ parts:
       export GOPATH=$(readlink -f $(pwd)/../go)
       export GOIMPORTPATH=$GOPATH/src/github.com/hashicorp/consul/
       export PATH="$GOPATH/bin:$PATH"
+      # limit build to native OS/architecture
+      export CONSUL_DEV=1
       mkdir -p $GOIMPORTPATH
       cp -r ./* $GOIMPORTPATH
       cd $GOIMPORTPATH


### PR DESCRIPTION
By default consul builds for multiple OSes and
architectures. By setting the env var CONSUL_DEV=1,
the snap now only builds for the native OS/arch.

Signed-off-by: Tony Espy <espy@canonical.com>