### PR TITLE
Addressing mongo/test issues w/core-data models

### DIFF
--- a/internal/pkg/db/mongo/metadata.go
+++ b/internal/pkg/db/mongo/metadata.go
@@ -1023,9 +1023,6 @@ func mapCommands(commands []models.Command, err error) ([]contract.Command, erro
 		mapped = append(mapped, cmd.ToContract())
 	}
 
-	if mapped == nil {
-		return nil, db.ErrNotFound
-	}
 	return mapped, nil
 }
 

--- a/internal/pkg/db/mongo/models/event.go
+++ b/internal/pkg/db/mongo/models/event.go
@@ -16,10 +16,10 @@ package models
 import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	contract "github.com/edgexfoundry/edgex-go/pkg/models"
-	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
 )
 
 type Event struct {
@@ -107,7 +107,9 @@ func (e Event) GetBSON() (interface{}, error) {
 	// Turn the readings into DBRef objects
 	var readings []mgo.DBRef
 	for _, reading := range e.Readings {
-		readings = append(readings, mgo.DBRef{Collection: db.ReadingsCollection, Id: reading.Id})
+		if reading.Id.Valid() {
+			readings = append(readings, mgo.DBRef{Collection: db.ReadingsCollection, Id: reading.Id})
+		}
 	}
 
 	return struct {
@@ -120,7 +122,7 @@ func (e Event) GetBSON() (interface{}, error) {
 		Origin   int64         `bson:"origin"`
 		Schedule string        `bson:"schedule,omitempty"` // Schedule identifier
 		Event    string        `bson:"event"`              // Schedule event identifier
-		Readings []mgo.DBRef   `bson:"readings"`           // List of readings
+		Readings []mgo.DBRef   `bson:"readings,omitempty"` // List of readings
 	}{
 		ID:       e.Id,
 		Uuid:     e.Uuid,

--- a/internal/pkg/db/mongo/models/reading.go
+++ b/internal/pkg/db/mongo/models/reading.go
@@ -16,12 +16,12 @@ package models
 import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	contract "github.com/edgexfoundry/edgex-go/pkg/models"
-	"github.com/google/uuid"
 	"github.com/globalsign/mgo/bson"
+	"github.com/google/uuid"
 )
 
 type Reading struct {
-	Id       bson.ObjectId `bson:"_id"`
+	Id       bson.ObjectId `bson:"_id,omitempty"`
 	Uuid     string        `bson:"uuid"`
 	Pushed   int64         `bson:"pushed"`  // When the data was pushed out of EdgeX (0 - not pushed yet)
 	Created  int64         `bson:"created"` // When the reading was created

--- a/internal/pkg/db/test/db_data.go
+++ b/internal/pkg/db/test/db_data.go
@@ -284,9 +284,7 @@ func testDBEvents(t *testing.T, db interfaces.DBClient) {
 	if err != nil {
 		t.Fatalf("Error getting events %v", err)
 	}
-	if events == nil {
-		t.Fatalf("Should return an empty array")
-	}
+
 	if len(events) != 0 {
 		t.Fatalf("There should be 0 events instead of %d", len(events))
 	}
@@ -497,9 +495,6 @@ func testDBValueDescriptors(t *testing.T, db interfaces.DBClient) {
 	values, err := db.ValueDescriptors()
 	if err != nil {
 		t.Fatalf("Error getting events %v", err)
-	}
-	if values == nil {
-		t.Fatalf("Should return an empty array")
 	}
 	if len(values) != 0 {
 		t.Fatalf("There should be 0 values instead of %d", len(values))

--- a/internal/pkg/db/test/db_metadata.go
+++ b/internal/pkg/db/test/db_metadata.go
@@ -8,7 +8,6 @@ package test
 
 import (
 	"fmt"
-	"github.com/google/uuid"
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
@@ -40,7 +39,6 @@ func getAddressable(i int, prefix string) models.Addressable {
 	name := fmt.Sprintf("%sname%d", prefix, i)
 	a := models.Addressable{}
 
-	a.Id = uuid.New().String()
 	a.Name = name
 	a.Protocol = name
 	a.HTTPMethod = name
@@ -70,6 +68,7 @@ func getDeviceService(db interfaces.DBClient, i int) (models.DeviceService, erro
 	if err != nil {
 		return ds, fmt.Errorf("Error creating addressable: %v", err)
 	}
+
 	return ds, nil
 }
 


### PR DESCRIPTION
#977 

Per the above issue, I've addressed the problems in the mongo/test functions dealing with events and their associated readings (core-data). There remain problems with the metadata relationships between addressable and device services because we are in the middle of refactoring the metadata service. The methodology of these tests will need to be changed to reflect the current implementation

- We have two possible identifiers now (BSON vs UUID) whereas before we only had one.
- We now have contract and provider-specific models whereas before we only had one.

As an example, rather than creating an addressable then saving it, then adding that instance to the parent device service, the approach going forward will be to instantiate the contract object graph as a whole which will then be passed into the MongoClient.AddDeviceService method. This can be done in a loop as it is now, but the constituent parts cannot be saved individually before stitching them all together. The tests will need to more accurately reflect how the DBClient API is used in practice, much like how the blackbox tests have been refactored.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>