### PR TITLE
Merge config-seed into edgex-go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docker/docker-compose.yml
 .project
 
 # binary files
+cmd/config-seed/config-seed
 cmd/core-command/core-command
 cmd/core-data/core-data
 cmd/core-metadata/core-metadata
@@ -17,6 +18,8 @@ cmd/support-notifications/support-notifications
 cmd/sys-mgmt-agent/sys-mgmt-agent
 
 # log dirs
+logs/
+cmd/config-seed/logs/
 cmd/core-command/logs/
 cmd/core-data/logs/
 cmd/core-metadata/logs/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ GOCGO=CGO_ENABLED=1 go
 DOCKERS=docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent
 .PHONY: $(DOCKERS)
 
-MICROSERVICES=cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-agent/sys-mgmt-agent
+MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-agent/sys-mgmt-agent
+
 .PHONY: $(MICROSERVICES)
 
 VERSION=$(shell cat ./VERSION)
@@ -25,6 +26,9 @@ GIT_SHA=$(shell git rev-parse HEAD)
 
 build: $(MICROSERVICES)
 	go build ./...
+
+cmd/config-seed/config-seed:
+	$(GO) build $(GOFLAGS) -o $@ ./cmd/config-seed
 
 cmd/core-metadata/core-metadata:
 	$(GO) build $(GOFLAGS) -o $@ ./cmd/core-metadata

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,14 @@ run_docker:
 
 docker: $(DOCKERS)
 
+docker_config-seed:
+	docker build \
+		-f docker/Dockerfile.config-seed \
+		--label "git_sha=$(GIT_SHA)" \
+		-t edgexfoundry/docker-core-config-seed-go:$(GIT_SHA) \
+		-t edgexfoundry/docker-core-config-seed-go:$(VERSION)-dev \
+		.
+
 docker_core_metadata:
 	docker build \
 		-f docker/Dockerfile.core-metadata \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 GO=CGO_ENABLED=0 go
 GOCGO=CGO_ENABLED=1 go
 
-DOCKERS=docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent
+DOCKERS=docker_config-seed docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent
 .PHONY: $(DOCKERS)
 
 MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-agent/sys-mgmt-agent

--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -15,13 +15,16 @@ package main
 
 import (
 	"flag"
-
 	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/seed/config"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
-	"sync"
 )
 
 var bootTimeout int = 30000 //Once we start the V2 configuration rework, this will be config driven
@@ -72,4 +75,12 @@ func bootstrap(profile string) {
 func logBeforeInit(err error) {
 	l := logger.NewClient(internal.ConfigSeedServiceKey, false, "")
 	l.Error(err.Error())
+}
+
+func listenForInterrupt(errChan chan error) {
+	go func() {
+		c := make(chan os.Signal)
+		signal.Notify(c, syscall.SIGINT)
+		errChan <- fmt.Errorf("%s", <-c)
+	}()
 }

--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package main
+
+import (
+	"flag"
+
+	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/edgex-go/internal/seed/config"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
+	"sync"
+)
+
+var bootTimeout int = 30000 //Once we start the V2 configuration rework, this will be config driven
+
+func main() {
+	var useProfile string
+
+	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.Usage = usage.HelpCallback
+	flag.Parse()
+
+	bootstrap(useProfile)
+	ok := config.Init()
+	if !ok {
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.ConfigSeedServiceKey))
+		return
+	}
+	config.LoggingClient.Info("Service dependencies resolved...")
+}
+
+func bootstrap(profile string) {
+	deps := make(chan error, 2)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go config.Retry(profile, bootTimeout, &wg, deps)
+	go func(ch chan error) {
+		for {
+			select {
+			case e, ok := <-ch:
+				if ok {
+					config.LoggingClient.Error(e.Error())
+				} else {
+					return
+				}
+			}
+		}
+	}(deps)
+
+	wg.Wait()
+}
+
+func logBeforeInit(err error) {
+	l := logger.NewClient(internal.ConfigSeedServiceKey, false, "")
+	l.Error(err.Error())
+}

--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -28,9 +28,13 @@ var bootTimeout int = 30000 //Once we start the V2 configuration rework, this wi
 
 func main() {
 	var useProfile string
+	var dirProperties string
 
 	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
 	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&dirProperties, "props", "./res/properties", "Specify alternate properties location")
+	flag.StringVar(&dirProperties, "r", "./res/properties", "Specify alternate properties location")
+
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
@@ -41,6 +45,7 @@ func main() {
 		return
 	}
 	config.LoggingClient.Info("Service dependencies resolved...")
+	config.ImportProperties(dirProperties)
 }
 
 func bootstrap(profile string) {

--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -37,7 +37,7 @@ func main() {
 	flag.StringVar(&dirCmd, "cmd", "../cmd", "Specify alternate cmd location as absolute path")
 	flag.StringVar(&dirCmd, "c", "../cmd", "Specify alternate cmd location as absolute path")
 
-	flag.Usage = usage.HelpCallback
+	flag.Usage = usage.HelpCallbackConfigSeed
 	flag.Parse()
 
 	bootstrap(useProfile)

--- a/cmd/config-seed/res/configuration-docker.toml
+++ b/cmd/config-seed/res/configuration-docker.toml
@@ -1,0 +1,14 @@
+ConfigPath = './config'
+GlobalPrefix = 'config'
+ConsulProtocol = 'http'
+ConsulHost = 'edgex-core-consul'
+ConsulPort = 8500
+IsReset = true
+FailLimit = 30
+FailWaitTime = 3
+AcceptablePropertyExtensions = ['.toml','.yaml', '.yml', '.properties']
+YamlExtensions = ['.yaml','.yml']
+TomlExtensions = ['.toml']
+EnableRemoteLogging = false
+LoggingFile = '/edgex/logs/edgex-config-seed.log'
+LoggingRemoteURL = 'http://edgex-support-logging:48061/api/v1/logs'

--- a/cmd/config-seed/res/configuration.toml
+++ b/cmd/config-seed/res/configuration.toml
@@ -1,0 +1,14 @@
+ConfigPath = './config'
+GlobalPrefix = 'config'
+ConsulProtocol = 'http'
+ConsulHost = 'localhost'
+ConsulPort = 8500
+IsReset = true
+FailLimit = 30
+FailWaitTime = 3
+AcceptablePropertyExtensions = ['.toml','.yaml', '.yml', '.properties']
+YamlExtensions = ['.yaml','.yml']
+TomlExtensions = ['.toml']
+EnableRemoteLogging = false
+LoggingFile = './logs/config-seed.log'
+LoggingRemoteURL = 'http://localhost:48061/api/v1/logs'

--- a/cmd/config-seed/res/properties/device-bacnet/application.properties
+++ b/cmd/config-seed/res/properties/device-bacnet/application.properties
@@ -1,0 +1,50 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-bacnet
+# @author: Tyler Cox, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=DEBUG
+
+app.open.msg=This is the device-bacnet micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49986
+
+#default device service settings
+service.name=device-bacnet
+service.host=localhost
+#service.host=${service.name}
+service.labels=bacnet
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+

--- a/cmd/config-seed/res/properties/device-bacnet;docker/application.properties
+++ b/cmd/config-seed/res/properties/device-bacnet;docker/application.properties
@@ -1,0 +1,78 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-bacnet
+# @author: Tyler Cox, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=INFO
+
+app.open.msg=This is the device-bacnet micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49986
+
+#default device service settings
+service.name=edgex-device-bacnet
+#service.host=localhost
+service.host=${service.name}
+service.labels=bacnet
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+
+bacnet.server=http://edgex-device-bacnet:5002
+meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
+meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
+
+core.db.event.url=http://edgex-core-data:48080/api/v1/event
+core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
+core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
+core.db.ping.url=http://edgex-core-data:48080/api/v1/ping
+
+logging.remote.enable=true
+logging.remote.url=http://edgex-support-logging:48061/api/v1/logs
+schedule.interval=500
+
+default.schedule.name=Interval-30s
+default.schedule.frequency=PT30S
+
+default.scheduleEvent.name=edgex-device-bacnet-QueryAll
+default.scheduleEvent.path=/api/v1/device/all/Query
+default.scheduleEvent.service=edgex-device-bacnet
+default.scheduleEvent.schedule=Interval-30s

--- a/cmd/config-seed/res/properties/device-bluetooth/application.properties
+++ b/cmd/config-seed/res/properties/device-bluetooth/application.properties
@@ -1,0 +1,55 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice: device-bluetooth
+# @author: Tyler Cox, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=DEBUG
+
+app.open.msg=This is the device-bluetooth micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49988
+
+#default device service settings
+service.name=device-bluetooth
+service.host=localhost
+#service.host=${service.name}
+service.labels=BLE,scheduler
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+
+#The paths of device profile definition files
+application.device-profile-paths=./deviceprofile_samples
+
+#Add default device profiles
+application.add-default-device-profiles=false

--- a/cmd/config-seed/res/properties/device-bluetooth;docker/application.properties
+++ b/cmd/config-seed/res/properties/device-bluetooth;docker/application.properties
@@ -1,0 +1,94 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-bluetooth
+# @author: Tyler Cox, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=INFO
+
+app.open.msg=This is the device-bluetooth micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49988
+
+#default device service settings
+service.name=edgex-device-bluetooth
+#service.host=localhost
+service.host=${service.name}
+service.labels=BLE,scheduler
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+
+#The paths of device profile definition files
+application.device-profile-paths=./deviceprofile_samples
+
+#Add default device profiles
+application.add-default-device-profiles=false
+
+#------------------- REST Endpoints ---------------------------------------
+# metadata database service connection information
+meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
+meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
+
+#IOT core database service connection information
+core.db.event.url=http://edgex-core-data:48080/api/v1/event
+core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
+core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
+core.db.ping.url=http://edgex-core-data:48080/api/v1/ping
+
+#-----------------Remote Logging Config------------------------------------------
+logging.remote.enable=true
+logging.remote.url=http://edgex-support-logging:48061/api/v1/logs
+
+default.schedule.name=Interval-5s,Interval-3s
+default.schedule.frequency=PT5S,PT3S
+
+default.scheduleEvent.name=edgex-device-bluetooth-Discovery,Read-All-Query
+default.scheduleEvent.path=/api/v1/discovery,/api/v1/device/all/Query
+default.scheduleEvent.service=edgex-device-bluetooth,edgex-device-bluetooth
+default.scheduleEvent.schedule=Interval-5s,Interval-3s
+
+default.watcher.name=BLE-Watcher,BLE-Watcher-2,BLE-Watcher-3
+default.watcher.service=edgex-device-bluetooth,edgex-device-bluetooth,edgex-device-bluetooth
+default.watcher.profile=SensorTag,XDK,BLELight
+default.watcher.name_identifiers=.*CC2650.*,XDK.*,.*beLight.*
+
+
+

--- a/cmd/config-seed/res/properties/device-fischertechnik/application.properties
+++ b/cmd/config-seed/res/properties/device-fischertechnik/application.properties
@@ -1,0 +1,50 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-fischertechnik
+# @author: Tyler Cox, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=DEBUG
+
+app.open.msg=This is the device-fischertechnik micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49985
+
+#default device service settings
+service.name=device-fischertechnik
+service.host=localhost
+#service.host=${service.name}
+service.labels=fischertechnik
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+

--- a/cmd/config-seed/res/properties/device-fischertechnik;docker/application.properties
+++ b/cmd/config-seed/res/properties/device-fischertechnik;docker/application.properties
@@ -1,0 +1,84 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-fischertechnik
+# @author: Tyler Cox, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=INFO
+
+app.open.msg=This is the device-fischertechnik micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49985
+
+#default device service settings
+service.name=edgex-device-fischertechnik
+#service.host=localhost
+service.host=${service.name}
+service.labels=fischertechnik
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+
+fischertech.device.init=Init
+fischertech.device.init.args={ value: "" }
+meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
+meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
+
+core.db.event.url=http://edgex-core-data:48080/api/v1/event
+core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
+core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
+core.db.ping.url=http://edgex-core-data:48080/api/v1/ping
+
+logging.remote.enable=true
+logging.remote.url=http://edgex-support-logging:48061/api/v1/logs
+schedule.interval=500
+
+default.schedule.name=Interval-15s
+default.schedule.frequency=PT15S
+
+default.scheduleEvent.name=edgex-device-fischertechnik-Discovery
+default.scheduleEvent.path=/api/v1/discovery
+default.scheduleEvent.service=edgex-device-fischertechnik
+default.scheduleEvent.schedule=Interval-15s
+
+default.watcher.name=Fischertechnik-Watcher
+default.watcher.service=edgex-device-fischertechnik
+default.watcher.profile=Fischertechnik Punching Machine
+default.watcher.name_identifiers=Fischertechnik

--- a/cmd/config-seed/res/properties/device-modbus/application.properties
+++ b/cmd/config-seed/res/properties/device-modbus/application.properties
@@ -1,0 +1,50 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-modbus
+# @author: Anantha Boyapalle, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR,INFO
+logging.level.org.apache=ERROR,INFO
+logging.level.org.edgexfoundry=DEBUG
+
+app.open.msg=This is the device-modbus micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49991
+
+#default device service settings
+service.name=device-modbus
+service.host=localhost
+#service.host=${service.name}
+service.labels=Modbus,scheduler
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=false
+

--- a/cmd/config-seed/res/properties/device-modbus;docker/application.properties
+++ b/cmd/config-seed/res/properties/device-modbus;docker/application.properties
@@ -1,0 +1,77 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-modbus
+# @author: Anantha Boyapalle, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR,INFO
+logging.level.org.apache=ERROR,INFO
+logging.level.org.edgexfoundry=INFO
+
+app.open.msg=This is the device-modbus micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49991
+
+#default device service settings
+service.name=edgex-device-modbus
+#service.host=localhost
+service.host=${service.name}
+service.labels=Modbus,scheduler
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=false
+
+meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
+meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
+
+core.db.event.url=http://edgex-core-data:48080/api/v1/event
+core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
+core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
+core.db.ping.url=http://edgex-core-data:48080/api/v1/ping
+
+logging.remote.enable=true
+logging.remote.url=http://edgex-support-logging:48061/api/v1/logs
+schedule.interval=500
+
+default.schedule.name=Interval-1m
+default.schedule.frequency=PT1m
+
+default.scheduleEvent.name=Read-AllData-edgex-device-modbus
+default.scheduleEvent.path=/api/v1/device/all/AllValues
+default.scheduleEvent.service=edgex-device-modbus
+default.scheduleEvent.schedule=Interval-1m

--- a/cmd/config-seed/res/properties/device-mqtt/application.properties
+++ b/cmd/config-seed/res/properties/device-mqtt/application.properties
@@ -1,0 +1,89 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-mqtt
+# @author: Jim White, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=DEBUG
+app.open.msg=This is the device-mqtt micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+server.port=49982
+#default device service settings
+service.name=device-mqtt
+service.host=localhost
+#service.host=${service.name}
+service.labels=MQTT
+service.callback=/api/v1/callback
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+spring.mvc.dispatch-options-request=true
+data.transform=true
+mqtt.device.init=Init
+mqtt.device.init.args={ value: 1 }
+mqtt.device.remove=Remove
+mqtt.device.remove.args={ value: 0 }
+#-----------------------------------
+#Cloud MQTT connection information
+#for incoming messages from devices
+#Use TestIoTMQTT Broker for testing/dev
+INCOMING_MQTT_BROKER_PROTO=tcp
+INCOMING_MQTT_BROKER=m11.cloudmqtt.com
+INCOMING_MQTT_BROKER_PORT=15757
+INCOMING_MQTT_CLIENT_ID=IncomingDataSubscriber
+INCOMING_MQTT_TOPIC=DataTopic
+INCOMING_MQTT_QOS=0
+INCOMING_MQTT_USER=tobeprovided
+INCOMING_MQTT_PASS=tobeprovided
+#keep alive set to 1 hour
+INCOMING_MQTT_KEEP_ALIVE=3600
+#for command response messages
+RESPONSE_MQTT_BROKER_PROTO=tcp
+RESPONSE_MQTT_BROKER=m11.cloudmqtt.com
+RESPONSE_MQTT_BROKER_PORT=15757
+RESPONSE_MQTT_CLIENT_ID=CommandResponseSubscriber
+RESPONSE_MQTT_TOPIC=ResponseTopic
+RESPONSE_MQTT_QOS=0
+RESPONSE_MQTT_USER=tobeprovided
+RESPONSE_MQTT_PASS=tobeprovided
+#keep alive set to 1 hour
+RESPONSE_MQTT_KEEP_ALIVE=3600
+#-----------example test device----------------
+provision.mqtt.device=true
+device.profile.name=MQTTTestDeviceProfile.yml
+device.name=TestMQTTDevice
+device.description=Default Test MQTT Device
+device.labels=MQTT, Test
+device.addressablename=testMQTTAddressable
+#for outgoing test command messages
+request.broker.proto=TCP
+request.broker=m11.cloudmqtt.com
+request.broker.port=15757
+request.client.id=OutgoingCommandPublisher
+request.topic=CommandTopic
+request.user=tobeprovided
+request.pass=tobeprovided
+
+

--- a/cmd/config-seed/res/properties/device-mqtt;docker/application.properties
+++ b/cmd/config-seed/res/properties/device-mqtt;docker/application.properties
@@ -1,0 +1,120 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-mqtt
+# @author: Jim White, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=INFO
+app.open.msg=This is the device-mqtt micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+server.port=49982
+#default device service settings
+service.name=edgex-device-mqtt
+#service.host=localhost
+service.host=${service.name}
+service.labels=MQTT
+service.callback=/api/v1/callback
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+spring.mvc.dispatch-options-request=true
+data.transform=true
+mqtt.device.init=Init
+mqtt.device.init.args={ value: 1 }
+mqtt.device.remove=Remove
+mqtt.device.remove.args={ value: 0 }
+#-----------------------------------
+#Cloud MQTT connection information
+#for incoming messages from devices
+#Use TestIoTMQTT Broker for testing/dev
+INCOMING_MQTT_BROKER_PROTO=tcp
+INCOMING_MQTT_BROKER=m11.cloudmqtt.com
+INCOMING_MQTT_BROKER_PORT=12439
+INCOMING_MQTT_CLIENT_ID=IncomingDataSubscriber
+INCOMING_MQTT_TOPIC=DataTopic
+INCOMING_MQTT_QOS=0
+INCOMING_MQTT_USER=tobeprovided
+INCOMING_MQTT_PASS=tobeprovided
+#keep alive set to 1 hour
+INCOMING_MQTT_KEEP_ALIVE=3600
+#for command response messages
+RESPONSE_MQTT_BROKER_PROTO=tcp
+RESPONSE_MQTT_BROKER=m11.cloudmqtt.com
+RESPONSE_MQTT_BROKER_PORT=12439
+RESPONSE_MQTT_CLIENT_ID=CommandResponseSubscriber
+RESPONSE_MQTT_TOPIC=ResponseTopic
+RESPONSE_MQTT_QOS=0
+RESPONSE_MQTT_USER=tobeprovided
+RESPONSE_MQTT_PASS=tobeprovided
+#keep alive set to 1 hour
+RESPONSE_MQTT_KEEP_ALIVE=3600
+#-----------example test device----------------
+provision.mqtt.device=true
+device.profile.name=MQTTTestDeviceProfile.yml
+device.name=TestMQTTDevice
+device.description=Default Test MQTT Device
+device.labels=MQTT, Test
+device.addressablename=testMQTTAddressable
+#for outgoing test command messages
+request.broker.proto=TCP
+request.broker=m11.cloudmqtt.com
+request.broker.port=12439
+request.client.id=OutgoingCommandPublisher
+request.topic=CommandTopic
+request.user=tobeprovided
+request.pass=tobeprovided
+#------------------- REST Endpoints ---------------------------------------
+# metadata database service connection information
+#meta.db.addressable.url=http://localhost:48081/api/v1/addressable
+#meta.db.deviceservice.url=http://localhost:48081/api/v1/deviceservice
+#meta.db.deviceprofile.url=http://localhost:48081/api/v1/deviceprofile
+#meta.db.device.url=http://localhost:48081/api/v1/device
+#meta.db.devicereport.url=http://localhost:48081/api/v1/devicereport
+#meta.db.command.url=http://localhost:48081/api/v1/command
+#meta.db.event.url=http://localhost:48081/api/v1/scheduleevent
+#meta.db.schedule.url=http://localhost:48081/api/v1/schedule
+#meta.db.provisionwatcher.url=http://localhost:48081/api/v1/provisionwatcher
+#meta.db.ping.url=http://localhost:48081/api/v1/ping
+meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
+meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
+
+#IOT core database service connection information
+#core.db.event.url=http://localhost:48080/api/v1/event
+#core.db.reading.url=http://localhost:48080/api/v1/reading
+#core.db.valuedescriptor.url=http://localhost:48080/api/v1/valuedescriptor
+#core.db.ping.url=http://localhost:48080/api/v1/ping
+core.db.event.url=http://edgex-core-data:48080/api/v1/event
+core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
+core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
+core.db.ping.url=http://edgex-core-data:48080/api/v1/ping
+logging.remote.url=http://edgex-support-logging:48061/api/v1/logs

--- a/cmd/config-seed/res/properties/device-snmp/application.properties
+++ b/cmd/config-seed/res/properties/device-snmp/application.properties
@@ -1,0 +1,50 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-snmp
+# @author: Anantha Boyapalle, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR,INFO
+logging.level.org.apache=ERROR,INFO
+logging.level.org.edgexfoundry=INFO,INFO
+
+app.open.msg=This is the device-snmp micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49989
+
+#default device service settings
+service.name=device-snmp
+service.host=localhost
+#service.host=${service.name}
+service.labels=SNMP,scheduler
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+

--- a/cmd/config-seed/res/properties/device-snmp;docker/application.properties
+++ b/cmd/config-seed/res/properties/device-snmp;docker/application.properties
@@ -1,0 +1,81 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-snmp
+# @author: Anantha Boyapalle, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=INFO
+
+app.open.msg=This is the device-snmp micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49989
+
+#default device service settings
+service.name=edgex-device-snmp
+#service.host=localhost
+service.host=${service.name}
+service.labels=SNMP,scheduler
+service.callback=/api/v1/callback
+
+#connection retry parameters
+service.connect.retries=20
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+
+meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
+meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
+
+core.db.event.url=http://edgex-core-data:48080/api/v1/event
+core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
+core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
+core.db.ping.url=http://edgex-core-data:48080/api/v1/ping
+
+logging.remote.enable=true
+logging.remote.url=http://edgex-support-logging:48061/api/v1/logs
+
+schedule.interval=500
+
+default.schedule.name=Interval-1m
+default.schedule.frequency=PT1m
+
+default.scheduleEvent.name=Read-AllData-edgex-device-snmp
+default.scheduleEvent.path=/api/v1/device/all/AllLightStates
+default.scheduleEvent.service=edgex-device-snmp
+default.scheduleEvent.schedule=Interval-1m
+snmp.version=1
+snmp.retries=2
+snmp.timeout=2000

--- a/cmd/config-seed/res/properties/device-virtual/application.properties
+++ b/cmd/config-seed/res/properties/device-virtual/application.properties
@@ -1,0 +1,73 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-virtual
+# @author: Cloud Tsai, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+
+#------------------- Logging Settings ---------------------------------------
+#the log location
+logging.file=edgex-device-virtual.log
+#the default logging level
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=INFO
+
+#-----------------Remote Logging Config------------------------------------------
+logging.remote.enable=false
+logging.remote.url=http://localhost:48061/api/v1/logs
+
+app.open.msg=This is the device-virtual micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49990
+
+#------------------- General Settings ---------------------------------------
+#The paths of device profile definition files
+application.device-profile-paths=./bacnet_sample_profiles,./modbus_sample_profiles
+#Clean up devices, profiles, and the device service instances 
+#from Metadata Service automatically when the application shudown 
+application.auto-cleanup=true
+#After provisioning profiles from YAML, create one device for each profile automatically
+application.auto-create-device=true
+#collection frequency in seconds
+application.collection-frequency=15
+
+#default device service settings
+service.name=device-virtual
+service.host=localhost
+#service.host=${service.name}
+service.labels=virtual
+service.callback=/api/v1/callback
+service.protocol=http
+service.port=${server.port}
+service.adminState=UNLOCKED
+service.operatingState=ENABLED
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+

--- a/cmd/config-seed/res/properties/device-virtual;docker/application.properties
+++ b/cmd/config-seed/res/properties/device-virtual;docker/application.properties
@@ -1,0 +1,90 @@
+###############################################################################
+# Copyright 2016-2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  device-virtual
+# @author: Cloud Tsai, Dell
+# @version: 1.0.0
+###############################################################################
+#REST read data limit
+read.max.limit=100
+
+#------------------- Logging Settings ---------------------------------------
+#the log location
+logging.file=/edgex/logs/edgex-device-virtual.log
+#the default logging level
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=INFO
+
+#-----------------Remote Logging Config------------------------------------------
+logging.remote.enable=true
+logging.remote.url=http://edgex-support-logging:48061/api/v1/logs
+
+app.open.msg=This is the device-virtual micro service
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+
+server.port=49990
+
+#------------------- General Settings ---------------------------------------
+#The paths of device profile definition files
+application.device-profile-paths=./bacnet_sample_profiles,./modbus_sample_profiles
+#Clean up devices, profiles, and the device service instances 
+#from Metadata Service automatically when the application shudown 
+application.auto-cleanup=false
+#After provisioning profiles from YAML, create one device for each profile automatically
+application.auto-create-device=true
+#collection frequency in seconds
+application.collection-frequency=15
+
+#default device service settings
+service.name=edgex-device-virtual
+service.host=${service.name}
+service.labels=virtual
+service.callback=/api/v1/callback
+service.protocol=http
+service.port=${server.port}
+service.adminState=UNLOCKED
+service.operatingState=ENABLED
+
+#connection retry parameters
+service.connect.retries=12
+service.connect.wait=5000
+service.connect.interval=10000
+# callback timeout in milliseconds
+service.timeout=5000
+
+spring.mvc.dispatch-options-request=true
+
+data.transform=true
+
+#------------------- REST Endpoints ---------------------------------------
+# metadata database service connection information
+meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+meta.db.event.url=http://edgex-core-metadata:48081/api/v1/scheduleevent
+meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+meta.db.ping.url=http://edgex-core-metadata:48081/api/v1/ping
+
+#IOT core database service connection information
+core.db.event.url=http://edgex-core-data:48080/api/v1/event
+core.db.reading.url=http://edgex-core-data:48080/api/v1/reading
+core.db.valuedescriptor.url=http://edgex-core-data:48080/api/v1/valuedescriptor
+core.db.ping.url=http://edgex-core-data:48080/api/v1/ping

--- a/cmd/config-seed/res/properties/edgex-support-rulesengine/application.properties
+++ b/cmd/config-seed/res/properties/edgex-support-rulesengine/application.properties
@@ -1,0 +1,88 @@
+###############################################################################
+# Copyright 2017 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  support-rulesengine
+# @author: Jim White, Dell
+# @version: 1.0.0
+###############################################################################
+#-----------------General Config-----------------------------------------------
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+#messages
+heart.beat.msg=Support Rules Engine data heart beat
+app.open.msg=This is the Support Rules Engine Micro Service.
+# set port (override Spring boot default port 8080 )
+server.port=48075
+#-----------------Export Service Config----------------------------------------
+#Turn on/off registration of rules engine as export distro client.  
+#Set to false to receive messages directly from core data
+export.client=true
+export.client.registration.url=http://localhost:48071/api/v1
+#export.client.registration.url=http://edgex-export-client:48071/api/v1
+export.client.registration.name=EdgeXRulesEngine
+#use port 5566 when connected to export distro
+#use port 5563 when connected to core data directly
+export.zeromq.port=5566
+#export.zeromq.port=5563
+export.zeromq.host=tcp://localhost
+#export.zeromq.host=tcp://edgex-export-distro
+#how long to wait to retry registration
+export.client.registration.retry.time=10000
+#how many times to try registration before exiting
+export.client.registration.retry.attempts=100
+#-----------------Logging Config-----------------------------------------------
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=INFO
+#log files are rotated after 10MB by default in Spring boot
+logging.file=edgex-support-rulesengine.log
+#-----------------Drools Config-----------------------------------------------
+#Drools drl resource path
+rules.default.path=edgex/rules
+#rules.default.path=/edgex/edgex-support-rulesengine/rules
+rules.packagename=org.edgexfoundry.rules
+rules.fileextension=.drl
+#rules.template.path=./src/main/resources
+rules.template.path=edgex/templates
+#rules.template.path=/edgex/edgex-support-rulesengine/templates
+rules.template.name=rule-template.drl
+rules.template.encoding=UTF-8
+#IOT core data database service connection information
+core.db.command.url=http://localhost:48082/api/v1/device
+#core.db.command.url=http://edgex-core-command:48082/api/v1/device
+#IOT metadata database service connection information
+meta.db.addressable.url=http://localhost:48081/api/v1/addressable
+meta.db.deviceservice.url=http://localhost:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://localhost:48081/api/v1/deviceprofile
+meta.db.device.url=http://localhost:48081/api/v1/device
+meta.db.devicereport.url=http://localhost:48081/api/v1/devicereport
+meta.db.command.url=http://localhost:48081/api/v1/command
+meta.db.event.url=http://localhost:48081/api/v1/event
+meta.db.schedule.url=http://localhost:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://localhost:48081/api/v1/provisionwatcher
+#meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+#meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+#meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+#meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+#meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+#meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+#meta.db.event.url=http://edgex-core-metadata:48081/api/v1/event
+#meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+#meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+#-----------------Remote Logging Config------------------------------------------
+#logging.remote.enable=true
+logging.remote.url=http://localhost:48061/api/v1/logs
+#logging.remote.url=http://edgex-support-logging:48061/api/v1/logs

--- a/cmd/config-seed/res/properties/edgex-support-rulesengine;docker/application.properties
+++ b/cmd/config-seed/res/properties/edgex-support-rulesengine;docker/application.properties
@@ -1,0 +1,89 @@
+###############################################################################
+# Copyright 2016-17 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @microservice:  support-rulesengine
+# @author: Jim White, Dell
+# @version: 1.0.0
+###############################################################################
+#--Docker container specific app properties -----
+#-----------------General Config-----------------------------------------------
+#every 5 minutes (in milliseconds)
+heart.beat.time=300000
+#messages
+heart.beat.msg=Support Rules Engine data heart beat
+app.open.msg=This is the Support Rules Engine Micro Service.
+# set port (override Spring boot default port 8080 )
+server.port=48075
+#-----------------Export Service Config----------------------------------------
+#Turn on/off registration of rules engine as export distro client.  
+#Set to false to receive messages directly from core data
+export.client=true
+#export.client.registration.url=http://localhost:48071/api/v1
+export.client.registration.url=http://edgex-export-client:48071/api/v1
+export.client.registration.name=EdgeXRulesEngine
+#use port 5566 when connected to export distro
+#use port 5563 when connected to core data directly
+export.zeromq.port=5566
+#export.zeromq.port=5563
+#export.zeromq.host=tcp://localhost
+export.zeromq.host=tcp://edgex-export-distro
+#how long to wait to retry registration
+export.client.registration.retry.time=10000
+#how many times to try registration before exiting
+export.client.registration.retry.attempts=100
+#-----------------Logging Config-----------------------------------------------
+#logging levels (used to control log4j entries)
+logging.level.org.springframework=ERROR
+logging.level.org.apache=ERROR
+logging.level.org.edgexfoundry=INFO
+#log files are rotated after 10MB by default in Spring boot
+logging.file=/edgex/logs/edgex-support-rulesengine.log
+#-----------------Drools Config-----------------------------------------------
+#Drools drl resource path
+#rules.default.path=/edgex/rules
+rules.default.path=/edgex/edgex-support-rulesengine/rules
+rules.packagename=org.edgexfoundry.rules
+rules.fileextension=.drl
+#rules.template.path=./src/main/resources
+#rules.template.path=/edgex/templates
+rules.template.path=/edgex/edgex-support-rulesengine/templates
+rules.template.name=rule-template.drl
+rules.template.encoding=UTF-8
+#IOT core data database service connection information
+#core.db.command.url=http://localhost:48082/api/v1/device
+core.db.command.url=http://edgex-core-command:48082/api/v1/device
+#IOT metadata database service connection information
+#meta.db.addressable.url=http://localhost:48081/api/v1/addressable
+#meta.db.deviceservice.url=http://localhost:48081/api/v1/deviceservice
+#meta.db.deviceprofile.url=http://localhost:48081/api/v1/deviceprofile
+#meta.db.device.url=http://localhost:48081/api/v1/device
+#meta.db.devicereport.url=http://localhost:48081/api/v1/devicereport
+#meta.db.command.url=http://localhost:48081/api/v1/command
+#meta.db.event.url=http://localhost:48081/api/v1/event
+#meta.db.schedule.url=http://localhost:48081/api/v1/schedule
+#meta.db.provisionwatcher.url=http://localhost:48081/api/v1/provisionwatcher
+meta.db.addressable.url=http://edgex-core-metadata:48081/api/v1/addressable
+meta.db.deviceservice.url=http://edgex-core-metadata:48081/api/v1/deviceservice
+meta.db.deviceprofile.url=http://edgex-core-metadata:48081/api/v1/deviceprofile
+meta.db.device.url=http://edgex-core-metadata:48081/api/v1/device
+meta.db.devicereport.url=http://edgex-core-metadata:48081/api/v1/devicereport
+meta.db.command.url=http://edgex-core-metadata:48081/api/v1/command
+meta.db.event.url=http://edgex-core-metadata:48081/api/v1/event
+meta.db.schedule.url=http://edgex-core-metadata:48081/api/v1/schedule
+meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
+#-----------------Remote Logging Config------------------------------------------
+logging.remote.enable=true
+#logging.remote.url=http://localhost:48061/api/v1/logs
+logging.remote.url=http://edgex-support-logging:48061/api/v1/logs

--- a/docker/Dockerfile.config-seed
+++ b/docker/Dockerfile.config-seed
@@ -1,0 +1,61 @@
+###############################################################################
+# Copyright 2018 Dell Technologies, Inc All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
+# Docker image for building EdgeX Foundry Config Seed
+FROM golang:1.9-alpine AS build-env
+
+# environment variables
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:$PATH
+
+# set the working directory
+WORKDIR $GOPATH/src/github.com/edgexfoundry/edgex-go
+
+# copy go source files
+COPY . .
+
+# build
+RUN apk update && apk add make glide git
+RUN make prepare
+RUN make cmd/config-seed/config-seed
+
+# Consul Docker image for EdgeX Foundry
+FROM golang:1.9-alpine
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2017: Samsung'
+
+RUN apk add --no-cache bash
+
+# environment variables
+ENV APP_DIR=/edgex/cmd/config-seed
+
+# set the working directory
+WORKDIR $APP_DIR
+
+# copy files
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/config-seed  .
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/res ./res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/core-command/res /edgex/cmd/core-command/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/core-data/res /edgex/cmd/core-data/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/core-metadata/res /edgex/cmd/core-metadata/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/export-client/res /edgex/cmd/export-client/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/export-distro/res /edgex/cmd/export-distro/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-logging/res /edgex/cmd/support-logging/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-notifications/res /edgex/cmd/support-notifications/res
+
+ENTRYPOINT /edgex/cmd/config-seed/config-seed --profile=docker

--- a/docker/Dockerfile.config-seed
+++ b/docker/Dockerfile.config-seed
@@ -58,4 +58,4 @@ COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/export-di
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-logging/res /edgex/cmd/support-logging/res
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-notifications/res /edgex/cmd/support-notifications/res
 
-ENTRYPOINT /edgex/cmd/config-seed/config-seed --profile=docker
+ENTRYPOINT /edgex/cmd/config-seed/config-seed --profile=docker --cmd=/edgex/cmd

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,6 +26,8 @@ import:
   version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 - package: github.com/mattn/go-xmpp
   version: e543ad3fcd51155e4b39f7487bdfcb5e3772f1ce
+- package: github.com/magiconair/properties
+  version: =1.8.0
 - package: github.com/satori/go.uuid
   version: =1.2.0
 - package: github.com/stretchr/testify

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package internal
 
+const ConfigSeedServiceKey = "edgex-config-seed"
 const CoreCommandServiceKey = "edgex-core-command"
 const CoreDataServiceKey = "edgex-core-data"
 const CoreMetaDataServiceKey = "edgex-core-metadata"

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package internal
 
+const ConfigFileDefaultProfile = "configuration.toml"
+const ConfigFileDockerProfile = "configuration-docker.toml"
+
+const ServiceKeyPrefix = "edgex-"
 const ConfigSeedServiceKey = "edgex-config-seed"
 const CoreCommandServiceKey = "edgex-core-command"
 const CoreDataServiceKey = "edgex-core-data"

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -27,9 +27,25 @@ Common Options:
     -h, --help                      Show this message
 `
 
+var configSeedUsageStr = `
+Usage: %s [options]
+Server Options:
+    -p, --profile <name>            Indicate configuration profile other than default
+    -r, --props <dir>               Provide alternate location for legacy application.properties files
+    -c, --cmd <dir>                 Provide absolute path to "cmd" directory containing EdgeX services
+Common Options:
+    -h, --help                      Show this message
+`
+
 // usage will print out the flag options for the server.
 func HelpCallback() {
 	msg := fmt.Sprintf(usageStr, os.Args[0])
+	fmt.Printf("%s\n", msg)
+	os.Exit(0)
+}
+
+func HelpCallbackConfigSeed() {
+	msg := fmt.Sprintf(configSeedUsageStr, os.Args[0])
 	fmt.Printf("%s\n", msg)
 	os.Exit(0)
 }

--- a/internal/seed/config/const.go
+++ b/internal/seed/config/const.go
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package config
+
+// Configuration struct populated from local TOML during service bootstrap
+// NOTE: I am only following the existing pattern of putting this struct into
+//       a file named "const.go". I do not think this properly belongs in a
+//       file whose intent by name is for constants. If I were to move this,
+//       then other services should also have their struct moved in a single PR.
+type ConfigurationStruct struct {
+	ConfigPath                   string
+	GlobalPrefix                 string
+	ConsulProtocol               string
+	ConsulHost                   string
+	ConsulPort                   int
+	IsReset                      bool
+	FailLimit                    int
+	FailWaitTime                 int
+	AcceptablePropertyExtensions []string
+	YamlExtensions               []string
+	TomlExtensions               []string
+	EnableRemoteLogging          bool
+	LoggingFile                  string
+	LoggingRemoteURL             string
+}
+
+const consulStatusPath = "/v1/agent/self"

--- a/internal/seed/config/init.go
+++ b/internal/seed/config/init.go
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package config
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
+	consulapi "github.com/hashicorp/consul/api"
+	"io/ioutil"
+)
+
+// Global variables
+var Configuration *ConfigurationStruct
+var LoggingClient logger.LoggingClient
+var Registry *consulapi.Client
+
+// The purpose of Retry is different here than in other services. In this case, we use a retry in order
+// to initialize the ConsulClient that will be used to write configuration information. Other services
+// use Retry to read their information. Config-seed writes information.
+func Retry(useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
+	for time.Now().Before(until) {
+		var err error
+		//When looping, only handle configuration if it hasn't already been set.
+		if Configuration == nil {
+			Configuration, err = initializeConfiguration(useProfile)
+			if err != nil {
+				ch <- err
+			} else {
+				// Setup Logging
+				logTarget := setLoggingTarget()
+				LoggingClient = logger.NewClient(internal.ConfigSeedServiceKey, Configuration.EnableRemoteLogging, logTarget)
+			}
+		}
+		//Check to verify consul connectivity
+		if Registry == nil {
+			Registry, err = initConsulClient()
+			if err != nil {
+				ch <- err
+			} else {
+				break
+			}
+		}
+		time.Sleep(time.Second * time.Duration(1))
+	}
+	close(ch)
+	wait.Done()
+
+	return
+}
+
+func Init() bool {
+	if Configuration != nil && Registry != nil {
+		return true
+	}
+	return false
+}
+
+func initializeConfiguration(useProfile string) (*ConfigurationStruct, error) {
+	conf := &ConfigurationStruct{}
+	err := config.LoadFromFile(useProfile, conf)
+	if err != nil {
+		return nil, err
+	}
+	return conf, nil
+}
+
+func initConsulClient() (*consulapi.Client, error) {
+	url := Configuration.ConsulProtocol + "://" + Configuration.ConsulHost + ":" + strconv.Itoa(Configuration.ConsulPort)
+
+	resp, err := http.Get(url + consulStatusPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		// Connect to the Consul Agent
+		cfg := consulapi.DefaultConfig()
+		cfg.Address = url
+
+		r, err := consulapi.NewClient(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+	body, err := getBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	return nil, types.NewErrServiceClient(resp.StatusCode, body)
+}
+
+// Helper method to get the body from the response after making the request
+func getBody(resp *http.Response) ([]byte, error) {
+	body, err := ioutil.ReadAll(resp.Body)
+
+	return body, err
+}
+
+func setLoggingTarget() string {
+	logTarget := Configuration.LoggingRemoteURL
+	if !Configuration.EnableRemoteLogging {
+		return Configuration.LoggingFile
+	}
+	return logTarget
+}

--- a/internal/seed/config/populate.go
+++ b/internal/seed/config/populate.go
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package config
+
+import (
+	"fmt"
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/magiconair/properties"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func ImportProperties(root string) error {
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories & unacceptable property extension
+		if info.IsDir() || !isAcceptablePropertyExtensions(info.Name()) {
+			return nil
+		}
+
+		dir, file := filepath.Split(path)
+		appKey := parseDirectoryName(dir)
+		LoggingClient.Info(fmt.Sprintf("dir: %s file: %s", appKey, file))
+		props, err := readPropertiesFile(path)
+		if err != nil {
+			return err
+		}
+
+		// Put config properties to Consul K/V store.
+		prefix := Configuration.GlobalPrefix + "/" + appKey + "/"
+		for k := range props {
+			p := &consulapi.KVPair{Key: prefix + k, Value: []byte(props[k])}
+			if _, err := (*consulapi.KV).Put(Registry.KV(), p, nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func isAcceptablePropertyExtensions(file string) bool {
+	for _, v := range Configuration.AcceptablePropertyExtensions {
+		if v == filepath.Ext(file) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseDirectoryName(path string) string {
+	path = strings.TrimRight(path, "/")
+	tokens := strings.Split(path, "/")
+	return tokens[len(tokens)-1]
+}
+
+// Parse a properties file to a map.
+func readPropertiesFile(filePath string) (map[string]string, error) {
+	props, err := properties.LoadFile(filePath, properties.UTF8)
+	if err != nil {
+		return nil, err
+	}
+
+	return props.Map(), nil
+}

--- a/internal/seed/config/populate.go
+++ b/internal/seed/config/populate.go
@@ -14,12 +14,16 @@
 package config
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
-	consulapi "github.com/hashicorp/consul/api"
-	"github.com/magiconair/properties"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/magiconair/properties"
 )
 
 func ImportProperties(root string) error {
@@ -58,8 +62,114 @@ func ImportProperties(root string) error {
 	return nil
 }
 
+func ImportConfiguration(root string) error {
+	dirs := listDirectories()
+	absRoot, err := determineAbsRoot(root)
+	if err != nil {
+		return err
+	}
+	for _, d := range dirs {
+		LoggingClient.Debug(fmt.Sprintf("importing: %s/%s", absRoot, d))
+		if err != nil {
+			return err
+		}
+		res := fmt.Sprintf("%s/%s/res", absRoot, d)
+		err = filepath.Walk(res, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// Only import TOML files. Ignore others.
+			if info.IsDir() || !isTomlExtension(info.Name()) {
+				return nil
+			}
+
+			LoggingClient.Debug("reading toml " + path)
+			props, err := readTomlFile(path)
+			if err != nil {
+				return err
+			}
+
+			appKey, err := buildAppKey(d, info.Name())
+			if err != nil {
+				return err
+			}
+			// Put config properties to Consul K/V store.
+			prefix := Configuration.GlobalPrefix + "/" + appKey + "/"
+			for k := range props {
+				p := &consulapi.KVPair{Key: prefix + k, Value: []byte(props[k])}
+				if _, err := (*consulapi.KV).Put(Registry.KV(), p, nil); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func listDirectories() [7]string {
+	var names = [7]string{internal.CoreCommandServiceKey, internal.CoreDataServiceKey, internal.CoreMetaDataServiceKey,
+		internal.ExportClientServiceKey, internal.ExportDistroServiceKey, internal.SupportLoggingServiceKey,
+		internal.SupportNotificationsServiceKey}
+
+	for i, name := range names {
+		names[i] = strings.Replace(name, internal.ServiceKeyPrefix, "", 1)
+	}
+
+	return names
+}
+
+func determineAbsRoot(root string) (string, error) {
+	// This should only be necessary when running the application locally as a developer
+	// so some knowledge of the tree layout is granted.
+	if strings.Contains(root, "../cmd") {
+		exec, err := os.Executable()
+		if err != nil {
+			return "", err
+		}
+		execDir := filepath.Dir(exec)
+		LoggingClient.Debug("executing dir " + execDir)
+		ixLast := strings.LastIndex(execDir, "/")
+		absRoot := execDir[0:(ixLast)] //Seems like there should be some other way
+		LoggingClient.Debug("absolute path " + absRoot)
+		return absRoot, nil
+	}
+	return root, nil
+}
+
+func buildAppKey(app string, fileName string) (string, error) {
+	var err error = nil
+	var key string = internal.ServiceKeyPrefix
+	switch fileName {
+	case internal.ConfigFileDefaultProfile:
+		key += app + ";go"
+		break
+	case internal.ConfigFileDockerProfile:
+		key += app + ";docker"
+		break
+	default:
+		err = errors.New("unrecognized name: " + fileName)
+		key = ""
+		break
+	}
+	return key, err
+}
+
 func isAcceptablePropertyExtensions(file string) bool {
 	for _, v := range Configuration.AcceptablePropertyExtensions {
+		if v == filepath.Ext(file) {
+			return true
+		}
+	}
+	return false
+}
+
+func isTomlExtension(file string) bool {
+	for _, v := range Configuration.TomlExtensions {
 		if v == filepath.Ext(file) {
 			return true
 		}
@@ -81,4 +191,28 @@ func readPropertiesFile(filePath string) (map[string]string, error) {
 	}
 
 	return props.Map(), nil
+}
+
+//This works for now because our TOML is simply key/value.
+//Will not work once we go hierarchical
+func readTomlFile(filePath string) (map[string]string, error) {
+	configProps := map[string]string{}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return configProps, fmt.Errorf("could not load configuration file (%s): %v", filePath, err.Error())
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "=") {
+			tokens := strings.Split(scanner.Text(), "=")
+			configProps[strings.Trim(tokens[0], " '")] = strings.Trim(tokens[1], " '")
+		}
+	}
+	return configProps, nil
 }


### PR DESCRIPTION
#517 

This PR contains work to merge the config-seed service into the edgex-go repo as has been discussed on the Core WG calls. There are several points to note w/r/t this PR:

- The PR looks bigger than it is due to all of the application.properties files that had to be brought over. This is so that we can avoid config file duplication between two repos.
- As described on the calls, the goal was to achieve functional parity with the existing core-config-seed-go service. No functionality for Config V2 has been added yet.
- Today the config-seed is not run unless one wishes to exercise EdgeX via docker containers, so I have not added it to the `make run` command. It IS present in `make build`. You can run the service via
```
cd cmd/config-seed
./config-seed
```
- I have added a docker target for creating the relevant image. I have tested this locally and verified Consul population.
- No accounting has been made for Snap deployment here. I was discussing my approach with @tonyespy last week and sent him the included Dockerfile. Feedback is TBD.
- For the legacy application.properties files, I put these in the local .config-seed/res/properties directory. This seemed the easiest to me and this directory will be removed after Edinburgh. (This was shown on last week's Core WG call)
- For the Go services, TOML is assumed. If not running the services via local cmd line, then one needs to use the "--cmd" command line property to specify where the `edgex/cmd` directory lives (this includes via GoLand IDE)
- Approval/merge of this PR is a pre-requisite for continuing on with the Config V2 work

I look forward to any comments/input you may have.