### PR TITLE
Add Google Analytics to generated documentation

### DIFF
--- a/docs/Dockerfile.build
+++ b/docs/Dockerfile.build
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y git python-pip latexmk texlive-latex-recommended \
   texlive-latex-extra texlive-fonts-recommended nodejs npm make linkchecker
 RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN pip install sphinx
+RUN pip install sphinx sphinxcontrib-googleanalytics
 RUN npm i -g raml2html@3.0.1
 RUN mkdir docbuild
 WORKDIR /docbuild

--- a/docs/Dockerfile.build
+++ b/docs/Dockerfile.build
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get install -y git python-pip latexmk texlive-latex-recommended \
   texlive-latex-extra texlive-fonts-recommended nodejs npm make linkchecker
 RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN pip install sphinx sphinxcontrib-googleanalytics
+RUN pip install sphinx==1.7.9 sphinxcontrib-googleanalytics==0.1
 RUN npm i -g raml2html@3.0.1
 RUN mkdir docbuild
 WORKDIR /docbuild

--- a/docs/general/conf.py
+++ b/docs/general/conf.py
@@ -34,7 +34,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
-    'sphinx.ext.githubpages']
+    'sphinx.ext.githubpages',
+    'sphinxcontrib.googleanalytics']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -182,5 +183,6 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-
+# Google Analytics Tracking ID
+googleanalytics_id = 'UA-82811140-6'
 


### PR DESCRIPTION
This was a change from the california branch that didn't make it into master

Signed-off-by: Michael Hall <mhall119@gmail.com>