### PR TITLE
Added the option to set the minimum log level severity

### DIFF
--- a/internal/support/logging/criteria_test.go
+++ b/internal/support/logging/criteria_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/support/logging/models"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 )
 
 func TestCriteriaMatch(t *testing.T) {
 	var services = []string{"service1", "service2"}
-	var levels = []string{models.TRACE, models.DEBUG}
+	var levels = []string{logger.TraceLog, logger.DebugLog}
 	var keywords = []string{"2"}
 	var keywordsEmptyString = []string{""}
 	var labels1 = []string{"label1"}
@@ -34,8 +35,8 @@ func TestCriteriaMatch(t *testing.T) {
 		{"wrongService", models.LogEntry{OriginService: "service11"}, matchCriteria{OriginServices: services}, false},
 		{"matchService", models.LogEntry{OriginService: "service1"}, matchCriteria{OriginServices: services}, true},
 		// Levels
-		{"wrongLevel", models.LogEntry{Level: models.WARN}, matchCriteria{LogLevels: levels}, false},
-		{"matchLevel", models.LogEntry{Level: models.DEBUG}, matchCriteria{LogLevels: levels}, true},
+		{"wrongLevel", models.LogEntry{Level: logger.WarnLog}, matchCriteria{LogLevels: levels}, false},
+		{"matchLevel", models.LogEntry{Level: logger.DebugLog}, matchCriteria{LogLevels: levels}, true},
 		// Start
 		{"0Start", models.LogEntry{Created: 5}, matchCriteria{Start: 0}, true},
 		{"wrongStart", models.LogEntry{Created: 5}, matchCriteria{Start: 6}, false},

--- a/internal/support/logging/models/log_entry.go
+++ b/internal/support/logging/models/log_entry.go
@@ -21,15 +21,3 @@ type LogEntry struct {
 	Message       string   `bson:"message" json:"message"`
 	Created       int64    `bson:"created" json:"created"`
 }
-
-const (
-	TRACE = "TRACE"
-	DEBUG = "DEBUG"
-	WARN  = "WARN"
-	INFO  = "INFO"
-	ERROR = "ERROR"
-)
-
-func IsValidLogLevel(l string) bool {
-	return l == TRACE || l == DEBUG || l == WARN || l == INFO || l == ERROR
-}

--- a/internal/support/logging/persistence_test.go
+++ b/internal/support/logging/persistence_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/support/logging/models"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 )
 
 const (
@@ -45,7 +46,7 @@ func testPersistenceFind(t *testing.T, persistence persistence) {
 	}
 
 	le := models.LogEntry{
-		Level:         models.TRACE,
+		Level:         logger.TraceLog,
 		OriginService: sampleService1,
 		Message:       message1,
 		Labels:        labels1,
@@ -121,7 +122,7 @@ func testPersistenceRemove(t *testing.T, persistence persistence) {
 			persistence.reset()
 
 			le := models.LogEntry{
-				Level:         models.TRACE,
+				Level:         logger.TraceLog,
 				OriginService: sampleService1,
 				Message:       message1,
 				Labels:        labels1,

--- a/internal/support/logging/server.go
+++ b/internal/support/logging/server.go
@@ -9,15 +9,16 @@ package logging
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/support/logging/models"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 	"github.com/go-zoo/bone"
 )
 
@@ -58,7 +59,7 @@ func addLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !models.IsValidLogLevel(l.Level) {
+	if !logger.IsValidLogLevel(l.Level) {
 		s := fmt.Sprintf("Invalid level in LogEntry: %s", l.Level)
 		w.WriteHeader(http.StatusBadRequest)
 		io.WriteString(w, s)
@@ -156,7 +157,7 @@ func getCriteria(w http.ResponseWriter, r *http.Request) *matchCriteria {
 		criteria.LogLevels = append(criteria.LogLevels,
 			strings.Split(logLevels, ",")...)
 		for _, l := range criteria.LogLevels {
-			if !models.IsValidLogLevel(l) {
+			if !logger.IsValidLogLevel(l) {
 				s := fmt.Sprintf("Invalid log level '%s'", l)
 				w.WriteHeader(http.StatusBadRequest)
 				io.WriteString(w, s)

--- a/internal/support/logging/server_test.go
+++ b/internal/support/logging/server_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/support/logging/models"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 )
 
 type dummyPersist struct {
@@ -118,8 +119,8 @@ func TestGetLogs(t *testing.T) {
 	var labels = []string{"label1", "label2"}
 	var services = []string{"service1", "service2"}
 	var keywords = []string{"keyword1", "keyword2"}
-	var logLevels = []string{models.TRACE, models.DEBUG, models.WARN,
-		models.INFO, models.ERROR}
+	var logLevels = []string{logger.TraceLog, logger.DebugLog, logger.WarnLog,
+		logger.InfoLog, logger.ErrorLog}
 	var tests = []struct {
 		name       string
 		url        string
@@ -257,8 +258,8 @@ func TestRemoveLogs(t *testing.T) {
 	var labels = []string{"label1", "label2"}
 	var services = []string{"service1", "service2"}
 	var keywords = []string{"keyword1", "keyword2"}
-	var logLevels = []string{models.TRACE, models.DEBUG, models.WARN,
-		models.INFO, models.ERROR}
+	var logLevels = []string{logger.TraceLog, logger.DebugLog, logger.WarnLog,
+		logger.InfoLog,	logger.ErrorLog}
 	var tests = []struct {
 		name     string
 		url      string

--- a/internal/support/logging/types.go
+++ b/internal/support/logging/types.go
@@ -14,6 +14,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/support/logging/models"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 )
 
 const (
@@ -34,20 +35,33 @@ type persistence interface {
 
 type privLogger struct {
 	stdOutLogger *log.Logger
+	logLevel     *string
 }
 
 func newPrivateLogger() privLogger {
 	p := privLogger{}
 	p.stdOutLogger = log.New(os.Stdout, "", log.Ldate|log.Ltime)
+	logLevel := logger.InfoLog
+	p.logLevel = &logLevel
 	return p
 }
 
-func (l privLogger) log(level string, msg string, labels []string) {
-	l.stdOutLogger.SetPrefix(fmt.Sprintf("%s: ", level))
+func (l privLogger) log(logLevel string, msg string, labels []string) {
+	// Check minimum log level
+	for _, name := range logger.LogLevels {
+		if name == *l.logLevel {
+			break
+		}
+		if name == logLevel {
+			return
+		}
+	}
+
+	l.stdOutLogger.SetPrefix(fmt.Sprintf("%s: ", logLevel))
 	l.stdOutLogger.Println(msg)
 	if dbClient != nil {
 		logEntry := models.LogEntry{
-			Level:         level,
+			Level:         logLevel,
 			Labels:        labels,
 			OriginService: internal.SupportLoggingServiceKey,
 			Message:       msg,
@@ -57,27 +71,34 @@ func (l privLogger) log(level string, msg string, labels []string) {
 	}
 }
 
+// SetLogLevel sets logger log level
+func (l privLogger) SetLogLevel(logLevel string) {
+	if logger.IsValidLogLevel(logLevel) == true {
+		*l.logLevel = logLevel
+	}
+}
+
 func (l privLogger) Debug(msg string, labels ...string) error {
-	l.log(models.DEBUG, msg, labels)
+	l.log(logger.DebugLog, msg, labels)
 	return nil
 }
 
 func (l privLogger) Error(msg string, labels ...string) error {
-	l.log(models.ERROR, msg, labels)
+	l.log(logger.ErrorLog, msg, labels)
 	return nil
 }
 
 func (l privLogger) Info(msg string, labels ...string) error {
-	l.log(models.INFO, msg, labels)
+	l.log(logger.InfoLog, msg, labels)
 	return nil
 }
 
 func (l privLogger) Trace(msg string, labels ...string) error {
-	l.log(models.TRACE, msg, labels)
+	l.log(logger.TraceLog, msg, labels)
 	return nil
 }
 
 func (l privLogger) Warn(msg string, labels ...string) error {
-	l.log(models.WARN, msg, labels)
+	l.log(logger.WarnLog, msg, labels)
 	return nil
 }

--- a/internal/support/logging/types_test.go
+++ b/internal/support/logging/types_test.go
@@ -8,6 +8,8 @@ package logging
 
 import (
 	"testing"
+
+	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 )
 
 func logAllLevels(pl privLogger, msg string) {
@@ -20,6 +22,7 @@ func logAllLevels(pl privLogger, msg string) {
 
 func TestPrivLogger(t *testing.T) {
 	pl := newPrivateLogger()
+	pl.SetLogLevel(logger.TraceLog)
 
 	// Does not break with nil persistence
 	dbClient = nil

--- a/pkg/clients/logging/logger.go
+++ b/pkg/clients/logging/logger.go
@@ -28,15 +28,24 @@ import (
 	"github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
+// These constants identify the log levels in order of increasing severity.
 const (
-	TRACE = "TRACE"
-	DEBUG = "DEBUG"
-	WARN  = "WARN"
-	INFO  = "INFO"
-	ERROR = "ERROR"
+	TraceLog = "TRACE"
+	DebugLog = "DEBUG"
+	InfoLog  = "INFO"
+	WarnLog  = "WARN"
+	ErrorLog = "ERROR"
 )
 
+var LogLevels = []string{
+	TraceLog,
+	DebugLog,
+	InfoLog,
+	WarnLog,
+	ErrorLog}
+
 type LoggingClient interface {
+	SetLogLevel(logLevel string)
 	Debug(msg string, labels ...string) error
 	Error(msg string, labels ...string) error
 	Info(msg string, labels ...string) error
@@ -48,6 +57,7 @@ type EdgeXLogger struct {
 	owningServiceName string
 	remoteEnabled     bool
 	logTarget         string
+	logLevel          *string
 	stdOutLogger      *log.Logger
 	fileLogger        *log.Logger
 }
@@ -70,15 +80,40 @@ func NewClient(owningServiceName string, isRemote bool, logTarget string) Loggin
 	lc.stdOutLogger = log.New(os.Stdout, "", log.Ldate|log.Ltime)
 	lc.fileLogger = &log.Logger{}
 	lc.fileLogger.SetFlags(log.Ldate | log.Ltime)
+	logLevel := InfoLog
+	lc.logLevel = &logLevel
 
 	return lc
 }
 
+// IsValidLogLevel checks if is a valid log level
+func IsValidLogLevel(l string) bool {
+	for _, name := range LogLevels {
+		if name == l {
+			return true
+		}
+	}
+	return false
+}
+
 // Send the log out as a REST request
 func (lc EdgeXLogger) log(logLevel string, msg string, labels []string) error {
+	// Check minimum log level
+	for _, name := range LogLevels {
+		if name == *lc.logLevel {
+			break
+		}
+		if name == logLevel {
+			return nil
+		}
+	}
+
+	lc.stdOutLogger.SetPrefix(fmt.Sprintf("%s: ", logLevel))
+	lc.stdOutLogger.Println(msg)
+
 	if !lc.remoteEnabled {
 		// Save to logging file if path was set
-		return lc.saveToLogFile(string(logLevel), msg)
+		return lc.saveToLogFile(logLevel, msg)
 	}
 
 	// Send to logging service
@@ -113,39 +148,36 @@ func verifyLogDirectory(path string) {
 	}
 }
 
+// SetLogLevel sets minimum severity log level
+func (lc EdgeXLogger) SetLogLevel(logLevel string) {
+	if IsValidLogLevel(logLevel) == true {
+		*lc.logLevel = logLevel
+	}
+}
+
 // Log an INFO level message
 func (lc EdgeXLogger) Info(msg string, labels ...string) error {
-	lc.stdOutLogger.SetPrefix("INFO: ")
-	lc.stdOutLogger.Println(msg)
-	return lc.log(INFO, msg, labels)
+	return lc.log(InfoLog, msg, labels)
 }
 
 // Log a TRACE level message
 func (lc EdgeXLogger) Trace(msg string, labels ...string) error {
-	lc.stdOutLogger.SetPrefix("TRACE: ")
-	lc.stdOutLogger.Println(msg)
-	return lc.log(TRACE, msg, labels)
+	return lc.log(TraceLog, msg, labels)
 }
 
 // Log a DEBUG level message
 func (lc EdgeXLogger) Debug(msg string, labels ...string) error {
-	lc.stdOutLogger.SetPrefix("DEBUG: ")
-	lc.stdOutLogger.Println(msg)
-	return lc.log(DEBUG, msg, labels)
+	return lc.log(DebugLog, msg, labels)
 }
 
 // Log a WARN level message
 func (lc EdgeXLogger) Warn(msg string, labels ...string) error {
-	lc.stdOutLogger.SetPrefix("WARN: ")
-	lc.stdOutLogger.Println(msg)
-	return lc.log(WARN, msg, labels)
+	return lc.log(WarnLog, msg, labels)
 }
 
 // Log an ERROR level message
 func (lc EdgeXLogger) Error(msg string, labels ...string) error {
-	lc.stdOutLogger.SetPrefix("ERROR: ")
-	lc.stdOutLogger.Println(msg)
-	return lc.log(ERROR, msg, labels)
+	return lc.log(ErrorLog, msg, labels)
 }
 
 // Build the log entry object

--- a/pkg/clients/logging/logger_test.go
+++ b/pkg/clients/logging/logger_test.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package models
+package logger
 
 import (
 	"testing"
@@ -15,11 +15,11 @@ func TestIsValidLogLevel(t *testing.T) {
 		level string
 		res   bool
 	}{
-		{TRACE, true},
-		{DEBUG, true},
-		{INFO, true},
-		{WARN, true},
-		{ERROR, true},
+		{TraceLog, true},
+		{DebugLog, true},
+		{InfoLog, true},
+		{WarnLog, true},
+		{ErrorLog, true},
 		{"EERROR", false},
 		{"ERRORR", false},
 		{"INF", false},

--- a/pkg/clients/logging/mock-logger.go
+++ b/pkg/clients/logging/mock-logger.go
@@ -21,6 +21,10 @@ func NewMockClient() LoggingClient {
 	return MockLogger{}
 }
 
+func (lc MockLogger) SetLogLevel(loglevel string) {
+	return
+}
+
 func (lc MockLogger) Info(msg string, labels ...string) error {
 	return nil
 }


### PR DESCRIPTION
Fix #628 

Added the option to set the minimum log level severity. Now by default is INFO, but in another PR we can add the LogLevel configuration parameter, to set this value. 

Signed-off-by: Joan Duran <jduran@circutor.com>