### PR TITLE
snapcraft.yaml: don't hard-code version in jar file names

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -366,7 +366,8 @@ parts:
       # The logic following logic is all handled by DockerFile for
       # the EdgeX support-scheduler docker image.
       install -d "$SNAPCRAFT_PART_INSTALL/jar/support-scheduler"
-      mv "$SNAPCRAFT_PART_INSTALL/jar/support-scheduler-0.7.0-SNAPSHOT.jar" \
+      JAR_FILE=$(find "$SNAPCRAFT_PART_INSTALL/jar" -name "support-scheduler-*-SNAPSHOT.jar")
+      mv "$JAR_FILE" \
          "$SNAPCRAFT_PART_INSTALL/jar/support-scheduler/support-scheduler.jar"
 
       # FIXME:
@@ -409,7 +410,8 @@ parts:
       # The logic following logic is all handled by DockerFile for
       # the EdgeX support-rulesengine docker image.
       install -d "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine"
-      mv "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine-0.7.0-SNAPSHOT.jar" \
+      JAR_FILE=$(find "$SNAPCRAFT_PART_INSTALL/jar" -name "support-rulesengine-*-SNAPSHOT.jar")
+      mv "$JAR_FILE" \
          "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine/support-rulesengine.jar"
 
       # FIXME:
@@ -454,7 +456,8 @@ parts:
       install -d "$SNAPCRAFT_PART_INSTALL/jar/device-virtual"
       install -d "$SNAPCRAFT_PART_INSTALL/jar/device-virtual/bacnet_sample_profiles"
       install -d "$SNAPCRAFT_PART_INSTALL/jar/device-virtual/modbus_sample_profiles"
-      mv "$SNAPCRAFT_PART_INSTALL/jar/device-virtual-0.5.0-SNAPSHOT.jar" \
+      JAR_FILE=$(find "$SNAPCRAFT_PART_INSTALL/jar" -name "device-virtual-*-SNAPSHOT.jar")
+      mv "$JAR_FILE" \
          "$SNAPCRAFT_PART_INSTALL/jar/device-virtual/device-virtual.jar"
       cp ./bacnet_sample_profiles/*.yaml \
          "$SNAPCRAFT_PART_INSTALL/jar/device-virtual/bacnet_sample_profiles/"


### PR DESCRIPTION
Duplicate of #818 but for master

Note that I just cherry picked this for master and didn't also fix the `support-scheduler` jar version because that will be replaced with the go implementation with a followup PR so the version number there doesn't much matter right now.