### PR TITLE
Add Support-Notifications to 'make run'.

### DIFF
--- a/bin/edgex-docker-launch.sh
+++ b/bin/edgex-docker-launch.sh
@@ -37,3 +37,5 @@ echo "Starting core-export-client"
 docker-compose -f $COMPOSE_FILE up -d export-client
 echo "Starting core-export-distro"
 docker-compose -f $COMPOSE_FILE up -d export-distro
+echo "Starting support-notifications"
+docker-compose -f $COMPOSE_FILE up -d notifications

--- a/bin/edgex-launch.sh
+++ b/bin/edgex-launch.sh
@@ -65,6 +65,13 @@ cd $CMD/export-distro
 exec -a edgex-export-distro ./export-distro &
 cd $DIR
 
+###
+# Support Notifications
+###
+cd $CMD/support-notifications
+# Add `edgex-` prefix on start, so we can find the process family
+exec -a edgex-support-notifications ./support-notifications &
+cd $DIR
 
 trap cleanup EXIT
 


### PR DESCRIPTION
Add Support-Notifications to 'make run'. Ensure that the 'make run_docker' command starts the relevant container.

- Per developer testing, here is the relevant snippet from starting the Support Notifications Micro Service outside a container:

`INFO: 2018/08/07 08:03:30 Starting edgex-support-notifications 0.7.0 
INFO: 2018/08/07 08:03:30 This is the Support Notifications Micro Service
INFO: 2018/08/07 08:03:30 Service started in: 22.058701ms
INFO: 2018/08/07 08:03:30 Listening on port: 48060
INFO: 2018/08/07 08:03:30 Service dependencies resolved...
`

- Also per developer testing, here is the relevant snippet from starting the Support Notifications Micro Service _inside_ a container:

`Starting support-notifications
Pulling notifications (edgexfoundry/docker-support-notifications:0.6.0)...
0.6.0: Pulling from edgexfoundry/docker-support-notifications
605ce1bd3f31: Pull complete
9022ad40380b: Pull complete
5b58bdb8d58d: Pull complete
01a079451e87: Pull complete
Digest: sha256:a8d4a2d6910d4f8fd6c7adb11a74ae1dd355d35e3248394f313564a269eb50df
Status: Downloaded newer image for edgexfoundry/docker-support-notifications:0.6.0
edgex-files is up-to-date`

Signed-off-by: Akram Ahmad <sftwr2020@gmail.com>