### PR TITLE
Refactored reading.go, valuedescriptor.go, and their routing logic in router.go

### DIFF
--- a/internal/core/data/device.go
+++ b/internal/core/data/device.go
@@ -14,6 +14,7 @@
 package data
 
 import (
+	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
@@ -82,4 +83,24 @@ func updateDeviceServiceLastReportedConnected(device string) {
 
 	msc.UpdateLastConnected(s.Service.Id.Hex(), t)
 	msc.UpdateLastReported(s.Service.Id.Hex(), t)
+}
+
+
+func checkMaxLimit(limit int) error {
+	if limit > Configuration.Service.ReadMaxLimit {
+		LoggingClient.Error(maxExceededString)
+		return errors.NewErrLimitExceeded(limit)
+	}
+
+	return nil
+}
+
+func checkDevice(device string) error {
+	if Configuration.MetaDataCheck {
+		_, err := mdc.CheckForDevice(device)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/core/data/errors/types.go
+++ b/internal/core/data/errors/types.go
@@ -13,7 +13,10 @@
  *******************************************************************************/
 package errors
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+)
 
 type ErrEventNotFound struct {
 	id string
@@ -86,4 +89,39 @@ func (e ErrValueDescriptorInUse) Error() string {
 
 func NewErrValueDescriptorInUse(name string) error {
 	return &ErrValueDescriptorInUse{name: name}
+}
+
+type ErrLimitExceeded struct {
+	limit int
+}
+
+func (e ErrLimitExceeded) Error() string {
+	return fmt.Sprintf("limit %d exceeds configured max", e.limit)
+}
+
+func NewErrLimitExceeded(limit int) error {
+	return &ErrLimitExceeded{limit: limit}
+}
+
+type ErrJsonDecoding struct {
+	name string
+}
+
+func (e ErrJsonDecoding) Error() string {
+	return fmt.Sprintf("error decoding the reading: %s", e.name)
+}
+
+func NewErrJsonDecoding(name string) error {
+	return &ErrJsonDecoding{name: name}
+}
+
+type ErrDbNotFound struct {
+}
+
+func (e ErrDbNotFound) Error() string {
+	return db.ErrNotFound.Error()
+}
+
+func NewErrDbNotFound() error {
+	return &ErrDbNotFound{}
 }

--- a/internal/core/data/event.go
+++ b/internal/core/data/event.go
@@ -41,16 +41,6 @@ func countEventsByDevice(device string) (int, error) {
 	return count, err
 }
 
-func checkDevice(device string) error {
-	if Configuration.MetaDataCheck {
-		_, err := mdc.CheckForDevice(device)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func deleteEventsByAge(age int64) (int, error) {
 	events, err := dbClient.EventsOlderThanAge(age)
 	if err != nil {
@@ -83,7 +73,7 @@ func getEvents(limit int) ([]models.Event, error) {
 	return events, err
 }
 
-func addNew(e models.Event) (string, error) {
+func addNewEvent(e models.Event) (string, error) {
 	retVal := "unsaved"
 	err := checkDevice(e.Device)
 	if err != nil {
@@ -218,15 +208,6 @@ func putEventOnQueue(e models.Event) {
 	}
 }
 
-func checkMaxLimit(limit int) error {
-	if limit > Configuration.Service.ReadMaxLimit {
-		LoggingClient.Error(maxExceededString)
-		return fmt.Errorf(maxExceededString)
-	}
-
-	return nil
-}
-
 func getEventsByDeviceIdLimit(limit int, deviceId string) ([]models.Event, error) {
 	eventList, err := dbClient.EventsForDeviceLimit(deviceId, limit)
 	if err != nil {
@@ -235,34 +216,6 @@ func getEventsByDeviceIdLimit(limit int, deviceId string) ([]models.Event, error
 	}
 
 	return eventList, nil
-}
-
-func getReadingsByDeviceId(limit int, deviceId string, valueDescriptor string) ([]models.Reading, error) {
-	eventList, err := dbClient.EventsForDevice(deviceId)
-	if err != nil {
-		LoggingClient.Error(err.Error())
-		return nil, err
-	}
-
-	// Only pick the readings who match the value descriptor
-	var readings []models.Reading
-	count := 0 // Make sure we stay below the limit
-	for _, event := range eventList {
-		if count >= limit {
-			break
-		}
-		for _, reading := range event.Readings {
-			if count >= limit {
-				break
-			}
-			if reading.Name == valueDescriptor {
-				readings = append(readings, reading)
-				count += 1
-			}
-		}
-	}
-
-	return readings, nil
 }
 
 func getEventsByCreationTime(limit int, start int64, end int64) ([]models.Event, error) {

--- a/internal/core/data/event_test.go
+++ b/internal/core/data/event_test.go
@@ -160,7 +160,7 @@ func TestAddEventWithPersistence(t *testing.T) {
 	wg.Add(1)
 	go handleDomainEvents(bitEvents, &wg, t)
 
-	newId, err := addNew(evt)
+	newId, err := addNewEvent(evt)
 	Configuration.PersistData = false
 	if err != nil {
 		t.Errorf(err.Error())
@@ -193,7 +193,7 @@ func TestAddEventNoPersistence(t *testing.T) {
 	wg.Add(1)
 	go handleDomainEvents(bitEvents, &wg, t)
 
-	newId, err := addNew(evt)
+	newId, err := addNewEvent(evt)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -230,7 +230,7 @@ func TestAddEventWithValidationValueDescriptorExistsAndIsInvalid(t *testing.T) {
 	wg.Add(1)
 	go handleDomainEvents(bitEvents, &wg, t)
 
-	_, err := addNew(evt)
+	_, err := addNewEvent(evt)
 	if err == nil {
 		t.Errorf("expected error")
 	}
@@ -248,7 +248,7 @@ func TestAddEventWithValidationValueDescriptorNotFound(t *testing.T) {
 	wg.Add(1)
 	go handleDomainEvents(bitEvents, &wg, t)
 
-	_, err := addNew(evt)
+	_, err := addNewEvent(evt)
 	if err == nil {
 		t.Errorf("expected error")
 	}
@@ -267,7 +267,7 @@ func TestAddEventWithValidationValueDescriptorDBError(t *testing.T) {
 	wg.Add(1)
 	go handleDomainEvents(bitEvents, &wg, t)
 
-	_, err := addNew(evt)
+	_, err := addNewEvent(evt)
 	if err == nil {
 		t.Errorf("expected error")
 	}
@@ -313,7 +313,7 @@ func TestUpdateEvent(t *testing.T) {
 	}
 }
 
-func TestDeleteAll(t *testing.T) {
+func TestDeleteAllEvents(t *testing.T) {
 	reset()
 	err := deleteAllEvents()
 	if err != nil {
@@ -456,61 +456,6 @@ func TestGetEventsByDeviceIdLimitDBThrowsError(t *testing.T) {
 	}
 }
 
-func TestGetReadingsByDeviceId(t *testing.T) {
-	reset()
-	dbClient = newMockDb()
-
-	expectedReadings, expectedNil := getReadingsByDeviceId(math.MaxInt32, "valid", "Pressure")
-
-	if expectedReadings == nil {
-		t.Errorf("Should return Readings")
-	}
-
-	if expectedNil != nil {
-		t.Errorf("Should not throw error")
-	}
-}
-
-func TestGetReadingsByDeviceIdLimited(t *testing.T) {
-	reset()
-	dbClient = newMockDb()
-
-	for limit:= 0; limit < 5; limit++ {
-		expectedReadings, expectedNil := getReadingsByDeviceId(limit, "valid", "Pressure")
-
-		if limit == 0 {
-			if expectedReadings != nil {
-				t.Errorf("Should return nil slice for zero limit")
-			}
-		} else if expectedReadings == nil {
-			t.Errorf("Should return Readings, limit: %d", limit)
-		}
-
-		if len(expectedReadings) > limit {
-			t.Errorf("Should only return %d Readings", limit)
-		}
-
-		if expectedNil != nil {
-			t.Errorf("Should not throw error")
-		}
-	}
-}
-
-func TestGetReadingsByDeviceIdDBThrowsError(t *testing.T) {
-	reset()
-	dbClient = newMockDb()
-
-	expectedNil, expectedErr := getReadingsByDeviceId(0, "error", "")
-
-	if expectedNil != nil {
-		t.Errorf("Should not return Readings on error")
-	}
-
-	if expectedErr == nil {
-		t.Errorf("Should throw error")
-	}
-}
-
 func TestGetEventsByCreationTime(t *testing.T) {
 	reset()
 	dbClient = newMockDb()
@@ -567,7 +512,7 @@ func TestDeleteEventsDBLookupThrowsError(t *testing.T) {
 	}
 }
 
-func TestDoScrub(t *testing.T) {
+func TestScrubPushedEvents(t *testing.T) {
 	reset()
 
 	pushedEvent := testEvent

--- a/internal/core/data/reading.go
+++ b/internal/core/data/reading.go
@@ -16,632 +16,252 @@ package data
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
-	"net/http"
-	"net/url"
-	"strconv"
-
+	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
-	"github.com/gorilla/mux"
+	"gopkg.in/mgo.v2/bson"
+	"io"
 )
 
-// Reading handler
-// GET, PUT, and POST readings
-func readingHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
+func getAllReadings() (readings []models.Reading, err error){
+	readings, err = dbClient.Readings()
 
-	switch r.Method {
-	case http.MethodGet:
-		r, err := dbClient.Readings()
+	// Check max limit
+	err = checkMaxLimit(len(readings))
+	if err != nil {
+		return nil, err
+	}
+
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		return nil, err
+	}
+
+	return readings, nil
+}
+
+func decodeReading(reader io.Reader) (reading models.Reading, err error) {
+	reading = models.Reading{}
+	err = json.NewDecoder(reader).Decode(&reading)
+
+	// Problem decoding
+	if err != nil {
+		LoggingClient.Error("Error decoding the reading: " + err.Error())
+
+		return models.Reading{}, errors.NewErrJsonDecoding(reading.Name)
+	}
+
+	if Configuration.ValidateCheck {
+		err = validateReading(reading)
+
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
+			return models.Reading{}, err
 		}
+	}
 
-		// Check max limit
-		if len(r) > Configuration.Service.ReadMaxLimit {
-			http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
-			LoggingClient.Error(maxExceededString)
-			return
-		}
+	return reading, nil
+}
 
-		encode(r, w)
-	case http.MethodPost:
-		reading := models.Reading{}
-		dec := json.NewDecoder(r.Body)
-		err := dec.Decode(&reading)
-
-		// Problem decoding
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			LoggingClient.Error("Error decoding the reading: " + err.Error())
-			return
-		}
-
-		if Configuration.ValidateCheck {
-			// Check the value descriptor
-			vd, err := dbClient.ValueDescriptorByName(reading.Name)
-			if err != nil {
-				if err == db.ErrNotFound {
-					http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
-				} else {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-				}
-				LoggingClient.Error(err.Error())
-				return
-			}
-
-			err = isValidValueDescriptor(vd, reading)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusConflict)
-				LoggingClient.Error(err.Error())
-				return
-			}
-		}
-
-		// Check device
-		if reading.Device != "" {
-			if checkDevice(reading.Device) != nil {
-				LoggingClient.Error(fmt.Sprintf("error checking device %s %v", reading.Device, err))
-				switch err := err.(type) {
-				case types.ErrNotFound:
-					http.Error(w, err.Error(), http.StatusNotFound)
-					return
-				default: //return an error on everything else.
-					http.Error(w, err.Error(), http.StatusServiceUnavailable)
-					return
-				}
-			}
-		}
-
-		if Configuration.PersistData {
-			id, err := dbClient.AddReading(reading)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				LoggingClient.Error(err.Error())
-				return
-			}
-
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(id.Hex()))
+func validateReading(reading models.Reading) error {
+	// Check the value descriptor
+	vd, err := dbClient.ValueDescriptorByName(reading.Name)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		if err == db.ErrNotFound {
+			return errors.NewErrDbNotFound()
 		} else {
-			// Didn't save the reading in the database
-			encode("unsaved", w)
-		}
-	case http.MethodPut:
-		from := models.Reading{}
-		dec := json.NewDecoder(r.Body)
-		err := dec.Decode(&from)
-
-		// Problem decoding
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			LoggingClient.Error("Error decoding the reading: " + err.Error())
-			return
-		}
-
-		// Check if the reading exists
-		to, err := dbClient.ReadingById(from.Id.Hex())
-		if err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Reading not found", http.StatusNotFound)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		// Update the fields
-		if from.Value != "" {
-			to.Value = from.Value
-		}
-		if from.Name != "" {
-			to.Name = from.Name
-		}
-		if from.Origin != 0 {
-			to.Origin = from.Origin
-		}
-
-		if from.Value != "" || from.Name != "" {
-			if Configuration.ValidateCheck {
-				// Check the value descriptor
-				vd, err := dbClient.ValueDescriptorByName(to.Name)
-				if err != nil {
-					if err == db.ErrNotFound {
-						http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
-					} else {
-						http.Error(w, err.Error(), http.StatusInternalServerError)
-					}
-					LoggingClient.Error(err.Error())
-					return
-				}
-
-				fmt.Println(to)
-
-				err = isValidValueDescriptor(vd, to)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusConflict)
-					LoggingClient.Error(err.Error())
-					return
-				}
-			}
-		}
-
-		err = dbClient.UpdateReading(to)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
-	}
-}
-
-// Get a reading by id
-// HTTP 404 not found if the reading can't be found by the ID
-// api/v1/reading/{id}
-func getReadingByIdHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-	id := vars["id"]
-
-	switch r.Method {
-	case http.MethodGet:
-		reading, err := dbClient.ReadingById(id)
-		if err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Reading not found", http.StatusNotFound)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		encode(reading, w)
-	}
-}
-
-// Return a count for the number of readings in core data
-// api/v1/reading/count
-func readingCountHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	switch r.Method {
-	case http.MethodGet:
-		count, err := dbClient.ReadingCount()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		_, err = w.Write([]byte(strconv.Itoa(count)))
-		if err != nil {
-			LoggingClient.Error(err.Error(), "")
+			return err
 		}
 	}
-}
 
-// Delete a reading by its id
-// api/v1/reading/id/{id}
-func deleteReadingByIdHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-	id := vars["id"]
-
-	switch r.Method {
-	case http.MethodDelete:
-		// Check if the reading exists
-		reading, err := dbClient.ReadingById(id)
-		if err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Reading not found", http.StatusNotFound)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		err = dbClient.DeleteReadingById(reading.Id.Hex())
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
-	}
-}
-
-// Get all the readings for the device - sort by creation date
-// 404 - device ID or name doesn't match
-// 413 - max count exceeded
-// api/v1/reading/device/{deviceId}/{limit}
-func readingByDeviceHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-	limit, err := strconv.Atoi(vars["limit"])
-	// Problems converting limit to int
+	err = isValidValueDescriptor(vd, reading)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
-		return
-	}
-	deviceId, err := url.QueryUnescape(vars["deviceId"])
-	// Problems unescaping URL
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping the device ID: " + err.Error())
-		return
+		LoggingClient.Error(err.Error())
+		return err
 	}
 
-	switch r.Method {
-	case http.MethodGet:
-		if limit > Configuration.Service.ReadMaxLimit {
-			http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
-			LoggingClient.Error(maxExceededString)
-			return
-		}
-
-		// Check device
-		if checkDevice(deviceId) != nil {
-			LoggingClient.Error(fmt.Sprintf("error checking device %s %v", deviceId, err))
-			switch err := err.(type) {
-			case types.ErrNotFound:
-				http.Error(w, err.Error(), http.StatusNotFound)
-				return
-			default: //return an error on everything else.
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
-				return
-			}
-		}
-
-		readings, err := dbClient.ReadingsByDevice(deviceId, limit)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		encode(readings, w)
-	}
+	return nil
 }
 
-// Return a list of readings associated with a value descriptor, limited by limit
-// HTTP 413 (limit exceeded) if the limit is greater than max limit
-// api/v1/reading/name/{name}/{limit}
-func readingbyValueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
+func addReading(reading models.Reading) (id bson.ObjectId, err error) {
+	id, err = dbClient.AddReading(reading)
 
-	vars := mux.Vars(r)
-	name, err := url.QueryUnescape(vars["name"])
-	// Problems with unescaping URL
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping value descriptor name: " + err.Error())
-		return
+		LoggingClient.Error(err.Error())
+
+		return bson.ObjectId(""), err
 	}
-	limit, err := strconv.Atoi(vars["limit"])
-	// Problems converting limit to int
+
+	return id, nil
+}
+
+func getReadingById(id string) (reading models.Reading, err error) {
+	reading, err = dbClient.ReadingById(id)
+
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
-		return
+		LoggingClient.Error(err.Error())
+		if err == db.ErrNotFound {
+			return models.Reading{}, errors.NewErrDbNotFound()
+		} else {
+			return models.Reading{}, err
+		}
+	}
+
+	return reading, nil
+}
+
+func getReadingsByDeviceId(limit int, deviceId string, valueDescriptor string) ([]models.Reading, error) {
+	eventList, err := dbClient.EventsForDevice(deviceId)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		return nil, err
+	}
+
+	// Only pick the readings who match the value descriptor
+	var readings []models.Reading
+	count := 0 // Make sure we stay below the limit
+	for _, event := range eventList {
+		if count >= limit {
+			break
+		}
+		for _, reading := range event.Readings {
+			if count >= limit {
+				break
+			}
+			if reading.Name == valueDescriptor {
+				readings = append(readings, reading)
+				count += 1
+			}
+		}
+	}
+
+	return readings, nil
+}
+
+func deleteReadingById(id string) error {
+	err := dbClient.DeleteReadingById(id)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func updateReading(reading models.Reading) error {
+	to, err := getReadingById(reading.Id.Hex())
+	if err != nil {
+		return err
+	}
+
+	// Update the fields
+	if reading.Value != "" {
+		to.Value = reading.Value
+	}
+	if reading.Name != "" {
+		to.Name = reading.Name
+	}
+	if reading.Origin != 0 {
+		to.Origin = reading.Origin
+	}
+
+	if reading.Value != "" || reading.Name != "" {
+		if Configuration.ValidateCheck {
+			fmt.Println(to)
+
+			err = validateReading(to)
+			if err != nil {
+				LoggingClient.Error("Error validating updated reading")
+				return err
+			}
+		}
+	}
+
+	err = dbClient.UpdateReading(reading)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func countReadings() (count int, err error) {
+	count, err = dbClient.ReadingCount()
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func getReadingsByDevice(deviceId string, limit int) (readings []models.Reading, err error) {
+	if checkDevice(deviceId) != nil {
+		LoggingClient.Error(fmt.Sprintf("error checking device %s %v", deviceId, err))
+
+		return []models.Reading{}, err
+	}
+
+	readings, err = dbClient.ReadingsByDevice(deviceId, limit)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		return []models.Reading{}, err
+	}
+
+	return readings, nil
+}
+
+func getReadingsByValueDescriptor(name string, limit int) (readings []models.Reading, err error) {
+	// Limit is too large
+	err = checkMaxLimit(limit)
+	if err != nil {
+		return []models.Reading{}, err
 	}
 
 	// Check for value descriptor
 	if Configuration.ValidateCheck {
-		_, err = dbClient.ValueDescriptorByName(name)
+		_, err = getValueDescriptorByName(name)
 		if err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
+			return []models.Reading{}, err
 		}
 	}
 
-	// Limit is too large
-	if limit > Configuration.Service.ReadMaxLimit {
-		http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
-		LoggingClient.Error(maxExceededString)
-		return
-	}
-
-	read, err := dbClient.ReadingsByValueDescriptor(name, limit)
+	readings, err = dbClient.ReadingsByValueDescriptor(name, limit)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error(err.Error())
-		return
+		return []models.Reading{}, err
 	}
 
-	encode(read, w)
+	return readings, nil
 }
 
-// Return a list of readings based on the UOM label for the value decriptor
-// api/v1/reading/uomlabel/{uomLabel}/{limit}
-func readingByUomLabelHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-
-	uomLabel, err := url.QueryUnescape(vars["uomLabel"])
-	// Problems unescaping URL
+func getReadingsByValueDescriptorNames(listOfNames []string, limit int) (readings []models.Reading, err error) {
+	readings, err = dbClient.ReadingsByValueDescriptorNames(listOfNames, limit)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping the UOM Label: " + err.Error())
-		return
-	}
-
-	limit, err := strconv.Atoi(vars["limit"])
-	// Problems converting limit to int
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
-		return
-	}
-
-	// Limit was exceeded
-	if limit > Configuration.Service.ReadMaxLimit {
-		http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
-		LoggingClient.Error(maxExceededString)
-		return
-	}
-
-	// Get the value descriptors
-	vList, err := dbClient.ValueDescriptorsByUomLabel(uomLabel)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error(err.Error())
-		return
+		return nil, err
 	}
 
-	var vNames []string
-	for _, v := range vList {
-		vNames = append(vNames, v.Name)
-	}
-
-	readings, err := dbClient.ReadingsByValueDescriptorNames(vNames, limit)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error(err.Error())
-		return
-	}
-
-	encode(readings, w)
+	return readings, nil
 }
 
-// Get readings by the value descriptor (specified by the label)
-// 413 - limit exceeded
-// api/v1/reading/label/{label}/{limit}
-func readingByLabelHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-	label, err := url.QueryUnescape(vars["label"])
-	// Problem unescaping
+func getReadingsByCreationTime(start int64, end int64, limit int) (readings []models.Reading, err error) {
+	readings, err = dbClient.ReadingsByCreationTime(start, end, limit)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping the label of the value descriptor: " + err.Error())
-		return
-	}
-	limit, err := strconv.Atoi(vars["limit"])
-	// Problems converting to int
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
-		return
-	}
-
-	// Limit is too large
-	if limit > Configuration.Service.ReadMaxLimit {
-		LoggingClient.Error(maxExceededString)
-		http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
-		return
-	}
-
-	// Get the value descriptors
-	vdList, err := dbClient.ValueDescriptorsByLabel(label)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error(err.Error())
-		return
-	}
-	var vdNames []string
-	for _, vd := range vdList {
-		vdNames = append(vdNames, vd.Name)
+		return nil, err
 	}
 
-	readings, err := dbClient.ReadingsByValueDescriptorNames(vdNames, limit)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error(err.Error())
-		return
-	}
-
-	encode(readings, w)
+	return readings, nil
 }
 
-// Return a list of readings who's value descriptor has the type
-// 413 - number exceeds the current limit
-// /reading/type/{type}/{limit}
-func readingByTypeHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-
-	t, err := url.QueryUnescape(vars["type"])
+func getReadingsByDeviceAndValueDescriptor(device string, name string, limit int) (readings []models.Reading, err error) {
+	readings, err = dbClient.ReadingsByDeviceAndValueDescriptor(device, name, limit)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error escaping the type: " + err.Error())
-		return
-	}
-
-	l, err := strconv.Atoi(vars["limit"])
-	// Problem converting to int
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
-		return
-	}
-
-	// Limit exceeds max limit
-	if l > Configuration.Service.ReadMaxLimit {
-		http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
-		LoggingClient.Error(maxExceededString)
-		return
-	}
-
-	// Get the value descriptors
-	vdList, err := dbClient.ValueDescriptorsByType(t)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error(err.Error())
-		return
-	}
-	var vdNames []string
-	for _, vd := range vdList {
-		vdNames = append(vdNames, vd.Name)
+		return nil, err
 	}
 
-	readings, err := dbClient.ReadingsByValueDescriptorNames(vdNames, l)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error(err.Error())
-		return
-	}
-
-	encode(readings, w)
-}
-
-// Return a list of readings between the start and end (creation time)
-// /reading/{start}/{end}/{limit}
-func readingByCreationTimeHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-	s, err := strconv.ParseInt((vars["start"]), 10, 64)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error converting the start time to an integer: " + err.Error())
-		return
-	}
-	e, err := strconv.ParseInt((vars["end"]), 10, 64)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error converting the end time to an integer: " + err.Error())
-		return
-	}
-	l, err := strconv.Atoi(vars["limit"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
-		return
-	}
-
-	switch r.Method {
-	case http.MethodGet:
-		if l > Configuration.Service.ReadMaxLimit {
-			LoggingClient.Error(maxExceededString)
-			http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
-			return
-		}
-
-		readings, err := dbClient.ReadingsByCreationTime(s, e, l)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		encode(readings, w)
-	}
-}
-
-// Return a list of redings associated with the device and value descriptor
-// Limit exceeded exception 413 if the limit exceeds the max limit
-// api/v1/reading/name/{name}/device/{device}/{limit}
-func readingByValueDescriptorAndDeviceHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-
-	// Get the variables from the URL
-	name, err := url.QueryUnescape(vars["name"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping the value descriptor name: " + err.Error())
-		return
-	}
-
-	device, err := url.QueryUnescape(vars["device"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping the device: " + err.Error())
-		return
-	}
-
-	limit, err := strconv.Atoi(vars["limit"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error converting limit to an integer: " + err.Error())
-		return
-	}
-
-	if limit > Configuration.Service.ReadMaxLimit {
-		LoggingClient.Error(maxExceededString)
-		http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
-		return
-	}
-
-	// Check device
-	if checkDevice(device) != nil {
-		LoggingClient.Error(fmt.Sprintf("error checking device %s %v", device, err))
-		switch err := err.(type) {
-		case types.ErrNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-			return
-		default: //return an error on everything else.
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
-			return
-		}
-	}
-
-	// Check for value descriptor
-	if Configuration.ValidateCheck {
-		_, err = dbClient.ValueDescriptorByName(name)
-		if err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
-		}
-	}
-
-	readings, err := dbClient.ReadingsByDeviceAndValueDescriptor(device, name, limit)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error(err.Error())
-		return
-	}
-
-	encode(readings, w)
+	return readings, nil
 }

--- a/internal/core/data/reading_test.go
+++ b/internal/core/data/reading_test.go
@@ -1,0 +1,61 @@
+package data
+
+import (
+	"math"
+	"testing"
+)
+
+func TestGetReadingsByDeviceId(t *testing.T) {
+	reset()
+	dbClient = newMockDb()
+
+	expectedReadings, expectedNil := getReadingsByDeviceId(math.MaxInt32, "valid", "Pressure")
+
+	if expectedReadings == nil {
+		t.Errorf("Should return Readings")
+	}
+
+	if expectedNil != nil {
+		t.Errorf("Should not throw error")
+	}
+}
+
+func TestGetReadingsByDeviceIdLimited(t *testing.T) {
+	reset()
+	dbClient = newMockDb()
+
+	for limit:= 0; limit < 5; limit++ {
+		expectedReadings, expectedNil := getReadingsByDeviceId(limit, "valid", "Pressure")
+
+		if limit == 0 {
+			if expectedReadings != nil {
+				t.Errorf("Should return nil slice for zero limit")
+			}
+		} else if expectedReadings == nil {
+			t.Errorf("Should return Readings, limit: %d", limit)
+		}
+
+		if len(expectedReadings) > limit {
+			t.Errorf("Should only return %d Readings", limit)
+		}
+
+		if expectedNil != nil {
+			t.Errorf("Should not throw error")
+		}
+	}
+}
+
+func TestGetReadingsByDeviceIdDBThrowsError(t *testing.T) {
+	reset()
+	dbClient = newMockDb()
+
+	expectedNil, expectedErr := getReadingsByDeviceId(0, "error", "")
+
+	if expectedNil != nil {
+		t.Errorf("Should not return Readings on error")
+	}
+
+	if expectedErr == nil {
+		t.Errorf("Should throw error")
+	}
+}

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -16,6 +16,7 @@ package data
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -212,7 +213,7 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 
 		LoggingClient.Info("Posting Event: " + e.String())
 
-		newId, err := addNew(e)
+		newId, err := addNewEvent(e)
 		if err != nil {
 			switch t := err.(type) {
 			case *errors.ErrValueDescriptorNotFound:
@@ -651,4 +652,870 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	encode(t, w)
 
 	return
+}
+
+// Reading handler
+// GET, PUT, and POST readings
+func readingHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	switch r.Method {
+	case http.MethodGet:
+		r, err := getAllReadings()
+
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrLimitExceeded:
+				http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		encode(r, w)
+	case http.MethodPost:
+		reading, err := decodeReading(r.Body)
+
+		// Problem decoding
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrJsonDecoding:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			case *errors.ErrDbNotFound:
+				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
+				return
+			case *errors.ErrValueDescriptorInvalid:
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Check device
+		if reading.Device != "" {
+			if checkDevice(reading.Device) != nil {
+				LoggingClient.Error(fmt.Sprintf("error checking device %s %v", reading.Device, err))
+				switch err := err.(type) {
+				case types.ErrNotFound:
+					http.Error(w, err.Error(), http.StatusNotFound)
+					return
+				default: //return an error on everything else.
+					http.Error(w, err.Error(), http.StatusServiceUnavailable)
+					return
+				}
+			}
+		}
+
+		if Configuration.PersistData {
+			id, err := addReading(reading)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(id.Hex()))
+		} else {
+			// Didn't save the reading in the database
+			encode("unsaved", w)
+		}
+	case http.MethodPut:
+		from, err := decodeReading(r.Body)
+		// Problem decoding
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrJsonDecoding:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			case *errors.ErrDbNotFound:
+				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
+				return
+			case *errors.ErrValueDescriptorInvalid:
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		err = updateReading(from)
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrDbNotFound:
+				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
+				return
+			case *errors.ErrValueDescriptorInvalid:
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("true"))
+	}
+}
+
+// Get a reading by id
+// HTTP 404 not found if the reading can't be found by the ID
+// api/v1/reading/{id}
+func getReadingByIdHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	switch r.Method {
+	case http.MethodGet:
+		reading, err := getReadingById(id)
+		if err != nil {
+			switch err := err.(type) {
+			case *errors.ErrDbNotFound:
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			default: //return an error on everything else.
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+
+		encode(reading, w)
+	}
+}
+
+// Return a count for the number of readings in core data
+// api/v1/reading/count
+func readingCountHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	switch r.Method {
+	case http.MethodGet:
+		count, err := countReadings()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(strconv.Itoa(count)))
+		if err != nil {
+			LoggingClient.Error(err.Error(), "")
+		}
+	}
+}
+
+// Delete a reading by its id
+// api/v1/reading/id/{id}
+func deleteReadingByIdHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	switch r.Method {
+	case http.MethodDelete:
+		err := deleteReadingById(id)
+		if err != nil {
+			switch err := err.(type) {
+			case *errors.ErrDbNotFound:
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			default: //return an error on everything else.
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("true"))
+	}
+}
+
+// Get all the readings for the device - sort by creation date
+// 404 - device ID or name doesn't match
+// 413 - max count exceeded
+// api/v1/reading/device/{deviceId}/{limit}
+func readingByDeviceHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	limit, err := strconv.Atoi(vars["limit"])
+	// Problems converting limit to int
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
+		return
+	}
+	deviceId, err := url.QueryUnescape(vars["deviceId"])
+	// Problems unescaping URL
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping the device ID: " + err.Error())
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		err := checkMaxLimit(limit)
+		if err != nil {
+			http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
+			return
+		}
+
+		readings, err := getReadingsByDevice(deviceId, limit)
+		if err != nil {
+			switch err := err.(type) {
+			case types.ErrNotFound:
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+
+		encode(readings, w)
+	}
+}
+
+// Return a list of readings associated with a value descriptor, limited by limit
+// HTTP 413 (limit exceeded) if the limit is greater than max limit
+// api/v1/reading/name/{name}/{limit}
+func readingbyValueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	name, err := url.QueryUnescape(vars["name"])
+	// Problems with unescaping URL
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping value descriptor name: " + err.Error())
+		return
+	}
+	limit, err := strconv.Atoi(vars["limit"])
+	// Problems converting limit to int
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
+		return
+	}
+
+	read, err := getReadingsByValueDescriptor(name, limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	encode(read, w)
+}
+
+// Return a list of readings based on the UOM label for the value decriptor
+// api/v1/reading/uomlabel/{uomLabel}/{limit}
+func readingByUomLabelHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+
+	uomLabel, err := url.QueryUnescape(vars["uomLabel"])
+	// Problems unescaping URL
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping the UOM Label: " + err.Error())
+		return
+	}
+
+	limit, err := strconv.Atoi(vars["limit"])
+	// Problems converting limit to int
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
+		return
+	}
+
+	// Limit was exceeded
+	err = checkMaxLimit(limit)
+	if err != nil {
+		http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Get the value descriptors
+	vList, err := getValueDescriptorsByUomLabel(uomLabel)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var vNames []string
+	for _, v := range vList {
+		vNames = append(vNames, v.Name)
+	}
+
+	readings, err := getReadingsByValueDescriptorNames(vNames, limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	encode(readings, w)
+}
+
+// Get readings by the value descriptor (specified by the label)
+// 413 - limit exceeded
+// api/v1/reading/label/{label}/{limit}
+func readingByLabelHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	label, err := url.QueryUnescape(vars["label"])
+	// Problem unescaping
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping the label of the value descriptor: " + err.Error())
+		return
+	}
+	limit, err := strconv.Atoi(vars["limit"])
+	// Problems converting to int
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
+		return
+	}
+
+	// Limit is too large
+	err = checkMaxLimit(limit)
+	if err != nil {
+		http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Get the value descriptors
+	vdList, err := getValueDescriptorsByLabel(label)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	var vdNames []string
+	for _, vd := range vdList {
+		vdNames = append(vdNames, vd.Name)
+	}
+
+	readings, err := getReadingsByValueDescriptorNames(vdNames, limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	encode(readings, w)
+}
+
+// Return a list of readings who's value descriptor has the type
+// 413 - number exceeds the current limit
+// /reading/type/{type}/{limit}
+func readingByTypeHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+
+	t, err := url.QueryUnescape(vars["type"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error escaping the type: " + err.Error())
+		return
+	}
+
+	limit, err := strconv.Atoi(vars["limit"])
+	// Problem converting to int
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
+		return
+	}
+
+	err = checkMaxLimit(limit)
+	if err != nil {
+		http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Get the value descriptors
+	vdList, err := getValueDescriptorsByType(t)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		LoggingClient.Error(err.Error())
+		return
+	}
+	var vdNames []string
+	for _, vd := range vdList {
+		vdNames = append(vdNames, vd.Name)
+	}
+
+	readings, err := getReadingsByValueDescriptorNames(vdNames, limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		LoggingClient.Error(err.Error())
+		return
+	}
+
+	encode(readings, w)
+}
+
+// Return a list of readings between the start and end (creation time)
+// /reading/{start}/{end}/{limit}
+func readingByCreationTimeHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	start, err := strconv.ParseInt((vars["start"]), 10, 64)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error converting the start time to an integer: " + err.Error())
+		return
+	}
+	end, err := strconv.ParseInt((vars["end"]), 10, 64)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error converting the end time to an integer: " + err.Error())
+		return
+	}
+	limit, err := strconv.Atoi(vars["limit"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error converting the limit to an integer: " + err.Error())
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		err = checkMaxLimit(limit)
+		if err != nil {
+			http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
+			return
+		}
+
+		readings, err := getReadingsByCreationTime(start, end, limit)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		encode(readings, w)
+	}
+}
+
+// Return a list of redings associated with the device and value descriptor
+// Limit exceeded exception 413 if the limit exceeds the max limit
+// api/v1/reading/name/{name}/device/{device}/{limit}
+func readingByValueDescriptorAndDeviceHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+
+	// Get the variables from the URL
+	name, err := url.QueryUnescape(vars["name"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping the value descriptor name: " + err.Error())
+		return
+	}
+
+	device, err := url.QueryUnescape(vars["device"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping the device: " + err.Error())
+		return
+	}
+
+	limit, err := strconv.Atoi(vars["limit"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error converting limit to an integer: " + err.Error())
+		return
+	}
+
+	err = checkMaxLimit(limit)
+	if err != nil {
+		http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Check device
+	if checkDevice(device) != nil {
+		LoggingClient.Error(fmt.Sprintf("error checking device %s %v", device, err))
+		switch err := err.(type) {
+		case types.ErrNotFound:
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		default: //return an error on everything else.
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+	}
+
+	// Check for value descriptor
+	if Configuration.ValidateCheck {
+		_, err = getValueDescriptorByName(name)
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrDbNotFound:
+				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+
+	readings, err := getReadingsByDeviceAndValueDescriptor(device, name, limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	encode(readings, w)
+}
+
+// Value Descriptors
+
+// GET, POST, and PUT for value descriptors
+// api/v1/valuedescriptor
+func valueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	switch r.Method {
+	case http.MethodGet:
+		vList, err := getAllValueDescriptors()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Check the limit
+		err = checkMaxLimit(len(vList))
+		if err != nil {
+			http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
+			return
+		}
+
+		encode(vList, w)
+	case http.MethodPost:
+		v, err := decodeValueDescriptor(r.Body)
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrJsonDecoding:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			case *errors.ErrValueDescriptorInvalid:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		id, err := addValueDescriptor(v)
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrValueDescriptorInUse:
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(id.Hex()))
+	case http.MethodPut:
+		vd, err := decodeValueDescriptor(r.Body)
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrJsonDecoding:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			case *errors.ErrValueDescriptorInvalid:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		err = updateValueDescriptor(vd)
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrDbNotFound:
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			case *errors.ErrValueDescriptorInvalid:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			case *errors.ErrValueDescriptorInUse:
+				http.Error(w, "Data integrity issue. Value Descriptor still in use by readings", http.StatusConflict)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("true"))
+	}
+}
+
+// Delete the value descriptor based on the ID
+// DataValidationException (HTTP 409) - The value descriptor is still referenced by readings
+// NotFoundException (404) - Can't find the value descriptor
+// valuedescriptor/id/{id}
+func deleteValueDescriptorByIdHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	err := deleteValueDescriptorById(id)
+	if err != nil {
+		switch err.(type) {
+		case *errors.ErrDbNotFound:
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		case *errors.ErrValueDescriptorInvalid:
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		case *errors.ErrValueDescriptorInUse:
+			http.Error(w, "Data integrity issue. Value Descriptor still in use by readings", http.StatusConflict)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("true"))
+}
+
+// Value descriptors based on name
+// api/v1/valuedescriptor/name/{name}
+func valueDescriptorByNameHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	name, err := url.QueryUnescape(vars["name"])
+
+	// Problems unescaping
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping the value descriptor name: " + err.Error())
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		v, err := dbClient.ValueDescriptorByName(name)
+		if err != nil {
+			if err == db.ErrNotFound {
+				http.Error(w, "Value Descriptor not found", http.StatusNotFound)
+			} else {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			LoggingClient.Error(err.Error())
+			return
+		}
+
+		encode(v, w)
+	case http.MethodDelete:
+		if err = deleteValueDescriptorByName(name); err != nil {
+			switch err.(type) {
+			case *errors.ErrDbNotFound:
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			case *errors.ErrValueDescriptorInvalid:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			case *errors.ErrValueDescriptorInUse:
+				http.Error(w, "Data integrity issue. Value Descriptor still in use by readings", http.StatusConflict)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("true"))
+	}
+}
+
+// Get a value descriptor based on the ID
+// HTTP 404 not found if the ID isn't in the database
+// api/v1/valuedescriptor/{id}
+func valueDescriptorByIdHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	switch r.Method {
+	case http.MethodGet:
+		vd, err := getValueDescriptorById(id)
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrDbNotFound:
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		encode(vd, w)
+	}
+}
+
+// Get the value descriptor from the UOM label
+// api/v1/valuedescriptor/uomlabel/{uomLabel}
+func valueDescriptorByUomLabelHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	uomLabel, err := url.QueryUnescape(vars["uomLabel"])
+
+	// Problem unescaping
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping the UOM Label of the value descriptor: " + err.Error())
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		vdList, err := getValueDescriptorsByUomLabel(uomLabel)
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrDbNotFound:
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		encode(vdList, w)
+	}
+}
+
+// Get value descriptors who have one of the labels
+// api/v1/valuedescriptor/label/{label}
+func valueDescriptorByLabelHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+	label, err := url.QueryUnescape(vars["label"])
+
+	// Problem unescaping
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping label for the value descriptor: " + err.Error())
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		v, err := getValueDescriptorsByLabel(label)
+		if err != nil {
+			switch err.(type) {
+			case *errors.ErrDbNotFound:
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		encode(v, w)
+	}
+}
+
+// Return the value descriptors that are associated with a device
+// The value descriptor is expected parameters on puts or expected values on get/put commands
+// api/v1/valuedescriptor/devicename/{device}
+func valueDescriptorByDeviceHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+
+	device, err := url.QueryUnescape(vars["device"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping the device: " + err.Error())
+		return
+	}
+
+	// Get the value descriptors
+	vdList, err := getValueDescriptorsByDeviceName(device)
+	if err != nil {
+		switch err.(type) {
+		case *errors.ErrDbNotFound:
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	encode(vdList, w)
+}
+
+// Return the value descriptors that are associated with the device specified by the device ID
+// Associated value descripts are expected parameters of PUT commands and expected results of PUT/GET commands
+// api/v1/valuedescriptor/deviceid/{id}
+func valueDescriptorByDeviceIdHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	vars := mux.Vars(r)
+
+	deviceId, err := url.QueryUnescape(vars["id"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		LoggingClient.Error("Error unescaping the device ID: " + err.Error())
+		return
+	}
+
+	// Get the value descriptors
+	vdList, err := getValueDescriptorsByDeviceId(deviceId)
+	if err != nil {
+		switch err.(type) {
+		case *errors.ErrDbNotFound:
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	encode(vdList, w)
 }

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -15,17 +15,14 @@ package data
 
 import (
 	"encoding/json"
-	"errors"
-	"net/http"
-	"net/url"
+	"gopkg.in/mgo.v2/bson"
+	"io"
 	"regexp"
 
-	"fmt"
-
+	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
-	"github.com/gorilla/mux"
 )
 
 const (
@@ -43,267 +40,255 @@ func validateFormatString(v models.ValueDescriptor) (bool, error) {
 	}
 }
 
-// GET, POST, and PUT for value descriptors
-// api/v1/valuedescriptor
-func valueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
+func getValueDescriptorByName(name string) (vd models.ValueDescriptor, err error) {
+	vd, err = dbClient.ValueDescriptorByName(name)
 
-	switch r.Method {
-	case http.MethodGet:
-		vList, err := dbClient.ValueDescriptors()
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		if err == db.ErrNotFound {
+			return models.ValueDescriptor{}, errors.NewErrDbNotFound()
+		} else {
+			return models.ValueDescriptor{}, err
+		}
+	}
+
+	return vd, nil
+}
+
+func getValueDescriptorsByUomLabel(uomLabel string) (vdList []models.ValueDescriptor, err error) {
+	vdList, err = dbClient.ValueDescriptorsByUomLabel(uomLabel)
+
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		if err == db.ErrNotFound {
+			return []models.ValueDescriptor{}, errors.NewErrDbNotFound()
+		} else {
+			return []models.ValueDescriptor{}, err
+		}
+	}
+
+	return vdList, nil
+}
+
+func getValueDescriptorsByLabel(label string) (vdList []models.ValueDescriptor, err error) {
+	vdList, err = dbClient.ValueDescriptorsByLabel(label)
+
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		if err == db.ErrNotFound {
+			return []models.ValueDescriptor{}, errors.NewErrDbNotFound()
+		} else {
+			return []models.ValueDescriptor{}, err
+		}
+	}
+
+	return vdList, nil
+}
+
+func getValueDescriptorsByType(typ string)(vd []models.ValueDescriptor, err error) {
+	vd, err = dbClient.ValueDescriptorsByType(typ)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		return nil, err
+	}
+
+	return vd, nil
+}
+
+func getValueDescriptorsByDevice(device models.Device)(vdList []models.ValueDescriptor, err error) {
+	// Get the names of the value descriptors
+	vdNames := []string{}
+	device.AllAssociatedValueDescriptors(&vdNames)
+
+	// Get the value descriptors
+	vdList = []models.ValueDescriptor{}
+	for _, name := range vdNames {
+		vd, err := getValueDescriptorByName(name)
+
+		// Not an error if not found
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
+			switch err.(type) {
+			case *errors.ErrDbNotFound:
+				continue
+			default:
+				return []models.ValueDescriptor{}, err
+			}
 		}
 
-		// Check the limit
-		if len(vList) > Configuration.Service.ReadMaxLimit {
-			http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
-			LoggingClient.Error(maxExceededString)
-			return
-		}
+		vdList = append(vdList, vd)
+	}
 
-		encode(vList, w)
-	case http.MethodPost:
-		dec := json.NewDecoder(r.Body)
-		v := models.ValueDescriptor{}
-		err := dec.Decode(&v)
-		// Problems decoding
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			LoggingClient.Error("Error decoding the value descriptor: " + err.Error())
-			return
-		}
+	return vdList, nil
+}
 
-		// Check the formatting
-		match, err := validateFormatString(v)
+func getValueDescriptorsByDeviceName(name string)(vdList []models.ValueDescriptor, err error) {
+	// Get the device
+	device, err := mdc.DeviceForName(name)
+	if err != nil {
+		switch err := err.(type) {
+		case types.ErrNotFound:
+			LoggingClient.Error("Device not found: " + err.Error())
+			return []models.ValueDescriptor{}, errors.NewErrDbNotFound()
+		default:
+			LoggingClient.Error("Problem getting device from metadata: " + err.Error())
+			return []models.ValueDescriptor{}, err
+		}
+	}
+
+	return getValueDescriptorsByDevice(device)
+}
+
+func getValueDescriptorsByDeviceId(id string)(vdList []models.ValueDescriptor, err error) {
+	// Get the device
+	device, err := mdc.Device(id)
+	if err != nil {
+		switch err := err.(type) {
+		case types.ErrNotFound:
+			LoggingClient.Error("Device not found: " + err.Error())
+			return []models.ValueDescriptor{}, errors.NewErrDbNotFound()
+		default:
+			LoggingClient.Error("Problem getting device from metadata: " + err.Error())
+			return []models.ValueDescriptor{}, err
+		}
+	}
+
+	return getValueDescriptorsByDevice(device)
+}
+
+func getAllValueDescriptors()(vd []models.ValueDescriptor, err error) {
+	vd, err = dbClient.ValueDescriptors()
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		return nil, err
+	}
+
+	return vd, nil
+}
+
+func decodeValueDescriptor(reader io.ReadCloser) (vd models.ValueDescriptor, err error) {
+	v := models.ValueDescriptor{}
+	err = json.NewDecoder(reader).Decode(&v)
+	// Problems decoding
+	if err != nil {
+		LoggingClient.Error("Error decoding the value descriptor: " + err.Error())
+		return models.ValueDescriptor{}, errors.NewErrJsonDecoding(v.Name)
+	}
+
+	// Check the formatting
+	match, err := validateFormatString(v)
+	if err != nil {
+		LoggingClient.Error("Error checking for format string for value descriptor " + v.Name)
+		return models.ValueDescriptor{}, err
+	}
+	if !match {
+		LoggingClient.Error("Error posting value descriptor. Format is not a valid printf format.")
+		return models.ValueDescriptor{}, errors.NewErrValueDescriptorInvalid(v.Name, err)
+	}
+
+	return v, nil
+}
+
+func addValueDescriptor(vd models.ValueDescriptor) (id bson.ObjectId, err error) {
+	id, err = dbClient.AddValueDescriptor(vd)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		if err == db.ErrNotUnique {
+			return bson.ObjectId(""), errors.NewErrValueDescriptorInUse(vd.Name)
+		} else {
+			return bson.ObjectId(""), err
+		}
+	}
+
+	return id, nil
+}
+
+func updateValueDescriptor(from models.ValueDescriptor) error {
+	to, err := getValueDescriptorById(from.Id.Hex())
+	if err != nil {
+		return err
+	}
+
+	// Update the fields
+	if from.DefaultValue != "" {
+		to.DefaultValue = from.DefaultValue
+	}
+	if from.Formatting != "" {
+		match, err := regexp.MatchString(formatSpecifier, from.Formatting)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			LoggingClient.Error("Error checking for format string for POSTed value descriptor")
-			return
+			LoggingClient.Error("Error checking formatting for updated value descriptor")
+			return err
 		}
 		if !match {
-			err := errors.New("Error posting value descriptor. Format is not a valid printf format.")
-			http.Error(w, err.Error(), http.StatusConflict)
-			LoggingClient.Error(err.Error())
-			return
+			LoggingClient.Error("value descriptor's format string doesn't fit the required pattern: " + formatSpecifier)
+			return errors.NewErrValueDescriptorInvalid(from.Name, err)
 		}
-
-		id, err := dbClient.AddValueDescriptor(v)
-		if err != nil {
-			if err == db.ErrNotUnique {
-				http.Error(w, "Value Descriptor already exists", http.StatusConflict)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(id.Hex()))
-	case http.MethodPut:
-		dec := json.NewDecoder(r.Body)
-		from := models.ValueDescriptor{}
-		err := dec.Decode(&from)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			LoggingClient.Error("Error decoding the value descriptor: " + err.Error())
-			return
-		}
-
-		// Find the value descriptor thats being updated
-		// Try by ID
-		to, err := dbClient.ValueDescriptorById(from.Id.Hex())
-		if err != nil {
-			to, err = dbClient.ValueDescriptorByName(from.Name)
-			if err != nil {
-				if err == db.ErrNotFound {
-					http.Error(w, "Value descriptor not found", http.StatusNotFound)
-				} else {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-				}
-				LoggingClient.Error(err.Error())
-				return
-			}
-		}
-
-		// Update the fields
-		if from.DefaultValue != "" {
-			to.DefaultValue = from.DefaultValue
-		}
-		if from.Formatting != "" {
-			match, err := regexp.MatchString(formatSpecifier, from.Formatting)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				LoggingClient.Error("Error checking formatting for updated value descriptor")
-				return
-			}
-			if !match {
-				http.Error(w, "Value descriptor's format string doesn't fit the required pattern", http.StatusConflict)
-				LoggingClient.Error("Value descriptor's format string doesn't fit the required pattern: " + formatSpecifier)
-				return
-			}
-			to.Formatting = from.Formatting
-		}
-		if from.Labels != nil {
-			to.Labels = from.Labels
-		}
-
-		if from.Max != "" {
-			to.Max = from.Max
-		}
-		if from.Min != "" {
-			to.Min = from.Min
-		}
-		if from.Name != "" {
-			// Check if value descriptor is still in use by readings if the name changes
-			if from.Name != to.Name {
-				r, err := dbClient.ReadingsByValueDescriptor(to.Name, 10) // Arbitrary limit, we're just checking if there are any readings
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					LoggingClient.Error("Error checking the readings for the value descriptor: " + err.Error())
-					return
-				}
-				// Value descriptor is still in use
-				if len(r) != 0 {
-					http.Error(w, "Data integrity issue. Value Descriptor still in use by readings", http.StatusConflict)
-					LoggingClient.Error("Data integrity issue.  Value Descriptor with name:  " + from.Name + " is still referenced by existing readings.")
-					return
-				}
-			}
-			to.Name = from.Name
-		}
-		if from.Origin != 0 {
-			to.Origin = from.Origin
-		}
-		if from.Type != "" {
-			to.Type = from.Type
-		}
-		if from.UomLabel != "" {
-			to.UomLabel = from.UomLabel
-		}
-
-		// Push the updated valuedescriptor to the database
-		err = dbClient.UpdateValueDescriptor(to)
-		if err != nil {
-			if err == db.ErrNotUnique {
-				http.Error(w, "Value descriptor name is not unique", http.StatusConflict)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
-		//encode(true, w)
+		to.Formatting = from.Formatting
 	}
-}
+	if from.Labels != nil {
+		to.Labels = from.Labels
+	}
 
-// Delete the value descriptor based on the ID
-// DataValidationException (HTTP 409) - The value descriptor is still referenced by readings
-// NotFoundException (404) - Can't find the value descriptor
-// valuedescriptor/id/{id}
-func deleteValueDescriptorByIdHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
+	if from.Max != "" {
+		to.Max = from.Max
+	}
+	if from.Min != "" {
+		to.Min = from.Min
+	}
+	if from.Name != "" {
+		// Check if value descriptor is still in use by readings if the name changes
+		if from.Name != to.Name {
+			r, err := getReadingsByValueDescriptor(to.Name, 10) // Arbitrary limit, we're just checking if there are any readings
+			if err != nil {
+				LoggingClient.Error("Error checking the readings for the value descriptor: " + err.Error())
+				return err
+			}
+			// Value descriptor is still in use
+			if len(r) != 0 {
+				LoggingClient.Error("Data integrity issue.  Value Descriptor with name:  " + from.Name + " is still referenced by existing readings.")
+				return errors.NewErrValueDescriptorInUse(from.Name)
+			}
+		}
+		to.Name = from.Name
+	}
+	if from.Origin != 0 {
+		to.Origin = from.Origin
+	}
+	if from.Type != "" {
+		to.Type = from.Type
+	}
+	if from.UomLabel != "" {
+		to.UomLabel = from.UomLabel
+	}
 
-	vars := mux.Vars(r)
-	id := vars["id"]
-
-	// Check if the value descriptor exists
-	vd, err := dbClient.ValueDescriptorById(id)
+	// Push the updated valuedescriptor to the database
+	err = dbClient.UpdateValueDescriptor(to)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Value descriptor not found", http.StatusNotFound)
+		if err == db.ErrNotUnique {
+			LoggingClient.Error("Value descriptor name is not unique")
+			return errors.NewErrValueDescriptorInUse(to.Name)
 		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			LoggingClient.Error(err.Error())
+			return err
 		}
-		LoggingClient.Error(err.Error())
-		return
 	}
 
-	if err = deleteValueDescriptor(vd, w); err != nil {
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("true"))
-	//encode(true, w)
+	return nil
 }
 
-// Value descriptors based on name
-// api/v1/valuedescriptor/name/{name}
-func valueDescriptorByNameHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-	name, err := url.QueryUnescape(vars["name"])
-
-	// Problems unescaping
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping the value descriptor name: " + err.Error())
-		return
-	}
-
-	switch r.Method {
-	case http.MethodGet:
-		v, err := dbClient.ValueDescriptorByName(name)
-		if err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Value Descriptor not found", http.StatusNotFound)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		encode(v, w)
-	case http.MethodDelete:
-		// Check if the value descriptor exists
-		vd, err := dbClient.ValueDescriptorByName(name)
-		if err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Value Descriptor not found", http.StatusNotFound)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		if err = deleteValueDescriptor(vd, w); err != nil {
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
-		//encode(true, w)
-	}
-}
-
-func deleteValueDescriptor(vd models.ValueDescriptor, w http.ResponseWriter) error {
+func deleteValueDescriptor(vd models.ValueDescriptor) error {
 	// Check if the value descriptor is still in use by readings
 	readings, err := dbClient.ReadingsByValueDescriptor(vd.Name, 10)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error(err.Error())
 		return err
 	}
 	if len(readings) > 0 {
-		err = errors.New("Data integrity issue.  Value Descriptor is still referenced by existing readings.")
-		http.Error(w, err.Error(), http.StatusConflict)
-		LoggingClient.Error(err.Error())
-		return err
+		LoggingClient.Error("Data integrity issue.  Value Descriptor is still referenced by existing readings.")
+		return errors.NewErrValueDescriptorInUse(vd.Name)
 	}
 
 	// Delete the value descriptor
 	if err = dbClient.DeleteValueDescriptorById(vd.Id.Hex()); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error(err.Error())
 		return err
 	}
@@ -311,184 +296,45 @@ func deleteValueDescriptor(vd models.ValueDescriptor, w http.ResponseWriter) err
 	return nil
 }
 
-// Get a value descriptor based on the ID
-// HTTP 404 not found if the ID isn't in the database
-// api/v1/valuedescriptor/{id}
-func valueDescriptorByIdHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-	id := vars["id"]
-
-	switch r.Method {
-	case http.MethodGet:
-		v, err := dbClient.ValueDescriptorById(id)
-		if err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Value descriptor not found", http.StatusNotFound)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		encode(v, w)
+func deleteValueDescriptorByName(name string) error {
+	// Check if the value descriptor exists
+	vd, err := getValueDescriptorByName(name)
+	if err != nil {
+		return err
 	}
+
+	if err = deleteValueDescriptor(vd); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-// Get the value descriptor from the UOM label
-// api/v1/valuedescriptor/uomlabel/{uomLabel}
-func valueDescriptorByUomLabelHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-	uomLabel, err := url.QueryUnescape(vars["uomLabel"])
-
-	// Problem unescaping
+func deleteValueDescriptorById(id string) error {
+	// Check if the value descriptor exists
+	vd, err := getValueDescriptorById(id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping the UOM Label of the value descriptor: " + err.Error())
-		return
+		return err
 	}
 
-	switch r.Method {
-	case http.MethodGet:
-		v, err := dbClient.ValueDescriptorsByUomLabel(uomLabel)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		encode(v, w)
+	if err = deleteValueDescriptor(vd); err != nil {
+		return err
 	}
+
+	return nil
 }
 
-// Get value descriptors who have one of the labels
-// api/v1/valuedescriptor/label/{label}
-func valueDescriptorByLabelHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
+func getValueDescriptorById(id string) (vd models.ValueDescriptor, err error) {
+	vd, err = dbClient.ValueDescriptorById(id)
 
-	vars := mux.Vars(r)
-	label, err := url.QueryUnescape(vars["label"])
-
-	// Problem unescaping
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping label for the value descriptor: " + err.Error())
-		return
-	}
-
-	switch r.Method {
-	case http.MethodGet:
-		v, err := dbClient.ValueDescriptorsByLabel(label)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		encode(v, w)
-	}
-}
-
-// Return the value descriptors that are associated with a device
-// The value descriptor is expected parameters on puts or expected values on get/put commands
-// api/v1/valuedescriptor/devicename/{device}
-func valueDescriptorByDeviceHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-
-	device, err := url.QueryUnescape(vars["device"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping the device: " + err.Error())
-		return
-	}
-
-	// Get the device
-	d, err := mdc.DeviceForName(device)
-	if err != nil {
-		http.Error(w, "Device not found", http.StatusNotFound)
-		LoggingClient.Error("Device not found: " + err.Error())
-		return
-	}
-
-	// Get the value descriptors
-	vdList, err := valueDescriptorsForDevice(d, w)
-	if err != nil {
-		return
-	}
-
-	encode(vdList, w)
-}
-
-// Return the value descriptors that are associated with the device specified by the device ID
-// Associated value descripts are expected parameters of PUT commands and expected results of PUT/GET commands
-// api/v1/valuedescriptor/deviceid/{id}
-func valueDescriptorByDeviceIdHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	vars := mux.Vars(r)
-
-	deviceId, err := url.QueryUnescape(vars["id"])
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error("Error unescaping the device ID: " + err.Error())
-		return
-	}
-
-	// Get the device
-	d, err := mdc.Device(deviceId)
-	if err != nil {
-		var msg string
-		switch err := err.(type) {
-		case types.ErrNotFound:
-			msg = fmt.Sprintf("Device not found: %v", err)
-			http.Error(w, msg, http.StatusNotFound)
-		default:
-			msg = fmt.Sprintf("Problem getting device from metadata: %v", err)
-			http.Error(w, msg, http.StatusInternalServerError)
-		}
-		LoggingClient.Error(msg)
-		return
-	}
-
-	// Get the value descriptors
-	vdList, err := valueDescriptorsForDevice(d, w)
-	if err != nil {
-		return
-	}
-
-	encode(vdList, w)
-}
-
-// Get the value descriptors for the device
-func valueDescriptorsForDevice(d models.Device, w http.ResponseWriter) ([]models.ValueDescriptor, error) {
-	// Get the names of the value descriptors
-	vdNames := []string{}
-	d.AllAssociatedValueDescriptors(&vdNames)
-
-	// Get the value descriptors
-	vdList := []models.ValueDescriptor{}
-	for _, name := range vdNames {
-		vd, err := dbClient.ValueDescriptorByName(name)
-
-		// Not an error if not found
+		LoggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
-			continue
+			return models.ValueDescriptor{}, errors.NewErrDbNotFound()
+		} else {
+			return models.ValueDescriptor{}, err
 		}
-
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
-			LoggingClient.Error(err.Error())
-			return vdList, err
-		}
-
-		vdList = append(vdList, vd)
 	}
 
-	return vdList, nil
+	return vd, nil
 }


### PR DESCRIPTION
Related to issue #457 

This pull request attempts to lay the foundational work that will make unit testing this functionality possible and tries to follow the example @tsconn23 used for event.go. Expect a second PR based off this branch very shortly that will add these unit tests.