### PR TITLE
snapcraft.yaml: stage Attribution.txt files for device services into snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -797,7 +797,7 @@ parts:
 
   security-secret-store:
     source: https://github.com/edgexfoundry/security-secret-store.git
-    source-branch: delhi
+    source-branch: "delhi"
     source-depth: 1
     plugin: make
     override-build: |
@@ -834,7 +834,7 @@ parts:
   security-api-gateway:
     after: [go]
     source: https://github.com/edgexfoundry/security-api-gateway.git
-    source-branch: delhi
+    source-branch: "delhi"
     source-depth: 1
     plugin: make
     stage-packages:
@@ -875,7 +875,7 @@ parts:
   device-modbus:
     source: https://github.com/edgexfoundry/device-modbus-go.git
     source-depth: 1
-    #source-branch: dehli
+    source-branch: "delhi"
     plugin: make
     after:
       - go
@@ -903,7 +903,7 @@ parts:
   device-mqtt:
     source: https://github.com/edgexfoundry/device-mqtt-go.git
     source-depth: 1
-    #source-branch: dehli
+    source-branch: "delhi"
     plugin: make
     after:
       - go
@@ -935,7 +935,7 @@ parts:
   device-random:
     source: https://github.com/edgexfoundry/device-random.git
     source-depth: 1
-    #source-branch: dehli
+    source-branch: "delhi"
     plugin: make
     after:
       - go

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -896,12 +896,10 @@ parts:
       cat "./cmd/res/configuration.toml" | \
         sed -e s:\"./device-Modbus.log\":\'\$SNAP_COMMON/device-Modbus.log\': > \
         "$SNAPCRAFT_PART_INSTALL/config/device-modbus/res/configuration.toml"
-
-      # FIXME: no Attribution.txt for 3rd party licenses; probably needs to be
-      # an aggregation of SDK's and this device service...
-
+      install -DT "./cmd/Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/Attribution.txt"
       install -DT "./LICENSE-2.0.txt" \
-         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mongo/LICENSE-2.0.txt"
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/LICENSE-2.0.txt"
   device-mqtt:
     source: https://github.com/edgexfoundry/device-mqtt-go.git
     source-depth: 1
@@ -930,9 +928,8 @@ parts:
       install -T "./cmd/res/configuration-driver.toml" \
         "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/configuration-driver.toml"
 
-      # FIXME: no Attribution.txt for 3rd party licenses; probably needs to be
-      # an aggregation of SDK's and this device service...
-
+      install -DT "./cmd/Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt/Attribution.txt"
       install -DT "./LICENSE-2.0.txt" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt/LICENSE-2.0.txt"
   device-random:
@@ -964,8 +961,7 @@ parts:
       install -T "./cmd/res/device.random.yaml" \
         "$SNAPCRAFT_PART_INSTALL/config/device-random/res/device.random.yaml"
 
-      # FIXME: no Attribution.txt for 3rd party licenses; probably needs to be
-      # an aggregation of SDK's and this device service...
-
+      install -DT "./cmd/Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-random/Attribution.txt"
       install -DT "./LICENSE-2.0.txt" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-random/LICENSE-2.0.txt"


### PR DESCRIPTION
Also fix a typo: device-mongo should be device-modbus

Note this PR will not build succesfully (and shouldn't be merged) until the following device-* PR's have been merged:
* https://github.com/edgexfoundry/device-mqtt-go/pull/4
* https://github.com/edgexfoundry/device-modbus-go/pull/5
* https://github.com/edgexfoundry/device-random/pull/17

After those get merged, just trigger a rebuild of this with "recheck" and it should be good to go.

I tested this branch by changing the `source-branch` and `source` specs for the parts to my fork and the various bugfix branches and then building from that. The diff can be applied with this patch:
```diff
diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
index 82d0efc..4cf5497 100644
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -859,9 +859,9 @@ parts:
         -e "s:host = \"edgex-device-virtual\":host = \"localhost\":" \
         $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res/configuration.toml
   device-modbus:
-    source: https://github.com/edgexfoundry/device-modbus-go.git
+    source: https://github.com/anonymouse64/device-modbus-go.git
     source-depth: 1
-    source-branch: dehli
+    source-branch: bugfix/3
     plugin: make
     after:
       - go
@@ -887,9 +887,9 @@ parts:
       install -DT "./LICENSE-2.0.txt" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/LICENSE-2.0.txt"
   device-mqtt:
-    source: https://github.com/edgexfoundry/device-mqtt-go.git
+    source: https://github.com/anonymouse64/device-mqtt-go.git
     source-depth: 1
-    source-branch: dehli
+    source-branch: bugfix/2
     plugin: make
     after:
       - go
@@ -919,9 +919,9 @@ parts:
       install -DT "./LICENSE-2.0.txt" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt/LICENSE-2.0.txt"
   device-random:
-    source: https://github.com/edgexfoundry/device-random.git
+    source: https://github.com/anonymouse64/device-random.git
     source-depth: 1
-    source-branch: dehli
+    source-branch: bugfix/14
     plugin: make
     after:
       - go
```


Then just make sure the Attribution.txt files are all there:
```bash
$ ls /snap/edgexfoundry/current/usr/share/doc/device-*/Attribution.txt
/snap/edgexfoundry/current/usr/share/doc/device-modbus/Attribution.txt
/snap/edgexfoundry/current/usr/share/doc/device-mqtt/Attribution.txt
/snap/edgexfoundry/current/usr/share/doc/device-random/Attribution.txt
```