### PR TITLE
Fix improper read from Consul during bootstrap (support-logging)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 GO=CGO_ENABLED=0 go
 GOCGO=CGO_ENABLED=1 go
 
-DOCKERS=docker_config-seed docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent
+DOCKERS=docker_config_seed docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent
 .PHONY: $(DOCKERS)
 
 MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-agent/sys-mgmt-agent
@@ -72,7 +72,7 @@ run_docker:
 
 docker: $(DOCKERS)
 
-docker_config-seed:
+docker_config_seed:
 	docker build \
 		-f docker/Dockerfile.config-seed \
 		--label "git_sha=$(GIT_SHA)" \

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -136,6 +136,10 @@ func connectToConsul(conf *ConfigurationStruct) (*ConfigurationStruct, error) {
 			return conf, errors.New("type check failed")
 		}
 		conf = actual
+		//Check that information was successfully read from Consul
+		if len(conf.Persistence) == 0 {
+			return nil, errors.New("error reading from Consul")
+		}
 	}
 	return conf, err
 }
@@ -171,9 +175,10 @@ func listenForConfigChanges() {
 }
 
 func getPersistence() error {
-	if Configuration.Persistence == PersistenceFile {
+	switch Configuration.Persistence {
+	case PersistenceFile:
 		dbClient = &fileLog{filename: Configuration.Logging.File}
-	} else if Configuration.Persistence == PersistenceDB {
+	case PersistenceDB:
 		// TODO: Integrate db layer with internal/pkg/db/ types so we can support other databases
 		ms, err := connectToMongo()
 		if err != nil {
@@ -181,6 +186,8 @@ func getPersistence() error {
 		} else {
 			dbClient = &mongoLog{session: ms}
 		}
+	default:
+		return errors.New(fmt.Sprintf("unrecognized value Configuration.Persistence: %s", Configuration.Persistence))
 	}
 	return nil
 }


### PR DESCRIPTION
#640 

Added content check to verify something received from Consul. If not, force reconnect.
Normalized docker build target name in Makefile

I verified this fix locally as follows:
1.) Stop all Docker containers
2.) Prune all Docker containers `docker container prune`
3.) `make docker_config_seed`
4.) `make docker_support_logging`
5.) cd docker
6.) `docker-compose run logging`

You will see one ERROR line logged followed by successful startup.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>