### PR TITLE
Adding version information to glide.yaml

### DIFF
--- a/export/distro/format.go
+++ b/export/distro/format.go
@@ -120,16 +120,10 @@ func NewAzureMessage() (*AzureMessage, error) {
 		Created:    time.Now(),
 	}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		return nil, err
-	}
+	id := uuid.NewV4()
 	msg.ID = id.String()
 
-	correlationID, err := uuid.NewV4()
-	if err != nil {
-		return nil, err
-	}
+	correlationID := uuid.NewV4()
 	msg.CorrelationID = correlationID.String()
 
 	return msg, nil

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,19 +1,32 @@
 package: github.com/edgexfoundry/edgex-go
 import:
 - package: github.com/BurntSushi/toml
+  version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
 - package: github.com/eclipse/paho.mqtt.golang
+  version: =1.1.1
 - package: github.com/go-zoo/bone
+  version: 9eaad4b99a9a66b85c0cc32cb9691621ccfa4278
 - package: github.com/gorilla/mux
+  version: =1.3.0
 - package: github.com/hashicorp/consul
+  version: =1.1.0
   subpackages:
   - api
 - package: github.com/pebbe/zmq4
+  version: =1.0.0
 - package: github.com/robfig/cron
+  version: =1.1.0
 - package: go.uber.org/zap
+  version: =1.7.1
 - package: gopkg.in/mgo.v2
+  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
 - package: gopkg.in/yaml.v2
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 - package: github.com/mattn/go-xmpp
+  version: e543ad3fcd51155e4b39f7487bdfcb5e3772f1ce
 - package: github.com/satori/go.uuid
+  version: =1.2.0
 - package: github.com/stretchr/testify
+  version: =1.2.1


### PR DESCRIPTION
#514 

Per discussion on the Core and DevOps WG calls these past few weeks, I have added explicit versions to the glide.yaml file. I had to make some decisions while doing this. I used SHAs in the California glide.lock file for reference.

- When a given tag was closely followed by a release, I used the release in the version field.
- When there wasn't a nearby release, I used the tag
- When there was no release at all (such as the XMPP repo) I used the tag

Note that this caused a build error in the export/distro/format.go file but it's very minor, so I fixed that and included it here.

Note that `make prepare` will pull in dependencies not explicitly listed in the glide.yaml so I can't version those. We're relying on the package mgmt of our dependencies in these cases.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>