### PR TITLE
Device service is notified when device addressable is updated

### DIFF
--- a/internal/core/metadata/rest_addressable.go
+++ b/internal/core/metadata/rest_addressable.go
@@ -360,13 +360,27 @@ func restGetAddressableByAddress(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(res)
 }
 
-// Notify the associated device services for the addressable
+// Notify the associated device services for changes in the device addressable
 func notifyAddressableAssociates(a models.Addressable, action string) error {
-	var ds []models.DeviceService
-	if err := dbClient.GetDeviceServicesByAddressableId(&ds, a.Id.Hex()); err != nil {
+	// Get the devices
+	var d []models.Device
+	if err := dbClient.GetDevicesByAddressableId(&d, a.Id.Hex()); err != nil {
 		LoggingClient.Error(err.Error(), "")
 		return err
 	}
+
+	// Get the services for each device
+	// Use map as a Set
+	dsMap := map[string]models.DeviceService{}
+	var ds []models.DeviceService
+	for _, device := range d {
+		// Only add if not there
+		if _, ok := dsMap[device.Service.Service.Id.Hex()]; !ok {
+			dsMap[device.Service.Service.Id.Hex()] = device.Service
+			ds = append(ds, device.Service)
+		}
+	}
+
 	if err := notifyAssociates(ds, a.Id.Hex(), action, models.ADDRESSABLE); err != nil {
 		LoggingClient.Error(err.Error(), "")
 		return err

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -629,7 +629,7 @@ func restGetYamlProfileById(w http.ResponseWriter, r *http.Request) {
 	w.Write(out)
 }
 
-// Notify the associated device services for the addressable
+// Notify the associated device services for changes in the device profile
 func notifyProfileAssociates(dp models.DeviceProfile, action string) error {
 	// Get the devices
 	var d []models.Device


### PR DESCRIPTION
This should fix #613.
Is implemented in the same way as it's done with profiles.

Signed-off-by: Joan Duran <jduran@circutor.com>