### PR TITLE
#841 Check for empty device profile name and return status 400

### DIFF
--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -73,6 +73,8 @@ func restAddDeviceProfile(w http.ResponseWriter, r *http.Request) {
 	if err := dbClient.AddDeviceProfile(&dp); err != nil {
 		if err == db.ErrNotUnique {
 			http.Error(w, "Duplicate name for device profile", http.StatusConflict)
+		} else if err == db.ErrNameEmpty {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -432,6 +434,8 @@ func addDeviceProfileYaml(data []byte, w http.ResponseWriter) {
 	if err := dbClient.AddDeviceProfile(&dp); err != nil {
 		if err == db.ErrNotUnique {
 			http.Error(w, "Duplicate profile name", http.StatusConflict)
+		} else if err == db.ErrNameEmpty {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		} else {
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		}

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -54,6 +54,7 @@ var (
 	ErrNotUnique           = errors.New("Resource already exists")
 	ErrCommandStillInUse   = errors.New("Command is still in use by device profiles")
 	ErrSlugEmpty           = errors.New("Slug is nil or empty")
+	ErrNameEmpty           = errors.New("Name is required")
 )
 
 type Configuration struct {

--- a/internal/pkg/db/mongo/metadata.go
+++ b/internal/pkg/db/mongo/metadata.go
@@ -467,6 +467,9 @@ func (m *MongoClient) GetDeviceProfile(d *contract.DeviceProfile, q bson.M) erro
 func (m *MongoClient) AddDeviceProfile(dp *contract.DeviceProfile) error {
 	s := m.session.Copy()
 	defer s.Close()
+	if len(dp.Name) == 0 {
+		return db.ErrNameEmpty
+	}
 	col := s.DB(m.database.Name).C(db.DeviceProfile)
 	count, err := col.Find(bson.M{"name": dp.Name}).Count()
 	if err != nil {


### PR DESCRIPTION
#841 

Check for empty device profile name in mongo client and
handle the error with a 400 status code.