### PR TITLE
[snap] Expose mongoimport as an app

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,6 +73,9 @@ apps:
   mongodump:
     command: bin/mongodump
     plugs: [network]
+  mongoimport:
+    command: bin/mongoimport
+    plugs: [home, network]
   consul-cli:
     command: bin/consul
     plugs: [network, network-bind]
@@ -283,7 +286,6 @@ parts:
       - -bin/bsondump
       - -bin/mongoexport
       - -bin/mongofiles
-      - -bin/mongoimport
       - -bin/mongooplog
       - -bin/mongoperf
       - -bin/mongoreplay


### PR DESCRIPTION
Allowing access to mongoimport allows easy import of
Blackbox test data required to run blackbox tests.

Signed-off-by: Tony Espy <espy@canonical.com>