### PR TITLE
Spread the EdgeX MSM API to the CoreData service.

### DIFF
--- a/api/raml/core-data.raml
+++ b/api/raml/core-data.raml
@@ -889,3 +889,11 @@ schemas:
         responses:
             "200":
                 description: The service's configuration as JSON document
+/metrics:
+    displayName: Metrics Resource
+    description: Example - http://localhost:48080/api/v1/metrics
+    get:
+        description: Fetch the current state of the service's metrics.
+        responses:
+            "200":
+                description: The service's metrics as JSON document

--- a/cmd/sys-mgmt-agent/res/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/configuration.toml
@@ -21,10 +21,10 @@ LoggingFile = './logs/edgex-sys-mgmt-agent.log'
   Host = 'localhost'
   Port = 48082
 
-  [Clients.Metadata]
+  [Clients.Coredata]
   Protocol = 'http'
   Host = 'localhost'
-  Port = 48081
+  Port = 48080
 
   [Clients.Logging]
   Protocol = 'http'

--- a/cmd/sys-mgmt-agent/res/docker/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/docker/configuration.toml
@@ -10,3 +10,35 @@ CheckInterval = '10s'
 LoggingFile = '/edgex/logs/edgex-sys-mgmt-agent.log'
 LoggingRemoteURL = 'http://edgex-support-logging:48061/api/v1/logs'
 
+[Service]
+BootTimeout = 30000
+ClientMonitor = 15000
+CheckInterval = '10s'
+Host = 'edgex-sys-mgmt-agent'
+Port = 48090
+Protocol = 'http'
+ReadMaxLimit = 100
+StartupMsg = 'This is the System Management Agent Service'
+Timeout = 5000
+
+[Clients]
+  [Clients.Notifications]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48060
+
+  [Clients.Command]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48082
+
+  [Clients.Coredata]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48080
+
+  [Clients.Logging]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48061
+

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -19,15 +19,28 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"runtime"
 
+	"github.com/gorilla/mux"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
-	"github.com/gorilla/mux"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/pkg/clients"
 )
 
 func LoadRestRoutes() *mux.Router {
 	r := mux.NewRouter()
+
+	// Ping Resource
+	r.HandleFunc(clients.ApiPingRoute, pingHandler).Methods(http.MethodGet)
+
+	//Config Resource
+	r.HandleFunc(clients.ApiConfigRoute, configHandler).Methods(http.MethodGet)
+
+	// Metrics
+	r.HandleFunc(clients.ApiMetricsRoute, metricsHandler).Methods(http.MethodGet)
+
 	b := r.PathPrefix("/api/v1").Subrouter()
 
 	// EVENTS
@@ -72,14 +85,6 @@ func LoadRestRoutes() *mux.Router {
 	vd.HandleFunc("/label/{label}", valueDescriptorByLabelHandler).Methods(http.MethodGet)
 	vd.HandleFunc("/devicename/{device}", valueDescriptorByDeviceHandler).Methods(http.MethodGet)
 	vd.HandleFunc("/deviceid/{id}", valueDescriptorByDeviceIdHandler).Methods(http.MethodGet)
-
-	// Ping Resource
-	// /api/v1/ping
-	b.HandleFunc("/ping", pingHandler)
-
-	//Config Resource
-	// /api/v1/config
-	b.HandleFunc("/config", configHandler)
 
 	return r
 }
@@ -587,7 +592,7 @@ func scrubHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodDelete:
-		count, err:= scrubPushedEvents()
+		count, err := scrubPushedEvents()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -597,4 +602,53 @@ func scrubHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(strconv.Itoa(count)))
 	}
+}
+
+func configHandler(w http.ResponseWriter, r *http.Request) {
+
+	if r.Body != nil {
+		defer r.Body.Close()
+	}
+
+	// The micro-service is to be considered the System Of Record (SOR) in terms of accurate information.
+	// Fetch configuration from cache (the in-memory store which is populated when micro-service is bootstrapped!)
+	w.Header().Set("Content-Type", "application/json")
+	encode(Configuration, w)
+
+	LoggingClient.Debug(fmt.Sprintf("Fetched this configuration for the Coredata service: {%v}: ", *Configuration))
+
+	return
+}
+
+func metricsHandler(w http.ResponseWriter, r *http.Request) {
+
+	var t internal.Telemetry
+
+	if r.Body != nil {
+		defer r.Body.Close()
+	}
+
+	// The micro-service is to be considered the System Of Record (SOR) in terms of accurate information.
+	// Fetch metrics for the notifications service.
+	var rtm runtime.MemStats
+
+	// Read full memory stats
+	runtime.ReadMemStats(&rtm)
+
+	// Miscellaneous memory stats
+	t.Alloc = rtm.Alloc
+	t.TotalAlloc = rtm.TotalAlloc
+	t.Sys = rtm.Sys
+	t.Mallocs = rtm.Mallocs
+	t.Frees = rtm.Frees
+
+	// Live objects = Mallocs - Frees
+	t.LiveObjects = t.Mallocs - t.Frees
+
+	w.Header().Set("Content-Type", "application/json")
+	encode(t, w)
+
+	LoggingClient.Debug(fmt.Sprintf("Fetched these metrics for the Coredata service: {%v}:", t))
+
+	return
 }

--- a/internal/core/data/utils.go
+++ b/internal/core/data/utils.go
@@ -56,9 +56,3 @@ func pingHandler(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error("Error writing pong: " + err.Error())
 	}
 }
-
-func configHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	encode(Configuration, w)
-}

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -25,6 +25,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/command"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/coredata"
 )
 
 // Global variables
@@ -32,9 +33,10 @@ var Configuration *ConfigurationStruct
 var LoggingClient logger.LoggingClient
 var Manifest *ManifestStruct
 var Conf = &ConfigurationStruct{}
-var nc notifications.NotificationsClient
 var ec interfaces.ExecutorClient
+var nc notifications.NotificationsClient
 var mcc command.MgmtClient
+var cdc coredata.MgmtClient
 
 func Retry(useConsul bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
@@ -166,4 +168,14 @@ func initializeClients(useConsul bool) {
 		Interval:    internal.ClientMonitorDefault,
 	}
 	mcc = command.NewMgmtClient(paramsCommand, startup.Endpoint{})
+
+	// Create coredata client
+	paramsCoreData := types.EndpointParams{
+		ServiceKey:  internal.CoreDataServiceKey,
+		Path:        "/",
+		UseRegistry: useConsul,
+		Url:         Configuration.Clients["Coredata"].Url(),
+		Interval:    internal.ClientMonitorDefault,
+	}
+	cdc = coredata.NewMgmtClient(paramsCoreData, startup.Endpoint{})
 }

--- a/internal/system/agent/services.go
+++ b/internal/system/agent/services.go
@@ -209,8 +209,14 @@ func getConfig(services []string) (ConfigRespMap, error) {
 			break
 
 		case internal.CoreDataServiceKey:
-			c.Configuration[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its configuration data...", internal.CoreDataServiceKey))
+			responseJSON, err := cdc.FetchConfiguration()
+			if err != nil {
+				msg := fmt.Sprintf("%s get config error: %s", service, err.Error())
+				c.Configuration[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				c.Configuration[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.CoreMetaDataServiceKey:
@@ -276,8 +282,14 @@ func getMetrics(services []string) (MetricsRespMap, error) {
 			break
 
 		case internal.CoreDataServiceKey:
-			m.Metrics[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its metrics data...", internal.CoreDataServiceKey))
+			responseJSON, err := cdc.FetchMetrics()
+			if err != nil {
+				msg := fmt.Sprintf("%s get metrics error: %s", service, err.Error())
+				m.Metrics[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				m.Metrics[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.CoreMetaDataServiceKey:

--- a/pkg/clients/coredata/mgmt.go
+++ b/pkg/clients/coredata/mgmt.go
@@ -1,0 +1,67 @@
+package coredata
+
+import (
+	"github.com/edgexfoundry/edgex-go/pkg/clients"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
+)
+
+type MgmtClient interface {
+	FetchConfiguration() (string, error)
+	FetchMetrics() (string, error)
+}
+
+type MgmtRestClient struct {
+	url      string
+	endpoint clients.Endpointer
+}
+
+func NewMgmtClient(params types.EndpointParams, m clients.Endpointer) MgmtClient {
+	cdc := MgmtRestClient{endpoint: m}
+	cdc.initClient(params)
+	return &cdc
+}
+
+func (cdc *MgmtRestClient) initClient(params types.EndpointParams) {
+	if params.UseRegistry {
+		ch := make(chan string, 1)
+		go cdc.endpoint.Monitor(params, ch)
+		go func(ch chan string) {
+			for {
+				select {
+				case url := <-ch:
+					cdc.url = url
+				}
+			}
+		}(ch)
+	} else {
+		cdc.url = params.Url
+	}
+}
+
+// Fetch configuration information from the command service.
+func (cdc *MgmtRestClient) FetchConfiguration() (string, error) {
+
+	var result string
+	data, err := clients.GetRequest(cdc.url + clients.ApiConfigRoute)
+	if err != nil {
+		return "", err
+	}
+	result = string(data)
+
+	return result, nil
+
+}
+
+// Fetch metrics information from the command service.
+func (cdc *MgmtRestClient) FetchMetrics() (string, error) {
+
+	var result string
+	data, err := clients.GetRequest(cdc.url + clients.ApiMetricsRoute)
+	if err != nil {
+		return "", err
+	}
+	result = string(data)
+
+	return result, nil
+
+}


### PR DESCRIPTION
- This PR contains the work done under the purview of: [Issue Number 648](https://github.com/edgexfoundry/edgex-go/issues/648)
- The essence of this work is to have the EdgeX MSM API be applied to the CoreData service.
- Details can be found here: [Issue Number 648](https://github.com/edgexfoundry/edgex-go/issues/648)