### PR TITLE
Issue 663 - Add overrides to edgex-docker-launch.sh

### DIFF
--- a/bin/edgex-docker-launch.sh
+++ b/bin/edgex-docker-launch.sh
@@ -7,16 +7,37 @@
 #
 
 # Start EdgeX Foundry services in right order, as described:
-# https://wiki.edgexfoundry.org/display/FA/Get+EdgeX+Foundry+-+Users
+# https://docs.edgexfoundry.org/Ch-GettingStartedUsers.html
 
-COMPOSE_FILE=../docker/docker-compose.yml
-COMPOSE_URL=https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/compose-files/docker-compose-california-0.6.0.yml
+# EDGEX_COMPOSE_FILE overrides the default compose file. 
+# EDGEX_CORE_DB identifies the DB for Core Services.
+# EDGEX_SERVICES lists the service to start
+#
+# E.g. Start everything but metadata and data, use Redis for Core Services and a local compose file
+# EDGEX_SERVICES="logging command export-client export-distro notifications" \
+# EDGEX_CORE_DB=redis EDGEX_COMPOSE_FILE=docker/local-docker-compose.yml \
+# bin/edgex-docker-launch.sh
 
-echo "Pulling latest compose file..."
-curl -o $COMPOSE_FILE $COMPOSE_URL
+if [[ -z $EDGEX_COMPOSE_FILE ]]; then
+  COMPOSE_FILE=../docker/docker-compose.yml
+  COMPOSE_URL=https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/compose-files/docker-compose-california-0.6.0.yml
 
-echo "Starting mongo"
+  echo "Pulling latest compose file..."
+  curl -o $COMPOSE_FILE $COMPOSE_URL
+else
+  COMPOSE_FILE=$EDGEX_COMPOSE_FILE
+fi
+
+EDGEX_CORE_DB=${EDGEX_CORE_DB:-"mongo"}
+
+echo "Starting Mongo"
 docker-compose -f $COMPOSE_FILE up -d mongo
+
+if [[ ${EDGEX_CORE_DB} != mongo ]]; then
+  echo "Starting $EDGEX_CORE_DB for Core Data Services"
+  docker-compose -f $COMPOSE_FILE up -d $EDGEX_CORE_DB
+fi
+
 echo "Starting consul"
 docker-compose -f $COMPOSE_FILE up -d consul
 echo "Populating configuration"
@@ -25,19 +46,17 @@ docker-compose -f $COMPOSE_FILE up -d config-seed
 echo "Sleeping before launching remaining services"
 sleep 15
 
-echo "Starting support-logging"
-docker-compose -f $COMPOSE_FILE up -d logging
-echo "Starting core-metadata"
-docker-compose -f $COMPOSE_FILE up -d metadata
-echo "Starting core-data"
-docker-compose -f $COMPOSE_FILE up -d data
-echo "Starting core-command"
-docker-compose -f $COMPOSE_FILE up -d command
-echo "Starting core-export-client"
-docker-compose -f $COMPOSE_FILE up -d export-client
-echo "Starting core-export-distro"
-docker-compose -f $COMPOSE_FILE up -d export-distro
-echo "Starting support-notifications"
-docker-compose -f $COMPOSE_FILE up -d notifications
-echo "Starting support-scheduler"
-docker-compose -f $COMPOSE_FILE up -d scheduler
+defaultServices="logging metadata data command export-client export-distro notifications scheduler"
+if [[ -z ${EDGEX_SERVICES} ]]; then
+  deps=
+  services=${defaultServices}
+else
+  deps=--no-deps
+  services=${EDGEX_SERVICES}
+fi
+
+for s in ${services}; do
+    echo Starting ${s}
+    docker-compose -f $COMPOSE_FILE up -d ${deps} $s
+done
+


### PR DESCRIPTION
Re Issue #663.

EDGEX_COMPOSE_FILE overrides the default compose file.
EDGEX_CORE_DB identifies the DB for Core Services.
EDGEX_SERVICES lists the service to start

E.g. Start everything but metadata and data, use Redis for Core Services and a local compose file

EDGEX_SERVICES="logging command export-client export-distro notifications" \
EDGEX_CORE_DB=redis EDGEX_COMPOSE_FILE=docker/local-docker-compose.yml \
bin/edgex-docker-launch.sh