### PR TITLE
Now it's allowed to have an empty logTarget

### DIFF
--- a/pkg/clients/logging/logger.go
+++ b/pkg/clients/logging/logger.go
@@ -89,7 +89,7 @@ func NewClient(owningServiceName string, isRemote bool, logTarget string, logLev
 	var err error
 
 	//If local logging, verify directory exists
-	if !lc.remoteEnabled {
+	if !lc.remoteEnabled && lc.logTarget != "" {
 		verifyLogDirectory(lc.logTarget)
 
 		w, err := newFileWriter(lc.logTarget)


### PR DESCRIPTION
This should fix #913. Also allows to log using only stdout.

Signed-off-by: Joan Duran <jduran@circutor.com>