### PR TITLE
internal/seed/config/populate.go: turn info line to debug

### DIFF
--- a/internal/seed/config/populate.go
+++ b/internal/seed/config/populate.go
@@ -42,7 +42,7 @@ func ImportProperties(root string) error {
 
 		dir, file := filepath.Split(path)
 		appKey := parseDirectoryName(dir)
-		LoggingClient.Info(fmt.Sprintf("dir: %s file: %s", appKey, file))
+		LoggingClient.Debug(fmt.Sprintf("dir: %s file: %s", appKey, file))
 		props, err := readPropertiesFile(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
This line isn't really necessary info and is rather debug info.