### PR TITLE
Issue 675  - Scheduler router info should return 404 with no data

### DIFF
--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -73,6 +73,7 @@ func main() {
 func logBeforeInit(err error) {
 	scheduler.LoggingClient = logger.NewClient(internal.CoreCommandServiceKey, false, "")
 	scheduler.LoggingClient.Error(err.Error())
+
 }
 
 func listenForInterrupt(errChan chan error) {

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/context"
 )
 
+
 func main() {
 
 	start := time.Now()
@@ -45,11 +46,14 @@ func main() {
 	scheduler.LoggingClient.Info("Service dependencies resolved...")
 	scheduler.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.SupportSchedulerServiceKey, edgex.Version))
 
+
 	// Bootstrap schedulers
 	err := scheduler.AddSchedulers()
+
 	if err != nil{
 		scheduler.LoggingClient.Error(fmt.Sprintf("Failed to load default schedules and events %s",err.Error()))
 	}
+
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(scheduler.Configuration.Service.Timeout), "Request timed out")
 	scheduler.LoggingClient.Info(scheduler.Configuration.Service.StartupMsg, "")

--- a/cmd/support-scheduler/res/docker/configuration.toml
+++ b/cmd/support-scheduler/res/docker/configuration.toml
@@ -20,6 +20,7 @@ Type = 'consul'
 EnableRemote = false
 File = '/edgex/logs/edgex-support-scheduler.log'
 
+
 [Clients]
   [Clients.Metadata]
   Protocol = 'http'

--- a/docker/Dockerfile.support-scheduler
+++ b/docker/Dockerfile.support-scheduler
@@ -27,7 +27,7 @@ ENV APP_PORT=48085
 #expose support scheduler port
 EXPOSE $APP_PORT
 
-
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/support-scheduler/support-scheduler /
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/support-scheduler/res/docker/configuration.toml /res/docker/configuration.toml
+
 ENTRYPOINT ["/support-scheduler","--consul","--profile=docker","--confdir=/res"]

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -1,8 +1,7 @@
 //
 // Copyright (c) 2018 Tencent
 //
-// Copyright (c) 2018 Dell Inc
-//
+// Copyright (c) 20178//
 // SPDX-License-Identifier: Apache-2.0
 package scheduler
 

--- a/internal/support/scheduler/router.go
+++ b/internal/support/scheduler/router.go
@@ -54,6 +54,7 @@ func replyConfig(w http.ResponseWriter, r *http.Request) {
 
 	enc := json.NewEncoder(w)
 	err := enc.Encode(Configuration)
+
 	// Problems encoding
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("Error encoding the data: %s", err.Error()))
@@ -70,6 +71,7 @@ func replyInfo(w http.ResponseWriter, r *http.Request) {
 	schedule, err := queryScheduleByName(vars)
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("read info request error %s", err.Error()))
+		http.Error(w, "Schedule/Event not found", http.StatusNotFound)
 		return
 	}
 

--- a/internal/support/scheduler/router.go
+++ b/internal/support/scheduler/router.go
@@ -13,7 +13,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
 	"github.com/go-zoo/bone"
-
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -82,6 +81,7 @@ func replyInfo(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error(fmt.Sprintf("Error encoding the data: %s", err.Error()))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+
 }
 
 func addCallbackAlert(rw http.ResponseWriter, r *http.Request) {
@@ -94,6 +94,7 @@ func addCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 
 	callbackAlert := models.CallbackAlert{}
 	if err := json.Unmarshal(data, &callbackAlert); err != nil {
+
 		LoggingClient.Error(fmt.Sprintf("failed to parse callback alert : %s", err.Error()))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
@@ -106,12 +107,14 @@ func addCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 		schedule, err := querySchedule(callbackAlert.Id)
 		if err != nil {
 			LoggingClient.Error(fmt.Sprintf("query schedule error : %s", err.Error()))
+
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		err = addSchedule(schedule)
 		if err != nil {
+
 			LoggingClient.Error(fmt.Sprintf("add schedule error : %s", err.Error()))
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		} else {
@@ -125,12 +128,15 @@ func addCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 		scheduleEvent, err := queryScheduleEvent(callbackAlert.Id)
 		if err != nil {
 			LoggingClient.Error(fmt.Sprintf("query schedule event error : %s", err.Error()))
+
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		if err := addScheduleEvent(scheduleEvent); err != nil {
+
 			LoggingClient.Error(fmt.Sprintf("add schedule event error : %s", err.Error()))
+
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		} else {
 			rw.WriteHeader(http.StatusCreated)
@@ -148,14 +154,18 @@ func addCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 func updateCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
+
 		LoggingClient.Error(fmt.Sprintf("reading the http request body error : %s", err.Error()))
+
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	callbackAlert := models.CallbackAlert{}
 	if err := json.Unmarshal(data, &callbackAlert); err != nil {
+
 		LoggingClient.Error(fmt.Sprintf("failed to parse callback alert : %s", err.Error()))
+
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -173,7 +183,9 @@ func updateCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 
 		err = updateSchedule(schedule)
 		if err != nil {
+
 			LoggingClient.Error(fmt.Sprintf("update schedule error : %s", err.Error()))
+
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		} else {
 			rw.WriteHeader(http.StatusCreated)
@@ -191,7 +203,9 @@ func updateCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := updateScheduleEvent(scheduleEvent); err != nil {
+
 			LoggingClient.Error(fmt.Sprintf("query schedule event error :%s ", err.Error()))
+
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		} else {
 			rw.WriteHeader(http.StatusCreated)
@@ -210,6 +224,7 @@ func removeCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 	//here we need the action type, so request the callback alert json
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
+
 		LoggingClient.Error(fmt.Sprintf("reading the http request body error : %s", err.Error()))
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
@@ -217,7 +232,9 @@ func removeCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 
 	callbackAlert := models.CallbackAlert{}
 	if err := json.Unmarshal(data, &callbackAlert); err != nil {
+
 		LoggingClient.Error(fmt.Sprintf("failed to parse callback alert : %s", err.Error()))
+
 		http.Error(rw, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -225,7 +242,9 @@ func removeCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 	switch callbackAlert.ActionType {
 	case models.SCHEDULE:
 		if err := removeSchedule(callbackAlert.Id); err != nil {
+
 			LoggingClient.Error(fmt.Sprintf("remove schedule error : %s", err.Error()))
+
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		} else {
 			rw.WriteHeader(http.StatusOK)
@@ -234,7 +253,9 @@ func removeCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 
 	case models.SCHEDULEEVENT:
 		if err := removeScheduleEvent(callbackAlert.Id); err != nil {
+
 			LoggingClient.Error(fmt.Sprintf("remove schedule event error : %s", err.Error()))
+
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		} else {
 			rw.WriteHeader(http.StatusOK)
@@ -246,5 +267,5 @@ func removeCallbackAlert(rw http.ResponseWriter, r *http.Request) {
 		http.Error(rw, fmt.Sprintf("unsupported action type : %s", callbackAlert.ActionType), http.StatusBadRequest)
 		break
 	}
-}
 
+}

--- a/internal/support/scheduler/schedule.go
+++ b/internal/support/scheduler/schedule.go
@@ -101,8 +101,9 @@ func queryScheduleByName(scheduleName string) (models.Schedule, error) {
 
 	scheduleContext, exists := scheduleNameToContextMap[scheduleName]
 	if !exists {
-		LoggingClient.Warn("can not find a schedule context with schedule name : " + scheduleName)
-		return models.Schedule{}, nil
+		LoggingClient.Warn(fmt.Sprintf("can not find a schedule context with schedule name :%s ", scheduleName))
+		err := errors.New(fmt.Sprintf("can not find a schedule context with schedule name :%s ", scheduleName))
+		return models.Schedule{}, err
 	}
 
 	LoggingClient.Debug("querying found the schedule with name : " + scheduleName)

--- a/internal/support/scheduler/schedule.go
+++ b/internal/support/scheduler/schedule.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
 	queueV1 "gopkg.in/eapache/queue.v1"
+
 	"gopkg.in/mgo.v2/bson"
 	"io/ioutil"
 	"net/http"
@@ -80,7 +81,6 @@ func addScheduleEventOperation(scheduleId string, scheduleEventId string, schedu
 	scheduleEventIdToScheduleIdMap[scheduleEventId] = scheduleId
 }
 
-
 func querySchedule(scheduleId string) (models.Schedule, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
@@ -111,7 +111,6 @@ func queryScheduleByName(scheduleName string) (models.Schedule, error){
 
 	return scheduleContext.Schedule, nil
 }
-
 
 func addSchedule(schedule models.Schedule) error {
 	mutex.Lock()
@@ -184,7 +183,6 @@ func removeSchedule(scheduleId string) error {
 
 	return nil
 }
-
 
 func queryScheduleEvent(scheduleEventId string) (models.ScheduleEvent, error) {
 	mutex.Lock()
@@ -486,6 +484,7 @@ func contains(a []string, x string) bool {
 	}
 	return false
 }
+
 
 
 // Utility function for adding configured locally schedulers and scheduled events

--- a/internal/support/scheduler/schedule.go
+++ b/internal/support/scheduler/schedule.go
@@ -21,10 +21,9 @@ import (
 )
 
 const (
-	ScheduleInterval                  = 500
+	ScheduleInterval = 500
 )
 
-//the schedule specific shared variables
 var (
 	mutex                          sync.Mutex
 	scheduleQueue                  = queueV1.New()                     // global schedule queue
@@ -96,8 +95,7 @@ func querySchedule(scheduleId string) (models.Schedule, error) {
 	return scheduleContext.Schedule, nil
 }
 
-
-func queryScheduleByName(scheduleName string) (models.Schedule, error){
+func queryScheduleByName(scheduleName string) (models.Schedule, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
@@ -413,7 +411,7 @@ func execute(context *ScheduleContext, wg *sync.WaitGroup) error {
 		}
 
 		client := &http.Client{
-			Timeout:       time.Duration(Configuration.Service.Timeout) * time.Millisecond,
+			Timeout: time.Duration(Configuration.Service.Timeout) * time.Millisecond,
 		}
 		responseBytes, statusCode, err := sendRequestAndGetResponse(client, req)
 		responseStr := string(responseBytes)
@@ -471,9 +469,9 @@ func validMethod(method string) bool {
 	   extension-method = token
 	     token          = 1*<any CHAR except CTLs or separators>
 	*/
-	a:= [] string {"GET","HEAD", "POST","PUT","DELETE","TRACE","CONNECT"}
+	a := []string{"GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT"}
 	method = strings.ToUpper(method)
-	return contains(a,method)
+	return contains(a, method)
 }
 
 func contains(a []string, x string) bool {
@@ -484,8 +482,6 @@ func contains(a []string, x string) bool {
 	}
 	return false
 }
-
-
 
 // Utility function for adding configured locally schedulers and scheduled events
 func AddSchedulers() error {
@@ -530,7 +526,7 @@ func AddSchedulers() error {
 		}
 
 		scheduleEvent := models.ScheduleEvent{
-			Id: 	 	 bson.NewObjectId(),
+			Id:          bson.NewObjectId(),
 			Name:        scheduleEvents[e].Name,
 			Schedule:    scheduleEvents[e].Schedule,
 			Parameters:  scheduleEvents[e].Parameters,
@@ -549,4 +545,5 @@ func AddSchedulers() error {
 	LoggingClient.Info(fmt.Sprintf("completed loading default schedules and schedule events"))
 	return nil
 }
+
 //endregion

--- a/internal/support/scheduler/schedulecontext.go
+++ b/internal/support/scheduler/schedulecontext.go
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2018 Tencent
 //
-// Copyright (c) 2017 Dell Inc
+// Copyright (c) 2018 Dell Inc
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/support/scheduler/schedulercontext_test.go
+++ b/internal/support/scheduler/schedulercontext_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 )
 
-
 // Test common const
 const (
 	TestUnexpectedMsg                     = "unexpected result"


### PR DESCRIPTION
Addressed issue with empty object being returned when using the info with an invalid schedule name. 
Will not return schedule/event not found as well as the 404 response. 

