### PR TITLE
#838, #839 CoreData readings error handling

### DIFF
--- a/internal/core/data/reading.go
+++ b/internal/core/data/reading.go
@@ -139,6 +139,9 @@ func getReadingsByDeviceId(limit int, deviceId string, valueDescriptor string) (
 func deleteReadingById(id string) error {
 	err := dbClient.DeleteReadingById(id)
 	if err != nil {
+		if err == db.ErrNotFound {
+			return errors.NewErrDbNotFound()
+		}
 		LoggingClient.Error(err.Error())
 		return err
 	}

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -712,7 +712,7 @@ func readingHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			switch err.(type) {
 			case *errors.ErrDbNotFound:
-				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
+				http.Error(w, "Value descriptor not found for reading", http.StatusNotFound)
 				return
 			case *errors.ErrValueDescriptorInvalid:
 				http.Error(w, err.Error(), http.StatusConflict)


### PR DESCRIPTION
When sending put command with an inexistent id to /reading
of Core Data API, 404 should be returned

When sending delete command with an inexistent id to
/reading/id/{id} of Core Data API, 404 should be returned