### PR TITLE
Omit empty fields in core-data JSONs

### DIFF
--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -41,14 +41,14 @@ type Event struct {
 func (e Event) MarshalJSON() ([]byte, error) {
 	test := struct {
 		ID       bson.ObjectId `json:"id"`
-		Pushed   int64         `json:"pushed"`
-		Device   *string       `json:"device"` // Device identifier (name or id)
-		Created  int64         `json:"created"`
-		Modified int64         `json:"modified"`
-		Origin   int64         `json:"origin"`
-		Schedule *string       `json:"schedule"` // Schedule identifier
-		Event    *string       `json:"event"`    // Schedule event identifier
-		Readings []Reading     `json:"readings"` // List of readings
+		Pushed   int64         `json:"pushed,omitempty"`
+		Device   *string       `json:"device,omitempty"` // Device identifier (name or id)
+		Created  int64         `json:"created,omitempty"`
+		Modified int64         `json:"modified,omitempty"`
+		Origin   int64         `json:"origin,omitempty"`
+		Schedule *string       `json:"schedule,omitempty"` // Schedule identifier
+		Event    *string       `json:"event,omitempty"`    // Schedule event identifier
+		Readings []Reading     `json:"readings,omitempty"` // List of readings
 	}{
 		ID:       e.ID,
 		Pushed:   e.Pushed,

--- a/pkg/models/event_test.go
+++ b/pkg/models/event_test.go
@@ -59,12 +59,9 @@ func TestEvent_String(t *testing.T) {
 		{"event to string", TestEvent,
 			"{\"id\":\"\"" +
 				",\"pushed\":" + strconv.FormatInt(TestEvent.Pushed, 10) +
-				",\"device\":null" +
 				",\"created\":" + strconv.FormatInt(TestEvent.Created, 10) +
 				",\"modified\":" + strconv.FormatInt(TestEvent.Modified, 10) +
 				",\"origin\":" + strconv.FormatInt(TestEvent.Origin, 10) +
-				",\"schedule\":null" +
-				",\"event\":null" +
 				",\"readings\":[" + TestReading.String() + "]" +
 				"}"},
 	}

--- a/pkg/models/reading.go
+++ b/pkg/models/reading.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"encoding/json"
+
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -41,13 +42,13 @@ type Reading struct {
 func (r Reading) MarshalJSON() ([]byte, error) {
 	test := struct {
 		Id       bson.ObjectId `json:"id"`
-		Pushed   int64         `json:"pushed"`  // When the data was pushed out of EdgeX (0 - not pushed yet)
-		Created  int64         `json:"created"` // When the reading was created
-		Origin   int64         `json:"origin"`
-		Modified int64         `json:"modified"`
-		Device   *string       `json:"device"`
-		Name     *string       `json:"name"`
-		Value    *string       `json:"value"` // Device sensor data value
+		Pushed   int64         `json:"pushed,omitempty"`  // When the data was pushed out of EdgeX (0 - not pushed yet)
+		Created  int64         `json:"created,omitempty"` // When the reading was created
+		Origin   int64         `json:"origin,omitempty"`
+		Modified int64         `json:"modified,omitempty"`
+		Device   *string       `json:"device,omitempty"`
+		Name     *string       `json:"name,omitempty"`
+		Value    *string       `json:"value,omitempty"` // Device sensor data value
 	}{
 		Id:       r.Id,
 		Pushed:   r.Pushed,

--- a/pkg/models/value-descriptor.go
+++ b/pkg/models/value-descriptor.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"encoding/json"
+
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -42,27 +43,24 @@ type ValueDescriptor struct {
 func (v ValueDescriptor) MarshalJSON() ([]byte, error) {
 	test := struct {
 		Id           bson.ObjectId `json:"id" bson:"_id,omitempty"`
-		Created      int64         `bson:"created" json:"created"`
-		Description  *string       `bson:"description" json:"description"`
-		Modified     int64         `bson:"modified" json:"modified"`
-		Origin       int64         `bson:"origin" json:"origin"`
-		Name         *string       `bson:"name" json:"name"`
-		Min          interface{}   `bson:"min,omitempty" json:"min"`
-		Max          interface{}   `bson:"max,omitempty" json:"max"`
-		DefaultValue interface{}   `bson:"defaultValue,omitempty" json:"defaultValue"`
-		Type         *string       `bson:"type" json:"type"`
-		UomLabel     *string       `bson:"uomLabel,omitempty" json:"uomLabel"`
-		Formatting   *string       `bson:"formatting,omitempty" json:"formatting"`
-		Labels       []string      `bson:"labels,omitempty" json:"labels"`
+		Created      int64         `json:"created,omitempty"`
+		Description  *string       `json:"description,omitempty"`
+		Modified     int64         `json:"modified,omitempty"`
+		Origin       int64         `json:"origin,omitempty"`
+		Name         *string       `json:"name,omitempty"`
+		Min          *interface{}  `json:"min,omitempty"`
+		Max          *interface{}  `json:"max,omitempty"`
+		DefaultValue *interface{}  `json:"defaultValue,omitempty"`
+		Type         *string       `json:"type,omitempty"`
+		UomLabel     *string       `json:"uomLabel,omitempty"`
+		Formatting   *string       `json:"formatting,omitempty"`
+		Labels       []string      `json:"labels,omitempty"`
 	}{
-		Id:           v.Id,
-		Created:      v.Created,
-		Modified:     v.Modified,
-		Origin:       v.Origin,
-		Min:          v.Min,
-		Max:          v.Max,
-		DefaultValue: v.DefaultValue,
-		Labels:       v.Labels,
+		Id:       v.Id,
+		Created:  v.Created,
+		Modified: v.Modified,
+		Origin:   v.Origin,
+		Labels:   v.Labels,
 	}
 
 	// Empty strings are null
@@ -71,6 +69,15 @@ func (v ValueDescriptor) MarshalJSON() ([]byte, error) {
 	}
 	if v.Description != "" {
 		test.Description = &v.Description
+	}
+	if v.Min != "" {
+		test.Min = &v.Min
+	}
+	if v.Max != "" {
+		test.Max = &v.Max
+	}
+	if v.Min != "" {
+		test.DefaultValue = &v.DefaultValue
 	}
 	if v.Type != "" {
 		test.Type = &v.Type

--- a/pkg/models/value-descriptor_test.go
+++ b/pkg/models/value-descriptor_test.go
@@ -73,7 +73,6 @@ func TestValueDescriptor_String(t *testing.T) {
 				",\"min\":" + strconv.Itoa(TestValueDescriptor.Min.(int)) +
 				",\"max\":" + strconv.Itoa(TestValueDescriptor.Max.(int)) +
 				",\"defaultValue\":" + strconv.Itoa(TestValueDescriptor.DefaultValue.(int)) +
-				",\"type\":null" +
 				",\"uomLabel\":\"" + TestValueDescriptor.UomLabel + "\"" +
 				",\"formatting\":\"" + TestValueDescriptor.Formatting + "\"" +
 				",\"labels\":" + fmt.Sprint(string(labelSlice)) + "}"},


### PR DESCRIPTION
Related with PR #314. Only implemented in core-data.

Signed-off-by: Joan Duran <jduran@circutor.com>