### PR TITLE
Support stopping services in snap with SMA

### DIFF
--- a/internal/system/agent/executor/snap.go
+++ b/internal/system/agent/executor/snap.go
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright 2018 Canonical Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
 package executor
 
 import (

--- a/internal/system/agent/executor/snap.go
+++ b/internal/system/agent/executor/snap.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent"
 )
 
 // ExecuteSnap is a struct for managing services inside the snap
@@ -59,11 +58,6 @@ func (oe *ExecuteSnap) StopService(service string, params string) error {
 	// use snapctl to stop the service - note that this won't disable the service
 	// so after a reboot the service will come up again
 	cmd := exec.Command("snapctl", "stop", snapName+"."+rootSvcName)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		// assume that the agent will have been initialize and this isn't a nil interface
-		// otherwise this will panic
-		agent.LoggingClient.Error(fmt.Sprintf("failed to stop snap service: %s", out))
-	}
+	_, err := cmd.CombinedOutput()
 	return err
 }

--- a/internal/system/agent/executor/snap.go
+++ b/internal/system/agent/executor/snap.go
@@ -1,0 +1,69 @@
+package executor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent"
+)
+
+// ExecuteSnap is a struct for managing services inside the snap
+type ExecuteSnap struct {
+}
+
+// StopService of ExecuteSnap will stop a service in the snap using `snapctl`
+func (oe *ExecuteSnap) StopService(service string, params string) error {
+
+	// use $SNAP to get the name of the snap as snapctl needs to use it
+	// and this also lets the name of the snap change if needed
+	// and ensures that if you're not running inside a snap we don't try to use
+	// snapctl which will fail
+	snapName := os.Getenv("SNAP")
+	if snapName == "" {
+		return errors.New("$SNAP not set, not running inside of a snap")
+	}
+
+	// make a map of the service names and use it as a set
+	// to check for membership
+	serviceNameSet := make(map[string]bool)
+	for _, supportedService := range []string{
+		internal.ConfigSeedServiceKey,
+		internal.CoreCommandServiceKey,
+		internal.CoreDataServiceKey,
+		internal.CoreMetaDataServiceKey,
+		internal.ExportClientServiceKey,
+		internal.ExportDistroServiceKey,
+		internal.SupportLoggingServiceKey,
+		internal.SupportNotificationsServiceKey,
+		// note that the sys-mgmt-agent is here and snapctl lets us stop
+		// ourselves, but this should probably be handled somewhere else in sys-mgmt-agent
+		// more gracefully
+		internal.SystemManagementAgentServiceKey,
+		internal.SupportSchedulerServiceKey,
+	} {
+		serviceNameSet[supportedService] = true
+	}
+
+	if _, found := serviceNameSet[service]; !found {
+		return fmt.Errorf("unknown snap service %s", service)
+	}
+
+	// trim the prefix, as the service names in the snap are like "core-command"
+	// but the name of the services here are "edgex-core-command"
+	rootSvcName := strings.TrimPrefix(service, internal.ServiceKeyPrefix)
+
+	// use snapctl to stop the service - note that this won't disable the service
+	// so after a reboot the service will come up again
+	cmd := exec.Command("snapctl", "stop", snapName+"."+rootSvcName)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// assume that the agent will have been initialize and this isn't a nil interface
+		// otherwise this will panic
+		agent.LoggingClient.Error(fmt.Sprintf("failed to stop snap service: %s", out))
+	}
+	return err
+}

--- a/internal/system/agent/executor/snap.go
+++ b/internal/system/agent/executor/snap.go
@@ -29,7 +29,7 @@ type ExecuteSnap struct {
 }
 
 // StopService of ExecuteSnap will stop a service in the snap using `snapctl`
-func (oe *ExecuteSnap) StopService(service string, params string) error {
+func (oe *ExecuteSnap) StopService(service string) error {
 
 	// use $SNAP_NAME to get the name of the snap as snapctl needs to use it
 	// and this also lets the name of the snap change if needed

--- a/internal/system/agent/executor/snap.go
+++ b/internal/system/agent/executor/snap.go
@@ -17,13 +17,13 @@ type ExecuteSnap struct {
 // StopService of ExecuteSnap will stop a service in the snap using `snapctl`
 func (oe *ExecuteSnap) StopService(service string, params string) error {
 
-	// use $SNAP to get the name of the snap as snapctl needs to use it
+	// use $SNAP_NAME to get the name of the snap as snapctl needs to use it
 	// and this also lets the name of the snap change if needed
 	// and ensures that if you're not running inside a snap we don't try to use
 	// snapctl which will fail
-	snapName := os.Getenv("SNAP")
+	snapName := os.Getenv("SNAP_NAME")
 	if snapName == "" {
-		return errors.New("$SNAP not set, not running inside of a snap")
+		return errors.New("$SNAP_NAME not set, not running inside of a snap")
 	}
 
 	// make a map of the service names and use it as a set

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -89,6 +89,8 @@ func newExecutorClient(operationsType string) (interfaces.ExecutorClient, error)
 		return &executor.ExecuteOs{}, nil
 	case "docker":
 		return &executor.ExecuteDocker{}, nil
+	case "snap":
+		return &executor.ExecuteSnap{}, nil
 	default:
 		return nil, nil
 	}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -446,8 +446,10 @@ parts:
             -e s:'http\://localhost\:48061/api/v1/logs':: > \
        "$SNAPCRAFT_PART_INSTALL/config/support-scheduler/res/configuration.toml"
       
+      # for sys-mgmt-agent we also need to specify the operations type as "snap"
       cat "./cmd/sys-mgmt-agent/res/configuration.toml" | \
         sed -e s:./logs/edgex-sys-mgmt-agent.log:\$SNAP_COMMON/sys-mgmt-agent.log: \
+            -e s:"OperationsType = 'docker'":"OperationsType = 'snap'": \
             -e s:'http\://localhost\:48061/api/v1/logs':: > \
        "$SNAPCRAFT_PART_INSTALL/config/sys-mgmt-agent/res/configuration.toml"
 


### PR DESCRIPTION
This is an initial implementation of stopping services using `snapctl` when running inside the snap and must be specified with a configuration.toml OperationsType value of "snap".

Note that currently starting/restarting services doesn't work with this.

To test this:
1. Build the snap from this branch 
```bash
git clone https://github.com/anonymouse64/edgex-go.git
cd edgex-go
git checkout bugfix/sma-snap
snapcraft
```
2. Install the snap (note that this will automatically start the services from the snap, including sys-mgmt-agent):
```bash
sudo snap install --devmode edgexfoundry*.snap
```
3. Verify that `sys-mgmt-agent` is running:
```bash
snap services | grep sys-mgmt-agent
```

4. Issue a stop command to a service that is running (for example `core-command`):
```bash
curl --header "Content-Type: application/json" --request POST --data '{"action":"stop","services":["edgex-core-command"]}' localhost:48090/api/v1/operation
```

5. Verify that the service stopped is now indeed stopped:

```bash
snap services | grep core-command
```