### PR TITLE
#845 Return a status 404 for core-command calls with bad device ID

### DIFF
--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -37,10 +37,13 @@ func commandByDeviceID(did string, cid string, b string, p bool) (string, int) {
 	if err != nil {
 		LoggingClient.Error(err.Error(), "")
 
-		chk, ok := err.(*types.ErrServiceClient)
-		if ok {
-			return "", chk.StatusCode
-		} else {
+		switch err.(type) {
+		case *types.ErrServiceClient:
+			errSC := err.(*types.ErrServiceClient)
+			return "", errSC.StatusCode
+		case types.ErrNotFound:
+			return "", http.StatusNotFound
+		default:
 			return "", http.StatusInternalServerError
 		}
 	}


### PR DESCRIPTION
#845 

Possibly a regression from commit: https://github.com/edgexfoundry/edgex-go/commit/40337b3b7d1dcbb47afc1e140e71d89914688f67#diff-2311174e4ebc3d4be67d0cf62dc5e1d2R72

It appears that other code (possibly just test code) depends on this case being handled by an ErrNotFound instead of an ErrServiceClient, so I've just updated the caller to handle this error appropriately.