### PR TITLE
snapcraft.yaml: simplify mongodb part to use advanced grammar

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -148,24 +148,12 @@ parts:
       - bin/stop-edgex.sh
       - config/edgex-services-env
   mongodb:
-    plugin: shell
-    source: .
-    shell: bash
-    shell-flags: ['-eux', '-o', 'pipefail']
-    build-packages: [wget]
-    shell-command: |
-      export ARCH=`arch`
-
-      if [ $ARCH = "x86_64" ] ; then
-        export PACKAGE="mongodb-linux-x86_64-ubuntu1604-3.4.10.tgz"
-      elif [ $ARCH = "aarch64" ] ; then
-        export PACKAGE="mongodb-linux-arm64-ubuntu1604-3.4.10.tgz"
-      fi
-
-      pushd $SNAPCRAFT_PART_INSTALL
-      wget "https://fastdl.mongodb.org/linux/$PACKAGE"
-      tar xvf "./$PACKAGE" --strip-components=1
-      popd
+    plugin: dump
+    source: 
+      - on amd64: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.4.10.tgz
+      - else:
+        - on arm64: https://fastdl.mongodb.org/linux/mongodb-linux-arm64-ubuntu1604-3.4.10.tgz
+      - else fail
     organize:
       GNU-AGPL-3.0: usr/share/doc/mongodb/GNU-AGPL-3.0
       MPL-2: usr/share/doc/mongodb/MPL-2
@@ -184,7 +172,6 @@ parts:
       - -bin/mongorestore
       - -bin/mongos
       - -bin/mongotop
-      - -mongodb-linux-*-ubuntu1604-3.4.10.tgz
   mongo-config:
     source: https://github.com/edgexfoundry/docker-edgex-mongo.git
     source-depth: 1


### PR DESCRIPTION
* This allows the build to fail immediately if not on amd64 or arm64
* This is also more concise, not requiring an override-build setting
* Is progress towards removing the shell plugin entirely