### PR TITLE
Use db.MakeTimestamp

### DIFF
--- a/export/client/clients/mongo-client.go
+++ b/export/client/clients/mongo-client.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/export"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -80,7 +81,7 @@ func (mc *MongoClient) AddRegistration(reg *export.Registration) (bson.ObjectId,
 	s := mc.GetSessionCopy()
 	defer s.Close()
 
-	reg.Created = time.Now().UnixNano() / int64(time.Millisecond)
+	reg.Created = db.MakeTimestamp()
 	reg.ID = bson.NewObjectId()
 
 	// Add the registration
@@ -99,7 +100,7 @@ func (mc *MongoClient) UpdateRegistration(reg export.Registration) error {
 	s := mc.GetSessionCopy()
 	defer s.Close()
 
-	reg.Modified = time.Now().UnixNano() / int64(time.Millisecond)
+	reg.Modified = db.MakeTimestamp()
 
 	err := s.DB(mc.Database.Name).C(EXPORT_COLLECTION).UpdateId(reg.ID, reg)
 	if err == mgo.ErrNotFound {

--- a/internal/core/data/event.go
+++ b/internal/core/data/event.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
@@ -77,7 +76,7 @@ func updateDeviceLastReportedConnected(device string) {
 		return
 	}
 
-	t := time.Now().UnixNano() / int64(time.Millisecond)
+	t := db.MakeTimestamp()
 	// Found device, now update lastReported
 	err = mdc.UpdateLastConnectedByName(d.Name, t)
 	if err != nil {
@@ -98,7 +97,7 @@ func updateDeviceServiceLastReportedConnected(device string) {
 		return
 	}
 
-	t := time.Now().UnixNano() / int64(time.Millisecond)
+	t := db.MakeTimestamp()
 
 	// Get the device
 	d, err := mdc.CheckForDevice(device)
@@ -432,7 +431,7 @@ func eventIdHandler(w http.ResponseWriter, r *http.Request) {
 
 		LoggingClient.Info("Updating event: " + e.ID.Hex())
 
-		e.Pushed = time.Now().UnixNano() / int64(time.Millisecond)
+		e.Pushed = db.MakeTimestamp()
 		err = dbClient.UpdateEvent(e)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/core/metadata/rest_device.go
+++ b/internal/core/metadata/rest_device.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	notifications "github.com/edgexfoundry/edgex-go/pkg/clients/notifications"
@@ -1216,7 +1215,7 @@ func postNotification(name string, action string) {
 	if Configuration.NotificationPostDeviceChanges {
 		// Make the notification
 		notification := notifications.Notification{
-			Slug:        Configuration.NotificationsSlug + strconv.FormatInt((time.Now().UnixNano()/int64(time.Millisecond)), 10),
+			Slug:        Configuration.NotificationsSlug + strconv.FormatInt(db.MakeTimestamp(), 10),
 			Content:     Configuration.NotificationContent + name + "-" + string(action),
 			Category:    notifications.SW_HEALTH,
 			Description: Configuration.NotificationDescription,

--- a/internal/pkg/db/mongo/notifications.go
+++ b/internal/pkg/db/mongo/notifications.go
@@ -16,11 +16,9 @@
 package mongo
 
 import (
-	"time"
-
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
 	"gopkg.in/mgo.v2/bson"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
 const (
@@ -111,7 +109,7 @@ func (mc *MongoClient) DeleteNotificationBySlug(slug string) error {
 }
 
 func (mc *MongoClient) DeleteNotificationsOld(age int) error {
-	currentTime := time.Now().UnixNano() / int64(time.Millisecond)
+	currentTime := db.MakeTimestamp()
 	end := int(currentTime) - age
 	query := bson.M{"modified": bson.M{
 		"$lt": end}, "status": "PROCESSED"}
@@ -190,7 +188,7 @@ func (mc *MongoClient) UpdateTransmission(t models.Transmission) error {
 }
 
 func (mc *MongoClient) DeleteTransmission(age int64, status models.TransmissionStatus) error {
-	currentTime := time.Now().UnixNano() / int64(time.Millisecond)
+	currentTime := db.MakeTimestamp()
 	end := currentTime - age
 	query := bson.M{"modified": bson.M{"$lt": end}, "status": status}
 	return mc.deleteAll(query, TRANSMISSION_COLLECTION)
@@ -223,7 +221,7 @@ func (mc *MongoClient) Cleanup() error {
 }
 
 func (mc *MongoClient) CleanupOld(age int) error {
-	currentTime := time.Now().UnixNano() / int64(time.Millisecond)
+	currentTime := db.MakeTimestamp()
 	end := int(currentTime) - age
 	query := bson.M{"modified": bson.M{"$lt": end}}
 	mns, err := mc.getNotifications(query)
@@ -256,7 +254,7 @@ func (mc *MongoClient) addNotification(n *models.Notification) (bson.ObjectId, e
 	s := mc.getSessionCopy()
 	defer s.Close()
 
-	n.Created = time.Now().UnixNano() / int64(time.Millisecond)
+	n.Created = db.MakeTimestamp()
 	n.ID = bson.NewObjectId()
 
 	// Handle DBRefs
@@ -290,7 +288,7 @@ func (mc *MongoClient) updateNotification(n models.Notification) error {
 	s := mc.getSessionCopy()
 	defer s.Close()
 
-	n.Modified = time.Now().UnixNano() / int64(time.Millisecond)
+	n.Modified = db.MakeTimestamp()
 
 	// Handle DBRef
 	mn := MongoNotification{Notification: n}
@@ -352,7 +350,7 @@ func (mc *MongoClient) addSubscription(sub *models.Subscription) (bson.ObjectId,
 	s := mc.getSessionCopy()
 	defer s.Close()
 
-	sub.Created = time.Now().UnixNano() / int64(time.Millisecond)
+	sub.Created = db.MakeTimestamp()
 	sub.ID = bson.NewObjectId()
 
 	// Handle DBRefs
@@ -386,7 +384,7 @@ func (mc *MongoClient) updateSubscription(sub models.Subscription) error {
 	s := mc.getSessionCopy()
 	defer s.Close()
 
-	sub.Modified = time.Now().UnixNano() / int64(time.Millisecond)
+	sub.Modified = db.MakeTimestamp()
 
 	// Handle DBRef
 	ms := MongoSubscription{Subscription: sub}
@@ -464,7 +462,7 @@ func (mc *MongoClient) addTransmission(tran *models.Transmission) (bson.ObjectId
 	s := mc.getSessionCopy()
 	defer s.Close()
 
-	tran.Created = time.Now().UnixNano() / int64(time.Millisecond)
+	tran.Created = db.MakeTimestamp()
 	tran.ID = bson.NewObjectId()
 
 	// Handle DBRefs
@@ -482,7 +480,7 @@ func (mc *MongoClient) updateTransmission(tran models.Transmission) error {
 	s := mc.getSessionCopy()
 	defer s.Close()
 
-	tran.Modified = time.Now().UnixNano() / int64(time.Millisecond)
+	tran.Modified = db.MakeTimestamp()
 
 	// Handle DBRef
 	mt := MongoTransmission{Transmission: tran}

--- a/internal/support/logging/server.go
+++ b/internal/support/logging/server.go
@@ -14,17 +14,11 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/support/logging/models"
 	"github.com/go-zoo/bone"
 )
-
-// Copied from core/metadata/mongoOps.go
-// FIXME share instead of copy
-func makeTimestamp() int64 {
-	return time.Now().UnixNano() / int64(time.Millisecond)
-}
 
 func replyPing(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -56,7 +50,7 @@ func addLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	l.Created = makeTimestamp()
+	l.Created = db.MakeTimestamp()
 
 	w.WriteHeader(http.StatusAccepted)
 

--- a/internal/support/notifications/sending_service.go
+++ b/internal/support/notifications/sending_service.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
@@ -58,7 +59,7 @@ func resendViaChannel(t models.Transmission) {
 
 func getTransmissionRecord(msg string, st models.TransmissionStatus) models.TransmissionRecord {
 	tr := models.TransmissionRecord{}
-	tr.Sent = time.Now().UnixNano() / int64(time.Millisecond)
+	tr.Sent = db.MakeTimestamp()
 	tr.Status = st
 	tr.Response = msg
 	return tr


### PR DESCRIPTION
Replaced all `time.Now().UnixNano() / int64(time.Millisecond)` by `db.MakeTimestamp()`

As this is a very simple PR, no issue it's created (but will be created if required)

Signed-off-by: Joan Duran <jduran@circutor.com>