### PR TITLE
Update security services for Delhi to use go binaries

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,9 +1,28 @@
 #!/bin/bash -e
 
+# setup env variables - none of these paths are setup for hooks like they are for
+# apps in snapcraft, so we have to do this ourselves
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+# for LD_LIBRARY_PATH, we need to handle the different architecture paths
+case $(arch) in
+    x86_64)
+        MULTI_ARCH_PATH="x86_64-linux-gnu";;
+    arm*)
+        MULTI_ARCH_PATH="arm-linux-gnueabihf";;
+    aarch64)
+        MULTI_ARCH_PATH="aarch64-linux-gnu";;
+    *)
+        echo "architecture $ARCH not supported"
+        exit 1
+        ;;
+esac
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$MULTI_ARCH_PATH:$SNAP/usr/lib/$MULTI_ARCH_PATH"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+
 # install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
 # into $SNAP_DATA/config
 mkdir -p ${SNAP_DATA}/config
-for service in security-api-gateway core-command config-seed core-data core-metadata export-client export-distro support-logging support-notifications support-scheduler sys-mgmt-agent; do
+for service in security-api-gateway security-secret-store core-command config-seed core-data core-metadata export-client export-distro support-logging support-notifications support-scheduler sys-mgmt-agent; do
     if [ ! -f "${SNAP_DATA}/config/${service}/res/configuration.toml" ]; then
         mkdir -p "${SNAP_DATA}/config/${service}/res"
         cp ${SNAP}/config/${service}/res/configuration.toml "${SNAP_DATA}/config/${service}/res/configuration.toml"
@@ -32,29 +51,43 @@ if [ ! -f "${SNAP_DATA}/support-rulesengine/rules" ]; then
     mkdir -p "${SNAP_DATA}/support-rulesengine/rules"
 fi
 
-
-# for the pki setup files from security services, we replace the password at install time with a psuedorandomly generated password from openssl
-# this isn't 100% secure, but it's unlikely that people will change the default password on initial install
-# and so generating a unique one at install time ensures that all snap installs don't suffer from a 
-# default password vulnerability for the certificates
-# additionally this file is installed into $SNAP_DATA with only owner read attributes, so the password can only be read by root
-for tlsEnvFile in pki-setup-config-kong.env pki-setup-config-vault.env; do
-    if [ ! -f "${SNAP_DATA}/config/security-secret-store/${tlsEnvFile}" ]; then
-        mkdir -p ${SNAP_DATA}/config/security-secret-store
-        newpw=$(openssl rand -base64 32)
-        cp ${SNAP}/config/security-secret-store/${tlsEnvFile} "${SNAP_DATA}/config/security-secret-store/${tlsEnvFile}"
-        sed -i "s@PKCS12_PASSWORD=\"s3cr3tp4th\"@PKCS12_PASSWORD=\"$newpw\"@g" "${SNAP_DATA}/config/security-secret-store/${tlsEnvFile}"
-
-        # these 2 sed command make look contradictory, but the kong env file will have HOST=edgex-kong, and the vault
-        # env file will have HOST=edgex-vault, so only one of these will actually do anything
-        sed -i "s@HOST=edgex-kong@HOST=localhost@" "${SNAP_DATA}/config/security-secret-store/${tlsEnvFile}"
-        sed -i "s@HOST=edgex-vault@HOST=localhost@" "${SNAP_DATA}/config/security-secret-store/${tlsEnvFile}"
-        chmod 600 "${SNAP_DATA}/config/security-secret-store/${tlsEnvFile}"
+# for security-secret-store, copy the hcl config files used with vault
+for hclType in admin kong; do 
+    if [ ! -f "${SNAP_DATA}/config/security-secret-store/res/vault-policy-${hclType}.hcl" ]; then
+        mkdir -p "${SNAP_DATA}/config/security-secret-store/res"
+        cp "${SNAP}/config/security-secret-store/res/vault-policy-${hclType}.hcl" "${SNAP_DATA}/config/security-secret-store/res/vault-policy-${hclType}.hcl"
     fi
 done
 
+# for the kong pki setup file, we need to set the hostname as localhost
+# and then set the directory to store the cert files as $SNAP_DATA/kong/ssl
+if [ ! -f "${SNAP_DATA}/config/security-secret-store/pkisetup-kong.json" ]; then
+    mkdir -p ${SNAP_DATA}/config/security-secret-store
+    CONFIG_FILE_PATH="config/security-secret-store/pkisetup-kong.json"
+    # replace the hostname with localhost using jq
+    jq --arg WORKDIR "$SNAP_DATA/vault" \
+        '.x509_tls_server_parameters.tls_host = "localhost" | .pki_setup_dir = "pki" | .working_dir  = $WORKDIR' \
+        "${SNAP}/${CONFIG_FILE_PATH}" > "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp"
+    mv "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp" "${SNAP_DATA}/${CONFIG_FILE_PATH}"
+    chmod 600 "${SNAP_DATA}/config/security-secret-store/pkisetup-kong.json"
+fi
+
+# for vault, we also need to set the hostname as localhost
+# and then set the directory to store the cert files as $SNAP_DATA/vault/pki
+if [ ! -f "${SNAP_DATA}/config/security-secret-store/pkisetup-vault.json" ]; then
+    mkdir -p ${SNAP_DATA}/config/security-secret-store
+    CONFIG_FILE_PATH="config/security-secret-store/pkisetup-vault.json"
+    # modify the parameters using jq
+    jq --arg WORKDIR "$SNAP_DATA/vault" \
+        '.x509_tls_server_parameters.tls_host = "localhost" | .pki_setup_dir = "pki" | .working_dir  = $WORKDIR' \
+        "${SNAP}/${CONFIG_FILE_PATH}" > "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp"
+    mv "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp" "${SNAP_DATA}/${CONFIG_FILE_PATH}"
+    chmod 600 "${SNAP_DATA}/config/security-secret-store/pkisetup-vault.json"
+fi
+
+
 # ensure vault setup directories exist
-for dir in vault vault/pki vault/file; do
+for dir in vault vault/pki; do
     if [ ! -d "${SNAP_DATA}/$dir" ]; then
         mkdir -p "${SNAP_DATA}/$dir"
     fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
-# setup env variables - none of these paths are setup for hooks like they are for
-# apps in snapcraft, so we have to do this ourselves
+# LD_LIBRARY_PATH isn't properly initialized for hooks as snapcraft does for apps, so this 
+# has to be constructed manually
+# Note - the env var SNAP_LIBRARY_PATH is set by snapd for hooks, so it can be referenced here
+# This is mainly necessary so we can use jq from the snap which needs libs from inside the snap
 export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 # for LD_LIBRARY_PATH, we need to handle the different architecture paths
 case $(arch) in
@@ -86,12 +88,8 @@ if [ ! -f "${SNAP_DATA}/config/security-secret-store/pkisetup-vault.json" ]; the
 fi
 
 
-# ensure vault setup directories exist
-for dir in vault vault/pki; do
-    if [ ! -d "${SNAP_DATA}/$dir" ]; then
-        mkdir -p "${SNAP_DATA}/$dir"
-    fi
-done
+# ensure vault pki directory exists
+mkdir -p "${SNAP_DATA}/vault/pki"
 
 # the vault config needs to be generated with sed, replacing $SNAP_DATA in the file 
 # with the actual absolute directory

--- a/snap/local/runtime-helpers/bin/security-start.sh
+++ b/snap/local/runtime-helpers/bin/security-start.sh
@@ -100,3 +100,6 @@ pushd ${SEC_API_GATEWAY_CONFIG_DIR} > /dev/null
 echo "running edgexproxy from security-api-gateway"
 $SNAP/bin/edgexproxy --configfile=${SEC_API_GATEWAY_CONFIG_DIR}/res/configuration.toml --init=true
 popd > /dev/null
+
+wait
+

--- a/snap/local/runtime-helpers/bin/security-start.sh
+++ b/snap/local/runtime-helpers/bin/security-start.sh
@@ -1,27 +1,27 @@
 #!/bin/bash -e
 
+# the kong wrapper script from $SNAP
 export KONG_SNAP="${SNAP}/bin/kong-wrapper.sh"
 
-export LOG_DIR=${SNAP_COMMON}/logs
+# general config dirs for security-api-gateway and security-secret-store 
 export CONFIG_DIR=${SNAP_DATA}/config
 export SEC_SEC_STORE_CONFIG_DIR=${CONFIG_DIR}/security-secret-store
 export SEC_API_GATEWAY_CONFIG_DIR=${CONFIG_DIR}/security-api-gateway
 
 # security-secret-store environment variables
-export _VAULT_SCRIPT_DIR=${SNAP}/bin
 export _VAULT_DIR=${SNAP_DATA}/vault
-export _VAULT_SVC=localhost
-export _KONG_SVC=localhost
 export _PKI_SETUP_VAULT_FILE=${SEC_SEC_STORE_CONFIG_DIR}/pkisetup-vault.json
 export _PKI_SETUP_KONG_FILE=${SEC_SEC_STORE_CONFIG_DIR}/pkisetup-kong.json
-export WATCHDOG_DELAY=3m
 
-# security-api-gateway environment variables
+# kong environment variables
+export LOG_DIR=${SNAP_COMMON}/logs
 export KONG_PROXY_ACCESS_LOG=${LOG_DIR}/kong-proxy-access.log
 export KONG_ADMIN_ACCESS_LOG=${LOG_DIR}/kong-admin-access.log
 export KONG_PROXY_ERROR_LOG=${LOG_DIR}/kong-admin-error.log
 export KONG_ADMIN_ERROR_LOG=${LOG_DIR}/kong-admin-error.log
 export KONG_ADMIN_LISTEN="0.0.0.0:8001, 0.0.0.0:8444 ssl"
+
+# vault environment variables
 export VAULT_ADDR=https://localhost:8200
 export VAULT_CONFIG_DIR=${_VAULT_DIR}/config
 export VAULT_UI=true
@@ -72,8 +72,8 @@ CERT_DIR=$(jq -r '.working_dir' "${_PKI_SETUP_VAULT_FILE}")
 CERT_SUBDIR=$(jq -r '.pki_setup_dir' "${_PKI_SETUP_VAULT_FILE}")
 ROOT_NAME=$(jq -r '.x509_root_ca_parameters | .ca_name' "${_PKI_SETUP_VAULT_FILE}")
 if [ ! -f "${CERT_DIR}/${CERT_SUBDIR}/${ROOT_NAME}/${ROOT_NAME}.pem" ]; then
-     ${_VAULT_SCRIPT_DIR}/pkisetup --config ${_PKI_SETUP_VAULT_FILE}
-     ${_VAULT_SCRIPT_DIR}/pkisetup --config ${_PKI_SETUP_KONG_FILE}
+     ${SNAP}/bin/pkisetup --config ${_PKI_SETUP_VAULT_FILE}
+     ${SNAP}/bin/pkisetup --config ${_PKI_SETUP_KONG_FILE}
 fi
 popd > /dev/null
 

--- a/snap/local/runtime-helpers/bin/security-start.sh
+++ b/snap/local/runtime-helpers/bin/security-start.sh
@@ -101,5 +101,11 @@ echo "running edgexproxy from security-api-gateway"
 $SNAP/bin/edgexproxy --configfile=${SEC_API_GATEWAY_CONFIG_DIR}/res/configuration.toml --init=true
 popd > /dev/null
 
+# wait for the forked processes to exit
+# this is necessary because currently the security-service is implemented as a "notify" daemon which 
+# means that systemd will kill the child processes of this process when this process exits
+# the ideal thing to do here would be have this be a "forking" daemon, but that has problems
+# timing out waiting for the fork to happen, as we need to wait for cassandra to finish coming up
+# before the default systemd service start timeout of 30 seconds
 wait
 

--- a/snap/local/runtime-helpers/config/security-secret-store/vault-config.json.in
+++ b/snap/local/runtime-helpers/config/security-secret-store/vault-config.json.in
@@ -12,9 +12,9 @@ listener "tcp" {
   tls_disable = "0" 
   cluster_address = "localhost:8201"
   tls_min_version = "tls12"
-  tls_client_ca_file ="$SNAP_DATA/vault/pki/EdgeXFoundryTrustCA/EdgeXFoundryTrustCA.pem"
-  tls_cert_file ="$SNAP_DATA/vault/pki/EdgeXFoundryTrustCA/localhost.pem"
-  tls_key_file = "$SNAP_DATA/vault/pki/EdgeXFoundryTrustCA/localhost.priv.key"
+  tls_client_ca_file ="$SNAP_DATA/vault/pki/EdgeXFoundryCA/EdgeXFoundryTrustCA.pem"
+  tls_cert_file ="$SNAP_DATA/vault/pki/EdgeXFoundryCA/localhost.pem"
+  tls_key_file = "$SNAP_DATA/vault/pki/EdgeXFoundryCA/localhost.priv.key"
 }
 
 backend "consul" {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -827,4 +827,13 @@ parts:
       sed -i \
         -e "s@tokenpath = \"res\\\\\\\\admin-token.json\"@tokenpath = \"\$SNAP_DATA/config/security-api-gateway/res/kong-token.json\"@" \
         -e "s:snis = \"edgex.com\":snis = \"localhost\":" \
+        -e "s:host = \"edgex-core-data\":host = \"localhost\":" \
+        -e "s:host = \"edgex-core-metadata\":host = \"localhost\":" \
+        -e "s:host = \"edgex-core-command\":host = \"localhost\":" \
+        -e "s:host = \"edgex-support-notifications\":host = \"localhost\":" \
+        -e "s:host = \"edgex-support-logging\":host = \"localhost\":" \
+        -e "s:host = \"edgex-export-distro\":host = \"localhost\":" \
+        -e "s:host = \"edgex-export-client\":host = \"localhost\":" \
+        -e "s:host = \"edgex-support-rulesengine\":host = \"localhost\":" \
+        -e "s:host = \"edgex-device-virtual\":host = \"localhost\":" \
         $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res/configuration.toml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -362,6 +362,7 @@ parts:
       . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
       gopartbootstrap github.com/edgexfoundry/edgex-go
 
+      glide cc
       make prepare
       make build
 
@@ -790,6 +791,7 @@ parts:
       . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
       gopartbootstrap github.com/edgexfoundry/security-api-gateway
 
+      glide cc
       glide install
       make build
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -762,23 +762,45 @@ parts:
 
   security-secret-store:
     source: https://github.com/edgexfoundry/security-secret-store.git
-    source-branch: california
-    plugin: dump
-    organize:
-      pki-setup.sh: bin/pki-setup.sh
-      pki-setup-config-kong.env: config/security-secret-store/pki-setup-config-kong.env
-      pki-setup-config-vault.env: config/security-secret-store/pki-setup-config-vault.env
-      vault-init-unseal.sh: bin/vault-init-unseal.sh
-      vault-kong.sh: bin/vault-kong.sh
-      vault-setup.sh: bin/vault-setup.sh
-      vault-worker.sh: bin/vault-worker.sh
+    source-branch: delhi
+    source-depth: 1
+    plugin: make
+    override-build: |
+      . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
+      gopartbootstrap github.com/edgexfoundry/security-secret-store
+
+      glide cc
+      make prepare
+      make build
+
+      install -DT pkisetup/pkisetup "$SNAPCRAFT_PART_INSTALL/bin/pkisetup"
+      install -DT core/edgex-vault-worker "$SNAPCRAFT_PART_INSTALL/bin/vault-worker"
+
+      # modify the configuration file for the vault-worker
+      install -d "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/"
+      cat "core/res/configuration.toml" | \
+        sed -e "s@tokenpath = \"res\\\\\\\\resp-init.json\"@tokenpath = \"res/resp-init.json\"@" \
+            -e "s@\"/vault/config/pki/@\"\$SNAP_DATA/vault/pki/@g" \
+            -e "s@EdgeXFoundryCA/edgex-vault.pem@EdgeXFoundryCA/localhost.pem@" \
+            -e "s@EdgeXFoundryCA/edgex-vault.priv.key@EdgeXFoundryCA/localhost.priv.key@" \
+            -e "s@tokenfolderpath = \"/vault/config/assets\"@tokenfolderpath = \"\$SNAP_DATA/config/security-secret-store/res\"@" \
+        > "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/configuration.toml"
+
+      # install the hcl files too for vault accesses
+      install -DT "core/res/vault-policy-admin.hcl" "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/vault-policy-admin.hcl"
+      install -DT "core/res/vault-policy-kong.hcl" "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/vault-policy-kong.hcl"
+
+      # also install the pki config files
+      install -DT pkisetup/pkisetup-kong.json "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/pkisetup-kong.json"
+      install -DT pkisetup/pkisetup-vault.json "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/pkisetup-vault.json"
     prime:
       - bin/*
       - config/*
   security-api-gateway:
     after: [go]
     source: https://github.com/edgexfoundry/security-api-gateway.git
-    source-branch: california
+    source-branch: delhi
+    source-depth: 1
     plugin: make
     stage-packages:
       - openssl
@@ -798,6 +820,11 @@ parts:
       install -DT core/edgexproxy "$SNAPCRAFT_PART_INSTALL/bin/edgexproxy"
 
       # also modify the configuration file to use "/" instead of "\" in the file
+      # and set the snis by default to be localhost so that https works when using the certificate authority 
+      # file generated and a url like "https://localhost:8443/{svc}" etc. for kong
       mkdir -p $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res
       cp core/res/configuration.toml $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res/configuration.toml
-      sed -i "s@tokenpath = \"res\\\\\\\\resp-init.json\"@tokenpath = \"res/resp-init.json\"@" $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res/configuration.toml
+      sed -i \
+        -e "s@tokenpath = \"res\\\\\\\\admin-token.json\"@tokenpath = \"\$SNAP_DATA/config/security-api-gateway/res/kong-token.json\"@" \
+        -e "s:snis = \"edgex.com\":snis = \"localhost\":" \
+        $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res/configuration.toml


### PR DESCRIPTION
Fixes #623 for Delhi.

This PR does a few things:
* It switches to using the new `vault-worker` and `pkisetup` binaries from security-secret-store for generating certs and loading them into vault, then also uploading them into kong.
* It now correctly checks if the certs have already been generated when re-running and doesn't regenerate them if they already exist
* We also now clear the glide cache before all go build parts that use glide because there's conflicts in the version of packages that `edgex-go`, `security-security-secret-store`, and `security-api-gateway`. This slows down builds somewhat as the packages will have to be fetched clean for each part, but ensures the builds always pass
* The kong routes now correctly present the certificate generated for Kong. 


The main things to test with this PR is that:
* The `security-services` service in the snap starts up correctly on install and on reboot. (you can inspect logs more easily with `journalctl -ef -u snap.edgexfoundry.security-services.service` than `sudo snap logs edgexfoundry.security-services`, `snap logs` seems to miss some things)
* The certificate presented by kong when accessing the proxy are signed by the `EdgeXFoundryCA.pem` file we generate using pkisetup. This can be tested by using curl with the `--cacert` option pointed at the generated root CA file like so (using the route configured for `core-command` as an example):
```bash
sudo cp /var/snap/edgexfoundry/current/vault/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem .
curl --cacert EdgeXFoundryCA.pem https://localhost:8443/command
```
* The certificate files are not regenerated after restarting the snap. To test this, run the previous test to make sure the certificates are correct, then do:
```
sudo snap restart edgexfoundry
```
And after all the services are back up again, do the same test with the EdgeXFoundryCA.pem file you originally copied, curl should still be able to connect to the server over HTTPS successfully.
