### PR TITLE
snapcraft.yaml: upgrade grade to stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,8 +11,7 @@ description: |
  security micro services. The packaging for this snap can be found at:
  https://github.com/edgexfoundry/edgex-go
 
-# TODO: upgrade to stable before releasing to beta/candidate/stable
-grade: devel
+grade: stable
 confinement: strict
 #
 # TODO: still a few bugs to work out for confinement;


### PR DESCRIPTION
This is specifically just to 0.7.1 Delhi dot release.