### PR TITLE
#848 POST to /valuedescriptor with duplicate name or invalid fmt stri…

### DIFF
--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -1182,7 +1182,7 @@ func valueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			case *errors.ErrValueDescriptorInvalid:
-				http.Error(w, err.Error(), http.StatusBadRequest)
+				http.Error(w, err.Error(), http.StatusConflict)
 				return
 			default:
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1212,7 +1212,7 @@ func valueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			case *errors.ErrValueDescriptorInvalid:
-				http.Error(w, err.Error(), http.StatusBadRequest)
+				http.Error(w, err.Error(), http.StatusConflict)
 				return
 			default:
 				http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/pkg/db/mongo/data.go
+++ b/internal/pkg/db/mongo/data.go
@@ -447,14 +447,15 @@ func (mc *MongoClient) AddValueDescriptor(v contract.ValueDescriptor) (string, e
 	}
 
 	// See if the name is unique and add the value descriptors
-	info, err := s.DB(mc.database.Name).C(db.ValueDescriptorCollection).Upsert(bson.M{"name": mapped.Name}, mapped)
-	if err != nil {
-		return v.Id, err
+	found, err := s.DB(mc.database.Name).C(db.ValueDescriptorCollection).Find(bson.M{"name": mapped.Name}).Count()
+	// Duplicate name
+	if found > 0 {
+		return v.Id, db.ErrNotUnique
 	}
 
-	// Duplicate name
-	if info.UpsertedId == nil {
-		return v.Id, db.ErrNotUnique
+	err = s.DB(mc.database.Name).C(db.ValueDescriptorCollection).Insert(mapped)
+	if err != nil {
+		return v.Id, err
 	}
 
 	to := mapped.ToContract()


### PR DESCRIPTION
…ng should 409

#848

Return a 409 status code and informative error when either an in-use name
or an improperly formatted formatting string is passed to /valuedescriptor's
POST handler.