### PR TITLE
Upgrade snapcraft version and refactor build scripts

### DIFF
--- a/snap/Dockerfile.build
+++ b/snap/Dockerfile.build
@@ -1,15 +1,41 @@
 FROM ubuntu:16.04
 
-# this is basically the same as the amd64 upstream:
-# https://github.com/snapcore/snapcraft/blob/master/Dockerfile
+# allow specifying the architecture from the build arg command line
+ARG ARCH
+
+# this is essentially the same as the upstream dockerfile
+# here: https://github.com/snapcore/snapcraft/blob/master/docker/stable.Dockerfile
+# except we also specify the architecture to download so that this works
+# on other architectures
+# basically, we send a command to the snap store for the info on the core +
+# snapcraft snaps, extract the download link from the result and 
+# download and extract the snaps into the docker container
+# we do this because we can't easily run snapd (and thus snaps) inside a docker
+# container without disabling important security protections enabled for 
+# docker containers
 RUN apt-get update && \
   apt-get dist-upgrade --yes && \
   apt-get install --yes \
-  git \
-  snapcraft \
-  && \
+  curl sudo jq squashfs-tools && \
+  curl -s -L $(curl -s -H 'X-Ubuntu-Series: 16' -H "X-Ubuntu-Architecture: $ARCH" 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap && \
+  mkdir -p /snap/core && unsquashfs -n -d /snap/core/current core.snap && rm core.snap && \
+  curl -s -L $(curl -s -H 'X-Ubuntu-Series: 16' -H "X-Ubuntu-Architecture: $ARCH" 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft' | jq '.download_url' -r) --output snapcraft.snap && \
+  mkdir -p /snap/snapcraft && unsquashfs -n -d /snap/snapcraft/current snapcraft.snap && rm snapcraft.snap && \
+  apt remove --yes --purge curl jq squashfs-tools && \
   apt-get autoclean --yes && \
   apt-get clean --yes
+
+# the upstream dockerfile just uses this file locally from the repo, but 
+# rather than copy that file here, we can just download it here
+# while unlikely it is possible that the file location could move in the git repo
+# on master branch, so for stability in our builds, we just hard-code the git 
+# commit that most recently updated this file as the revision to download from
+# if this ever breaks, just change this file to copy what the upstream master dockerfile does
+ADD https://raw.githubusercontent.com/snapcore/snapcraft/25043ab3667d24688b3d93dcac9f9a74f35dae9e/docker/bin/snapcraft-wrapper /snap/bin/snapcraft
+RUN sed -i -e "s@\"amd64\"@$ARCH@" /snap/bin/snapcraft && chmod +x /snap/bin/snapcraft
+
+# snapcraft will be in /snap/bin, so we need to put that on the $PATH
+ENV PATH=/snap/bin:$PATH
 
 # include all of the build context inside /build
 COPY . /build

--- a/snap/build.sh
+++ b/snap/build.sh
@@ -16,15 +16,18 @@ if [ ! -z "$JENKINS_URL" ]; then
         echo "I seem to be running on Jenkins, but there's not a snap store login file..." 
     fi
 
-    # check if this is a release job or not, if it is set the corresponding env var
+    # figure out what kind of job this is using $JOB_NAME and simplify that 
+    # into $JOB_TYPE
+    JOB_TYPE="build"
     if [[ "$JOB_NAME" =~ edgex-go-snap-.*-stage-snap.* ]]; then
-        IS_RELEASE_JOB="YES"
-    else
-        IS_RELEASE_JOB="NO"
+        JOB_TYPE="stage"
+    elif [[ "$JOB_NAME" =~ edgex-go-snap-.*-release-snap.* ]]; then
+        JOB_TYPE="release"
     fi
 fi
 
-# build the container image - providing the relevant architecture base image
+# build the container image - providing the relevant architecture we're on
+# to determine which snap arch to download in the docker container
 case $(arch) in 
     x86_64)
         arch="amd64";;
@@ -39,7 +42,7 @@ docker build -t edgex-snap-builder:latest -f ${SCRIPT_DIR}/Dockerfile.build --bu
 rm $GIT_ROOT/edgex-snap-store-login
 
 # now run the build with the environment variables 
-docker run --rm -e "IS_RELEASE_JOB=$IS_RELEASE_JOB" -e "RELEASE=$RELEASE" -e "SNAP_CHANNEL=$SNAP_CHANNEL" edgex-snap-builder:latest
+docker run --rm -e "JOB_TYPE=$JOB_TYPE" -e "SNAP_REVISION=$SNAP_REVISION" -e "SNAP_CHANNEL=$SNAP_CHANNEL" edgex-snap-builder:latest
 
 # note that we don't need to delete the docker images here, that's done for us by jenkins in the 
 # edgex-provide-docker-cleanup macro defined for all the snap jobs

--- a/snap/build.sh
+++ b/snap/build.sh
@@ -25,7 +25,15 @@ if [ ! -z "$JENKINS_URL" ]; then
 fi
 
 # build the container image - providing the relevant architecture base image
-docker build -t edgex-snap-builder:latest -f ${SCRIPT_DIR}/Dockerfile.build $GIT_ROOT
+case $(arch) in 
+    x86_64)
+        arch="amd64";;
+    aarch64)
+        arch="arm64";;
+    arm*)
+        arch="armhf";;
+esac
+docker build -t edgex-snap-builder:latest -f ${SCRIPT_DIR}/Dockerfile.build --build-arg ARCH="$arch" $GIT_ROOT
 
 # delete the login file we copied to the git root so it doesn't persist around
 rm $GIT_ROOT/edgex-snap-store-login

--- a/snap/entrypoint.sh
+++ b/snap/entrypoint.sh
@@ -13,19 +13,56 @@ export SNAPCRAFT_BUILD_INFO=1
 # to send a report
 export SNAPCRAFT_ENABLE_SILENT_REPORT=1
 
-# build the snap
-cd /build
-snapcraft clean
-snapcraft
 
-# only on release jobs release the snap
-if [ "$IS_RELEASE_JOB" = "YES" ]; then
-    # login using the provided login
+# clean the environment and build the snap
+build_snap()
+{
+    pushd /build > /dev/null
+    snapcraft clean
+    snapcraft
+    popd > /dev/null
+}
+
+# login to the snap store using the provided login macaroon file
+snapcraft_login()
+{    
     snapcraft login --with /build/edgex-snap-store-login
+}
+
+# release a locally build snap to the store
+release_local_snap() 
+{
+    pushd /build > /dev/null
+    snapcraft_login
     # push the snap up to the store and get the revision of the snap
     REVISION=$(snapcraft push edgexfoundry*.snap | awk '/Revision/ {print $2}')
     # now release it on the provided revision and snap channel
     snapcraft release edgexfoundry $REVISION $SNAP_CHANNEL 
     # also update the meta-data automatically
     snapcraft push-metadata edgexfoundry*.snap --force
-fi
+    popd > /dev/null
+}
+
+# release a snap revision already in the store
+release_store_snap()
+{
+    snapcraft_login
+    snapcraft release edgexfoundry $SNAP_REVISION $SNAP_CHANNEL 
+}
+
+case "$JOB_TYPE" in 
+    "stage")
+        # stage jobs build the snap locally and release it
+        build_snap
+        release_local_snap
+    ;;
+    "release")
+        # release jobs will promote an already built snap revision
+        # in the store to a channel
+        release_store_snap
+    ;;
+    *)
+        # do normal build and nothing else
+        build_snap
+    ;;
+esac

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,11 @@ description: |
   for this snap can be found at: https://github.com/edgexfoundry/edgex-go
 icon: snap/local/assets/edgex-snap-icon.png
 
+# TODO: add armhf here when that's supported
+architectures: 
+  - arm64
+  - amd64
+
 # TODO: upgrade to stable before releasing to beta/candidate/stable
 grade: devel
 confinement: strict


### PR DESCRIPTION
* Adjusts the build scripts + Dockerfile to install snapcraft from the stable snap channel rather than through debian packages. As per the snapcraft maintainers, snapcraft 3.0 will not be backported/SRU'd to xenial, and so to get bugfixes and other features with snapcraft 3.0 we need to start installing from the snap. The trick here used to install it is exactly the same on that upstream snapcraft does, but adapted slightly to work for non-amd64 architectures. 
* Adjusts build scripts to allow for a new "release" job in jenkins (specified by the JOB_NAME jenkins environment variable). This job will specify an env var `SNAP_REVISION` and `SNAP_CHANNEL`, and release that snap revision to that snap channel. This release job is meant to only be manually triggered by users in jenkins. 
* Explicitly specify the supported architectures in the snapcraft.yaml so that it fails quicker if someone inadvertently tries to build it on other architectures.

For the corresponding jenkins job see https://github.com/edgexfoundry/ci-management/pull/281

Closes #888 
Closes #1079 (from the edgex-go side)