### PR TITLE
FIX: Client monitor update in milliseconds, not seconds

### DIFF
--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -168,7 +168,6 @@ func initializeClients(useConsul bool) {
 	// Create export-distro client
 	params := types.EndpointParams{
 		ServiceKey:  internal.ExportDistroServiceKey,
-		Path:        "/",
 		UseRegistry: useConsul,
 		Url:         Configuration.Clients["Distro"].Url(),
 		Interval:    Configuration.Service.ClientMonitor,

--- a/internal/pkg/startup/endpoint.go
+++ b/internal/pkg/startup/endpoint.go
@@ -32,6 +32,6 @@ func (e Endpoint) Monitor(params types.EndpointParams, ch chan string) {
 		}
 		url := fmt.Sprintf("http://%s:%v%s", data.Address, data.Port, params.Path)
 		ch <- url
-		time.Sleep(time.Second * time.Duration(params.Interval))
+		time.Sleep(time.Millisecond * time.Duration(params.Interval))
 	}
 }


### PR DESCRIPTION
Issue #622 

Root cause analysis has been added to the above issue. This was actually a problem running services with Consul enabled. Docker uses Consul and thereby exposed the problem, but I could also observe the behavior locally by just running everything with the `--consul` flag.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>