### PR TITLE
snap/many: replace usage of systemd-notify with forking daemons

### DIFF
--- a/snap/local/runtime-helpers/bin/fork-wrapper.sh
+++ b/snap/local/runtime-helpers/bin/fork-wrapper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# launch whatever arguments were provided in the background
+"$@" &

--- a/snap/local/runtime-helpers/bin/go-services-wrapper.sh
+++ b/snap/local/runtime-helpers/bin/go-services-wrapper.sh
@@ -1,11 +1,15 @@
 #!/bin/bash -e
 
-systemd-notify --ready
-
 # wait for consul to come up
 $SNAP/bin/wait-for-consul.sh $1
 
 # if we get here, just assume that consul is up, otherwise this 
 # service will fail after 10 seconds
 cd $SNAP_DATA/config/$1
-$SNAP/bin/$1 "${@:2}"
+
+# note we have to exec the process so it takes over the 
+# same pid as the calling bash process since this bash script
+# is forked from another script that systemd runs
+# this ensures that systemd will end up tracking the actual go 
+# service process and not the shell process
+exec $SNAP/bin/$1 "${@:2}"

--- a/snap/local/runtime-helpers/bin/security-start.sh
+++ b/snap/local/runtime-helpers/bin/security-start.sh
@@ -34,8 +34,6 @@ export MAX_VAULT_UNSEAL_TRIES=10
 # on some systems. See issue #509 for more details
 cd $SNAP_DATA
 
-systemd-notify --ready
-
 # start up cassandra
 $SNAP/bin/cassandra-wrapper.sh
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,9 +30,9 @@ apps:
     daemon: simple
     plugs: [network, network-bind]
   core-config-seed:
-    command: bin/go-services-wrapper.sh config-seed -c ${SNAP_DATA}/config
-    plugs: [network, network-bind, daemon-notify]
-    daemon: notify
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh config-seed -c ${SNAP_DATA}/config
+    plugs: [network, network-bind]
+    daemon: forking
     passthrough:
       after:
         - consul
@@ -52,53 +52,52 @@ apps:
       after:
         - mongod
   security-services:
-    command: bin/security-start.sh
+    command: bin/fork-wrapper.sh $SNAP/bin/security-start.sh
     stop-command: bin/security-stop.sh
-    daemon: notify
+    daemon: forking
     plugs: 
       - network
       - network-bind
-      - daemon-notify
       - mount-observe
     passthrough:
       after:
         - core-config-seed
   support-logging:
-    command: bin/go-services-wrapper.sh support-logging --consul
-    daemon: notify
-    plugs: [network, network-bind, daemon-notify]
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh support-logging --consul
+    daemon: forking
+    plugs: [network, network-bind]
     passthrough:
       after:
         - core-config-seed
         - mongo-worker
   support-notifications:
-    command: bin/go-services-wrapper.sh support-notifications --consul
-    daemon: notify
-    plugs: [network, network-bind, daemon-notify]
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh support-notifications --consul
+    daemon: forking
+    plugs: [network, network-bind]
     passthrough:
       after:
         - core-config-seed
         - mongo-worker
   core-data:
-    command: bin/go-services-wrapper.sh core-data --consul
-    daemon: notify
-    plugs: [network, network-bind, daemon-notify]
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh core-data --consul
+    daemon: forking
+    plugs: [network, network-bind]
     passthrough:
       after:
         - core-config-seed
         - mongo-worker
   core-metadata:
-    command: bin/go-services-wrapper.sh core-metadata --consul
-    daemon: notify
-    plugs: [network, network-bind, daemon-notify]
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh core-metadata --consul
+    daemon: forking
+    plugs: [network, network-bind]
     passthrough:
       after:
         - core-config-seed
         - mongo-worker
   core-command:
-    command: bin/go-services-wrapper.sh core-command --consul
-    daemon: notify
-    plugs: [network, network-bind, daemon-notify]
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh core-command --consul
+    daemon: forking
+    plugs: [network, network-bind, ]
     passthrough:
       after:
         - core-config-seed
@@ -112,33 +111,33 @@ apps:
         - core-config-seed
         - mongo-worker
   support-scheduler:
-    command: bin/go-services-wrapper.sh support-scheduler --consul
-    daemon: notify
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh support-scheduler --consul
+    daemon: forking
     plugs: [network, network-bind]
     passthrough:
       after:
         - core-config-seed
         - mongo-worker
   export-client:
-    command: bin/go-services-wrapper.sh export-client --consul
-    daemon: notify
-    plugs: [network, network-bind, daemon-notify]
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh export-client --consul
+    daemon: forking
+    plugs: [network, network-bind]
     passthrough:
       after:
         - core-config-seed
         - mongo-worker
   export-distro:
-    command: bin/go-services-wrapper.sh export-distro --consul
-    daemon: notify
-    plugs: [network, network-bind, daemon-notify]
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh export-distro --consul
+    daemon: forking
+    plugs: [network, network-bind]
     passthrough:
       after:
         - core-config-seed
         - mongo-worker
   sys-mgmt-agent:
-    command: bin/go-services-wrapper.sh sys-mgmt-agent
-    daemon: notify
-    plugs: [network, network-bind, daemon-notify]
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh sys-mgmt-agent
+    daemon: forking
+    plugs: [network, network-bind]
     passthrough:
       after:
         - core-config-seed


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry/edgex-go/issues/884

This change is necessary because the daemon-notify interface is not implemented properly and is missing the capabilities "net_admin" and "sys_admin" in AppArmor in order to notify for a different process than the one that `systemd-notify` runs as. 
To remedy this, we instead make all of the daemons that were using systemd-notify into forking daemons, with an additional forking wrapper which immediately forks a process such that systemd can always immediately think that the process has successfully started up. We also need to ensure that the process that is initially forked stays alive for the remainder of the lifetime of the service because that service will be the "main" PID that systemd tracks. So for the go services we need to use exec instead of just running it normally, and for the security-services wrapper we already are doing the right thing in the script by waiting for all the child processes to exit. This point is doubly important because systemd docs say that forking daemons should specify a PIDFile, which unfortunately we can't do in the snap, as snapd doesn't support this, so if the main PID isn't the PID that systemd sees initially, bad things will happen. As currently implemented however it's not a problem.


The following things should be tested:

- [ ] All services that are enabled come up properly (and stay running) when installed from the local file in `devmode`.
Example of how to test:
```bash
$ snapcraft # build the snap locally
$ sudo snap install --devmode edgexfoundry*.snap
$ snap services edgexfoundry
Service                             Startup   Current
edgexfoundry.consul                 enabled   active
edgexfoundry.core-command           enabled   active
edgexfoundry.core-config-seed       enabled   inactive
edgexfoundry.core-data              enabled   active
edgexfoundry.core-metadata          enabled   active
edgexfoundry.device-virtual         disabled  inactive
edgexfoundry.export-client          disabled  inactive
edgexfoundry.export-distro          disabled  inactive
edgexfoundry.mongo-worker           enabled   inactive
edgexfoundry.mongod                 enabled   active
edgexfoundry.security-services      enabled   active
edgexfoundry.support-logging        disabled  inactive
edgexfoundry.support-notifications  disabled  inactive
edgexfoundry.support-rulesengine    disabled  inactive
edgexfoundry.support-scheduler      disabled  inactive
edgexfoundry.sys-mgmt-agent         enabled   active
```

- [ ] All services that are enabled come up properly (and stay running) when rebooting after installation
Example:
```bash
$ sudo reboot
...
$ snap services edgexfoundry
Service                             Startup   Current
edgexfoundry.consul                 enabled   active
edgexfoundry.core-command           enabled   active
edgexfoundry.core-config-seed       enabled   inactive
edgexfoundry.core-data              enabled   active
edgexfoundry.core-metadata          enabled   active
edgexfoundry.device-virtual         disabled  inactive
edgexfoundry.export-client          disabled  inactive
edgexfoundry.export-distro          disabled  inactive
edgexfoundry.mongo-worker           enabled   inactive
edgexfoundry.mongod                 enabled   active
edgexfoundry.security-services      enabled   active
edgexfoundry.support-logging        disabled  inactive
edgexfoundry.support-notifications  disabled  inactive
edgexfoundry.support-rulesengine    disabled  inactive
edgexfoundry.support-scheduler      disabled  inactive
edgexfoundry.sys-mgmt-agent         enabled   active
```
- [ ] All services start up properly (and stay running) when issuing `snap restart` (note there is a bug with `snap restart` ignoring disabled services, this is reported as https://bugs.launchpad.net/snapd/+bug/1803212)
Example:
```bash
$ snap services edgexfoundry
Service                             Startup   Current
edgexfoundry.consul                 enabled   active
edgexfoundry.core-command           enabled   active
edgexfoundry.core-config-seed       enabled   inactive
edgexfoundry.core-data              enabled   active
edgexfoundry.core-metadata          enabled   active
edgexfoundry.device-virtual         disabled  inactive
edgexfoundry.export-client          disabled  inactive
edgexfoundry.export-distro          disabled  inactive
edgexfoundry.mongo-worker           enabled   inactive
edgexfoundry.mongod                 enabled   active
edgexfoundry.security-services      enabled   active
edgexfoundry.support-logging        disabled  inactive
edgexfoundry.support-notifications  disabled  inactive
edgexfoundry.support-rulesengine    disabled  inactive
edgexfoundry.support-scheduler      disabled  inactive
edgexfoundry.sys-mgmt-agent         enabled   active
$ sudo snap restart edgexfoundry && sleep 60 && snap services edgexfoundry
Restarted.
Service                             Startup   Current
edgexfoundry.consul                 enabled   active
edgexfoundry.core-command           enabled   active
edgexfoundry.core-config-seed       enabled   inactive
edgexfoundry.core-data              enabled   active
edgexfoundry.core-metadata          enabled   active
edgexfoundry.device-virtual         disabled  active
edgexfoundry.export-client          disabled  active
edgexfoundry.export-distro          disabled  active
edgexfoundry.mongo-worker           enabled   inactive
edgexfoundry.mongod                 enabled   active
edgexfoundry.security-services      enabled   active
edgexfoundry.support-logging        disabled  active
edgexfoundry.support-notifications  disabled  active
edgexfoundry.support-rulesengine    disabled  active
edgexfoundry.support-scheduler      disabled  active
edgexfoundry.sys-mgmt-agent         enabled   active
```
- [ ] systemd correctly reports the PID of the main process running the service (this is the PID of the executable for the individual go and java services, and the PID of the wrapper script for the security services)
Example for core-command:
```bash
$ systemctl status snap.edgexfoundry.core-command | grep "Main PID"
 Main PID: 9721 (core-command)
$ ps -aux | grep -v grep | grep core-command
root      9721  0.0  0.1  12896  5760 ?        Sl   20:23   0:00 /snap/edgexfoundry/x1/bin/core-command --consul
$ snap services edgexfoundry.core-command
Service                    Startup  Current
edgexfoundry.core-command  enabled  active
```

For security services:
```bash
$ systemctl status snap.edgexfoundry.security-services.service | grep "Main PID"
 Main PID: 9032 (security-start.)
$ ps -aux | grep -v grep | grep "security-start.sh"
root      9032  0.0  0.0  18068  2816 ?        S    20:21   0:00 /bin/bash -e /snap/edgexfoundry/x1/bin/security-start.sh
$ snap services edgexfoundry.security-services
Service                         Startup  Current
edgexfoundry.security-services  enabled  active
```
- [ ] `snap services` reports when a service is running properly
See above item for how this can be tested with `ps` and grep
- [ ] Individual go services can be stopped with `snap stop` and `snap services`/`systemctl status` reports when a service is stopped
Example:
```bash
$ systemctl status snap.edgexfoundry.core-data.service | grep "Main PID"
 Main PID: 11208 (core-data)
$ snap services edgexfoundry.core-data
Service                 Startup  Current
edgexfoundry.core-data  enabled  active
$ ps -aux | grep -v grep | grep core-data
root     11208  0.1  0.3 941504 12172 ?        Sl   20:35   0:01 /snap/edgexfoundry/x1/bin/core-data --consul
$ sudo snap stop edgexfoundry.core-data
Stopped.
$ snap services edgexfoundry.core-data
Service                 Startup  Current
edgexfoundry.core-data  enabled  inactive
$ sudo snap stop edgexfoundry.core-data
Stopped.
$ ps -aux | grep -v grep | grep core-data
$ systemctl status snap.edgexfoundry.core-data.service | grep "Main PID"
 Main PID: 11208 (code=killed, signal=TERM)
```
- [ ] The services startup again properly when killed out-of-band with `kill`, etc. (and has a different PID because the original process was killed, then restarted with systemd)
Example:
```
$ ps -aux | grep -v grep | grep core-data
root     12639  0.1  0.3 817508 12508 ?        Sl   20:51   0:00 /snap/edgexfoundry/x1/bin/core-data --consul
$ systemctl status snap.edgexfoundry.core-data.service | grep "Main PID"
 Main PID: 12639 (core-data)
$ snap services edgexfoundry.core-data
Service                 Startup  Current
edgexfoundry.core-data  enabled  active
$ sudo kill -9 12639
$ snap services edgexfoundry.core-data
Service                 Startup  Current
edgexfoundry.core-data  enabled  active
$ ps -aux | grep -v grep | grep core-data
root     12824  0.1  0.2 537592 11232 ?        Sl   20:53   0:00 /snap/edgexfoundry/x1/bin/core-data --consul
$ systemctl status snap.edgexfoundry.core-data.service | grep "Main PID"
 Main PID: 12824 (core-data)
```
- [ ] The security services can be stopped atomically with `snap stop` and results in all forked child processes (i.e. nginx, cassandra, vault, etc.) exiting.
Example:
```
$ ps -aux | grep -v grep | grep security-start.sh
root     10889  0.0  0.0  18068  2892 ?        S    20:35   0:00 /bin/bash -e /snap/edgexfoundry/x1/bin/security-start.sh
$ ps -aux | grep -v grep | grep nginx
root     11528  0.0  0.1 259508  7172 ?        Ss   20:36   0:00 nginx: master process nginx -p /var/snap/edgexfoundry/x1/kong -c nginx.conf
root     11529  0.0  0.5 273848 23040 ?        S    20:36   0:00 nginx: worker process
root     11530  0.0  0.6 275252 25060 ?        S    20:36   0:00 nginx: worker process
root     11531  0.0  0.5 273848 23160 ?        S    20:36   0:00 nginx: worker process
root     11532  0.0  0.5 273848 23084 ?        S    20:36   0:00 nginx: worker process
$ ps -aux | grep -v grep | grep cassandra
root     10993  5.8 32.3 2996860 1310476 ?     SLl  20:35   0:20 /snap/edgexfoundry/x1/usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -Dcassandra.config=file:///var/snap/edgexfo ....
$ sudo snap stop edgexfoundry.security-services
Stopped.
$ snap services edgexfoundry.security-services
Service                         Startup  Current
edgexfoundry.security-services  enabled  inactive
$ ps -aux | grep -v grep | grep security-start.sh
$ ps -aux | grep -v grep | grep nginx
$ ps -aux | grep -v grep | grep cassandra
$ systemctl status snap.edgexfoundry.security-services.service | grep "Main PID"
 Main PID: 10889 (code=killed, signal=TERM)
```

I have tested all of the above on an Ubuntu 16.04 Classic VM.