### PR TITLE
cmd/many: add go-toml to Attribution.txt files

### DIFF
--- a/cmd/config-seed/Attribution.txt
+++ b/cmd/config-seed/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/robfig/cron/blob/master/LICENSE
 satori/go.uuid (MIT) https://github.com/satori/go.uuid
 https://github.com/satori/go.uuid/blob/master/LICENSE
 
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
 influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
 https://github.com/influxdata/influxdb/blob/master/LICENSE
 

--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/robfig/cron/blob/master/LICENSE
 satori/go.uuid (MIT) https://github.com/satori/go.uuid
 https://github.com/satori/go.uuid/blob/master/LICENSE
 
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
 influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
 https://github.com/influxdata/influxdb/blob/master/LICENSE
 

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/robfig/cron/blob/master/LICENSE
 satori/go.uuid (MIT) https://github.com/satori/go.uuid
 https://github.com/satori/go.uuid/blob/master/LICENSE
 
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
 influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
 https://github.com/influxdata/influxdb/blob/master/LICENSE
 

--- a/cmd/export-client/Attribution.txt
+++ b/cmd/export-client/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/robfig/cron/blob/master/LICENSE
 satori/go.uuid (MIT) https://github.com/satori/go.uuid
 https://github.com/satori/go.uuid/blob/master/LICENSE
 
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
 influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
 https://github.com/influxdata/influxdb/blob/master/LICENSE
 

--- a/cmd/export-distro/Attribution.txt
+++ b/cmd/export-distro/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/robfig/cron/blob/master/LICENSE
 satori/go.uuid (MIT) https://github.com/satori/go.uuid
 https://github.com/satori/go.uuid/blob/master/LICENSE
 
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
 influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
 https://github.com/influxdata/influxdb/blob/master/LICENSE
 

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/robfig/cron/blob/master/LICENSE
 satori/go.uuid (MIT) https://github.com/satori/go.uuid
 https://github.com/satori/go.uuid/blob/master/LICENSE
 
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
 influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
 https://github.com/influxdata/influxdb/blob/master/LICENSE
 

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/robfig/cron/blob/master/LICENSE
 satori/go.uuid (MIT) https://github.com/satori/go.uuid
 https://github.com/satori/go.uuid/blob/master/LICENSE
 
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
 influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
 https://github.com/influxdata/influxdb/blob/master/LICENSE
 

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/robfig/cron/blob/master/LICENSE
 satori/go.uuid (MIT) https://github.com/satori/go.uuid
 https://github.com/satori/go.uuid/blob/master/LICENSE
 
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
 influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
 https://github.com/influxdata/influxdb/blob/master/LICENSE
 

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/robfig/cron/blob/master/LICENSE
 satori/go.uuid (MIT) https://github.com/satori/go.uuid
 https://github.com/satori/go.uuid/blob/master/LICENSE
 
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
 influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
 https://github.com/influxdata/influxdb/blob/master/LICENSE
 


### PR DESCRIPTION
Seems I missed `go-toml` in #908.