### PR TITLE
Recheck consul connection in case of bootstrap race

### DIFF
--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -144,6 +144,10 @@ func connectToConsul(conf *ConfigurationStruct) (*ConfigurationStruct, error) {
 			return conf, errors.New("type check failed")
 		}
 		conf = actual
+		//Check that information was successfully read from Consul
+		if conf.Service.Port == 0 {
+			return nil, errors.New("error reading from Consul")
+		}
 	}
 
 	return conf, err

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -201,6 +201,10 @@ func connectToConsul(conf *ConfigurationStruct) (*ConfigurationStruct, error) {
 			return conf, errors.New("type check failed")
 		}
 		conf = actual
+		//Check that information was successfully read from Consul
+		if conf.Service.Port == 0 {
+			return nil, errors.New("error reading from Consul")
+		}
 	}
 
 	return conf, err

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -151,6 +151,10 @@ func connectToConsul(conf *ConfigurationStruct) (*ConfigurationStruct, error) {
 			return conf, errors.New("type check failed")
 		}
 		conf = actual
+		//Check that information was successfully read from Consul
+		if conf.Service.Port == 0 {
+			return nil, errors.New("error reading from Consul")
+		}
 	}
 
 	return conf, err

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -203,6 +203,10 @@ func connectToConsul(conf *ConfigurationStruct) (*ConfigurationStruct, error) {
 			return conf, errors.New("type check failed")
 		}
 		conf = actual
+		//Check that information was successfully read from Consul
+		if conf.Service.Port == 0 {
+			return nil, errors.New("error reading from Consul")
+		}
 	}
 	return conf, err
 }

--- a/internal/export/distro/init.go
+++ b/internal/export/distro/init.go
@@ -114,6 +114,10 @@ func connectToConsul(conf *ConfigurationStruct) (*ConfigurationStruct, error) {
 			return conf, errors.New("type check failed")
 		}
 		conf = actual
+		//Check that information was successfully read from Consul
+		if conf.Service.Port == 0 {
+			return nil, errors.New("error reading from Consul")
+		}
 	}
 	return conf, err
 }
@@ -182,4 +186,3 @@ func setLoggingTarget() string {
 	}
 	return Configuration.Logging.File
 }
-

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -137,7 +137,7 @@ func connectToConsul(conf *ConfigurationStruct) (*ConfigurationStruct, error) {
 		}
 		conf = actual
 		//Check that information was successfully read from Consul
-		if len(conf.Persistence) == 0 {
+		if conf.Service.Port == 0 {
 			return nil, errors.New("error reading from Consul")
 		}
 	}

--- a/internal/support/notifications/init.go
+++ b/internal/support/notifications/init.go
@@ -187,7 +187,7 @@ func connectToConsul(conf *ConfigurationStruct) (*ConfigurationStruct, error) {
 		}
 		conf = actual
 		//Check that information was successfully read from Consul
-		if conf.ResendLimit == 0 {
+		if conf.Service.Port == 0 {
 			return nil, errors.New("error reading from Consul")
 		}
 	}
@@ -230,4 +230,3 @@ func setLoggingTarget() string {
 	}
 	return Configuration.Logging.File
 }
-

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -71,8 +71,6 @@ func Retry(useConsul bool, useProfile string, timeout int, wait *sync.WaitGroup,
 	return
 }
 
-
-
 func Init(useConsul bool) bool {
 	if Configuration == nil {
 		return false
@@ -147,6 +145,10 @@ func connectToConsul(conf *ConfigurationStruct) (*ConfigurationStruct, error) {
 			return conf, errors.New("type check failed")
 		}
 		conf = actual
+		//Check that information was successfully read from Consul
+		if conf.Service.Port == 0 {
+			return nil, errors.New("error reading from Consul")
+		}
 	}
 
 	return conf, err


### PR DESCRIPTION
#792 

Standardizing on service port check == 0 to determine if service is in race condition with config-seed population in Consul.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>