### PR TITLE
Don't apply default values to data transformation fields (core-metadata)

### DIFF
--- a/pkg/models/propertyvalue.go
+++ b/pkg/models/propertyvalue.go
@@ -40,22 +40,22 @@ type PropertyValue struct {
 // Custom marshaling to make empty strings null
 func (pv PropertyValue) MarshalJSON() ([]byte, error) {
 	test := struct {
-		Type         *string `json:"type"`         // ValueDescriptor Type of property after transformations
-		ReadWrite    *string `json:"readWrite"`    // Read/Write Permissions set for this property
-		Minimum      *string `json:"minimum"`      // Minimum value that can be get/set from this property
-		Maximum      *string `json:"maximum"`      // Maximum value that can be get/set from this property
-		DefaultValue *string `json:"defaultValue"` // Default value set to this property if no argument is passed
-		Size         *string `json:"size"`         // Size of this property in its type  (i.e. bytes for numeric types, characters for string types)
-		Word         *string `json:"word"`         // Word size of property used for endianness
-		LSB          *string `json:"lsb"`          // Endianness setting for a property
-		Mask         *string `json:"mask"`         // Mask to be applied prior to get/set of property
-		Shift        *string `json:"shift"`        // Shift to be applied after masking, prior to get/set of property
-		Scale        *string `json:"scale"`        // Multiplicative factor to be applied after shifting, prior to get/set of property
-		Offset       *string `json:"offset"`       // Additive factor to be applied after multiplying, prior to get/set of property
-		Base         *string `json:"base"`         // Base for property to be applied to, leave 0 for no power operation (i.e. base ^ property: 2 ^ 10)
-		Assertion    *string `json:"assertion"`    // Required value of the property, set for checking error state.  Failing an assertion condition will mark the device with an error state
-		Signed       bool    `json:"signed"`       // Treat the property as a signed or unsigned value
-		Precision    *string `json:"precision"`
+		Type         *string `json:"type,omitempty"`         // ValueDescriptor Type of property after transformations
+		ReadWrite    *string `json:"readWrite,omitempty"`    // Read/Write Permissions set for this property
+		Minimum      *string `json:"minimum,omitempty"`      // Minimum value that can be get/set from this property
+		Maximum      *string `json:"maximum,omitempty"`      // Maximum value that can be get/set from this property
+		DefaultValue *string `json:"defaultValue,omitempty"` // Default value set to this property if no argument is passed
+		Size         *string `json:"size,omitempty"`         // Size of this property in its type  (i.e. bytes for numeric types, characters for string types)
+		Word         *string `json:"word,omitempty"`         // Word size of property used for endianness
+		LSB          *string `json:"lsb,omitempty"`          // Endianness setting for a property
+		Mask         *string `json:"mask,omitempty"`         // Mask to be applied prior to get/set of property
+		Shift        *string `json:"shift,omitempty"`        // Shift to be applied after masking, prior to get/set of property
+		Scale        *string `json:"scale,omitempty"`        // Multiplicative factor to be applied after shifting, prior to get/set of property
+		Offset       *string `json:"offset,omitempty"`       // Additive factor to be applied after multiplying, prior to get/set of property
+		Base         *string `json:"base,omitempty"`         // Base for property to be applied to, leave 0 for no power operation (i.e. base ^ property: 2 ^ 10)
+		Assertion    *string `json:"assertion,omitempty"`    // Required value of the property, set for checking error state.  Failing an assertion condition will mark the device with an error state
+		Signed       bool    `json:"signed,omitempty"`       // Treat the property as a signed or unsigned value
+		Precision    *string `json:"precision,omitempty"`
 	}{
 		Signed: pv.Signed,
 	}
@@ -124,18 +124,13 @@ func (pv PropertyValue) String() string {
 // Custom unmarshaling to handle default values
 func (p *PropertyValue) UnmarshalJSON(data []byte) error {
 	type testAlias PropertyValue
-	test := testAlias{Word: "2", Mask: "0x00", Shift: "0", Scale: "1.0", Offset: "0.0", Base: "0", Signed: true}
+	test := testAlias{Word: "2", Signed: true}
 	if err := json.Unmarshal(data, &test); err != nil {
 		return err
 	}
 
 	// Set the default values
 	//	if test.Word == "" {test.Word = "2"}
-	//	if test.Mask == "" {test.Mask = "0x00"}
-	//	if test.Shift == "" {test.Shift = "0"}
-	//	if test.Scale == "" {test.Scale = "1.0"}
-	//	if test.Offset == "" {test.Offset = "0.0"}
-	//	if test.Base == "" {test.Base = "0"}
 
 	*p = PropertyValue(test)
 
@@ -145,18 +140,13 @@ func (p *PropertyValue) UnmarshalJSON(data []byte) error {
 // Custom YAML unmarshaling
 func (p *PropertyValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type testAlias PropertyValue
-	test := testAlias{Word: "2", Mask: "0x00", Shift: "0", Scale: "1.0", Offset: "0.0", Base: "0", Signed: true}
+	test := testAlias{Word: "2", Signed: true}
 	if err := unmarshal(&test); err != nil {
 		return err
 	}
 
 	// Set the default values
 	//	if test.Word == "" {test.Word = "2"}
-	//	if test.Mask == "" {test.Mask = "0x00"}
-	//	if test.Shift == "" {test.Shift = "0"}
-	//	if test.Scale == "" {test.Scale = "1.0"}
-	//	if test.Offset == "" {test.Offset = "0.0"}
-	//	if test.Base == "" {test.Base = "0"}
 
 	*p = PropertyValue(test)
 


### PR DESCRIPTION
#855 

* Removes default values for data transformation fields when creating a device profile
* Marks json properties as omitempty in the PropertyValue `MarshalJSON()` function.