### PR TITLE
Decoupling mongo types from metadata/Addressable endpoint

### DIFF
--- a/internal/core/metadata/interfaces/db.go
+++ b/internal/core/metadata/interfaces/db.go
@@ -15,7 +15,6 @@ package interfaces
 
 import (
 	contract "github.com/edgexfoundry/edgex-go/pkg/models"
-	"github.com/globalsign/mgo/bson"
 )
 
 type DBClient interface {
@@ -76,15 +75,15 @@ type DBClient interface {
 	GetDeviceProfilesUsingCommand(dp *[]contract.DeviceProfile, c contract.Command) error
 
 	// Addressable
-	UpdateAddressable(ra *contract.Addressable, r *contract.Addressable) error
-	AddAddressable(a *contract.Addressable) (bson.ObjectId, error)
-	GetAddressableById(a *contract.Addressable, id string) error
-	GetAddressableByName(a *contract.Addressable, n string) error
-	GetAddressablesByTopic(a *[]contract.Addressable, t string) error
-	GetAddressablesByPort(a *[]contract.Addressable, p int) error
-	GetAddressablesByPublisher(a *[]contract.Addressable, p string) error
-	GetAddressablesByAddress(a *[]contract.Addressable, add string) error
-	GetAddressables(d *[]contract.Addressable) error
+	UpdateAddressable(a contract.Addressable) error
+	AddAddressable(a contract.Addressable) (string, error)
+	GetAddressableById(id string) (contract.Addressable, error)
+	GetAddressableByName(n string) (contract.Addressable, error)
+	GetAddressablesByTopic(t string) ([]contract.Addressable, error)
+	GetAddressablesByPort(p int) ([]contract.Addressable, error)
+	GetAddressablesByPublisher(p string) ([]contract.Addressable, error)
+	GetAddressablesByAddress(add string) ([]contract.Addressable, error)
+	GetAddressables() ([]contract.Addressable, error)
 	DeleteAddressableById(id string) error
 
 	// Device service

--- a/internal/core/metadata/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/interfaces/mocks/DBClient.go
@@ -2,8 +2,6 @@
 
 package mocks
 
-import bson "github.com/globalsign/mgo/bson"
-
 import mock "github.com/stretchr/testify/mock"
 import models "github.com/edgexfoundry/edgex-go/pkg/models"
 
@@ -13,18 +11,18 @@ type DBClient struct {
 }
 
 // AddAddressable provides a mock function with given fields: a
-func (_m *DBClient) AddAddressable(a *models.Addressable) (bson.ObjectId, error) {
+func (_m *DBClient) AddAddressable(a models.Addressable) (string, error) {
 	ret := _m.Called(a)
 
-	var r0 bson.ObjectId
-	if rf, ok := ret.Get(0).(func(*models.Addressable) bson.ObjectId); ok {
+	var r0 string
+	if rf, ok := ret.Get(0).(func(models.Addressable) string); ok {
 		r0 = rf(a)
 	} else {
-		r0 = ret.Get(0).(bson.ObjectId)
+		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.Addressable) error); ok {
+	if rf, ok := ret.Get(1).(func(models.Addressable) error); ok {
 		r1 = rf(a)
 	} else {
 		r1 = ret.Error(1)
@@ -290,102 +288,161 @@ func (_m *DBClient) DeleteScheduleEventById(id string) error {
 	return r0
 }
 
-// GetAddressableById provides a mock function with given fields: a, id
-func (_m *DBClient) GetAddressableById(a *models.Addressable, id string) error {
-	ret := _m.Called(a, id)
+// GetAddressableById provides a mock function with given fields: id
+func (_m *DBClient) GetAddressableById(id string) (models.Addressable, error) {
+	ret := _m.Called(id)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*models.Addressable, string) error); ok {
-		r0 = rf(a, id)
+	var r0 models.Addressable
+	if rf, ok := ret.Get(0).(func(string) models.Addressable); ok {
+		r0 = rf(id)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(models.Addressable)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// GetAddressableByName provides a mock function with given fields: a, n
-func (_m *DBClient) GetAddressableByName(a *models.Addressable, n string) error {
-	ret := _m.Called(a, n)
+// GetAddressableByName provides a mock function with given fields: n
+func (_m *DBClient) GetAddressableByName(n string) (models.Addressable, error) {
+	ret := _m.Called(n)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*models.Addressable, string) error); ok {
-		r0 = rf(a, n)
+	var r0 models.Addressable
+	if rf, ok := ret.Get(0).(func(string) models.Addressable); ok {
+		r0 = rf(n)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(models.Addressable)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(n)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// GetAddressables provides a mock function with given fields: d
-func (_m *DBClient) GetAddressables(d *[]models.Addressable) error {
-	ret := _m.Called(d)
+// GetAddressables provides a mock function with given fields:
+func (_m *DBClient) GetAddressables() ([]models.Addressable, error) {
+	ret := _m.Called()
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]models.Addressable) error); ok {
-		r0 = rf(d)
+	var r0 []models.Addressable
+	if rf, ok := ret.Get(0).(func() []models.Addressable); ok {
+		r0 = rf()
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Addressable)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// GetAddressablesByAddress provides a mock function with given fields: a, add
-func (_m *DBClient) GetAddressablesByAddress(a *[]models.Addressable, add string) error {
-	ret := _m.Called(a, add)
+// GetAddressablesByAddress provides a mock function with given fields: add
+func (_m *DBClient) GetAddressablesByAddress(add string) ([]models.Addressable, error) {
+	ret := _m.Called(add)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]models.Addressable, string) error); ok {
-		r0 = rf(a, add)
+	var r0 []models.Addressable
+	if rf, ok := ret.Get(0).(func(string) []models.Addressable); ok {
+		r0 = rf(add)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Addressable)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(add)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// GetAddressablesByPort provides a mock function with given fields: a, p
-func (_m *DBClient) GetAddressablesByPort(a *[]models.Addressable, p int) error {
-	ret := _m.Called(a, p)
+// GetAddressablesByPort provides a mock function with given fields: p
+func (_m *DBClient) GetAddressablesByPort(p int) ([]models.Addressable, error) {
+	ret := _m.Called(p)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]models.Addressable, int) error); ok {
-		r0 = rf(a, p)
+	var r0 []models.Addressable
+	if rf, ok := ret.Get(0).(func(int) []models.Addressable); ok {
+		r0 = rf(p)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Addressable)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(p)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// GetAddressablesByPublisher provides a mock function with given fields: a, p
-func (_m *DBClient) GetAddressablesByPublisher(a *[]models.Addressable, p string) error {
-	ret := _m.Called(a, p)
+// GetAddressablesByPublisher provides a mock function with given fields: p
+func (_m *DBClient) GetAddressablesByPublisher(p string) ([]models.Addressable, error) {
+	ret := _m.Called(p)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]models.Addressable, string) error); ok {
-		r0 = rf(a, p)
+	var r0 []models.Addressable
+	if rf, ok := ret.Get(0).(func(string) []models.Addressable); ok {
+		r0 = rf(p)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Addressable)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(p)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// GetAddressablesByTopic provides a mock function with given fields: a, t
-func (_m *DBClient) GetAddressablesByTopic(a *[]models.Addressable, t string) error {
-	ret := _m.Called(a, t)
+// GetAddressablesByTopic provides a mock function with given fields: t
+func (_m *DBClient) GetAddressablesByTopic(t string) ([]models.Addressable, error) {
+	ret := _m.Called(t)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]models.Addressable, string) error); ok {
-		r0 = rf(a, t)
+	var r0 []models.Addressable
+	if rf, ok := ret.Get(0).(func(string) []models.Addressable); ok {
+		r0 = rf(t)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Addressable)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(t)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetAllCommands provides a mock function with given fields: d
@@ -1004,13 +1061,13 @@ func (_m *DBClient) ScrubMetadata() error {
 	return r0
 }
 
-// UpdateAddressable provides a mock function with given fields: ra, r
-func (_m *DBClient) UpdateAddressable(ra *models.Addressable, r *models.Addressable) error {
-	ret := _m.Called(ra, r)
+// UpdateAddressable provides a mock function with given fields: a
+func (_m *DBClient) UpdateAddressable(a models.Addressable) error {
+	ret := _m.Called(a)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*models.Addressable, *models.Addressable) error); ok {
-		r0 = rf(ra, r)
+	if rf, ok := ret.Get(0).(func(models.Addressable) error); ok {
+		r0 = rf(a)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/core/metadata/rest_device.go
+++ b/internal/core/metadata/rest_device.go
@@ -66,10 +66,11 @@ func restAddNewDevice(w http.ResponseWriter, r *http.Request) {
 
 	// Addressable check
 	// Try by name
-	err = dbClient.GetAddressableByName(&d.Addressable, d.Addressable.Name)
+	//TODO: Is what we really need here a checkForAddressable() function?
+	_, err = dbClient.GetAddressableByName(d.Addressable.Name)
 	if err != nil {
 		// Try by ID
-		err = dbClient.GetAddressableById(&d.Addressable, d.Addressable.Id.Hex())
+		_, err = dbClient.GetAddressableById(d.Addressable.Id)
 		if err != nil {
 			LoggingClient.Error(err.Error(), "")
 			http.Error(w, err.Error()+": A device must be associated to an Addressable", http.StatusBadRequest)
@@ -182,10 +183,10 @@ func updateDeviceFields(from models.Device, to *models.Device) error {
 		// Check if the new addressable exists
 		var a models.Addressable
 		// Try ID first
-		err := dbClient.GetAddressableById(&a, from.Addressable.Id.Hex())
+		a, err := dbClient.GetAddressableById(from.Addressable.Id)
 		if err != nil {
 			// Then try name
-			err = dbClient.GetAddressableByName(&a, from.Addressable.Name)
+			a, err = dbClient.GetAddressableByName(from.Addressable.Name)
 			if err != nil {
 				return errors.New("Addressable not found for updated device")
 			}
@@ -401,8 +402,7 @@ func restGetDeviceByAddressableName(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if the addressable exists
-	var a models.Addressable
-	err = dbClient.GetAddressableByName(&a, an)
+	a, err := dbClient.GetAddressableByName(an)
 	if err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -416,7 +416,7 @@ func restGetDeviceByAddressableName(w http.ResponseWriter, r *http.Request) {
 	res := make([]models.Device, 0)
 
 	// Use the addressable ID now that you have the addressable object
-	err = dbClient.GetDevicesByAddressableId(&res, a.Id.Hex())
+	err = dbClient.GetDevicesByAddressableId(&res, a.Id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		LoggingClient.Error(err.Error(), "")
@@ -468,8 +468,7 @@ func restGetDeviceByAddressableId(w http.ResponseWriter, r *http.Request) {
 	var aid string = vars[ADDRESSABLEID]
 
 	// Check if the addressable exists
-	var a models.Addressable
-	err := dbClient.GetAddressableById(&a, aid)
+	_, err := dbClient.GetAddressableById(aid)
 	if err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)

--- a/internal/core/metadata/rest_deviceservice.go
+++ b/internal/core/metadata/rest_deviceservice.go
@@ -24,7 +24,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
 	"github.com/gorilla/mux"
-	"github.com/globalsign/mgo/bson"
 )
 
 // Get the addressable by its ID or Name
@@ -33,9 +32,9 @@ func getAddressableByIdOrName(a *models.Addressable, w http.ResponseWriter) erro
 	name := a.Name
 
 	// Try by ID
-	if err := dbClient.GetAddressableById(a, id.Hex()); err != nil {
+	if _, err := dbClient.GetAddressableById(id); err != nil {
 		// Try by name
-		if err = dbClient.GetAddressableByName(a, name); err != nil {
+		if _, err = dbClient.GetAddressableByName(name); err != nil {
 			if err == db.ErrNotFound {
 				http.Error(w, "Addressable not found", http.StatusServiceUnavailable)
 			} else {
@@ -80,7 +79,7 @@ func restAddDeviceService(w http.ResponseWriter, r *http.Request) {
 
 	// Addressable Check
 	// No ID or Name given for addressable
-	if ds.Service.Addressable.Id.Hex() == "" && ds.Service.Addressable.Name == "" {
+	if ds.Service.Addressable.Id == "" && ds.Service.Addressable.Name == "" {
 		err = errors.New("Must provide an Addressable for Device Service")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		LoggingClient.Error(err.Error(), "")
@@ -89,7 +88,7 @@ func restAddDeviceService(w http.ResponseWriter, r *http.Request) {
 
 	var foundAddressable = false
 	// First try by name
-	err = dbClient.GetAddressableByName(&ds.Service.Addressable, ds.Service.Addressable.Name)
+	_, err = dbClient.GetAddressableByName(ds.Service.Addressable.Name)
 	if err != nil {
 		if err != db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -102,7 +101,7 @@ func restAddDeviceService(w http.ResponseWriter, r *http.Request) {
 
 	// Then try by ID
 	if !foundAddressable {
-		err := dbClient.GetAddressableById(&ds.Service.Addressable, ds.Service.Addressable.Id.Hex())
+		_, err := dbClient.GetAddressableById(ds.Service.Addressable.Id)
 		if err != nil {
 			http.Error(w, "Addressable not found by ID or Name", http.StatusNotFound)
 			LoggingClient.Error("Addressable not found by ID or Name: "+err.Error(), "")
@@ -200,7 +199,7 @@ func getAddressablesForAssociatedDevices(addressables *[]models.Addressable, ds 
 	// Get the addressables for all the devices
 	// Use a map to maintain a set (no duplicates)
 	// Convert to a slice afterwards
-	aMap := map[bson.ObjectId]models.Addressable{}
+	aMap := map[string]models.Addressable{}
 	for _, d := range devices {
 		// Only append addressable if its not in the map
 		if _, ok := aMap[d.Addressable.Id]; !ok {
@@ -331,8 +330,8 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 	res := make([]models.DeviceService, 0)
 
 	// Check if the addressable exists
-	var a models.Addressable
-	if err = dbClient.GetAddressableByName(&a, an); err != nil {
+	a, err := dbClient.GetAddressableByName(an)
+	if err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Addressable not found", http.StatusNotFound)
 		} else {
@@ -342,7 +341,7 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = dbClient.GetDeviceServicesByAddressableId(&res, a.Id.Hex()); err != nil {
+	if err = dbClient.GetDeviceServicesByAddressableId(&res, a.Id); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error(err.Error(), "")
 		return
@@ -358,8 +357,8 @@ func restGetServiceByAddressableId(w http.ResponseWriter, r *http.Request) {
 	res := make([]models.DeviceService, 0)
 
 	// Check if the Addressable exists
-	var a models.Addressable
-	if err := dbClient.GetAddressableById(&a, sid); err != nil {
+	_, err := dbClient.GetAddressableById(sid)
+	if err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Addressable not found", http.StatusNotFound)
 		} else {

--- a/internal/pkg/db/memory/metadata.go
+++ b/internal/pkg/db/memory/metadata.go
@@ -19,19 +19,19 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 	"github.com/globalsign/mgo/bson"
 )
 
 // Schedule event
-func (m *MemDB) GetAllScheduleEvents(se *[]models.ScheduleEvent) error {
-	cpy := make([]models.ScheduleEvent, len(m.scheduleEvents))
+func (m *MemDB) GetAllScheduleEvents(se *[]contract.ScheduleEvent) error {
+	cpy := make([]contract.ScheduleEvent, len(m.scheduleEvents))
 	copy(cpy, m.scheduleEvents)
 	*se = cpy
 	return nil
 }
 
-func (m *MemDB) AddScheduleEvent(se *models.ScheduleEvent) error {
+func (m *MemDB) AddScheduleEvent(se *contract.ScheduleEvent) error {
 	currentTime := db.MakeTimestamp()
 	se.Created = currentTime
 	se.Modified = currentTime
@@ -64,14 +64,15 @@ func (m *MemDB) AddScheduleEvent(se *models.ScheduleEvent) error {
 	return nil
 }
 
-func (m *MemDB) GetScheduleEventByName(se *models.ScheduleEvent, n string) error {
+func (m *MemDB) GetScheduleEventByName(se *contract.ScheduleEvent, n string) error {
 	for _, s := range m.scheduleEvents {
 		if s.Name == n {
-			err := m.GetAddressableById(&s.Addressable, s.Addressable.Id.Hex())
+			a, err := m.GetAddressableById(s.Addressable.Id)
 			if err != nil {
 				return fmt.Errorf("Could not find addressable %s for ds %s",
-					se.Addressable.Id.Hex(), se.Id.Hex())
+					se.Addressable.Id, se.Id.Hex())
 			}
+			s.Addressable = a
 			*se = s
 			return nil
 		}
@@ -79,7 +80,7 @@ func (m *MemDB) GetScheduleEventByName(se *models.ScheduleEvent, n string) error
 	return db.ErrNotFound
 }
 
-func (m *MemDB) UpdateScheduleEvent(se models.ScheduleEvent) error {
+func (m *MemDB) UpdateScheduleEvent(se contract.ScheduleEvent) error {
 	for i, s := range m.scheduleEvents {
 		if s.Id == se.Id {
 			m.scheduleEvents[i] = se
@@ -89,14 +90,15 @@ func (m *MemDB) UpdateScheduleEvent(se models.ScheduleEvent) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetScheduleEventById(se *models.ScheduleEvent, id string) error {
+func (m *MemDB) GetScheduleEventById(se *contract.ScheduleEvent, id string) error {
 	for _, s := range m.scheduleEvents {
 		if s.Id.Hex() == id {
-			err := m.GetAddressableById(&s.Addressable, s.Addressable.Id.Hex())
+			a, err := m.GetAddressableById(s.Addressable.Id)
 			if err != nil {
 				return fmt.Errorf("Could not find addressable %s for ds %s",
-					se.Addressable.Id.Hex(), se.Id.Hex())
+					se.Addressable.Id, se.Id.Hex())
 			}
+			s.Addressable = a
 			*se = s
 			return nil
 		}
@@ -104,15 +106,16 @@ func (m *MemDB) GetScheduleEventById(se *models.ScheduleEvent, id string) error 
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetScheduleEventsByScheduleName(ses *[]models.ScheduleEvent, n string) error {
-	l := []models.ScheduleEvent{}
+func (m *MemDB) GetScheduleEventsByScheduleName(ses *[]contract.ScheduleEvent, n string) error {
+	l := []contract.ScheduleEvent{}
 	for _, se := range m.scheduleEvents {
 		if se.Schedule == n {
-			err := m.GetAddressableById(&se.Addressable, se.Addressable.Id.Hex())
+			a, err := m.GetAddressableById(se.Addressable.Id)
 			if err != nil {
 				return fmt.Errorf("Could not find addressable %s for se %s",
-					se.Addressable.Id.Hex(), se.Id.Hex())
+					se.Addressable.Id, se.Id.Hex())
 			}
+			se.Addressable = a
 			l = append(l, se)
 		}
 	}
@@ -120,15 +123,16 @@ func (m *MemDB) GetScheduleEventsByScheduleName(ses *[]models.ScheduleEvent, n s
 	return nil
 }
 
-func (m *MemDB) GetScheduleEventsByAddressableId(ses *[]models.ScheduleEvent, id string) error {
-	l := []models.ScheduleEvent{}
+func (m *MemDB) GetScheduleEventsByAddressableId(ses *[]contract.ScheduleEvent, id string) error {
+	l := []contract.ScheduleEvent{}
 	for _, se := range m.scheduleEvents {
-		if se.Addressable.Id.Hex() == id {
-			err := m.GetAddressableById(&se.Addressable, se.Addressable.Id.Hex())
+		if se.Addressable.Id == id {
+			a, err := m.GetAddressableById(se.Addressable.Id)
 			if err != nil {
 				return fmt.Errorf("Could not find addressable %s for se %s",
-					se.Addressable.Id.Hex(), se.Id.Hex())
+					se.Addressable.Id, se.Id.Hex())
 			}
+			se.Addressable = a
 			l = append(l, se)
 		}
 	}
@@ -136,15 +140,16 @@ func (m *MemDB) GetScheduleEventsByAddressableId(ses *[]models.ScheduleEvent, id
 	return nil
 }
 
-func (m *MemDB) GetScheduleEventsByServiceName(ses *[]models.ScheduleEvent, n string) error {
-	l := []models.ScheduleEvent{}
+func (m *MemDB) GetScheduleEventsByServiceName(ses *[]contract.ScheduleEvent, n string) error {
+	l := []contract.ScheduleEvent{}
 	for _, se := range m.scheduleEvents {
 		if se.Service == n {
-			err := m.GetAddressableById(&se.Addressable, se.Addressable.Id.Hex())
+			a, err := m.GetAddressableById(se.Addressable.Id)
 			if err != nil {
 				return fmt.Errorf("Could not find addressable %s for se %s",
-					se.Addressable.Id.Hex(), se.Id.Hex())
+					se.Addressable.Id, se.Id.Hex())
 			}
+			se.Addressable = a
 			l = append(l, se)
 		}
 	}
@@ -163,14 +168,14 @@ func (m *MemDB) DeleteScheduleEventById(id string) error {
 }
 
 // Schedule
-func (m *MemDB) GetAllSchedules(s *[]models.Schedule) error {
-	cpy := make([]models.Schedule, len(m.schedules))
+func (m *MemDB) GetAllSchedules(s *[]contract.Schedule) error {
+	cpy := make([]contract.Schedule, len(m.schedules))
 	copy(cpy, m.schedules)
 	*s = cpy
 	return nil
 }
 
-func (m *MemDB) AddSchedule(s *models.Schedule) error {
+func (m *MemDB) AddSchedule(s *contract.Schedule) error {
 	currentTime := db.MakeTimestamp()
 	s.Created = currentTime
 	s.Modified = currentTime
@@ -186,7 +191,7 @@ func (m *MemDB) AddSchedule(s *models.Schedule) error {
 	return nil
 }
 
-func (m *MemDB) GetScheduleByName(s *models.Schedule, n string) error {
+func (m *MemDB) GetScheduleByName(s *contract.Schedule, n string) error {
 	for _, ss := range m.schedules {
 		if ss.Name == n {
 			*s = ss
@@ -196,7 +201,7 @@ func (m *MemDB) GetScheduleByName(s *models.Schedule, n string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) UpdateSchedule(s models.Schedule) error {
+func (m *MemDB) UpdateSchedule(s contract.Schedule) error {
 	s.Modified = db.MakeTimestamp()
 	for i, ss := range m.schedules {
 		if ss.Id == s.Id {
@@ -208,7 +213,7 @@ func (m *MemDB) UpdateSchedule(s models.Schedule) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetScheduleById(s *models.Schedule, id string) error {
+func (m *MemDB) GetScheduleById(s *contract.Schedule, id string) error {
 	for _, ss := range m.schedules {
 		if ss.Id.Hex() == id {
 			*s = ss
@@ -229,15 +234,15 @@ func (m *MemDB) DeleteScheduleById(id string) error {
 }
 
 // Device Report
-func (m *MemDB) GetAllDeviceReports(drs *[]models.DeviceReport) error {
-	cpy := make([]models.DeviceReport, len(m.deviceReports))
+func (m *MemDB) GetAllDeviceReports(drs *[]contract.DeviceReport) error {
+	cpy := make([]contract.DeviceReport, len(m.deviceReports))
 	copy(cpy, m.deviceReports)
 	*drs = cpy
 	return nil
 }
 
-func (m *MemDB) GetDeviceReportByDeviceName(drs *[]models.DeviceReport, n string) error {
-	l := []models.DeviceReport{}
+func (m *MemDB) GetDeviceReportByDeviceName(drs *[]contract.DeviceReport, n string) error {
+	l := []contract.DeviceReport{}
 	for _, dr := range m.deviceReports {
 		if dr.Name == n {
 			l = append(l, dr)
@@ -247,7 +252,7 @@ func (m *MemDB) GetDeviceReportByDeviceName(drs *[]models.DeviceReport, n string
 	return nil
 }
 
-func (m *MemDB) GetDeviceReportByName(dr *models.DeviceReport, n string) error {
+func (m *MemDB) GetDeviceReportByName(dr *contract.DeviceReport, n string) error {
 	for _, d := range m.deviceReports {
 		if d.Name == n {
 			*dr = d
@@ -257,7 +262,7 @@ func (m *MemDB) GetDeviceReportByName(dr *models.DeviceReport, n string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetDeviceReportById(dr *models.DeviceReport, id string) error {
+func (m *MemDB) GetDeviceReportById(dr *contract.DeviceReport, id string) error {
 	for _, d := range m.deviceReports {
 		if d.Id.Hex() == id {
 			*dr = d
@@ -267,13 +272,13 @@ func (m *MemDB) GetDeviceReportById(dr *models.DeviceReport, id string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) AddDeviceReport(dr *models.DeviceReport) error {
+func (m *MemDB) AddDeviceReport(dr *contract.DeviceReport) error {
 	currentTime := db.MakeTimestamp()
 	dr.Created = currentTime
 	dr.Modified = currentTime
 	dr.Id = bson.NewObjectId()
 
-	dummy := models.DeviceReport{}
+	dummy := contract.DeviceReport{}
 	if m.GetDeviceReportByName(&dummy, dr.Name) == nil {
 		return db.ErrNotUnique
 	}
@@ -283,7 +288,7 @@ func (m *MemDB) AddDeviceReport(dr *models.DeviceReport) error {
 
 }
 
-func (m *MemDB) UpdateDeviceReport(dr *models.DeviceReport) error {
+func (m *MemDB) UpdateDeviceReport(dr *contract.DeviceReport) error {
 	for i, d := range m.deviceReports {
 		if d.Id == dr.Id {
 			m.deviceReports[i] = *dr
@@ -293,8 +298,8 @@ func (m *MemDB) UpdateDeviceReport(dr *models.DeviceReport) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetDeviceReportsByScheduleEventName(drs *[]models.DeviceReport, n string) error {
-	l := []models.DeviceReport{}
+func (m *MemDB) GetDeviceReportsByScheduleEventName(drs *[]contract.DeviceReport, n string) error {
+	l := []contract.DeviceReport{}
 	for _, dr := range m.deviceReports {
 		if dr.Event == n {
 			l = append(l, dr)
@@ -315,12 +320,14 @@ func (m *MemDB) DeleteDeviceReportById(id string) error {
 }
 
 // Device
-func (m *MemDB) updateDeviceValues(d *models.Device) error {
-	err := m.GetAddressableById(&d.Addressable, d.Addressable.Id.Hex())
+func (m *MemDB) updateDeviceValues(d *contract.Device) error {
+	a, err := m.GetAddressableById(d.Addressable.Id)
 	if err != nil {
 		return fmt.Errorf("Could not find addressable %s for ds %s",
-			d.Addressable.Id.Hex(), d.Id.Hex())
+			d.Addressable.Id, d.Id.Hex())
 	}
+	d.Addressable = a
+
 	err = m.GetDeviceServiceById(&d.Service, d.Service.Id.Hex())
 	if err != nil {
 		return fmt.Errorf("Could not find DeviceService %s for ds %s",
@@ -334,9 +341,9 @@ func (m *MemDB) updateDeviceValues(d *models.Device) error {
 	return nil
 }
 
-type deviceCmp func(models.Device) bool
+type deviceCmp func(contract.Device) bool
 
-func (m *MemDB) getDeviceBy(d *models.Device, f deviceCmp) error {
+func (m *MemDB) getDeviceBy(d *contract.Device, f deviceCmp) error {
 	for _, dd := range m.devices {
 		if f(dd) {
 			if err := m.updateDeviceValues(&dd); err != nil {
@@ -349,8 +356,8 @@ func (m *MemDB) getDeviceBy(d *models.Device, f deviceCmp) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) getDevicesBy(d *[]models.Device, f deviceCmp) error {
-	l := []models.Device{}
+func (m *MemDB) getDevicesBy(d *[]contract.Device, f deviceCmp) error {
+	l := []contract.Device{}
 	for _, dd := range m.devices {
 		if f(dd) {
 			if err := m.updateDeviceValues(&dd); err != nil {
@@ -363,7 +370,7 @@ func (m *MemDB) getDevicesBy(d *[]models.Device, f deviceCmp) error {
 	return nil
 }
 
-func (m *MemDB) UpdateDevice(d models.Device) error {
+func (m *MemDB) UpdateDevice(d contract.Device) error {
 	for i, dd := range m.devices {
 		if dd.Id == d.Id {
 			m.devices[i] = d
@@ -373,56 +380,56 @@ func (m *MemDB) UpdateDevice(d models.Device) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetDeviceById(d *models.Device, id string) error {
+func (m *MemDB) GetDeviceById(d *contract.Device, id string) error {
 	return m.getDeviceBy(d,
-		func(dd models.Device) bool {
+		func(dd contract.Device) bool {
 			return dd.Id.Hex() == id
 		})
 }
 
-func (m *MemDB) GetDeviceByName(d *models.Device, n string) error {
+func (m *MemDB) GetDeviceByName(d *contract.Device, n string) error {
 	return m.getDeviceBy(d,
-		func(dd models.Device) bool {
+		func(dd contract.Device) bool {
 			return dd.Name == n
 		})
 }
 
-func (m *MemDB) GetAllDevices(d *[]models.Device) error {
-	cpy := make([]models.Device, len(m.devices))
+func (m *MemDB) GetAllDevices(d *[]contract.Device) error {
+	cpy := make([]contract.Device, len(m.devices))
 	copy(cpy, m.devices)
 	*d = cpy
 	return nil
 }
 
-func (m *MemDB) GetDevicesByProfileId(d *[]models.Device, id string) error {
+func (m *MemDB) GetDevicesByProfileId(d *[]contract.Device, id string) error {
 	return m.getDevicesBy(d,
-		func(dd models.Device) bool {
+		func(dd contract.Device) bool {
 			return dd.Profile.Id.Hex() == id
 		})
 }
 
-func (m *MemDB) GetDevicesByServiceId(d *[]models.Device, id string) error {
+func (m *MemDB) GetDevicesByServiceId(d *[]contract.Device, id string) error {
 	return m.getDevicesBy(d,
-		func(dd models.Device) bool {
+		func(dd contract.Device) bool {
 			return dd.Service.Id.Hex() == id
 		})
 }
 
-func (m *MemDB) GetDevicesByAddressableId(d *[]models.Device, id string) error {
+func (m *MemDB) GetDevicesByAddressableId(d *[]contract.Device, id string) error {
 	return m.getDevicesBy(d,
-		func(dd models.Device) bool {
-			return dd.Addressable.Id.Hex() == id
+		func(dd contract.Device) bool {
+			return dd.Addressable.Id == id
 		})
 }
 
-func (m *MemDB) GetDevicesWithLabel(d *[]models.Device, l string) error {
+func (m *MemDB) GetDevicesWithLabel(d *[]contract.Device, l string) error {
 	return m.getDevicesBy(d,
-		func(dd models.Device) bool {
+		func(dd contract.Device) bool {
 			return stringInSlice(l, dd.Labels)
 		})
 }
 
-func (m *MemDB) AddDevice(d *models.Device) error {
+func (m *MemDB) AddDevice(d *contract.Device) error {
 	currentTime := db.MakeTimestamp()
 	d.Created = currentTime
 	d.Modified = currentTime
@@ -465,7 +472,7 @@ func (m *MemDB) DeleteDeviceById(id string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) UpdateDeviceProfile(dp *models.DeviceProfile) error {
+func (m *MemDB) UpdateDeviceProfile(dp *contract.DeviceProfile) error {
 	for i, d := range m.deviceProfiles {
 		if d.Id == dp.Id {
 			m.deviceProfiles[i] = *dp
@@ -475,7 +482,7 @@ func (m *MemDB) UpdateDeviceProfile(dp *models.DeviceProfile) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) AddDeviceProfile(d *models.DeviceProfile) error {
+func (m *MemDB) AddDeviceProfile(d *contract.DeviceProfile) error {
 	currentTime := db.MakeTimestamp()
 	d.Created = currentTime
 	d.Modified = currentTime
@@ -491,14 +498,14 @@ func (m *MemDB) AddDeviceProfile(d *models.DeviceProfile) error {
 	return nil
 }
 
-func (m *MemDB) GetAllDeviceProfiles(d *[]models.DeviceProfile) error {
-	cpy := make([]models.DeviceProfile, len(m.deviceProfiles))
+func (m *MemDB) GetAllDeviceProfiles(d *[]contract.DeviceProfile) error {
+	cpy := make([]contract.DeviceProfile, len(m.deviceProfiles))
 	copy(cpy, m.deviceProfiles)
 	*d = cpy
 	return nil
 }
 
-func (m *MemDB) GetDeviceProfileById(d *models.DeviceProfile, id string) error {
+func (m *MemDB) GetDeviceProfileById(d *contract.DeviceProfile, id string) error {
 	for _, dp := range m.deviceProfiles {
 		if dp.Id.Hex() == id {
 			*d = dp
@@ -518,8 +525,8 @@ func (m *MemDB) DeleteDeviceProfileById(id string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetDeviceProfilesByModel(dps *[]models.DeviceProfile, model string) error {
-	l := []models.DeviceProfile{}
+func (m *MemDB) GetDeviceProfilesByModel(dps *[]contract.DeviceProfile, model string) error {
+	l := []contract.DeviceProfile{}
 	for _, dp := range m.deviceProfiles {
 		if dp.Model == model {
 			l = append(l, dp)
@@ -529,8 +536,8 @@ func (m *MemDB) GetDeviceProfilesByModel(dps *[]models.DeviceProfile, model stri
 	return nil
 }
 
-func (m *MemDB) GetDeviceProfilesWithLabel(dps *[]models.DeviceProfile, label string) error {
-	l := []models.DeviceProfile{}
+func (m *MemDB) GetDeviceProfilesWithLabel(dps *[]contract.DeviceProfile, label string) error {
+	l := []contract.DeviceProfile{}
 	for _, dp := range m.deviceProfiles {
 		if stringInSlice(label, dp.Labels) {
 			l = append(l, dp)
@@ -540,8 +547,8 @@ func (m *MemDB) GetDeviceProfilesWithLabel(dps *[]models.DeviceProfile, label st
 	return nil
 }
 
-func (m *MemDB) GetDeviceProfilesByManufacturerModel(dps *[]models.DeviceProfile, man string, mod string) error {
-	l := []models.DeviceProfile{}
+func (m *MemDB) GetDeviceProfilesByManufacturerModel(dps *[]contract.DeviceProfile, man string, mod string) error {
+	l := []contract.DeviceProfile{}
 	for _, dp := range m.deviceProfiles {
 		if dp.Manufacturer == man && dp.Model == mod {
 			l = append(l, dp)
@@ -551,8 +558,8 @@ func (m *MemDB) GetDeviceProfilesByManufacturerModel(dps *[]models.DeviceProfile
 	return nil
 }
 
-func (m *MemDB) GetDeviceProfilesByManufacturer(dps *[]models.DeviceProfile, man string) error {
-	l := []models.DeviceProfile{}
+func (m *MemDB) GetDeviceProfilesByManufacturer(dps *[]contract.DeviceProfile, man string) error {
+	l := []contract.DeviceProfile{}
 	for _, dp := range m.deviceProfiles {
 		if dp.Manufacturer == man {
 			l = append(l, dp)
@@ -562,7 +569,7 @@ func (m *MemDB) GetDeviceProfilesByManufacturer(dps *[]models.DeviceProfile, man
 	return nil
 }
 
-func (m *MemDB) GetDeviceProfileByName(d *models.DeviceProfile, n string) error {
+func (m *MemDB) GetDeviceProfileByName(d *contract.DeviceProfile, n string) error {
 	for _, dp := range m.deviceProfiles {
 		if dp.Name == n {
 			*d = dp
@@ -573,41 +580,11 @@ func (m *MemDB) GetDeviceProfileByName(d *models.DeviceProfile, n string) error 
 }
 
 // Addressable
-func (m *MemDB) UpdateAddressable(updated *models.Addressable, orig *models.Addressable) error {
-	if updated == nil {
-		return nil
-	}
-	if updated.Name != "" {
-		orig.Name = updated.Name
-	}
-	if updated.Protocol != "" {
-		orig.Protocol = updated.Protocol
-	}
-	if updated.Address != "" {
-		orig.Address = updated.Address
-	}
-	if updated.Port != int(0) {
-		orig.Port = updated.Port
-	}
-	if updated.Path != "" {
-		orig.Path = updated.Path
-	}
-	if updated.Publisher != "" {
-		orig.Publisher = updated.Publisher
-	}
-	if updated.User != "" {
-		orig.User = updated.User
-	}
-	if updated.Password != "" {
-		orig.Password = updated.Password
-	}
-	if updated.Topic != "" {
-		orig.Topic = updated.Topic
-	}
+func (m *MemDB) UpdateAddressable(orig contract.Addressable) error {
 
 	for i, aa := range m.addressables {
 		if aa.Id == orig.Id {
-			m.addressables[i] = *orig
+			m.addressables[i] = orig
 			return nil
 		}
 	}
@@ -615,11 +592,10 @@ func (m *MemDB) UpdateAddressable(updated *models.Addressable, orig *models.Addr
 	return db.ErrNotFound
 }
 
-func (m *MemDB) AddAddressable(a *models.Addressable) (bson.ObjectId, error) {
+func (m *MemDB) AddAddressable(a contract.Addressable) (string, error) {
 	currentTime := db.MakeTimestamp()
 	a.Created = currentTime
 	a.Modified = currentTime
-	a.Id = bson.NewObjectId()
 
 	for _, aa := range m.addressables {
 		if aa.Name == a.Name {
@@ -627,97 +603,96 @@ func (m *MemDB) AddAddressable(a *models.Addressable) (bson.ObjectId, error) {
 		}
 	}
 
-	m.addressables = append(m.addressables, *a)
+	m.addressables = append(m.addressables, a)
 	return a.Id, nil
 }
 
-type addressableCmp func(models.Addressable) bool
+type addressableCmp func(contract.Addressable) bool
 
-func (m *MemDB) getAddressableBy(a *models.Addressable, f addressableCmp) error {
+func (m *MemDB) getAddressableBy(f addressableCmp) (contract.Addressable, error) {
 	for _, aa := range m.addressables {
 		if f(aa) {
-			*a = aa
-			return nil
+			return aa, nil
 		}
 	}
-	return db.ErrNotFound
+	return contract.Addressable{}, db.ErrNotFound
 }
 
-func (m *MemDB) getAddressablesBy(a *[]models.Addressable, f addressableCmp) {
-	l := []models.Addressable{}
+func (m *MemDB) getAddressablesBy(f addressableCmp) []contract.Addressable {
+	l := []contract.Addressable{}
 	for _, aa := range m.addressables {
 		if f(aa) {
 			l = append(l, aa)
 		}
 	}
-	*a = l
+	return l
 }
 
-func (m *MemDB) GetAddressableById(a *models.Addressable, id string) error {
-	return m.getAddressableBy(a,
-		func(aa models.Addressable) bool {
-			return aa.Id.Hex() == id
+func (m *MemDB) GetAddressableById(id string) (contract.Addressable, error) {
+	return m.getAddressableBy(
+		func(aa contract.Addressable) bool {
+			return aa.Id == id
 		})
 }
 
-func (m *MemDB) GetAddressableByName(a *models.Addressable, n string) error {
-	return m.getAddressableBy(a,
-		func(aa models.Addressable) bool {
+func (m *MemDB) GetAddressableByName(n string) (contract.Addressable, error) {
+	return m.getAddressableBy(
+		func(aa contract.Addressable) bool {
 			return aa.Name == n
 		})
 }
 
-func (m *MemDB) GetAddressablesByTopic(a *[]models.Addressable, t string) error {
-	m.getAddressablesBy(a,
-		func(aa models.Addressable) bool {
+func (m *MemDB) GetAddressablesByTopic(t string) ([]contract.Addressable, error) {
+	return m.getAddressablesBy(
+		func(aa contract.Addressable) bool {
 			return aa.Topic == t
-		})
-	return nil
+		}), nil
 }
 
-func (m *MemDB) GetAddressablesByPort(a *[]models.Addressable, p int) error {
-	m.getAddressablesBy(a,
-		func(aa models.Addressable) bool {
+func (m *MemDB) GetAddressablesByPort(p int) ([]contract.Addressable, error) {
+	return m.getAddressablesBy(
+		func(aa contract.Addressable) bool {
 			return aa.Port == p
-		})
-	return nil
+		}), nil
 }
 
-func (m *MemDB) GetAddressablesByPublisher(a *[]models.Addressable, p string) error {
-	m.getAddressablesBy(a,
-		func(aa models.Addressable) bool {
+func (m *MemDB) GetAddressablesByPublisher(p string) ([]contract.Addressable, error) {
+	return m.getAddressablesBy(
+		func(aa contract.Addressable) bool {
 			return aa.Publisher == p
-		})
-	return nil
+		}), nil
 }
 
-func (m *MemDB) GetAddressablesByAddress(a *[]models.Addressable, add string) error {
-	m.getAddressablesBy(a,
-		func(aa models.Addressable) bool {
+func (m *MemDB) GetAddressablesByAddress(add string) ([]contract.Addressable, error) {
+	return m.getAddressablesBy(
+		func(aa contract.Addressable) bool {
 			return aa.Address == add
-		})
-	return nil
+		}), nil
 }
 
-func (m *MemDB) GetAddressables(d *[]models.Addressable) error {
-	cpy := make([]models.Addressable, len(m.addressables))
-	copy(cpy, m.addressables)
-	*d = cpy
-	return nil
+func (m *MemDB) GetAddressables() ([]contract.Addressable, error) {
+	return m.addressables, nil
 }
 
 func (m *MemDB) DeleteAddressableById(id string) error {
+	var found bool
+	list := []contract.Addressable{}
 	for i, aa := range m.addressables {
-		if aa.Id.Hex() == id {
-			m.addressables = append(m.addressables[:i], m.addressables[i+1:]...)
-			return nil
+		if aa.Id != id {
+			list = append(list, m.addressables[i])
+		} else {
+			found = true
 		}
 	}
-	return db.ErrNotFound
+	if !found {
+		return db.ErrNotFound
+	}
+	m.addressables = list
+	return nil
 }
 
 // Device service
-func (m *MemDB) UpdateDeviceService(ds models.DeviceService) error {
+func (m *MemDB) UpdateDeviceService(ds contract.DeviceService) error {
 	for i, d := range m.deviceServices {
 		if d.Id == ds.Id {
 			m.deviceServices[i] = ds
@@ -727,14 +702,14 @@ func (m *MemDB) UpdateDeviceService(ds models.DeviceService) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetDeviceServicesByAddressableId(d *[]models.DeviceService, id string) error {
-	l := []models.DeviceService{}
+func (m *MemDB) GetDeviceServicesByAddressableId(d *[]contract.DeviceService, id string) error {
+	l := []contract.DeviceService{}
 	for _, ds := range m.deviceServices {
-		if ds.Addressable.Id.Hex() == id {
-			err := m.GetAddressableById(&ds.Addressable, ds.Addressable.Id.Hex())
+		if ds.Addressable.Id == id {
+			_, err := m.GetAddressableById(ds.Addressable.Id)
 			if err != nil {
 				return fmt.Errorf("Could not find addressable %s for ds %s",
-					ds.Addressable.Id.Hex(), ds.Id.Hex())
+					ds.Addressable.Id, ds.Id.Hex())
 			}
 			l = append(l, ds)
 		}
@@ -743,14 +718,14 @@ func (m *MemDB) GetDeviceServicesByAddressableId(d *[]models.DeviceService, id s
 	return nil
 }
 
-func (m *MemDB) GetDeviceServicesWithLabel(d *[]models.DeviceService, label string) error {
-	l := []models.DeviceService{}
+func (m *MemDB) GetDeviceServicesWithLabel(d *[]contract.DeviceService, label string) error {
+	l := []contract.DeviceService{}
 	for _, ds := range m.deviceServices {
 		if stringInSlice(label, ds.Labels) {
-			err := m.GetAddressableById(&ds.Addressable, ds.Addressable.Id.Hex())
+			_, err := m.GetAddressableById(ds.Addressable.Id)
 			if err != nil {
 				return fmt.Errorf("Could not find addressable %s for ds %s",
-					ds.Addressable.Id.Hex(), ds.Id.Hex())
+					ds.Addressable.Id, ds.Id.Hex())
 			}
 			l = append(l, ds)
 		}
@@ -759,13 +734,13 @@ func (m *MemDB) GetDeviceServicesWithLabel(d *[]models.DeviceService, label stri
 	return nil
 }
 
-func (m *MemDB) GetDeviceServiceById(d *models.DeviceService, id string) error {
+func (m *MemDB) GetDeviceServiceById(d *contract.DeviceService, id string) error {
 	for _, ds := range m.deviceServices {
 		if ds.Id.Hex() == id {
-			err := m.GetAddressableById(&ds.Addressable, ds.Addressable.Id.Hex())
+			_, err := m.GetAddressableById(ds.Addressable.Id)
 			if err != nil {
 				return fmt.Errorf("Could not find addressable %s for ds %s",
-					ds.Addressable.Id.Hex(), ds.Id.Hex())
+					ds.Addressable.Id, ds.Id.Hex())
 			}
 			*d = ds
 			return nil
@@ -774,13 +749,13 @@ func (m *MemDB) GetDeviceServiceById(d *models.DeviceService, id string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetDeviceServiceByName(d *models.DeviceService, n string) error {
+func (m *MemDB) GetDeviceServiceByName(d *contract.DeviceService, n string) error {
 	for _, ds := range m.deviceServices {
 		if ds.Name == n {
-			err := m.GetAddressableById(&ds.Addressable, ds.Addressable.Id.Hex())
+			_, err := m.GetAddressableById(ds.Addressable.Id)
 			if err != nil {
 				return fmt.Errorf("Could not find addressable %s for ds %s",
-					ds.Addressable.Id.Hex(), ds.Id.Hex())
+					ds.Addressable.Id, ds.Id.Hex())
 			}
 			*d = ds
 			return nil
@@ -789,21 +764,21 @@ func (m *MemDB) GetDeviceServiceByName(d *models.DeviceService, n string) error 
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetAllDeviceServices(d *[]models.DeviceService) error {
+func (m *MemDB) GetAllDeviceServices(d *[]contract.DeviceService) error {
 	for _, ds := range m.deviceServices {
-		err := m.GetAddressableById(&ds.Addressable, ds.Addressable.Id.Hex())
+		_, err := m.GetAddressableById(ds.Addressable.Id)
 		if err != nil {
 			return fmt.Errorf("Could not find addressable %s for ds %s",
-				ds.Addressable.Id.Hex(), ds.Id.Hex())
+				ds.Addressable.Id, ds.Id.Hex())
 		}
 	}
-	cpy := make([]models.DeviceService, len(m.deviceServices))
+	cpy := make([]contract.DeviceService, len(m.deviceServices))
 	copy(cpy, m.deviceServices)
 	*d = cpy
 	return nil
 }
 
-func (m *MemDB) AddDeviceService(ds *models.DeviceService) error {
+func (m *MemDB) AddDeviceService(ds *contract.DeviceService) error {
 	currentTime := db.MakeTimestamp()
 	ds.Created = currentTime
 	ds.Modified = currentTime
@@ -847,9 +822,9 @@ func (m *MemDB) DeleteDeviceServiceById(id string) error {
 }
 
 // Provision watcher
-type provisionWatcherComp func(models.ProvisionWatcher) bool
+type provisionWatcherComp func(contract.ProvisionWatcher) bool
 
-func (m *MemDB) getProvisionWatcherBy(pw *models.ProvisionWatcher, f provisionWatcherComp) error {
+func (m *MemDB) getProvisionWatcherBy(pw *contract.ProvisionWatcher, f provisionWatcherComp) error {
 	for _, p := range m.provisionWatchers {
 		if f(p) {
 			err := m.GetDeviceServiceById(&p.Service, p.Service.Id.Hex())
@@ -869,8 +844,8 @@ func (m *MemDB) getProvisionWatcherBy(pw *models.ProvisionWatcher, f provisionWa
 	return db.ErrNotFound
 }
 
-func (m *MemDB) getProvisionWatchersBy(pws *[]models.ProvisionWatcher, f provisionWatcherComp) error {
-	l := []models.ProvisionWatcher{}
+func (m *MemDB) getProvisionWatchersBy(pws *[]contract.ProvisionWatcher, f provisionWatcherComp) error {
+	l := []contract.ProvisionWatcher{}
 	for _, pw := range m.provisionWatchers {
 		if f(pw) {
 			err := m.GetDeviceServiceById(&pw.Service, pw.Service.Id.Hex())
@@ -890,50 +865,50 @@ func (m *MemDB) getProvisionWatchersBy(pws *[]models.ProvisionWatcher, f provisi
 	return nil
 }
 
-func (m *MemDB) GetProvisionWatcherById(pw *models.ProvisionWatcher, id string) error {
+func (m *MemDB) GetProvisionWatcherById(pw *contract.ProvisionWatcher, id string) error {
 	return m.getProvisionWatcherBy(pw,
-		func(p models.ProvisionWatcher) bool {
+		func(p contract.ProvisionWatcher) bool {
 			return p.Id.Hex() == id
 		})
 }
 
-func (m *MemDB) GetAllProvisionWatchers(pw *[]models.ProvisionWatcher) error {
+func (m *MemDB) GetAllProvisionWatchers(pw *[]contract.ProvisionWatcher) error {
 	*pw = m.provisionWatchers
 	return nil
 }
 
-func (m *MemDB) GetProvisionWatcherByName(pw *models.ProvisionWatcher, n string) error {
+func (m *MemDB) GetProvisionWatcherByName(pw *contract.ProvisionWatcher, n string) error {
 	return m.getProvisionWatcherBy(pw,
-		func(p models.ProvisionWatcher) bool {
+		func(p contract.ProvisionWatcher) bool {
 			return p.Name == n
 		})
 }
 
-func (m *MemDB) GetProvisionWatchersByProfileId(pw *[]models.ProvisionWatcher, id string) error {
+func (m *MemDB) GetProvisionWatchersByProfileId(pw *[]contract.ProvisionWatcher, id string) error {
 	return m.getProvisionWatchersBy(pw,
-		func(p models.ProvisionWatcher) bool {
+		func(p contract.ProvisionWatcher) bool {
 			return p.Profile.Id.Hex() == id
 		})
 }
 
-func (m *MemDB) GetProvisionWatchersByServiceId(pw *[]models.ProvisionWatcher, id string) error {
+func (m *MemDB) GetProvisionWatchersByServiceId(pw *[]contract.ProvisionWatcher, id string) error {
 	return m.getProvisionWatchersBy(pw,
-		func(p models.ProvisionWatcher) bool {
+		func(p contract.ProvisionWatcher) bool {
 			return p.Service.Id.Hex() == id
 		})
 }
 
-func (m *MemDB) GetProvisionWatchersByIdentifier(pw *[]models.ProvisionWatcher, k string, v string) error {
+func (m *MemDB) GetProvisionWatchersByIdentifier(pw *[]contract.ProvisionWatcher, k string, v string) error {
 	return m.getProvisionWatchersBy(pw,
-		func(p models.ProvisionWatcher) bool {
+		func(p contract.ProvisionWatcher) bool {
 			return p.Identifiers[k] == v
 		})
 }
 
-func (m *MemDB) updateProvisionWatcherValues(pw *models.ProvisionWatcher) error {
+func (m *MemDB) updateProvisionWatcherValues(pw *contract.ProvisionWatcher) error {
 	// get Device Service
 	validDeviceService := false
-	var dev models.DeviceService
+	var dev contract.DeviceService
 	var err error
 	if pw.Service.Id.Hex() != "" {
 		if err = m.GetDeviceServiceById(&dev, pw.Service.Id.Hex()); err == nil {
@@ -953,7 +928,7 @@ func (m *MemDB) updateProvisionWatcherValues(pw *models.ProvisionWatcher) error 
 
 	// get Device Profile
 	validDeviceProfile := false
-	var dp models.DeviceProfile
+	var dp contract.DeviceProfile
 	if pw.Profile.Id.Hex() != "" {
 		if err = m.GetDeviceProfileById(&dp, pw.Profile.Id.Hex()); err == nil {
 			validDeviceProfile = true
@@ -972,13 +947,13 @@ func (m *MemDB) updateProvisionWatcherValues(pw *models.ProvisionWatcher) error 
 	return nil
 }
 
-func (m *MemDB) AddProvisionWatcher(pw *models.ProvisionWatcher) error {
+func (m *MemDB) AddProvisionWatcher(pw *contract.ProvisionWatcher) error {
 	currentTime := db.MakeTimestamp()
 	pw.Created = currentTime
 	pw.Modified = currentTime
 	pw.Id = bson.NewObjectId()
 
-	p := models.ProvisionWatcher{}
+	p := contract.ProvisionWatcher{}
 	if err := m.GetProvisionWatcherByName(&p, pw.Name); err == nil {
 		return db.ErrNotUnique
 	}
@@ -990,7 +965,7 @@ func (m *MemDB) AddProvisionWatcher(pw *models.ProvisionWatcher) error {
 	return nil
 }
 
-func (m *MemDB) UpdateProvisionWatcher(pw models.ProvisionWatcher) error {
+func (m *MemDB) UpdateProvisionWatcher(pw contract.ProvisionWatcher) error {
 	pw.Modified = db.MakeTimestamp()
 
 	if err := m.updateProvisionWatcherValues(&pw); err != nil {
@@ -1016,7 +991,7 @@ func (m *MemDB) DeleteProvisionWatcherById(id string) error {
 }
 
 // Command
-func (m *MemDB) GetCommandById(c *models.Command, id string) error {
+func (m *MemDB) GetCommandById(c *contract.Command, id string) error {
 	for _, cc := range m.commands {
 		if cc.Id == id {
 			*c = cc
@@ -1026,8 +1001,8 @@ func (m *MemDB) GetCommandById(c *models.Command, id string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetCommandByName(d *[]models.Command, name string) error {
-	cmds := []models.Command{}
+func (m *MemDB) GetCommandByName(d *[]contract.Command, name string) error {
+	cmds := []contract.Command{}
 	for _, cc := range m.commands {
 		if cc.Name == name {
 			cmds = append(cmds, cc)
@@ -1037,7 +1012,7 @@ func (m *MemDB) GetCommandByName(d *[]models.Command, name string) error {
 	return nil
 }
 
-func (m *MemDB) AddCommand(c *models.Command) error {
+func (m *MemDB) AddCommand(c *contract.Command) error {
 	currentTime := db.MakeTimestamp()
 	c.Created = currentTime
 	c.Modified = currentTime
@@ -1047,24 +1022,24 @@ func (m *MemDB) AddCommand(c *models.Command) error {
 	return nil
 }
 
-func (m *MemDB) GetAllCommands(d *[]models.Command) error {
-	cpy := make([]models.Command, len(m.commands))
+func (m *MemDB) GetAllCommands(d *[]contract.Command) error {
+	cpy := make([]contract.Command, len(m.commands))
 	copy(cpy, m.commands)
 	*d = cpy
 	return nil
 }
 
-func (m *MemDB) UpdateCommand(updated *models.Command, orig *models.Command) error {
+func (m *MemDB) UpdateCommand(updated *contract.Command, orig *contract.Command) error {
 	if updated == nil {
 		return nil
 	}
 	if updated.Name != "" {
 		orig.Name = updated.Name
 	}
-	if updated.Get != nil && (updated.Get.String() != models.Get{}.String()) {
+	if updated.Get != nil && (updated.Get.String() != contract.Get{}.String()) {
 		orig.Get = updated.Get
 	}
-	if updated.Put != nil && (updated.Put.String() != models.Put{}.String()) {
+	if updated.Put != nil && (updated.Put.String() != contract.Put{}.String()) {
 		orig.Put = updated.Put
 	}
 	if updated.Origin != 0 {
@@ -1091,8 +1066,8 @@ func (m *MemDB) DeleteCommandById(id string) error {
 	return db.ErrNotFound
 }
 
-func (m *MemDB) GetDeviceProfilesUsingCommand(dps *[]models.DeviceProfile, c models.Command) error {
-	l := []models.DeviceProfile{}
+func (m *MemDB) GetDeviceProfilesUsingCommand(dps *[]contract.DeviceProfile, c contract.Command) error {
+	l := []contract.DeviceProfile{}
 	for _, dp := range m.deviceProfiles {
 		for _, cc := range dp.Commands {
 			if cc.Id == c.Id {

--- a/internal/pkg/db/mongo/models/addressable.go
+++ b/internal/pkg/db/mongo/models/addressable.go
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package models
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/globalsign/mgo/bson"
+	"github.com/google/uuid"
+)
+
+type Addressable struct {
+	Id         bson.ObjectId `bson:"_id,omitempty"`
+	Uuid       string        `bson:"uuid,omitempty"`
+	Name       string        `bson:"name"`
+	Protocol   string        `bson:"protocol"`  // Protocol for the address (HTTP/TCP)
+	HTTPMethod string        `bson:"method"`    // Method for connecting (i.e. POST)
+	Address    string        `bson:"address"`   // Address of the addressable
+	Port       int           `bson:"port"`      // Port for the address
+	Path       string        `bson:"path"`      // Path for callbacks
+	Publisher  string        `bson:"publisher"` // For message bus protocols
+	User       string        `bson:"user"`      // User id for authentication
+	Password   string        `bson:"password"`  // Password of the user for authentication for the addressable
+	Topic      string        `bson:"topic"`     // Topic for message bus addressables
+	Created    int64         `bson:"created"`
+	Modified   int64         `bson:"modified"`
+	Origin     int64         `bson:"origin"`
+}
+
+func (a Addressable) ToContract() contract.Addressable {
+	// Always hand back the UUID as the contract event ID unless it's blank (an old event, for example blackbox test scripts
+	id := a.Uuid
+	if id == "" {
+		id = a.Id.Hex()
+	}
+	to := contract.Addressable{
+		Id:         id,
+		Name:       a.Name,
+		Protocol:   a.Protocol,
+		HTTPMethod: a.HTTPMethod,
+		Address:    a.Address,
+		Port:       a.Port,
+		Path:       a.Path,
+		Publisher:  a.Publisher,
+		User:       a.User,
+		Password:   a.Password,
+		Topic:      a.Topic,
+	}
+	to.Created = a.Created
+	to.Modified = a.Modified
+	to.Origin = a.Origin
+
+	return to
+}
+
+func (a *Addressable) FromContract(from contract.Addressable) error {
+	// In this first case, ID is empty so this must be an add.
+	// Generate new BSON/UUIDs
+	if from.Id == "" {
+		a.Id = bson.NewObjectId()
+		a.Uuid = uuid.New().String()
+	} else {
+		// In this case, we're dealing with an existing event
+		if !bson.IsObjectIdHex(from.Id) {
+			// EventID is not a BSON ID. Is it a UUID?
+			_, err := uuid.Parse(from.Id)
+			if err != nil { // It is some unsupported type of string
+				return db.ErrInvalidObjectId
+			}
+			// Leave model's ID blank for now. We will be querying based on the UUID.
+			a.Uuid = from.Id
+		} else {
+			// ID of pre-existing event is a BSON ID. We will query using the BSON ID.
+			a.Id = bson.ObjectIdHex(from.Id)
+		}
+	}
+	a.Name = from.Name
+	a.Protocol = from.Protocol
+	a.HTTPMethod = from.HTTPMethod
+	a.Address = from.Address
+	a.Port = from.Port
+	a.Path = from.Path
+	a.Publisher = from.Publisher
+	a.User = from.User
+	a.Password = from.Password
+	a.Topic = from.Topic
+	a.Origin = from.Origin
+
+	if a.Created == 0 {
+		ts := db.MakeTimestamp()
+		a.Created = ts
+		a.Modified = ts
+	} else {
+		a.Modified = from.Modified
+	}
+
+	return nil
+}

--- a/internal/pkg/db/mongo/models/event.go
+++ b/internal/pkg/db/mongo/models/event.go
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
 package models
 
 import (

--- a/internal/pkg/db/mongo/models/reading.go
+++ b/internal/pkg/db/mongo/models/reading.go
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
 package models
 
 import (

--- a/internal/pkg/db/mongo/models/value_descriptor.go
+++ b/internal/pkg/db/mongo/models/value_descriptor.go
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
 package models
 
 import (

--- a/internal/pkg/db/test/db_metadata.go
+++ b/internal/pkg/db/test/db_metadata.go
@@ -8,6 +8,7 @@ package test
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
@@ -43,6 +44,8 @@ func TestMetadataDB(t *testing.T, db interfaces.DBClient) {
 func getAddressable(i int, prefix string) models.Addressable {
 	name := fmt.Sprintf("%sname%d", prefix, i)
 	a := models.Addressable{}
+
+	a.Id = uuid.New().String()
 	a.Name = name
 	a.Protocol = name
 	a.HTTPMethod = name
@@ -67,8 +70,8 @@ func getDeviceService(db interfaces.DBClient, i int) (models.DeviceService, erro
 	ds.LastConnected = 5
 	ds.LastReported = 5
 	ds.Description = name
-	var err error
-	_, err = db.AddAddressable(&ds.Addressable)
+
+	_, err := db.AddAddressable(ds.Addressable)
 	if err != nil {
 		return ds, fmt.Errorf("Error creating addressable: %v", err)
 	}
@@ -104,12 +107,12 @@ func getDeviceProfile(db interfaces.DBClient, i int) (models.DeviceProfile, erro
 	return dp, nil
 }
 
-func populateAddressable(db interfaces.DBClient, count int) (bson.ObjectId, error) {
-	var id bson.ObjectId
+func populateAddressable(db interfaces.DBClient, count int) (string, error) {
+	var id string
 	for i := 0; i < count; i++ {
 		var err error
 		a := getAddressable(i, "")
-		id, err = db.AddAddressable(&a)
+		id, err = db.AddAddressable(a)
 		if err != nil {
 			return id, err
 		}
@@ -198,7 +201,7 @@ func populateScheduleEvent(db interfaces.DBClient, count int) (bson.ObjectId, er
 		se.Parameters = name
 		se.Service = name
 		se.Addressable = getAddressable(i, "se_")
-		_, err = db.AddAddressable(&se.Addressable)
+		_, err = db.AddAddressable(se.Addressable)
 		if err != nil {
 			return id, fmt.Errorf("Error creating addressable: %v", err)
 		}
@@ -225,7 +228,7 @@ func populateDevice(db interfaces.DBClient, count int) (bson.ObjectId, error) {
 		d.Labels = append(d.Labels, name)
 
 		d.Addressable = getAddressable(i, "device")
-		_, err = db.AddAddressable(&d.Addressable)
+		_, err = db.AddAddressable(d.Addressable)
 		if err != nil {
 			return id, fmt.Errorf("Error creating addressable: %v", err)
 		}
@@ -308,13 +311,12 @@ func populateProvisionWatcher(db interfaces.DBClient, count int) (bson.ObjectId,
 }
 
 func clearAddressables(t *testing.T, db interfaces.DBClient) {
-	var addrs []models.Addressable
-	err := db.GetAddressables(&addrs)
+	addrs, err := db.GetAddressables()
 	if err != nil {
 		t.Fatalf("Error getting addressables %v", err)
 	}
 	for _, a := range addrs {
-		if err = db.DeleteAddressableById(a.Id.Hex()); err != nil {
+		if err = db.DeleteAddressableById(a.Id); err != nil {
 			t.Fatalf("Error removing addressable %v: %v", a, err)
 		}
 	}
@@ -415,7 +417,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Should not be able to add a duplicated addressable\n")
 	}
 
-	err = db.GetAddressables(&addrs)
+	addrs, err = db.GetAddressables()
 	if err != nil {
 		t.Fatalf("Error getting addressables %v", err)
 	}
@@ -423,30 +425,30 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 100 addressables instead of %d", len(addrs))
 	}
 	a := models.Addressable{}
-	err = db.GetAddressableById(&a, id.Hex())
+	a, err = db.GetAddressableById(id)
 	if err != nil {
 		t.Fatalf("Error getting addressable by id %v", err)
 	}
-	if a.Id.Hex() != id.Hex() {
+	if a.Id != id {
 		t.Fatalf("Id does not match %s - %s", a.Id, id)
 	}
-	err = db.GetAddressableById(&a, "INVALID")
+	a, err = db.GetAddressableById("INVALID")
 	if err == nil {
 		t.Fatalf("Addressable should not be found")
 	}
-	err = db.GetAddressableByName(&a, "name1")
+	a, err = db.GetAddressableByName("name1")
 	if err != nil {
 		t.Fatalf("Error getting addressable by name %v", err)
 	}
 	if a.Name != "name1" {
 		t.Fatalf("name does not match %s - %s", a.Name, "name1")
 	}
-	err = db.GetAddressableByName(&a, "INVALID")
+	a, err = db.GetAddressableByName("INVALID")
 	if err == nil {
 		t.Fatalf("Addressable should not be found")
 	}
 
-	err = db.GetAddressablesByTopic(&addrs, "name1")
+	addrs, err = db.GetAddressablesByTopic("name1")
 	if err != nil {
 		t.Fatalf("Error getting addressables by topic: %v", err)
 	}
@@ -454,7 +456,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 addressable, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByTopic(&addrs, "INVALID")
+	addrs, err = db.GetAddressablesByTopic("INVALID")
 	if err != nil {
 		t.Fatalf("Error getting addressables by topic: %v", err)
 	}
@@ -462,7 +464,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be no addressables, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByPort(&addrs, 2)
+	addrs, err = db.GetAddressablesByPort(2)
 	if err != nil {
 		t.Fatalf("Error getting addressables by port: %v", err)
 	}
@@ -470,7 +472,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 addressable, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByPort(&addrs, -1)
+	addrs, err = db.GetAddressablesByPort(-1)
 	if err != nil {
 		t.Fatalf("Error getting addressables by port: %v", err)
 	}
@@ -478,7 +480,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be no addressables, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByPublisher(&addrs, "name1")
+	addrs, err = db.GetAddressablesByPublisher("name1")
 	if err != nil {
 		t.Fatalf("Error getting addressables by publisher: %v", err)
 	}
@@ -486,7 +488,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 addressable, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByPublisher(&addrs, "INVALID")
+	addrs, err = db.GetAddressablesByPublisher("INVALID")
 	if err != nil {
 		t.Fatalf("Error getting addressables by publisher: %v", err)
 	}
@@ -494,7 +496,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be no addressables, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByAddress(&addrs, "name1")
+	addrs, err = db.GetAddressablesByAddress("name1")
 	if err != nil {
 		t.Fatalf("Error getting addressables by Address: %v", err)
 	}
@@ -502,7 +504,7 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 addressable, not %d", len(addrs))
 	}
 
-	err = db.GetAddressablesByAddress(&addrs, "INVALID")
+	addrs, err = db.GetAddressablesByAddress("INVALID")
 	if err != nil {
 		t.Fatalf("Error getting addressables by Address: %v", err)
 	}
@@ -510,27 +512,25 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be no addressables, not %d", len(addrs))
 	}
 
-	err = db.GetAddressableById(&a, id.Hex())
+	a, err = db.GetAddressableById(id)
 	if err != nil {
 		t.Fatalf("Error getting addressable %v", err)
 	}
-	err = db.GetAddressableByName(&a, "name1")
+	a, err = db.GetAddressableByName("name1")
 	if err != nil {
 		t.Fatalf("Error getting addressable %v", err)
 	}
 
-	aa := models.Addressable{}
-	aa.Id = id
-	aa.Name = "name"
-	err = db.UpdateAddressable(&aa, &a)
+	a.Name = "name"
+	err = db.UpdateAddressable(a)
 	if err != nil {
 		t.Fatalf("Error updating Addressable %v", err)
 	}
-	err = db.GetAddressableByName(&a, "name1")
+	a, err = db.GetAddressableByName("name1")
 	if err == nil {
 		t.Fatalf("Addressable name1 should be renamed")
 	}
-	err = db.GetAddressableByName(&a, "name")
+	a, err = db.GetAddressableByName("name")
 	if err != nil {
 		t.Fatalf("Addressable name should be renamed")
 	}
@@ -543,16 +543,16 @@ func testDBAddressables(t *testing.T, db interfaces.DBClient) {
 
 	a.Id = "INVALID"
 	a.Name = "INVALID"
-	err = db.DeleteAddressableById(a.Id.Hex())
+	err = db.DeleteAddressableById(a.Id)
 	if err == nil {
 		t.Fatalf("Addressable should not be deleted")
 	}
 
-	err = db.GetAddressableByName(&a, "name")
+	a, err = db.GetAddressableByName("name")
 	if err != nil {
 		t.Fatalf("Error getting addressable")
 	}
-	err = db.DeleteAddressableById(a.Id.Hex())
+	err = db.DeleteAddressableById(a.Id)
 	if err != nil {
 		t.Fatalf("Addressable should be deleted: %v", err)
 	}
@@ -644,6 +644,8 @@ func testDBDeviceService(t *testing.T, db interfaces.DBClient) {
 	var deviceServices []models.DeviceService
 
 	clearDeviceServices(t, db)
+	clearAddressables(t, db)
+
 	id, err := populateDeviceService(db, 100)
 	if err != nil {
 		t.Fatalf("Error populating db: %v\n", err)
@@ -689,7 +691,7 @@ func testDBDeviceService(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be a not found error")
 	}
 
-	err = db.GetDeviceServicesByAddressableId(&deviceServices, ds.Addressable.Id.Hex())
+	err = db.GetDeviceServicesByAddressableId(&deviceServices, ds.Addressable.Id)
 	if err != nil {
 		t.Fatalf("Error getting deviceServices by addressable id %v", err)
 	}
@@ -995,7 +997,7 @@ func testDBScheduleEvent(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 ScheduleEvents instead of %d", len(scheduleEvents))
 	}
 
-	err = db.GetScheduleEventsByAddressableId(&scheduleEvents, e.Addressable.Id.Hex())
+	err = db.GetScheduleEventsByAddressableId(&scheduleEvents, e.Addressable.Id)
 	if err != nil {
 		t.Fatalf("Error getting ScheduleEvents %v", err)
 	}
@@ -1296,7 +1298,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 devices instead of %d", len(devices))
 	}
 
-	err = db.GetDevicesByAddressableId(&devices, d.Addressable.Id.Hex())
+	err = db.GetDevicesByAddressableId(&devices, d.Addressable.Id)
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}

--- a/internal/support/scheduler/loader.go
+++ b/internal/support/scheduler/loader.go
@@ -84,7 +84,7 @@ func callMetaDataService() (int, error) {
 	client := &http.Client{
 		Timeout: time.Duration(Configuration.Service.Timeout) * time.Millisecond,
 	}
-	executingUrl := fmt.Sprintf("%s%s", Configuration.Clients["Metadata"].Url(),clients.ApiPingRoute)
+	executingUrl := fmt.Sprintf("%s%s", Configuration.Clients["Metadata"].Url(), clients.ApiPingRoute)
 
 	req, _ := http.NewRequest(http.MethodGet, executingUrl, nil)
 	req.Header.Set(ContentTypeKey, ContentTypeJsonValue)
@@ -283,7 +283,7 @@ func loadConfigScheduleEvents() error {
 				LoggingClient.Info(fmt.Sprintf("Added addressable into core-metadata name: %s id: %s path: %s", addressable.Name, addressableId, addressable.Path))
 
 				// add the core-metadata id value
-				addressable.Id = bson.ObjectId(addressableId)
+				addressable.Id = addressableId
 			}
 
 			// add the schedule event with addressable event to core-metadata

--- a/pkg/clients/metadata/addressable_test.go
+++ b/pkg/clients/metadata/addressable_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/pkg/clients"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
-	"github.com/globalsign/mgo/bson"
+	"github.com/google/uuid"
 )
 
 func TestNewAddressableClientWithConsul(t *testing.T) {
@@ -54,11 +54,11 @@ func TestNewAddressableClientWithConsul(t *testing.T) {
 // Test adding an addressable using the client
 func TestAddAddressable(t *testing.T) {
 	addressable := models.Addressable{
-		Id:   bson.ObjectIdHex("5baca80d64562a6fcd22070c"),
+		Id:   uuid.New().String(),
 		Name: "TestName",
 	}
 
-	addingAddressableID := addressable.Id.Hex()
+	addingAddressableID := addressable.Id
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -100,7 +100,7 @@ func TestAddAddressable(t *testing.T) {
 // Test get an addressable using the client
 func TestGetAddressable(t *testing.T) {
 	addressable := models.Addressable{
-		Id:   bson.ObjectIdHex("5baca80d64562a6fcd22070c"),
+		Id:   uuid.New().String(),
 		Name: "TestName",
 	}
 
@@ -111,7 +111,7 @@ func TestGetAddressable(t *testing.T) {
 			t.Errorf("expected http method is %s, active http method is : %s", http.MethodGet, r.Method)
 		}
 
-		path := clients.ApiAddressableRoute + "/" + addressable.Id.Hex()
+		path := clients.ApiAddressableRoute + "/" + addressable.Id
 		if r.URL.EscapedPath() != path {
 			t.Errorf("expected uri path is %s, actual uri path is %s", path, r.URL.EscapedPath())
 		}
@@ -132,7 +132,7 @@ func TestGetAddressable(t *testing.T) {
 		Interval:    clients.ClientMonitorDefault}
 	ac := NewAddressableClient(params, MockEndpoint{})
 
-	receivedAddressable, err := ac.Addressable(addressable.Id.Hex())
+	receivedAddressable, err := ac.Addressable(addressable.Id)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -145,7 +145,7 @@ func TestGetAddressable(t *testing.T) {
 // Test get an addressable using the client
 func TestGetAddressableForName(t *testing.T) {
 	addressable := models.Addressable{
-		Id:   bson.ObjectIdHex("5baca80d64562a6fcd22070c"),
+		Id:   uuid.New().String(),
 		Name: "TestName",
 	}
 
@@ -190,7 +190,7 @@ func TestGetAddressableForName(t *testing.T) {
 // Test updating an addressable using the client
 func TestUpdateAddressable(t *testing.T) {
 	addressable := models.Addressable{
-		Id:   bson.ObjectIdHex("5baca80d64562a6fcd22070c"),
+		Id:   uuid.New().String(),
 		Name: "TestName",
 	}
 
@@ -228,7 +228,7 @@ func TestUpdateAddressable(t *testing.T) {
 // Test deleting an addressable using the client
 func TestDeleteAddressable(t *testing.T) {
 	addressable := models.Addressable{
-		Id:   bson.ObjectIdHex("5baca80d64562a6fcd22070c"),
+		Id:   uuid.New().String(),
 		Name: "TestName",
 	}
 
@@ -239,7 +239,7 @@ func TestDeleteAddressable(t *testing.T) {
 			t.Errorf("expected http method is %s, active http method is : %s", http.MethodDelete, r.Method)
 		}
 
-		path := clients.ApiAddressableRoute + "/id/" + addressable.Id.Hex()
+		path := clients.ApiAddressableRoute + "/id/" + addressable.Id
 		if r.URL.EscapedPath() != path {
 			t.Errorf("expected uri path is %s, actual uri path is %s", path, r.URL.EscapedPath())
 		}
@@ -258,7 +258,7 @@ func TestDeleteAddressable(t *testing.T) {
 		Interval:    clients.ClientMonitorDefault}
 	ac := NewAddressableClient(params, MockEndpoint{})
 
-	err := ac.Delete(addressable.Id.Hex())
+	err := ac.Delete(addressable.Id)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/pkg/models/addressable.go
+++ b/pkg/models/addressable.go
@@ -19,8 +19,6 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
-
-	"github.com/globalsign/mgo/bson"
 )
 
 /*
@@ -30,18 +28,18 @@ import (
  * Addressable struct
  */
 type Addressable struct {
-	BaseObject `bson:",inline"`
-	Id         bson.ObjectId `bson:"_id,omitempty" json:"id"`
-	Name       string        `bson:"name" json:"name"`
-	Protocol   string        `bson:"protocol" json:"protocol"`   // Protocol for the address (HTTP/TCP)
-	HTTPMethod string        `bson:"method" json:"method"`       // Method for connecting (i.e. POST)
-	Address    string        `bson:"address" json:"address"`     // Address of the addressable
-	Port       int           `bson:"port" json:"port,Number"`    // Port for the address
-	Path       string        `bson:"path" json:"path"`           // Path for callbacks
-	Publisher  string        `bson:"publisher" json:"publisher"` // For message bus protocols
-	User       string        `bson:"user" json:"user"`           // User id for authentication
-	Password   string        `bson:"password" json:"password"`   // Password of the user for authentication for the addressable
-	Topic      string        `bson:"topic" json:"topic"`         // Topic for message bus addressables
+	BaseObject
+	Id         string `json:"id"`
+	Name       string `json:"name"`
+	Protocol   string `json:"protocol"`    // Protocol for the address (HTTP/TCP)
+	HTTPMethod string `json:"method"`      // Method for connecting (i.e. POST)
+	Address    string `json:"address"`     // Address of the addressable
+	Port       int    `json:"port,Number"` // Port for the address
+	Path       string `json:"path"`        // Path for callbacks
+	Publisher  string `json:"publisher"`   // For message bus protocols
+	User       string `json:"user"`        // User id for authentication
+	Password   string `json:"password"`    // Password of the user for authentication for the addressable
+	Topic      string `json:"topic"`       // Topic for message bus addressables
 }
 
 // Custom marshaling for JSON
@@ -50,19 +48,19 @@ type Addressable struct {
 func (a Addressable) MarshalJSON() ([]byte, error) {
 	aux := struct {
 		BaseObject
-		Id         *bson.ObjectId `json:"id"`
-		Name       *string        `json:"name"`
-		Protocol   *string        `json:"protocol"`    // Protocol for the address (HTTP/TCP)
-		HTTPMethod *string        `json:"method"`      // Method for connecting (i.e. POST)
-		Address    *string        `json:"address"`     // Address of the addressable
-		Port       int            `json:"port,Number"` // Port for the address
-		Path       *string        `json:"path"`        // Path for callbacks
-		Publisher  *string        `json:"publisher"`   // For message bus protocols
-		User       *string        `json:"user"`        // User id for authentication
-		Password   *string        `json:"password"`    // Password of the user for authentication for the addressable
-		Topic      *string        `json:"topic"`       // Topic for message bus addressables
-		BaseURL    *string        `json:"baseURL"`
-		URL        *string        `json:"url"`
+		Id         *string `json:"id,omitempty"`
+		Name       *string `json:"name,omitempty"`
+		Protocol   *string `json:"protocol,omitempty"`    // Protocol for the address (HTTP/TCP)
+		HTTPMethod *string `json:"method,omitempty"`      // Method for connecting (i.e. POST)
+		Address    *string `json:"address,omitempty"`     // Address of the addressable
+		Port       int     `json:"port,Number,omitempty"` // Port for the address
+		Path       *string `json:"path,omitempty"`        // Path for callbacks
+		Publisher  *string `json:"publisher,omitempty"`   // For message bus protocols
+		User       *string `json:"user,omitempty"`        // User id for authentication
+		Password   *string `json:"password,omitempty"`    // Password of the user for authentication for the addressable
+		Topic      *string `json:"topic,omitempty"`       // Topic for message bus addressables
+		BaseURL    *string `json:"baseURL,omitempty"`
+		URL        *string `json:"url,omitempty"`
 	}{
 		BaseObject: a.BaseObject,
 		Port:       a.Port,

--- a/pkg/models/addressable_test.go
+++ b/pkg/models/addressable_test.go
@@ -70,7 +70,7 @@ func TestAddressable_String(t *testing.T) {
 		{"full addressable", TestAddressable, "{\"created\":" + strconv.FormatInt(TestAddressable.Created, 10) +
 			",\"modified\":" + strconv.FormatInt(TestAddressable.Modified, 10) +
 			",\"origin\":" + strconv.FormatInt(TestAddressable.Origin, 10) +
-			",\"id\":null,\"name\":\"" + TestAddressable.Name +
+			",\"name\":\"" + TestAddressable.Name +
 			"\",\"protocol\":\"" + TestAddressable.Protocol +
 			"\",\"method\":\"" + TestAddressable.HTTPMethod +
 			"\",\"address\":\"" + TestAddressable.Address +
@@ -82,7 +82,7 @@ func TestAddressable_String(t *testing.T) {
 			"\",\"topic\":\"" + TestAddressable.Topic +
 			"\",\"baseURL\":\"" + TestAddressable.Protocol + "://" + TestAddressable.Address + ":" + strconv.Itoa(TestAddressable.Port) +
 			"\",\"url\":\"" + TestAddressable.Protocol + "://" + TestAddressable.Address + ":" + strconv.Itoa(TestAddressable.Port) + TestAddressable.Path + "\"}"},
-		{"empty", EmptyAddressable, "{\"created\":0,\"modified\":0,\"origin\":0,\"id\":null,\"name\":null,\"protocol\":null,\"method\":null,\"address\":null,\"port\":0,\"path\":null,\"publisher\":null,\"user\":null,\"password\":null,\"topic\":null,\"baseURL\":null,\"url\":null}"},
+		{"empty", EmptyAddressable, "{\"created\":0,\"modified\":0,\"origin\":0}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/models/baseobject.go
+++ b/pkg/models/baseobject.go
@@ -18,6 +18,11 @@ import (
 	"encoding/json"
 )
 
+/*
+TODO: Since this type is embedded throughout many contract models, we must leave the bson tags in place until
+the full decoupling from Mongo is complete. This shouldn't have any impact since there isn't a direct import
+to mgo/bson
+*/
 type BaseObject struct {
 	Created  int64 `bson:"created" json:"created"`
 	Modified int64 `bson:"modified" json:"modified"`


### PR DESCRIPTION
#881 
    
- GET functions should return values, not populate pointers to types passed as arguments. Side-effect hell.
- Implemented Mongo provider logic, also MemoryDB changes
- Adding fix for issue #932

Signed-off-by: Trevor Conn <trevor_conn@dell.com>