### PR TITLE
#846 Return HTTP 423 LOCKED when issuing a GET command to a locked device

### DIFF
--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -45,7 +45,7 @@ func commandByDeviceID(did string, cid string, b string, p bool) (string, int) {
 		}
 	}
 
-	if p && (d.AdminState == models.Locked) {
+	if d.AdminState == models.Locked {
 		LoggingClient.Error(d.Name + " is in admin locked state")
 
 		return "", http.StatusLocked


### PR DESCRIPTION
#846 
This seems to work as-is for PUT requests, but the check below prevented it from working for other types of requests.

Signed-off-by: Daniel Harms <jdharms@gmail.com>