### PR TITLE
snapcraft.yaml: remove base64 part

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -763,12 +763,3 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res
       cp core/res/configuration.toml $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res/configuration.toml
       sed -i "s@tokenpath = \"res\\\\\\\\resp-init.json\"@tokenpath = \"res/resp-init.json\"@" $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res/configuration.toml
-  base64:
-    # TODO: the core snap currently ships base64, but doesn't allow it in the default apparmor:
-    # https://forum.snapcraft.io/t/adding-base64-command-to-default-snap-apparmor/6744
-    # when/if it gets added to the apparmor we can remove this part
-    plugin: nil
-    prime: 
-    - usr/bin/base64
-    stage-packages:
-      - coreutils


### PR DESCRIPTION
No longer necessary with snapd 2.35

This resolves #478.