### PR TITLE
addressing issue 650 integration with core-metadata

### DIFF
--- a/api/raml/support-scheduler.raml
+++ b/api/raml/support-scheduler.raml
@@ -48,3 +48,14 @@ schemas:
                 description: return value of "pong"
             "503":
                 description: for unknown or unanticipated issues
+/flush:
+    displayName: Flush Scheduler Schedules
+    description: example - http://localhost:48085/api/v1/flush
+    get:
+        description: Flushes all of the current schedule(s), schedule event(s) from the Scheduler. Will reload from core-metadata and config.
+        displayName: Flush Scheduler Schedules
+        responses:
+            "200":
+                description: return value of value  of "success"
+            "500":
+                description: for unknown or unanticipated issues

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -48,7 +48,7 @@ func main() {
 	// Bootstrap schedulers
 	err := scheduler.AddSchedulers()
 	if err != nil{
-		scheduler.LoggingClient.Error(fmt.Sprintf("Failed to load default schedules and events %s",err.Error()))
+		scheduler.LoggingClient.Error(fmt.Sprintf("Failed to load schedules and events %s",err.Error()))
 	}
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(scheduler.Configuration.Service.Timeout), "Request timed out")

--- a/internal/core/metadata/const.go
+++ b/internal/core/metadata/const.go
@@ -63,4 +63,5 @@ const (
 	DEVICEADDRESSABLESBYNAME = "deviceaddressablesbyname"
 	UNLOCKED                 = "UNLOCKED"
 	ENABLED                  = "ENABLED"
+	SCHEDULER_TIMELAYOUT     = "20060102T150405"
 )

--- a/internal/core/metadata/rest_scheduleevent.go
+++ b/internal/core/metadata/rest_scheduleevent.go
@@ -39,6 +39,11 @@ func isIntervalValid(frequency string) bool {
 func msToTime(ms string) (time.Time, error) {
 	msInt, err := strconv.ParseInt(ms, 10, 64)
 	if err != nil {
+		// todo: support-scheduler will be removed later issue_650a
+		t, err := time.Parse(SCHEDULER_TIMELAYOUT, ms)
+		if err == nil{
+			return t, nil
+		}
 		return time.Time{}, err
 	}
 


### PR DESCRIPTION
Signed-off-by: xmlviking <ecotter@gmail.com>

Addressing issue with scheduler and core-metadata integration with schedules,scheduleevents, and addressables.  Scheduler will now use core-metadata as the source of truth for schedules and only use it's local configuration scheduler,events when not included in the core-metadata.  Additionally new schedules, events, and addressable unique id's will be generated from core-metadata. 

We currently do not have reactive feedback to the support-scheduler from the metadata client.
For now any changes made to core-metadata which require support-scheduler notification should be accomplished via the /api/v1/flush router call on the support-scheduler.  This will flush the current schedules and reload the entire schedules, events, and addressables "including any changes made in the support-scheduler config". 

Work to be completed in a future will include:

- [ ] - Mocks and Unit Tests around the new enhancement features for the core-metadata 
- [ ] - Mocks ScheduleClient, ScheduleEventClient, and AddressableClient

