### PR TITLE
Main.go unused function, wrong key, dbClient nil

### DIFF
--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	ok := data.Init()
 	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.CoreMetaDataServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.CoreDataServiceKey))
 		return
 	}
 
@@ -75,14 +75,6 @@ func main() {
 func logBeforeInit(err error) {
 	l := logger.NewClient(internal.CoreDataServiceKey, false, "")
 	l.Error(err.Error())
-}
-
-func setLoggingTarget(conf data.ConfigurationStruct) string {
-	logTarget := conf.LoggingRemoteURL
-	if !conf.EnableRemoteLogging {
-		return conf.LoggingFile
-	}
-	return logTarget
 }
 
 func listenForInterrupt(errChan chan error) {

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -109,12 +109,14 @@ func connectToDatabase() error {
 	}
 	dbClient, err = newDBClient(Configuration.DBType, dbConfig)
 	if err != nil {
+		dbClient = nil
 		return fmt.Errorf("couldn't create database client: %v", err.Error())
 	}
 
 	// Connect to the database
 	err = dbClient.Connect()
 	if err != nil {
+		dbClient = nil
 		return fmt.Errorf("couldn't connect to database: %v", err.Error())
 	}
 	return nil


### PR DESCRIPTION
#458 

Also made change in init.go to explicitly set dbClient to nil if connection fails. Otherwise Init() function may return incorrect success.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>