### PR TITLE
Integrate the newly-created GeneralClient into the SMA.

### DIFF
--- a/cmd/sys-mgmt-agent/res/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/configuration.toml
@@ -30,3 +30,23 @@ LoggingFile = './logs/edgex-sys-mgmt-agent.log'
   Protocol = 'http'
   Host = 'localhost'
   Port = 48061
+
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48080
+
+  [Clients.Scheduler]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48085
+
+  [Clients.Export]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48071
+
+  [Clients.Distro]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48070

--- a/cmd/sys-mgmt-agent/res/docker/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/docker/configuration.toml
@@ -10,3 +10,43 @@ CheckInterval = '10s'
 LoggingFile = '/edgex/logs/edgex-sys-mgmt-agent.log'
 LoggingRemoteURL = 'http://edgex-support-logging:48061/api/v1/logs'
 
+[Clients]
+  [Clients.Notifications]
+  Protocol = 'http'
+  Host = 'edgex-support-notifications'
+  Port = 48060
+
+  [Clients.Command]
+  Protocol = 'http'
+  Host = 'edgex-core-command'
+  Port = 48082
+
+  [Clients.Metadata]
+  Protocol = 'http'
+  Host = 'edgex-core-metadata'
+  Port = 48081
+
+  [Clients.Logging]
+  Protocol = 'http'
+  Host = 'edgex-support-logging'
+  Port = 48061
+
+  [Clients.CoreData]
+  Protocol = 'http'
+  Host = 'edgex-core-data'
+  Port = 48080
+
+  [Clients.Scheduler]
+  Protocol = 'http'
+  Host = 'edgex-support-scheduler'
+  Port = 48085
+
+  [Clients.Export]
+  Protocol = 'http'
+  Host = 'edgex-export-client'
+  Port = 48071
+
+  [Clients.Distro]
+  Protocol = 'http'
+  Host = 'edgex-export-distro'
+  Port = 48070

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -32,9 +32,15 @@ var Configuration *ConfigurationStruct
 var LoggingClient logger.LoggingClient
 var Manifest *ManifestStruct
 var Conf = &ConfigurationStruct{}
-var nc general.GeneralClient
 var ec interfaces.ExecutorClient
-var mcc general.GeneralClient
+var gccc general.GeneralClient
+var gccd general.GeneralClient
+var gccm general.GeneralClient
+var gcec general.GeneralClient
+var gced general.GeneralClient
+var gcsl general.GeneralClient
+var gcsn general.GeneralClient
+var gcss general.GeneralClient
 
 func Retry(useConsul bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
@@ -147,23 +153,83 @@ func setLoggingTarget() string {
 }
 
 func initializeClients(useConsul bool) {
-	// Create notification client
-	paramsNotification := types.EndpointParams{
+	// Create support-notifications client.
+	paramsNotifications := types.EndpointParams{
 		ServiceKey:  internal.SupportNotificationsServiceKey,
 		Path:        "/",
 		UseRegistry: useConsul,
 		Url:         Configuration.Clients["Notifications"].Url(),
 		Interval:    internal.ClientMonitorDefault,
 	}
-	nc = general.NewGeneralClient(paramsNotification, startup.Endpoint{})
+	gcsn = general.NewGeneralClient(paramsNotifications, startup.Endpoint{})
 
-	// Create command client
-	paramsCommand := types.EndpointParams{
+	// Create core-command client.
+	paramsCoreCommand := types.EndpointParams{
 		ServiceKey:  internal.CoreCommandServiceKey,
 		Path:        "/",
 		UseRegistry: useConsul,
 		Url:         Configuration.Clients["Command"].Url(),
 		Interval:    internal.ClientMonitorDefault,
 	}
-	mcc = general.NewGeneralClient(paramsCommand, startup.Endpoint{})
+	gccc = general.NewGeneralClient(paramsCoreCommand, startup.Endpoint{})
+
+	// Create core-data client.
+	paramsCoreData := types.EndpointParams{
+		ServiceKey:  internal.CoreDataServiceKey,
+		Path:        "/",
+		UseRegistry: useConsul,
+		Url:         Configuration.Clients["CoreData"].Url(),
+		Interval:    internal.ClientMonitorDefault,
+	}
+	gccd = general.NewGeneralClient(paramsCoreData, startup.Endpoint{})
+
+	// Create core-metadata client.
+	paramsCoreMetadata := types.EndpointParams{
+		ServiceKey:  internal.CoreMetaDataServiceKey,
+		Path:        "/",
+		UseRegistry: useConsul,
+		Url:         Configuration.Clients["Metadata"].Url(),
+		Interval:    internal.ClientMonitorDefault,
+	}
+	gccm = general.NewGeneralClient(paramsCoreMetadata, startup.Endpoint{})
+
+	// Create export-client client.
+	paramsExportClient := types.EndpointParams{
+		ServiceKey:  internal.ExportClientServiceKey,
+		Path:        "/",
+		UseRegistry: useConsul,
+		Url:         Configuration.Clients["Export"].Url(),
+		Interval:    internal.ClientMonitorDefault,
+	}
+	gcec = general.NewGeneralClient(paramsExportClient, startup.Endpoint{})
+
+	// Create export-distro client.
+	paramsExportDistro := types.EndpointParams{
+		ServiceKey:  internal.ExportDistroServiceKey,
+		Path:        "/",
+		UseRegistry: useConsul,
+		Url:         Configuration.Clients["Distro"].Url(),
+		Interval:    internal.ClientMonitorDefault,
+	}
+	gced = general.NewGeneralClient(paramsExportDistro, startup.Endpoint{})
+
+	// Create support-logging client.
+	paramsSupportLogging := types.EndpointParams{
+		ServiceKey:  internal.SupportLoggingServiceKey,
+		Path:        "/",
+		UseRegistry: useConsul,
+		Url:         Configuration.Clients["Logging"].Url(),
+		Interval:    internal.ClientMonitorDefault,
+	}
+	gcsl = general.NewGeneralClient(paramsSupportLogging, startup.Endpoint{})
+
+	// Create support-scheduler client.
+	paramsSupportScheduler := types.EndpointParams{
+		ServiceKey:  internal.SupportSchedulerServiceKey,
+		Path:        "/",
+		UseRegistry: useConsul,
+		Url:         Configuration.Clients["Scheduler"].Url(),
+		Interval:    internal.ClientMonitorDefault,
+	}
+	gcss = general.NewGeneralClient(paramsSupportScheduler, startup.Endpoint{})
 }

--- a/internal/system/agent/services.go
+++ b/internal/system/agent/services.go
@@ -187,7 +187,7 @@ func getConfig(services []string) (ConfigRespMap, error) {
 
 		case internal.SupportNotificationsServiceKey:
 
-			responseJSON, err := nc.FetchConfiguration()
+			responseJSON, err := gcsn.FetchConfiguration()
 			if err != nil {
 				msg := fmt.Sprintf("%s get config error: %s", service, err.Error())
 				c.Configuration[service] = msg
@@ -198,7 +198,7 @@ func getConfig(services []string) (ConfigRespMap, error) {
 			break
 
 		case internal.CoreCommandServiceKey:
-			responseJSON, err := mcc.FetchConfiguration()
+			responseJSON, err := gccc.FetchConfiguration()
 			if err != nil {
 				msg := fmt.Sprintf("%s get config error: %s", service, err.Error())
 				c.Configuration[service] = msg
@@ -209,28 +209,69 @@ func getConfig(services []string) (ConfigRespMap, error) {
 			break
 
 		case internal.CoreDataServiceKey:
-			c.Configuration[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its configuration data...", internal.CoreDataServiceKey))
+			responseJSON, err := gccd.FetchConfiguration()
+			if err != nil {
+				msg := fmt.Sprintf("%s get config error: %s", service, err.Error())
+				c.Configuration[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				c.Configuration[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.CoreMetaDataServiceKey:
-			c.Configuration[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its configuration data...", internal.CoreMetaDataServiceKey))
+			responseJSON, err := gccm.FetchConfiguration()
+			if err != nil {
+				msg := fmt.Sprintf("%s get config error: %s", service, err.Error())
+				c.Configuration[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				c.Configuration[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.ExportClientServiceKey:
-			c.Configuration[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its configuration data...", internal.ExportClientServiceKey))
+			responseJSON, err := gcec.FetchConfiguration()
+			if err != nil {
+				msg := fmt.Sprintf("%s get config error: %s", service, err.Error())
+				c.Configuration[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				c.Configuration[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.ExportDistroServiceKey:
-			c.Configuration[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its configuration data...", internal.ExportDistroServiceKey))
+			responseJSON, err := gced.FetchConfiguration()
+			if err != nil {
+				msg := fmt.Sprintf("%s get config error: %s", service, err.Error())
+				c.Configuration[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				c.Configuration[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.SupportLoggingServiceKey:
-			c.Configuration[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its configuration data...", internal.SupportLoggingServiceKey))
+			responseJSON, err := gcsl.FetchConfiguration()
+			if err != nil {
+				msg := fmt.Sprintf("%s get config error: %s", service, err.Error())
+				c.Configuration[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				c.Configuration[service] = ProcessResponse(responseJSON)
+			}
+			break
+
+		case internal.SupportSchedulerServiceKey:
+			responseJSON, err := gcss.FetchConfiguration()
+			if err != nil {
+				msg := fmt.Sprintf("%s get config error: %s", service, err.Error())
+				c.Configuration[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				c.Configuration[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		default:
@@ -254,7 +295,7 @@ func getMetrics(services []string) (MetricsRespMap, error) {
 		switch service {
 
 		case internal.SupportNotificationsServiceKey:
-			responseJSON, err := nc.FetchMetrics()
+			responseJSON, err := gcsn.FetchMetrics()
 			if err != nil {
 				msg := fmt.Sprintf("%s get metrics error: %s", service, err.Error())
 				m.Metrics[service] = msg
@@ -265,7 +306,7 @@ func getMetrics(services []string) (MetricsRespMap, error) {
 			break
 
 		case internal.CoreCommandServiceKey:
-			responseJSON, err := mcc.FetchMetrics()
+			responseJSON, err := gccc.FetchMetrics()
 			if err != nil {
 				msg := fmt.Sprintf("%s get metrics error: %s", service, err.Error())
 				m.Metrics[service] = msg
@@ -276,28 +317,69 @@ func getMetrics(services []string) (MetricsRespMap, error) {
 			break
 
 		case internal.CoreDataServiceKey:
-			m.Metrics[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its metrics data...", internal.CoreDataServiceKey))
+			responseJSON, err := gccd.FetchMetrics()
+			if err != nil {
+				msg := fmt.Sprintf("%s get metrics error: %s", service, err.Error())
+				m.Metrics[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				m.Metrics[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.CoreMetaDataServiceKey:
-			m.Metrics[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its metrics data...", internal.CoreMetaDataServiceKey))
+			responseJSON, err := gccm.FetchMetrics()
+			if err != nil {
+				msg := fmt.Sprintf("%s get metrics error: %s", service, err.Error())
+				m.Metrics[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				m.Metrics[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.ExportClientServiceKey:
-			m.Metrics[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its metrics data...", internal.ExportClientServiceKey))
+			responseJSON, err := gcec.FetchMetrics()
+			if err != nil {
+				msg := fmt.Sprintf("%s get metrics error: %s", service, err.Error())
+				m.Metrics[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				m.Metrics[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.ExportDistroServiceKey:
-			m.Metrics[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its metrics data...", internal.ExportDistroServiceKey))
+			responseJSON, err := gced.FetchMetrics()
+			if err != nil {
+				msg := fmt.Sprintf("%s get metrics error: %s", service, err.Error())
+				m.Metrics[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				m.Metrics[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		case internal.SupportLoggingServiceKey:
-			m.Metrics[service] = "N/A"
-			LoggingClient.Info(fmt.Sprintf("The micro-service {%v} currently does not support an endpoint for providing its metrics data...", internal.SupportLoggingServiceKey))
+			responseJSON, err := gcsl.FetchMetrics()
+			if err != nil {
+				msg := fmt.Sprintf("%s get metrics error: %s", service, err.Error())
+				m.Metrics[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				m.Metrics[service] = ProcessResponse(responseJSON)
+			}
+			break
+
+		case internal.SupportSchedulerServiceKey:
+			responseJSON, err := gcss.FetchMetrics()
+			if err != nil {
+				msg := fmt.Sprintf("%s get metrics error: %s", service, err.Error())
+				m.Metrics[service] = msg
+				LoggingClient.Error(msg)
+			} else {
+				m.Metrics[service] = ProcessResponse(responseJSON)
+			}
 			break
 
 		default:


### PR DESCRIPTION
- This PR contains the work done in accordance with: [Issue Number 697](https://github.com/edgexfoundry/edgex-go/issues/697)
- With a view to providing insight into DEV testing, Postman was used with the **following two HTTP GET requests** repeatedly:

**api/v1/metrics:**
- http://localhost:48090/api/v1/metrics/edgex-support-logging,edgex-core-metadata,edgex-support-notifications,edgex-core-data,edgex-core-command,edgex-export-client,edgex-export-distro,edgex-support-scheduler

**api/v1/config:**
- http://localhost:48090/api/v1/config/edgex-support-logging,edgex-core-metadata,edgex-support-notifications,edgex-core-data,edgex-core-command,edgex-export-client,edgex-export-distro,edgex-support-scheduler
