### PR TITLE
snapcraft.yaml: use VERSION file to set snap version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: edgexfoundry
-version: '0.5.2'
+version: 'replace-me'
 version-script: |
-    echo $SNAPCRAFT_PROJECT_VERSION-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
+    echo $(cat VERSION)-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
 summary: Provides a full set of Edgex Foundry core microservices.
 description: |
  This snap provides a full set of EdgeX Foundry core micro services.


### PR DESCRIPTION
Note that we only want to do this for the master releases that go to `latest/edge`. We don't want to do this for versioned releases that go into tracks, as with those the versions must be carefully gated.