### PR TITLE
snapcraft.yaml: include COPYRIGHT for openresty

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -642,6 +642,9 @@ parts:
       snapcraftctl build
       # remove the openresy link, we will handle that in the kong part
       rm -rf $SNAPCRAFT_PART_INSTALL/bin/openresty
+
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/doc/openresty.org/openresty/
+      cp COPYRIGHT "$SNAPCRAFT_PART_INSTALL/usr/share/doc/openresty.org/openresty/COPYRIGHT"
   kong:
     after: 
       - openresty


### PR DESCRIPTION
This PR adds a missing COPYRIGHT file for openresty to the snap.