### PR TITLE
Add new device services

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -27,6 +27,9 @@ ALL_SERVICES="$ALL_SERVICES export-client"
 
 # device services
 ALL_SERVICES="$ALL_SERVICES device-virtual"
+ALL_SERVICES="$ALL_SERVICES device-modbus"
+ALL_SERVICES="$ALL_SERVICES device-mqtt"
+ALL_SERVICES="$ALL_SERVICES device-random"
 
 # security services
 ALL_SERVICES="$ALL_SERVICES security-services"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -24,7 +24,7 @@ export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 # install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
 # into $SNAP_DATA/config
 mkdir -p ${SNAP_DATA}/config
-for service in security-api-gateway security-secret-store core-command config-seed core-data core-metadata export-client export-distro support-logging support-notifications support-scheduler sys-mgmt-agent; do
+for service in security-api-gateway security-secret-store core-command config-seed core-data core-metadata export-client export-distro support-logging support-notifications support-scheduler sys-mgmt-agent device-modbus device-mqtt device-random; do
     if [ ! -f "${SNAP_DATA}/config/${service}/res/configuration.toml" ]; then
         mkdir -p "${SNAP_DATA}/config/${service}/res"
         cp ${SNAP}/config/${service}/res/configuration.toml "${SNAP_DATA}/config/${service}/res/configuration.toml"
@@ -32,6 +32,12 @@ for service in security-api-gateway security-secret-store core-command config-se
         sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" -e "s@\$SNAP_DATA@$SNAP_DATA@g" "${SNAP_DATA}/config/${service}/res/configuration.toml"
     fi
 done
+
+# handle device-mqtt driver configuration
+cp ${SNAP}/config/device-mqtt/res/configuration-driver.toml "${SNAP_DATA}/config/device-mqtt/res/configuration-driver.toml"
+
+# handle device-random device profile
+cp ${SNAP}/config/device-random/res/device.random.yaml "${SNAP_DATA}/config/device-random/res/device.random.yaml"
 
 # also handle java services' application.properties
 for jsvc in device-virtual edgex-support-rulesengine; do
@@ -120,6 +126,6 @@ fi
 
 # finally, disable services in the snap that aren't meant to come up by default
 # by default, we want the export-*, support-*, and device-virtual services off
-for svc in export-distro export-client support-notifications support-scheduler support-rulesengine support-logging device-virtual; do
+for svc in export-distro export-client support-notifications support-scheduler support-rulesengine support-logging device-virtual device-modbus device-mqtt device-random; do
     snapctl stop --disable edgexfoundry.$svc
 done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -150,7 +150,30 @@ apps:
       after:
         - core-config-seed
         - mongo-worker
-
+  device-modbus:
+    command: bin/go-services-wrapper.sh device-modbus
+    daemon: simple
+    plugs: [network, network-bind]
+    passthrough:
+      after:
+        - core-config-seed
+        - mongo-worker
+  device-mqtt:
+    command: bin/go-services-wrapper.sh device-mqtt
+    daemon: simple
+    plugs: [network, network-bind]
+    passthrough:
+      after:
+        - core-config-seed
+        - mongo-worker
+  device-random:
+    command: bin/go-services-wrapper.sh device-random
+    daemon: simple
+    plugs: [network, network-bind]
+    passthrough:
+      after:
+        - core-config-seed
+        - mongo-worker
 
   # helper commands the snap exposes
   mongo:
@@ -835,3 +858,100 @@ parts:
         -e "s:host = \"edgex-support-rulesengine\":host = \"localhost\":" \
         -e "s:host = \"edgex-device-virtual\":host = \"localhost\":" \
         $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res/configuration.toml
+  device-modbus:
+    source: https://github.com/edgexfoundry/device-modbus-go.git
+    source-depth: 1
+    #source-branch: dehli
+    plugin: make
+    after:
+      - go
+    override-build: |
+      . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
+      gopartbootstrap github.com/edgexfoundry/device-modbus-go
+
+      glide cc
+      make prepare
+      make build
+
+      install -DT "./cmd/device-modbus" "$SNAPCRAFT_PART_INSTALL/bin/device-modbus"
+
+      # FIXME: settings can't be overridden from the cmd-line!
+      # Override 'LogFile' and 'LoggingRemoteURL'
+      install -d "$SNAPCRAFT_PART_INSTALL/config/device-modbus/res/"
+
+      cat "./cmd/res/configuration.toml" | \
+        sed -e s:\"./device-Modbus.log\":\'\$SNAP_COMMON/device-Modbus.log\': > \
+        "$SNAPCRAFT_PART_INSTALL/config/device-modbus/res/configuration.toml"
+
+      # FIXME: no Attribution.txt for 3rd party licenses; probably needs to be
+      # an aggregation of SDK's and this device service...
+
+      install -DT "./LICENSE-2.0.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mongo/LICENSE-2.0.txt"
+  device-mqtt:
+    source: https://github.com/edgexfoundry/device-mqtt-go.git
+    source-depth: 1
+    #source-branch: dehli
+    plugin: make
+    after:
+      - go
+    override-build: |
+      . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
+      gopartbootstrap github.com/edgexfoundry/device-mqtt-go
+
+      glide cc
+      make prepare
+      make build
+
+      install -DT "./cmd/device-mqtt" "$SNAPCRAFT_PART_INSTALL/bin/device-mqtt"
+
+      # FIXME: settings can't be overridden from the cmd-line!
+      # Override 'LogFile' and 'LoggingRemoteURL'
+      install -d "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/"
+
+      cat "./cmd/res/configuration.toml" | \
+        sed -e s:\"./device-mqtt.log\":\'\$SNAP_COMMON/device-mqtt.log\': > \
+        "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/configuration.toml"
+
+      install -T "./cmd/res/configuration-driver.toml" \
+        "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/configuration-driver.toml"
+
+      # FIXME: no Attribution.txt for 3rd party licenses; probably needs to be
+      # an aggregation of SDK's and this device service...
+
+      install -DT "./LICENSE-2.0.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt/LICENSE-2.0.txt"
+  device-random:
+    source: https://github.com/edgexfoundry/device-random.git
+    source-depth: 1
+    #source-branch: dehli
+    plugin: make
+    after:
+      - go
+    override-build: |
+      . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
+      gopartbootstrap github.com/edgexfoundry/device-random
+
+      glide cc
+      make prepare
+      make build
+
+      install -DT "./cmd/device-random" "$SNAPCRAFT_PART_INSTALL/bin/device-random"
+
+      # FIXME: settings can't be overridden from the cmd-line!
+      # Override 'LogFile'
+      install -d "$SNAPCRAFT_PART_INSTALL/config/device-random/res/"
+
+      # install configuratin & default device profile
+      cat "./cmd/res/configuration.toml" | \
+        sed -e s:\"./device-random.log\":\'\$SNAP_COMMON/device-random.log\': > \
+        "$SNAPCRAFT_PART_INSTALL/config/device-random/res/configuration.toml"
+
+      install -T "./cmd/res/device.random.yaml" \
+        "$SNAPCRAFT_PART_INSTALL/config/device-random/res/device.random.yaml"
+
+      # FIXME: no Attribution.txt for 3rd party licenses; probably needs to be
+      # an aggregation of SDK's and this device service...
+
+      install -DT "./LICENSE-2.0.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-random/LICENSE-2.0.txt"


### PR DESCRIPTION
This change adds the following new device services to the snap:

 - device-modbus-go
 - device-mqtt-go
 - device-random

They are all disabled by default, and therefore must be enabled using:

'snap set edgexfoundry `service name`=on'

Enabling device-random will trigger a trio of random signed integer readings to be pushed to Core Data every 5 seconds. 

Enabling device-modbus or device-mqtt will start the respective device service, however no readings will be generated automatically as there are no device profiles configured by default. In order to produce readings from either service, device profiles must be copied to service's configuration directory ($SNAP_DATA/config/service name/res) before starting.

This PR has been tested on Ubuntu 18.04 desktop and on a Dell Gateway 3000 running Ubuntu Core 16.