### PR TITLE
Add schedule related clients

### DIFF
--- a/pkg/clients/metadata/schedule.go
+++ b/pkg/clients/metadata/schedule.go
@@ -1,0 +1,307 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package metadata
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/edgexfoundry/edgex-go/pkg/clients"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
+	"github.com/edgexfoundry/edgex-go/pkg/models"
+)
+
+// ScheduleClient is an interface used to operate on Core Metadata schedule objects.
+type ScheduleClient interface {
+	Add(dev *models.Schedule) (string, error)
+	Delete(id string) error
+	DeleteByName(name string) error
+	Schedule(id string) (models.Schedule, error)
+	ScheduleForName(name string) (models.Schedule, error)
+	Schedules() ([]models.Schedule, error)
+	Update(dev models.Schedule) error
+}
+
+// ScheduleRestClient is struct used as a receiver for ScheduleClient interface methods.
+type ScheduleRestClient struct {
+	url      string
+	endpoint clients.Endpointer
+}
+
+// NewScheduleClient returns a new instance of ScheduleClient.
+func NewScheduleClient(params types.EndpointParams, m clients.Endpointer) ScheduleClient {
+	s := ScheduleRestClient{endpoint: m}
+	s.init(params)
+	return &s
+}
+
+func (s *ScheduleRestClient) init(params types.EndpointParams) {
+	if params.UseRegistry {
+		ch := make(chan string, 1)
+		go s.endpoint.Monitor(params, ch)
+		go func(ch chan string) {
+			for {
+				select {
+				case url := <-ch:
+					s.url = url
+				}
+			}
+		}(ch)
+	} else {
+		s.url = params.Url
+	}
+}
+
+// Help method to decode a schedule slice
+func (s *ScheduleRestClient) decodeScheduleSlice(resp *http.Response) ([]models.Schedule, error) {
+	dec := json.NewDecoder(resp.Body)
+	sSlice := []models.Schedule{}
+
+	err := dec.Decode(&sSlice)
+	if err != nil {
+		return []models.Schedule{}, err
+	}
+
+	return sSlice, err
+}
+
+// Helper method to decode a schedule and return the schedule
+func (s *ScheduleRestClient) decodeSchedule(resp *http.Response) (models.Schedule, error) {
+	dec := json.NewDecoder(resp.Body)
+	sched := models.Schedule{}
+
+	err := dec.Decode(&sched)
+	if err != nil {
+		return models.Schedule{}, err
+	}
+
+	return sched, err
+}
+
+// Add a schedule.
+func (s *ScheduleRestClient) Add(dev *models.Schedule) (string, error) {
+	jsonStr, err := json.Marshal(dev)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.url, bytes.NewReader(jsonStr))
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	// Get the body
+	bodyBytes, err := getBody(resp)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return string(bodyBytes), nil
+}
+
+// Delete a schedule (specified by id).
+func (s *ScheduleRestClient) Delete(id string) error {
+	req, err := http.NewRequest(http.MethodDelete, s.url+"/id/"+id, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return err
+		}
+
+		return types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return nil
+}
+
+// Delete a schedule (specified by name).
+func (s *ScheduleRestClient) DeleteByName(name string) error {
+	req, err := http.NewRequest(http.MethodDelete, s.url+"/name/"+url.QueryEscape(name), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return err
+		}
+
+		return types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return nil
+}
+
+// Schedule returns the Schedule specified by id.
+func (s *ScheduleRestClient) Schedule(id string) (models.Schedule, error) {
+	req, err := http.NewRequest(http.MethodGet, s.url+"/"+id, nil)
+	if err != nil {
+		return models.Schedule{}, err
+	}
+
+	// Make the request and get response
+	resp, err := makeRequest(req)
+	if err != nil {
+		return models.Schedule{}, err
+	}
+	if resp == nil {
+		return models.Schedule{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return models.Schedule{}, err
+		}
+
+		return models.Schedule{}, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return s.decodeSchedule(resp)
+}
+
+// ScheduleForName returns the Schedule specified by name.
+func (s *ScheduleRestClient) ScheduleForName(name string) (models.Schedule, error) {
+	req, err := http.NewRequest(http.MethodGet, s.url+"/name/"+url.QueryEscape(name), nil)
+	if err != nil {
+		return models.Schedule{}, err
+	}
+
+	// Make the request and get response
+	resp, err := makeRequest(req)
+	if err != nil {
+		return models.Schedule{}, err
+	}
+	if resp == nil {
+		return models.Schedule{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return models.Schedule{}, err
+		}
+
+		return models.Schedule{}, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+	return s.decodeSchedule(resp)
+}
+
+// Schedules returns the list of all schedules.
+func (s *ScheduleRestClient) Schedules() ([]models.Schedule, error) {
+	req, err := http.NewRequest(http.MethodGet, s.url, nil)
+	if err != nil {
+		return []models.Schedule{}, err
+	}
+
+	// Make the request and get response
+	resp, err := makeRequest(req)
+	if err != nil {
+		return []models.Schedule{}, err
+	}
+	if resp == nil {
+		return []models.Schedule{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return []models.Schedule{}, err
+		}
+
+		return []models.Schedule{}, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+	return s.decodeScheduleSlice(resp)
+}
+
+// Update a schedule.
+func (s *ScheduleRestClient) Update(dev models.Schedule) error {
+	jsonStr, err := json.Marshal(&dev)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, s.url, bytes.NewReader(jsonStr))
+	if err != nil {
+		return err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return err
+		}
+
+		return types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return nil
+}

--- a/pkg/clients/metadata/schedule_test.go
+++ b/pkg/clients/metadata/schedule_test.go
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package metadata
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
+	"github.com/edgexfoundry/edgex-go/pkg/models"
+)
+
+const (
+	scheduleUriPath = "/api/v1/schedule"
+)
+
+// Test adding a schedule using the client
+func TestAddSchedule(t *testing.T) {
+	d := models.Schedule{
+		Id:        "1234",
+		Name:      "Test name for schedule",
+		Start:     "", // defaults to now
+		End:       "", // defaults to ZDT MAX
+		Frequency: "PT30S",
+	}
+
+	addingScheduleId := d.Id.Hex()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method != http.MethodPost {
+			t.Errorf("expected http method is %s, active http method is : %s", http.MethodPost, r.Method)
+		}
+
+		if r.URL.EscapedPath() != scheduleUriPath {
+			t.Errorf("expected uri path is %s, actual uri path is %s", scheduleUriPath, r.URL.EscapedPath())
+		}
+
+		w.Write([]byte(addingScheduleId))
+
+	}))
+
+	defer ts.Close()
+
+	url := ts.URL + scheduleUriPath
+
+	params := types.EndpointParams{
+		ServiceKey:  internal.CoreMetaDataServiceKey,
+		Path:        scheduleUriPath,
+		UseRegistry: false,
+		Url:         url}
+	sc := NewScheduleClient(params, MockEndpoint{})
+
+	receivedScheduleId, err := sc.Add(&d)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if receivedScheduleId != addingScheduleId {
+		t.Errorf("expected schedule id : %s, actual schedule id : %s", receivedScheduleId, addingScheduleId)
+	}
+}
+
+func TestNewScheduleClientWithConsul(t *testing.T) {
+	scheduleUrl := "http://localhost:48081" + scheduleUriPath
+	params := types.EndpointParams{
+		ServiceKey:  internal.CoreMetaDataServiceKey,
+		Path:        scheduleUriPath,
+		UseRegistry: true,
+		Url:         scheduleUrl}
+
+	sc := NewScheduleClient(params, MockEndpoint{})
+
+	r, ok := sc.(*ScheduleRestClient)
+	if !ok {
+		t.Error("sc is not of expected type")
+	}
+
+	time.Sleep(25 * time.Millisecond)
+	if len(r.url) == 0 {
+		t.Error("url was not initialized")
+	} else if r.url != scheduleUrl {
+		t.Errorf("unexpected url value %s", r.url)
+	}
+}

--- a/pkg/clients/metadata/scheduleevent.go
+++ b/pkg/clients/metadata/scheduleevent.go
@@ -1,0 +1,397 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package metadata
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/edgexfoundry/edgex-go/pkg/clients"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
+	"github.com/edgexfoundry/edgex-go/pkg/models"
+)
+
+// ScheduleEventClient is an interface used to operate on Core Metadata schedule event objects.
+type ScheduleEventClient interface {
+	Add(dev *models.ScheduleEvent) (string, error)
+	Delete(id string) error
+	DeleteByName(name string) error
+	ScheduleEvent(id string) (models.ScheduleEvent, error)
+	ScheduleEventForName(name string) (models.ScheduleEvent, error)
+	ScheduleEvents() ([]models.ScheduleEvent, error)
+	ScheduleEventsForAddressable(name string) ([]models.ScheduleEvent, error)
+	ScheduleEventsForAddressableByName(name string) ([]models.ScheduleEvent, error)
+	ScheduleEventsForServiceByName(name string) ([]models.ScheduleEvent, error)
+	Update(dev models.ScheduleEvent) error
+}
+
+// ScheduleEventRestClient is struct used as a receiver for ScheduleEventClient interface methods.
+type ScheduleEventRestClient struct {
+	url      string
+	endpoint clients.Endpointer
+}
+
+// NewScheduleEventClient returns a new instance of ScheduleEventClient.
+func NewScheduleEventClient(params types.EndpointParams, m clients.Endpointer) ScheduleEventClient {
+	s := ScheduleEventRestClient{endpoint: m}
+	s.init(params)
+	return &s
+}
+
+func (s *ScheduleEventRestClient) init(params types.EndpointParams) {
+	if params.UseRegistry {
+		ch := make(chan string, 1)
+		go s.endpoint.Monitor(params, ch)
+		go func(ch chan string) {
+			for {
+				select {
+				case url := <-ch:
+					s.url = url
+				}
+			}
+		}(ch)
+	} else {
+		s.url = params.Url
+	}
+}
+
+// Help method to decode a schedule event slice
+func (s *ScheduleEventRestClient) decodeScheduleEventSlice(resp *http.Response) ([]models.ScheduleEvent, error) {
+	dec := json.NewDecoder(resp.Body)
+	seSlice := []models.ScheduleEvent{}
+
+	err := dec.Decode(&seSlice)
+	if err != nil {
+		return []models.ScheduleEvent{}, err
+	}
+
+	return seSlice, err
+}
+
+// Helper method to decode a schedule and return the schedule event
+func (s *ScheduleEventRestClient) decodeScheduleEvent(resp *http.Response) (models.ScheduleEvent, error) {
+	dec := json.NewDecoder(resp.Body)
+	event := models.ScheduleEvent{}
+
+	err := dec.Decode(&event)
+	if err != nil {
+		return models.ScheduleEvent{}, err
+	}
+
+	return event, err
+}
+
+// Add a schedule event.
+func (s *ScheduleEventRestClient) Add(dev *models.ScheduleEvent) (string, error) {
+	jsonStr, err := json.Marshal(dev)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.url, bytes.NewReader(jsonStr))
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		return "", err
+	}
+	if resp == nil {
+		return "", ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	// Get the body
+	bodyBytes, err := getBody(resp)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return string(bodyBytes), nil
+}
+
+// Delete a schedule event (specified by id).
+func (s *ScheduleEventRestClient) Delete(id string) error {
+	req, err := http.NewRequest(http.MethodDelete, s.url+"/id/"+id, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return err
+		}
+
+		return types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return nil
+}
+
+// Delete a schedule event (specified by name).
+func (s *ScheduleEventRestClient) DeleteByName(name string) error {
+	req, err := http.NewRequest(http.MethodDelete, s.url+"/name/"+url.QueryEscape(name), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return err
+		}
+
+		return types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return nil
+}
+
+// ScheduleEvent returns the ScheduleEvent specified by id.
+func (s *ScheduleEventRestClient) ScheduleEvent(id string) (models.ScheduleEvent, error) {
+	req, err := http.NewRequest(http.MethodGet, s.url+"/"+id, nil)
+	if err != nil {
+		return models.ScheduleEvent{}, err
+	}
+
+	// Make the request and get response
+	resp, err := makeRequest(req)
+	if err != nil {
+		return models.ScheduleEvent{}, err
+	}
+	if resp == nil {
+		return models.ScheduleEvent{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return models.ScheduleEvent{}, err
+		}
+
+		return models.ScheduleEvent{}, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return s.decodeScheduleEvent(resp)
+}
+
+// ScheduleEventForName returns the ScheduleEvent specified by name.
+func (s *ScheduleEventRestClient) ScheduleEventForName(name string) (models.ScheduleEvent, error) {
+	req, err := http.NewRequest(http.MethodGet, s.url+"/name/"+url.QueryEscape(name), nil)
+	if err != nil {
+		return models.ScheduleEvent{}, err
+	}
+
+	// Make the request and get response
+	resp, err := makeRequest(req)
+	if err != nil {
+		return models.ScheduleEvent{}, err
+	}
+	if resp == nil {
+		return models.ScheduleEvent{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return models.ScheduleEvent{}, err
+		}
+
+		return models.ScheduleEvent{}, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+	return s.decodeScheduleEvent(resp)
+}
+
+// Get a list of all schedules events.
+func (s *ScheduleEventRestClient) ScheduleEvents() ([]models.ScheduleEvent, error) {
+	req, err := http.NewRequest(http.MethodGet, s.url, nil)
+	if err != nil {
+		return []models.ScheduleEvent{}, err
+	}
+
+	// Make the request and get response
+	resp, err := makeRequest(req)
+	if err != nil {
+		return []models.ScheduleEvent{}, err
+	}
+	if resp == nil {
+		return []models.ScheduleEvent{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return []models.ScheduleEvent{}, err
+		}
+
+		return []models.ScheduleEvent{}, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+	return s.decodeScheduleEventSlice(resp)
+}
+
+// ScheduleEventForAddressable returns the ScheduleEvent specified by addressable.
+func (s *ScheduleEventRestClient) ScheduleEventsForAddressable(addressable string) ([]models.ScheduleEvent, error) {
+	req, err := http.NewRequest(http.MethodGet, s.url+"/addressable/"+url.QueryEscape(addressable), nil)
+	if err != nil {
+		return []models.ScheduleEvent{}, err
+	}
+
+	// Make the request and get response
+	resp, err := makeRequest(req)
+	if err != nil {
+		return []models.ScheduleEvent{}, err
+	}
+	if resp == nil {
+		return []models.ScheduleEvent{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return []models.ScheduleEvent{}, err
+		}
+
+		return []models.ScheduleEvent{}, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+	return s.decodeScheduleEventSlice(resp)
+}
+
+// ScheduleEventForAddressableByName returns the ScheduleEvent specified by addressable name.
+func (s *ScheduleEventRestClient) ScheduleEventsForAddressableByName(name string) ([]models.ScheduleEvent, error) {
+	req, err := http.NewRequest(http.MethodGet, s.url+"/addressablename/"+url.QueryEscape(name), nil)
+	if err != nil {
+		return []models.ScheduleEvent{}, err
+	}
+
+	// Make the request and get response
+	resp, err := makeRequest(req)
+	if err != nil {
+		return []models.ScheduleEvent{}, err
+	}
+	if resp == nil {
+		return []models.ScheduleEvent{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return []models.ScheduleEvent{}, err
+		}
+
+		return []models.ScheduleEvent{}, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+	return s.decodeScheduleEventSlice(resp)
+}
+
+// Get the schedule event for service by name.
+func (s *ScheduleEventRestClient) ScheduleEventsForServiceByName(name string) ([]models.ScheduleEvent, error) {
+	req, err := http.NewRequest(http.MethodGet, s.url+"/servicename/"+url.QueryEscape(name), nil)
+	if err != nil {
+		return []models.ScheduleEvent{}, err
+	}
+
+	// Make the request and get response
+	resp, err := makeRequest(req)
+	if err != nil {
+		return []models.ScheduleEvent{}, err
+	}
+	if resp == nil {
+		return []models.ScheduleEvent{}, ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return []models.ScheduleEvent{}, err
+		}
+
+		return []models.ScheduleEvent{}, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+	return s.decodeScheduleEventSlice(resp)
+}
+
+// Update a schedule event - handle error codes
+func (s *ScheduleEventRestClient) Update(dev models.ScheduleEvent) error {
+	jsonStr, err := json.Marshal(&dev)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, s.url, bytes.NewReader(jsonStr))
+	if err != nil {
+		return err
+	}
+
+	resp, err := makeRequest(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return ErrResponseNil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Get the response body
+		bodyBytes, err := getBody(resp)
+		if err != nil {
+			return err
+		}
+
+		return types.NewErrServiceClient(resp.StatusCode, bodyBytes)
+	}
+
+	return nil
+}

--- a/pkg/clients/metadata/scheduleevent_test.go
+++ b/pkg/clients/metadata/scheduleevent_test.go
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ * Copyright (C) 2018 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package metadata
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
+	"github.com/edgexfoundry/edgex-go/pkg/models"
+)
+
+const (
+	scheduleEventUriPath = "/api/v1/scheduleevent"
+)
+
+// Test adding a schedule event using the client
+func TestAddScheduleEvent(t *testing.T) {
+	se := models.ScheduleEvent{
+		Id:          "1234",
+		Name:        "Test name for schedule event",
+		Schedule:    "Test name of owning schedule",
+		Addressable: models.Addressable{},
+		Parameters:  "{\"VDS-CurrentTemperature\": \"98.6\"}",
+		Service:     "Test device service name",
+	}
+
+	addingScheduleEventId := se.Id.Hex()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		if r.Method != http.MethodPost {
+			t.Errorf("expected http method is %s, active http method is : %s", http.MethodPost, r.Method)
+		}
+
+		if r.URL.EscapedPath() != scheduleEventUriPath {
+			t.Errorf("expected uri path is %s, actual uri path is %s", scheduleEventUriPath, r.URL.EscapedPath())
+		}
+
+		w.Write([]byte(addingScheduleEventId))
+
+	}))
+
+	defer ts.Close()
+
+	url := ts.URL + scheduleEventUriPath
+
+	params := types.EndpointParams{
+		ServiceKey:  internal.CoreMetaDataServiceKey,
+		Path:        scheduleEventUriPath,
+		UseRegistry: false,
+		Url:         url}
+	sc := NewScheduleEventClient(params, MockEndpoint{})
+
+	receivedScheduleEventId, err := sc.Add(&se)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if receivedScheduleEventId != addingScheduleEventId {
+		t.Errorf("expected schedule event id : %s, actual schedule event id : %s", receivedScheduleEventId, addingScheduleEventId)
+	}
+}
+
+func TestNewScheduleEventClientWithConsul(t *testing.T) {
+	scheduleEventUrl := "http://localhost:48081" + scheduleEventUriPath
+	params := types.EndpointParams{
+		ServiceKey:  internal.CoreMetaDataServiceKey,
+		Path:        scheduleEventUriPath,
+		UseRegistry: true,
+		Url:         scheduleEventUrl}
+
+	sc := NewScheduleEventClient(params, MockEndpoint{})
+
+	r, ok := sc.(*ScheduleEventRestClient)
+	if !ok {
+		t.Error("sc is not of expected type")
+	}
+
+	time.Sleep(25 * time.Millisecond)
+	if len(r.url) == 0 {
+		t.Error("url was not initialized")
+	} else if r.url != scheduleEventUrl {
+		t.Errorf("unexpected url value %s", r.url)
+	}
+}


### PR DESCRIPTION
This commit adds public REST clients for Core Metadata's **schedule** and **scheduleevent** endpoints.  These are needed to allow device-sdk-go to query and add both object types.