### PR TITLE
Download jar files for java services in the snap

### DIFF
--- a/snap/local/bin/nexus-jar-download.sh
+++ b/snap/local/bin/nexus-jar-download.sh
@@ -9,8 +9,10 @@ download_jar_file()
     export JAR_FILE=$SERVICE-$VERSION.jar
 
     # download the jar file and the md5 sum for it
-    curl https://nexus.edgexfoundry.org/content/repositories/$REPO/org/edgexfoundry/$SERVICE/$VERSION/$JAR_FILE -o $JAR_FILE
-    curl https://nexus.edgexfoundry.org/content/repositories/$REPO/org/edgexfoundry/$SERVICE/$VERSION/$JAR_FILE.md5 -o $JAR_FILE.md5
+    curl https://nexus.edgexfoundry.org/content/repositories/$REPO/org/edgexfoundry/$SERVICE/$VERSION/$JAR_FILE \
+        -s -S -f -o $JAR_FILE 
+    curl https://nexus.edgexfoundry.org/content/repositories/$REPO/org/edgexfoundry/$SERVICE/$VERSION/$JAR_FILE.md5 \
+        -s -S -f -o $JAR_FILE.md5
 
     # confirm that the sum matches - note we can't use `md5sum -c` here because 
     # the md5sum file is just the hash, not the filename and so md5sum doesn't accept it

--- a/snap/local/bin/nexus-jar-download.sh
+++ b/snap/local/bin/nexus-jar-download.sh
@@ -1,0 +1,29 @@
+# example usage:
+# $ download_jar_file support-scheduler 0.7.0 staging
+download_jar_file() 
+{
+    export SERVICE=$1
+    export VERSION=$2
+    export REPO=$3
+
+    export JAR_FILE=$SERVICE-$VERSION.jar
+
+    # download the jar file and the md5 sum for it
+    curl https://nexus.edgexfoundry.org/content/repositories/$REPO/org/edgexfoundry/$SERVICE/$VERSION/$JAR_FILE -o $JAR_FILE
+    curl https://nexus.edgexfoundry.org/content/repositories/$REPO/org/edgexfoundry/$SERVICE/$VERSION/$JAR_FILE.md5 -o $JAR_FILE.md5
+
+    # confirm that the sum matches - note we can't use `md5sum -c` here because 
+    # the md5sum file is just the hash, not the filename and so md5sum doesn't accept it
+    sum=$(md5sum $JAR_FILE | awk '{print $1}')
+    if [ "$sum" = "$(cat $JAR_FILE.md5)" ]; then
+        # posix sh can't do "!=", so we just have an empty block here
+        echo ""
+    else
+        echo "invalid md5sum for file $JAR_FILE"
+        exit 1
+    fi
+
+    # install the jar file into the part install directory
+    install -d "$SNAPCRAFT_PART_INSTALL/jar/$SERVICE"
+    mv "$JAR_FILE" "$SNAPCRAFT_PART_INSTALL/jar/$SERVICE/$SERVICE.jar"
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -191,10 +191,12 @@ parts:
     source: ./snap/local
     stage:
       - bin/go-build-helper.sh
+      - bin/nexus-jar-download.sh
       - config/*
       - bin/*
     prime:
       - -bin/go-build-helper.sh
+      - -bin/nexus-jar-download.sh
       - bin/*
       - config/*
   mongodb:
@@ -357,16 +359,13 @@ parts:
     source: https://github.com/edgexfoundry/support-scheduler.git
     # the following commit == 0.7.0 version update
     source-commit: "194094a3cf2a0a3a2cc608cec7cd3c4904ac6b5b"
-    plugin: maven
+    plugin: make
+    build-packages: [curl]
     override-build: |
-      snapcraftctl build
+      . $SNAPCRAFT_STAGE/bin/nexus-jar-download.sh
       echo "Installing support-scheduler files"
 
-      # The logic following logic is all handled by DockerFile for
-      # the EdgeX support-scheduler docker image.
-      install -d "$SNAPCRAFT_PART_INSTALL/jar/support-scheduler"
-      mv "$SNAPCRAFT_PART_INSTALL/jar/support-scheduler-0.7.0-SNAPSHOT.jar" \
-         "$SNAPCRAFT_PART_INSTALL/jar/support-scheduler/support-scheduler.jar"
+      download_jar_file support-scheduler 0.7.0 staging
 
       # FIXME:
       # copy service license into /usr/share/java/doc, because the
@@ -376,39 +375,18 @@ parts:
          "$SNAPCRAFT_PART_INSTALL/usr/share/java/doc/support-scheduler/Attribution.txt"
       install -DT "./LICENSE-2.0.txt" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/java/doc/support-scheduler/LICENSE-2.0.txt"
-    prime:
-      - -etc/fonts
-      - -etc/fonts/X11
-      - -usr/lib/jvm/*/ASSEMBLY_EXCEPTION
-      - -usr/lib/jvm/*/THIRD_PARTY_README
-      - -usr/lib/jvm/*/jre/ASSEMBLY_EXCEPTION
-      - -usr/lib/jvm/*/jre/THIRD_PARTY_README
-      - -usr/lib/jvm/*/man
-      - -usr/lib/jvm/*/jre/man
-      - -usr/lib/jvm/*/jre/lib/images
-      - -usr/lib/jvm/*/include
-      - -usr/lib/jvm/*/bin
-      - -usr/lib/jvm/*/lib
-      - -usr/lib/jvm/*/docs
-      - -usr/lib/jvm/*/src.zip
-      - -usr/share/X11
-      - -usr/share/man
-      - -usr/share/fonts
-      - -usr/share/
+
   support-rulesengine:
     source: https://github.com/edgexfoundry/support-rulesengine.git
     # the following commit == 0.7.0 version update
     source-commit: "3aca4a7bf9774ad07b9b74c7b05c45deb74412f2"
-    plugin: maven
+    plugin: make
+    build-packages: [curl]
     override-build: |
-      snapcraftctl build
+      . $SNAPCRAFT_STAGE/bin/nexus-jar-download.sh
       echo "Installing support-rulesengine files"
 
-      # The logic following logic is all handled by DockerFile for
-      # the EdgeX support-rulesengine docker image.
-      install -d "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine"
-      mv "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine-0.7.0-SNAPSHOT.jar" \
-         "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine/support-rulesengine.jar"
+      download_jar_file support-rulesengine 0.7.0 staging
 
       # FIXME:
       # copy service license into /usr/share/java/doc, because the
@@ -418,32 +396,14 @@ parts:
          "$SNAPCRAFT_PART_INSTALL/usr/share/java/doc/support-rulesengine/Attribution.txt"
       install -DT "./LICENSE-2.0.txt" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/java/doc/support-rulesengine/LICENSE-2.0.txt"
-    prime:
-      - -etc/fonts
-      - -etc/fonts/X11
-      - -usr/lib/jvm/*/ASSEMBLY_EXCEPTION
-      - -usr/lib/jvm/*/THIRD_PARTY_README
-      - -usr/lib/jvm/*/jre/ASSEMBLY_EXCEPTION
-      - -usr/lib/jvm/*/jre/THIRD_PARTY_README
-      - -usr/lib/jvm/*/man
-      - -usr/lib/jvm/*/jre/man
-      - -usr/lib/jvm/*/jre/lib/images
-      - -usr/lib/jvm/*/include
-      - -usr/lib/jvm/*/bin
-      - -usr/lib/jvm/*/lib
-      - -usr/lib/jvm/*/docs
-      - -usr/lib/jvm/*/src.zip
-      - -usr/share/X11
-      - -usr/share/man
-      - -usr/share/fonts
-      - -usr/share/alsa
   device-virtual:
     source: https://github.com/edgexfoundry/device-virtual.git
     # the following commit == 0.5.0 version update +1 (core-domain fix)
     source-commit: "2033429"
-    plugin: maven
+    plugin: make
+    build-packages: [curl]
     override-build: |
-      snapcraftctl build
+      . $SNAPCRAFT_STAGE/bin/nexus-jar-download.sh
       echo "Installing device-virtual files"
 
       # The logic following logic is all handled by DockerFile for
@@ -451,8 +411,9 @@ parts:
       install -d "$SNAPCRAFT_PART_INSTALL/jar/device-virtual"
       install -d "$SNAPCRAFT_PART_INSTALL/jar/device-virtual/bacnet_sample_profiles"
       install -d "$SNAPCRAFT_PART_INSTALL/jar/device-virtual/modbus_sample_profiles"
-      mv "$SNAPCRAFT_PART_INSTALL/jar/device-virtual-0.5.0-SNAPSHOT.jar" \
-         "$SNAPCRAFT_PART_INSTALL/jar/device-virtual/device-virtual.jar"
+
+      download_jar_file device-virtual 0.5.0 staging
+
       cp ./bacnet_sample_profiles/*.yaml \
          "$SNAPCRAFT_PART_INSTALL/jar/device-virtual/bacnet_sample_profiles/"
       cp ./modbus_sample_profiles/*.yaml \


### PR DESCRIPTION
This change switches from using the `maven` plugin in snapcraft to build the jars to instead just download them directly from the nexus via cURL.

@JPWKU we spoke about this over rocketchat and it sounds like using the `staging` repo is the right thing for the master builds of the snap.

Resolves #644 