### PR TITLE
"export-client couldn't notify exprot-distro" bug fixed

### DIFF
--- a/cmd/export-client/res/docker/configuration.toml
+++ b/cmd/export-client/res/docker/configuration.toml
@@ -1,6 +1,6 @@
 [Service]
 BootTimeout = 30000
-ClientMonitor = 15000
+ClientMonitor = 300 
 CheckInterval = '10s'
 Host = 'edgex-export-client'
 Port = 48071

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -156,7 +156,7 @@ func initializeClients(useConsul bool) {
 	// Create export-distro client
 	params := types.EndpointParams{
 		ServiceKey:  internal.ExportDistroServiceKey,
-		Path:        "/",
+		Path:        "",
 		UseRegistry: useConsul,
 		Url:         Configuration.Clients["Distro"].Url(),
 		Interval:    Configuration.Service.ClientMonitor,


### PR DESCRIPTION
#755 

After the export-client service is started, it will get Services Info from consul. However, at this time, export-distro service or rules-engine service has not started. Hence, export-client service couldn't get export-distro service info from consul. Besides, if I want to register a new export client via `POST http://localhost:48071/api/v1/registration` at this time, the logs of export-client will print `ERROR PUT http:// : //api/v1/notify/registrations`.

Two problem:
1. why ipaddress and port are null ?
The `ClientMonitor` in `cmd/export-client/res/docker/configuration.toml` is 15000. It means that export-client service will wait 15000s, then it will get latest Services Info from consul. Hence, when the export-client service first started, it doesn't get the export-distro service info. Only after waiting 15000s, the export-client will get latest Service Info from consul. So I modify the 'ClientMonitor' to reduce the waiting time.
2. error url -  " http:// : //api/v1/notify/registrations` " 


```
[root@localhost compose-files]# docker logs -t -f --tail 20 27ea8c888ab5
2018-11-07T12:54:37.663270732Z INFO: 2018/11/07 12:54:37 Service dependencies resolved...
2018-11-07T12:54:37.663347214Z INFO: 2018/11/07 12:54:37 Starting edgex-export-client 1.0.0 
2018-11-07T12:54:37.663361198Z INFO: 2018/11/07 12:54:37 This is the Export Client Microservice
2018-11-07T12:54:37.663372615Z INFO: 2018/11/07 12:54:37 Service started in: 27.241579ms
2018-11-07T12:54:37.663381884Z INFO: 2018/11/07 12:54:37 Listening on port: 48071
2018-11-07T12:57:35.504670246Z ERROR: 2018/11/07 12:57:35 error from distro: Put http://:0//api/v1/notify/registrations: dial tcp :0: getsockopt: connection refused
```


There are two "/" in front of the "api " , so export-client couldn't request "PUT http:// : //api/v1/notify/registrations". Hence, I remove the "/" in `params `
   