### PR TITLE
docs/Dockerfile.build: specify version for pip packages

### DIFF
--- a/docs/Dockerfile.build
+++ b/docs/Dockerfile.build
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y git python-pip latexmk texlive-latex-recommended \
   texlive-latex-extra texlive-fonts-recommended nodejs npm make linkchecker
 RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN pip install sphinx==1.7.9 sphinxcontrib-googleanalytics
+RUN pip install sphinx==1.7.9 sphinxcontrib-googleanalytics==0.1
 RUN npm i -g raml2html@3.0.1
 RUN mkdir docbuild
 WORKDIR /docbuild

--- a/docs/Dockerfile.build
+++ b/docs/Dockerfile.build
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y git python-pip latexmk texlive-latex-recommended \
   texlive-latex-extra texlive-fonts-recommended nodejs npm make linkchecker
 RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN pip install sphinx sphinxcontrib-googleanalytics
+RUN pip install sphinx==1.7.9 sphinxcontrib-googleanalytics
 RUN npm i -g raml2html@3.0.1
 RUN mkdir docbuild
 WORKDIR /docbuild


### PR DESCRIPTION
This fixes #576 by versioning the pip packages used to build the docs. Apparently Sphinx v1.8 breaks on Linux Foundation CI running Python 2.7.5.