### PR TITLE
Don't remove mongo db dir on start

### DIFF
--- a/snap/local/runtime-helpers/bin/mongod-wrapper.sh
+++ b/snap/local/runtime-helpers/bin/mongod-wrapper.sh
@@ -2,9 +2,7 @@
 
 # check the mongo database path
 MONGO_DATA_DIR="$SNAP_DATA"/mongo/db
-if [ -e "$MONGO_DATA_DIR" ] ; then
-    rm -rf "${MONGO_DATA_DIR:?}"/*
-else
+if [ ! -e "$MONGO_DATA_DIR" ] ; then
     mkdir -p "$MONGO_DATA_DIR"
 fi
 


### PR DESCRIPTION
The mongod wrapper script in the snap checks
to see if the mongo db data directory exists
on start-up. If it does, it's removed, otherwise
the dir is created. Removing the db means the
EdgeX instance loses all state stored in Mongo
on every restart.

Signed-off-by: Tony Espy <espy@canonical.com>