### PR TITLE
#845, #844 Fix error handling in core-command service

### DIFF
--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -56,7 +56,6 @@ func restPutDeviceAdminState(w http.ResponseWriter, r *http.Request) {
 	status, err := putDeviceAdminState(did, as)
 	if err != nil {
 		LoggingClient.Error(err.Error(), "")
-		w.WriteHeader(http.StatusInternalServerError)
 	}
 	w.WriteHeader(status)
 
@@ -69,7 +68,6 @@ func restPutDeviceAdminStateByDeviceName(w http.ResponseWriter, r *http.Request)
 	status, err := putDeviceAdminStateByName(dn, as)
 	if err != nil {
 		LoggingClient.Error(err.Error(), "")
-		w.WriteHeader(http.StatusInternalServerError)
 	}
 	w.WriteHeader(status)
 }
@@ -81,7 +79,6 @@ func restPutDeviceOpState(w http.ResponseWriter, r *http.Request) {
 	status, err := putDeviceOpState(did, os)
 	if err != nil {
 		LoggingClient.Error(err.Error(), "")
-		w.WriteHeader(http.StatusInternalServerError)
 	}
 	w.WriteHeader(status)
 }
@@ -93,7 +90,6 @@ func restPutDeviceOpStateByDeviceName(w http.ResponseWriter, r *http.Request) {
 	status, err := putDeviceOpStateByName(dn, os)
 	if err != nil {
 		LoggingClient.Error(err.Error(), "")
-		w.WriteHeader(http.StatusInternalServerError)
 	}
 	w.WriteHeader(status)
 }
@@ -132,7 +128,7 @@ func restGetAllCommands(w http.ResponseWriter, _ *http.Request) {
 	status, devices, err := getCommands()
 	if err != nil {
 		LoggingClient.Error(err.Error(), "")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(status)
 	} else if status != http.StatusOK {
 		w.WriteHeader(status)
 	}

--- a/internal/core/data/device_test.go
+++ b/internal/core/data/device_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"fmt"
 	"math"
+	"net/http"
 	"os"
 	"sync"
 	"testing"
@@ -108,7 +109,7 @@ func newMockDeviceClient() *mocks.DeviceClient {
 	})).Return(mockDeviceResultFn, nil)
 	client.On("Device", mock.MatchedBy(func(id string) bool {
 		return id == "404"
-	})).Return(mockDeviceResultFn, types.ErrNotFound{})
+	})).Return(mockDeviceResultFn, types.NewErrServiceClient(http.StatusNotFound, []byte{}))
 	client.On("Device", mock.Anything).Return(mockDeviceResultFn, fmt.Errorf("some error"))
 
 	mockDeviceForNameResultFn := func(name string) models.Device {
@@ -121,7 +122,7 @@ func newMockDeviceClient() *mocks.DeviceClient {
 	})).Return(mockDeviceForNameResultFn, nil)
 	client.On("DeviceForName", mock.MatchedBy(func(name string) bool {
 		return name == "404"
-	})).Return(mockDeviceForNameResultFn, types.ErrNotFound{})
+	})).Return(mockDeviceForNameResultFn, types.NewErrServiceClient(http.StatusNotFound, []byte{}))
 	client.On("DeviceForName", mock.Anything).Return(mockDeviceForNameResultFn, fmt.Errorf("some error"))
 
 	return client

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
 	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
@@ -157,14 +156,8 @@ func getValueDescriptorsByDeviceName(name string) (vdList []contract.ValueDescri
 	// Get the device
 	device, err := mdc.DeviceForName(name)
 	if err != nil {
-		switch err := err.(type) {
-		case types.ErrNotFound:
-			LoggingClient.Error("Device not found: " + err.Error())
-			return []contract.ValueDescriptor{}, errors.NewErrDbNotFound()
-		default:
-			LoggingClient.Error("Problem getting device from metadata: " + err.Error())
-			return []contract.ValueDescriptor{}, err
-		}
+		LoggingClient.Error("Problem getting device from metadata: " + err.Error())
+		return []contract.ValueDescriptor{}, err
 	}
 
 	return getValueDescriptorsByDevice(device)
@@ -174,14 +167,8 @@ func getValueDescriptorsByDeviceId(id string) (vdList []contract.ValueDescriptor
 	// Get the device
 	device, err := mdc.Device(id)
 	if err != nil {
-		switch err := err.(type) {
-		case types.ErrNotFound:
-			LoggingClient.Error("Device not found: " + err.Error())
-			return []contract.ValueDescriptor{}, errors.NewErrDbNotFound()
-		default:
-			LoggingClient.Error("Problem getting device from metadata: " + err.Error())
-			return []contract.ValueDescriptor{}, err
-		}
+		LoggingClient.Error("Problem getting device from metadata: " + err.Error())
+		return []contract.ValueDescriptor{}, err
 	}
 
 	return getValueDescriptorsByDevice(device)

--- a/internal/core/data/valuedescriptor_test.go
+++ b/internal/core/data/valuedescriptor_test.go
@@ -2,6 +2,8 @@ package data
 
 import (
 	"bytes"
+	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
+	"net/http"
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
@@ -260,8 +262,11 @@ func TestGetValueDescriptorsByDeviceNameNotFound(t *testing.T) {
 	_, err := getValueDescriptorsByDeviceName("404")
 
 	if err != nil {
-		switch err.(type) {
-		case *errors.ErrDbNotFound:
+		switch err := err.(type) {
+		case *types.ErrServiceClient:
+			if err.StatusCode != http.StatusNotFound {
+				t.Errorf("Expected a 404 error")
+			}
 			return
 		default:
 			t.Errorf("Unexpected error getting value descriptor by device name missing in DB")
@@ -302,8 +307,11 @@ func TestGetValueDescriptorsByDeviceIdNotFound(t *testing.T) {
 	_, err := getValueDescriptorsByDeviceId("404")
 
 	if err != nil {
-		switch err.(type) {
-		case *errors.ErrDbNotFound:
+		switch err := err.(type) {
+		case *types.ErrServiceClient:
+			if err.StatusCode != http.StatusNotFound {
+				t.Errorf("Expected a 404 error")
+			}
 			return
 		default:
 			t.Errorf("Unexpected error getting value descriptor by device id missing in DB")

--- a/pkg/clients/request.go
+++ b/pkg/clients/request.go
@@ -69,9 +69,7 @@ func GetRequest(url string) ([]byte, error) {
 		return nil, err
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, types.ErrNotFound{}
-	} else if (resp.StatusCode != http.StatusOK) && (resp.StatusCode != http.StatusAccepted) {
+	if (resp.StatusCode != http.StatusOK) && (resp.StatusCode != http.StatusAccepted) {
 		return nil, types.NewErrServiceClient(resp.StatusCode, bodyBytes)
 	}
 


### PR DESCRIPTION
#844, #845

I believe this PR fixes some regressions caused by (or related to) commit: https://github.com/edgexfoundry/edgex-go/commit/40337b3b7d1dcbb47afc1e140e71d89914688f67#diff-2311174e4ebc3d4be67d0cf62dc5e1d2R72 around error handling in the core-command service.

Error codes in this service were being passed up to the rest layer alongside golang errors, and then discarded and 500's written out anyway.  This change causes the rest layer to respect the status codes returned by these functions even when an err value is returned.