### PR TITLE
Issue 877 - core-metadata DeviceService: Eliminate Mongo Types from Models

### DIFF
--- a/internal/core/data/device.go
+++ b/internal/core/data/device.go
@@ -81,10 +81,9 @@ func updateDeviceServiceLastReportedConnected(device string) {
 		return
 	}
 
-	msc.UpdateLastConnected(s.Service.Id.Hex(), t)
-	msc.UpdateLastReported(s.Service.Id.Hex(), t)
+	msc.UpdateLastConnected(s.Service.Id, t)
+	msc.UpdateLastReported(s.Service.Id, t)
 }
-
 
 func checkMaxLimit(limit int) error {
 	if limit > Configuration.Service.ReadMaxLimit {

--- a/internal/core/metadata/interfaces/db.go
+++ b/internal/core/metadata/interfaces/db.go
@@ -86,12 +86,12 @@ type DBClient interface {
 
 	// Device service
 	UpdateDeviceService(ds contract.DeviceService) error
-	GetDeviceServicesByAddressableId(d *[]contract.DeviceService, id string) error
-	GetDeviceServicesWithLabel(d *[]contract.DeviceService, l string) error
-	GetDeviceServiceById(d *contract.DeviceService, id string) error
-	GetDeviceServiceByName(d *contract.DeviceService, n string) error
-	GetAllDeviceServices(d *[]contract.DeviceService) error
-	AddDeviceService(ds *contract.DeviceService) error
+	GetDeviceServicesByAddressableId(id string) ([]contract.DeviceService, error)
+	GetDeviceServicesWithLabel(l string) ([]contract.DeviceService, error)
+	GetDeviceServiceById(id string) (contract.DeviceService, error)
+	GetDeviceServiceByName(n string) (contract.DeviceService, error)
+	GetAllDeviceServices() ([]contract.DeviceService, error)
+	AddDeviceService(ds contract.DeviceService) (string, error)
 	DeleteDeviceServiceById(id string) error
 
 	// Provision watcher

--- a/internal/core/metadata/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/interfaces/mocks/DBClient.go
@@ -102,17 +102,24 @@ func (_m *DBClient) AddDeviceReport(dr models.DeviceReport) (string, error) {
 }
 
 // AddDeviceService provides a mock function with given fields: ds
-func (_m *DBClient) AddDeviceService(ds *models.DeviceService) error {
+func (_m *DBClient) AddDeviceService(ds models.DeviceService) (string, error) {
 	ret := _m.Called(ds)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*models.DeviceService) error); ok {
+	var r0 string
+	if rf, ok := ret.Get(0).(func(models.DeviceService) string); ok {
 		r0 = rf(ds)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(string)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(models.DeviceService) error); ok {
+		r1 = rf(ds)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // AddProvisionWatcher provides a mock function with given fields: pw
@@ -160,20 +167,6 @@ func (_m *DBClient) AddScheduleEvent(se *models.ScheduleEvent) error {
 // CloseSession provides a mock function with given fields:
 func (_m *DBClient) CloseSession() {
 	_m.Called()
-}
-
-// Connect provides a mock function with given fields:
-func (_m *DBClient) Connect() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
 }
 
 // DeleteAddressableById provides a mock function with given fields: id
@@ -519,18 +512,27 @@ func (_m *DBClient) GetAllDeviceReports() ([]models.DeviceReport, error) {
 	return r0, r1
 }
 
-// GetAllDeviceServices provides a mock function with given fields: d
-func (_m *DBClient) GetAllDeviceServices(d *[]models.DeviceService) error {
-	ret := _m.Called(d)
+// GetAllDeviceServices provides a mock function with given fields:
+func (_m *DBClient) GetAllDeviceServices() ([]models.DeviceService, error) {
+	ret := _m.Called()
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]models.DeviceService) error); ok {
-		r0 = rf(d)
+	var r0 []models.DeviceService
+	if rf, ok := ret.Get(0).(func() []models.DeviceService); ok {
+		r0 = rf()
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.DeviceService)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetAllDevices provides a mock function with given fields: d
@@ -847,60 +849,92 @@ func (_m *DBClient) GetDeviceReportsByScheduleEventName(n string) ([]models.Devi
 	return r0, r1
 }
 
-// GetDeviceServiceById provides a mock function with given fields: d, id
-func (_m *DBClient) GetDeviceServiceById(d *models.DeviceService, id string) error {
-	ret := _m.Called(d, id)
+// GetDeviceServiceById provides a mock function with given fields: id
+func (_m *DBClient) GetDeviceServiceById(id string) (models.DeviceService, error) {
+	ret := _m.Called(id)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*models.DeviceService, string) error); ok {
-		r0 = rf(d, id)
+	var r0 models.DeviceService
+	if rf, ok := ret.Get(0).(func(string) models.DeviceService); ok {
+		r0 = rf(id)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(models.DeviceService)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// GetDeviceServiceByName provides a mock function with given fields: d, n
-func (_m *DBClient) GetDeviceServiceByName(d *models.DeviceService, n string) error {
-	ret := _m.Called(d, n)
+// GetDeviceServiceByName provides a mock function with given fields: n
+func (_m *DBClient) GetDeviceServiceByName(n string) (models.DeviceService, error) {
+	ret := _m.Called(n)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*models.DeviceService, string) error); ok {
-		r0 = rf(d, n)
+	var r0 models.DeviceService
+	if rf, ok := ret.Get(0).(func(string) models.DeviceService); ok {
+		r0 = rf(n)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(models.DeviceService)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(n)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// GetDeviceServicesByAddressableId provides a mock function with given fields: d, id
-func (_m *DBClient) GetDeviceServicesByAddressableId(d *[]models.DeviceService, id string) error {
-	ret := _m.Called(d, id)
+// GetDeviceServicesByAddressableId provides a mock function with given fields: id
+func (_m *DBClient) GetDeviceServicesByAddressableId(id string) ([]models.DeviceService, error) {
+	ret := _m.Called(id)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]models.DeviceService, string) error); ok {
-		r0 = rf(d, id)
+	var r0 []models.DeviceService
+	if rf, ok := ret.Get(0).(func(string) []models.DeviceService); ok {
+		r0 = rf(id)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.DeviceService)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// GetDeviceServicesWithLabel provides a mock function with given fields: d, l
-func (_m *DBClient) GetDeviceServicesWithLabel(d *[]models.DeviceService, l string) error {
-	ret := _m.Called(d, l)
+// GetDeviceServicesWithLabel provides a mock function with given fields: l
+func (_m *DBClient) GetDeviceServicesWithLabel(l string) ([]models.DeviceService, error) {
+	ret := _m.Called(l)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]models.DeviceService, string) error); ok {
-		r0 = rf(d, l)
+	var r0 []models.DeviceService
+	if rf, ok := ret.Get(0).(func(string) []models.DeviceService); ok {
+		r0 = rf(l)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.DeviceService)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(l)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetDevicesByAddressableId provides a mock function with given fields: d, aid

--- a/internal/core/metadata/rest_addressable.go
+++ b/internal/core/metadata/rest_addressable.go
@@ -217,8 +217,7 @@ func isAddressableStillInUse(a models.Addressable) (bool, error) {
 	}
 
 	// Check device services
-	var ds []models.DeviceService
-	err = dbClient.GetDeviceServicesByAddressableId(&ds, a.Id)
+	ds, err := dbClient.GetDeviceServicesByAddressableId(a.Id)
 	if err != nil {
 		return false, err
 	}
@@ -345,8 +344,8 @@ func notifyAddressableAssociates(a models.Addressable, action string) error {
 	var ds []models.DeviceService
 	for _, device := range d {
 		// Only add if not there
-		if _, ok := dsMap[device.Service.Service.Id.Hex()]; !ok {
-			dsMap[device.Service.Service.Id.Hex()] = device.Service
+		if _, ok := dsMap[device.Service.Service.Id]; !ok {
+			dsMap[device.Service.Service.Id] = device.Service
 			ds = append(ds, device.Service)
 		}
 	}

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -656,8 +656,8 @@ func notifyProfileAssociates(dp models.DeviceProfile, action string) error {
 	var ds []models.DeviceService
 	for _, device := range d {
 		// Only add if not there
-		if _, ok := dsMap[device.Service.Service.Id.Hex()]; !ok {
-			dsMap[device.Service.Service.Id.Hex()] = device.Service
+		if _, ok := dsMap[device.Service.Service.Id]; !ok {
+			dsMap[device.Service.Service.Id] = device.Service
 			ds = append(ds, device.Service)
 		}
 	}

--- a/internal/core/metadata/rest_devicereport.go
+++ b/internal/core/metadata/rest_devicereport.go
@@ -371,13 +371,14 @@ func deleteDeviceReport(dr models.DeviceReport, w http.ResponseWriter) error {
 func notifyDeviceReportAssociates(dr models.DeviceReport, action string) error {
 	// Get the device of the report
 	var d models.Device
-	if err := dbClient.GetDeviceByName(&d, dr.Device); err != nil {
+	var err error
+	if err = dbClient.GetDeviceByName(&d, dr.Device); err != nil {
 		return err
 	}
 
 	// Get the device service for the device
 	var ds models.DeviceService
-	if err := dbClient.GetDeviceServiceById(&ds, d.Service.Service.Id.Hex()); err != nil {
+	if ds, err = dbClient.GetDeviceServiceById(d.Service.Service.Id); err != nil {
 		return err
 	}
 
@@ -385,7 +386,7 @@ func notifyDeviceReportAssociates(dr models.DeviceReport, action string) error {
 	services = append(services, ds)
 
 	// Notify the associating device services
-	if err := notifyAssociates(services, dr.Id, action, models.REPORT); err != nil {
+	if err = notifyAssociates(services, dr.Id, action, models.REPORT); err != nil {
 		return err
 	}
 

--- a/internal/core/metadata/rest_deviceservice.go
+++ b/internal/core/metadata/rest_deviceservice.go
@@ -48,8 +48,9 @@ func getAddressableByIdOrName(a *models.Addressable, w http.ResponseWriter) erro
 }
 
 func restGetAllDeviceServices(w http.ResponseWriter, _ *http.Request) {
-	r := make([]models.DeviceService, 0)
-	if err := dbClient.GetAllDeviceServices(&r); err != nil {
+	var r []models.DeviceService
+	var err error
+	if r, err = dbClient.GetAllDeviceServices(); err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -89,13 +90,13 @@ func restAddDeviceService(w http.ResponseWriter, r *http.Request) {
 	var addressable models.Addressable
 	// First try by name
 	addressable, err = dbClient.GetAddressableByName(ds.Service.Addressable.Name)
-	if err != nil && err == db.ErrNotFound {
+	if err != nil && err == db.ErrNotFound && ds.Service.Addressable.Id != "" {
 		addressable, err = dbClient.GetAddressableById(ds.Service.Addressable.Id)
 	}
 	if err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Addressable not found by ID or Name", http.StatusNotFound)
-			LoggingClient.Error("Addressable not found by ID or Name: "+err.Error(), "")
+			LoggingClient.Error("Addressable not found by ID or Name: " + err.Error())
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			LoggingClient.Error(err.Error())
@@ -105,7 +106,7 @@ func restAddDeviceService(w http.ResponseWriter, r *http.Request) {
 	ds.Service.Addressable = addressable
 
 	// Add the device service
-	if err := dbClient.AddDeviceService(&ds); err != nil {
+	if ds.Service.Id, err = dbClient.AddDeviceService(ds); err != nil {
 		if err == db.ErrNotUnique {
 			http.Error(w, "Duplicate name for the device service", http.StatusConflict)
 		} else {
@@ -116,7 +117,7 @@ func restAddDeviceService(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(ds.Service.Id.Hex()))
+	w.Write([]byte(ds.Service.Id))
 }
 
 // Get all the addressables for the devices that are associated with the device service
@@ -125,9 +126,10 @@ func restGetAddressablesForAssociatedDevicesById(w http.ResponseWriter, r *http.
 	vars := mux.Vars(r)
 	var id string = vars[ID]
 	var ds models.DeviceService
+	var err error
 
 	// Check if the device service exists
-	if err := dbClient.GetDeviceServiceById(&ds, id); err != nil {
+	if ds, err = dbClient.GetDeviceServiceById(id); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -161,7 +163,7 @@ func restGetAddressablesForAssociatedDevicesByName(w http.ResponseWriter, r *htt
 
 	// Check if the device service exists
 	var ds models.DeviceService
-	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
+	if ds, err = dbClient.GetDeviceServiceByName(n); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -186,7 +188,7 @@ func restGetAddressablesForAssociatedDevicesByName(w http.ResponseWriter, r *htt
 func getAddressablesForAssociatedDevices(addressables *[]models.Addressable, ds models.DeviceService, w http.ResponseWriter) error {
 	// Get the associated devices
 	var devices []models.Device
-	if err := dbClient.GetDevicesByServiceId(&devices, ds.Service.Id.Hex()); err != nil {
+	if err := dbClient.GetDevicesByServiceId(&devices, ds.Service.Id); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}
@@ -219,9 +221,9 @@ func restUpdateDeviceService(w http.ResponseWriter, r *http.Request) {
 	// Check if the device service exists and get it
 	var to models.DeviceService
 	// Try by ID
-	if err = dbClient.GetDeviceServiceById(&to, from.Service.Id.Hex()); err != nil {
+	if to, err = dbClient.GetDeviceServiceById(from.Service.Id); err != nil {
 		// Try by Name
-		if err = dbClient.GetDeviceServiceByName(&to, from.Service.Name); err != nil {
+		if to, err = dbClient.GetDeviceServiceByName(from.Service.Name); err != nil {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 			LoggingClient.Error(err.Error())
 			return
@@ -278,7 +280,7 @@ func updateDeviceServiceFields(from models.DeviceService, to *models.DeviceServi
 
 		// Check if the new name is unique
 		var checkDS models.DeviceService
-		err := dbClient.GetDeviceServiceByName(&checkDS, from.Service.Name)
+		checkDS, err := dbClient.GetDeviceServiceByName(from.Service.Name)
 		if err != nil {
 			// A problem occurred accessing database
 			if err != db.ErrNotFound {
@@ -322,7 +324,6 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	res := make([]models.DeviceService, 0)
 
 	// Check if the addressable exists
 	a, err := dbClient.GetAddressableByName(an)
@@ -336,7 +337,8 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = dbClient.GetDeviceServicesByAddressableId(&res, a.Id); err != nil {
+	res := make([]models.DeviceService, 0)
+	if res, err = dbClient.GetDeviceServicesByAddressableId(a.Id); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error(err.Error())
 		return
@@ -349,7 +351,6 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 func restGetServiceByAddressableId(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	var sid string = vars[ADDRESSABLEID]
-	res := make([]models.DeviceService, 0)
 
 	// Check if the Addressable exists
 	_, err := dbClient.GetAddressableById(sid)
@@ -363,7 +364,8 @@ func restGetServiceByAddressableId(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := dbClient.GetDeviceServicesByAddressableId(&res, sid); err != nil {
+	res := make([]models.DeviceService, 0)
+	if res, err = dbClient.GetDeviceServicesByAddressableId(sid); err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -381,9 +383,9 @@ func restGetServiceWithLabel(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	res := make([]models.DeviceService, 0)
 
-	if err := dbClient.GetDeviceServicesWithLabel(&res, l); err != nil {
+	res := make([]models.DeviceService, 0)
+	if res, err = dbClient.GetDeviceServicesWithLabel(l); err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -402,8 +404,7 @@ func restGetServiceByName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var res models.DeviceService
-	err = dbClient.GetDeviceServiceByName(&res, dn)
+	res, err := dbClient.GetDeviceServiceByName(dn)
 	if err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -424,7 +425,8 @@ func restDeleteServiceById(w http.ResponseWriter, r *http.Request) {
 
 	// Check if the device service exists and get it
 	var ds models.DeviceService
-	if err := dbClient.GetDeviceServiceById(&ds, id); err != nil {
+	var err error
+	if ds, err = dbClient.GetDeviceServiceById(id); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -434,7 +436,7 @@ func restDeleteServiceById(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := deleteDeviceService(ds, w); err != nil {
+	if err = deleteDeviceService(ds, w); err != nil {
 		LoggingClient.Error(err.Error())
 		return
 	}
@@ -453,7 +455,7 @@ func restDeleteServiceByName(w http.ResponseWriter, r *http.Request) {
 
 	// Check if the device service exists
 	var ds models.DeviceService
-	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
+	if ds, err = dbClient.GetDeviceServiceByName(n); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -479,7 +481,7 @@ func restDeleteServiceByName(w http.ResponseWriter, r *http.Request) {
 func deleteDeviceService(ds models.DeviceService, w http.ResponseWriter) error {
 	// Delete the associated devices
 	var devices []models.Device
-	if err := dbClient.GetDevicesByServiceId(&devices, ds.Service.Id.Hex()); err != nil {
+	if err := dbClient.GetDevicesByServiceId(&devices, ds.Service.Id); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}
@@ -491,7 +493,7 @@ func deleteDeviceService(ds models.DeviceService, w http.ResponseWriter) error {
 
 	// Delete the associated provision watchers
 	var watchers []models.ProvisionWatcher
-	if err := dbClient.GetProvisionWatchersByServiceId(&watchers, ds.Service.Id.Hex()); err != nil {
+	if err := dbClient.GetProvisionWatchersByServiceId(&watchers, ds.Service.Id); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}
@@ -502,7 +504,7 @@ func deleteDeviceService(ds models.DeviceService, w http.ResponseWriter) error {
 	}
 
 	// Delete the device service
-	if err := dbClient.DeleteDeviceServiceById(ds.Id.Hex()); err != nil {
+	if err := dbClient.DeleteDeviceServiceById(ds.Id); err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}
@@ -523,7 +525,7 @@ func restUpdateServiceLastConnectedById(w http.ResponseWriter, r *http.Request) 
 
 	// Check if the device service exists
 	var ds models.DeviceService
-	if err = dbClient.GetDeviceServiceById(&ds, id); err != nil {
+	if ds, err = dbClient.GetDeviceServiceById(id); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -560,7 +562,7 @@ func restUpdateServiceLastConnectedByName(w http.ResponseWriter, r *http.Request
 
 	// Check if the device service exists
 	var ds models.DeviceService
-	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
+	if ds, err = dbClient.GetDeviceServiceByName(n); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -596,8 +598,9 @@ func restGetServiceById(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	var did string = vars[ID]
 	var res models.DeviceService
+	var err error
 
-	if err := dbClient.GetDeviceServiceById(&res, did); err != nil {
+	if res, err = dbClient.GetDeviceServiceById(did); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
@@ -615,11 +618,12 @@ func restUpdateServiceOpStateById(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	var id string = vars[ID]
 	var os string = vars[OPSTATE]
+	var err error
 
 	// Check the OpState
 	newOs, f := models.GetOperatingState(os)
 	if !f {
-		err := errors.New("Invalid State: " + os + " Must be 'ENABLED' or 'DISABLED'")
+		err = errors.New("Invalid State: " + os + " Must be 'ENABLED' or 'DISABLED'")
 		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -627,7 +631,7 @@ func restUpdateServiceOpStateById(w http.ResponseWriter, r *http.Request) {
 
 	// Check if the device service exists
 	var ds models.DeviceService
-	if err := dbClient.GetDeviceServiceById(&ds, id); err != nil {
+	if ds, err = dbClient.GetDeviceServiceById(id); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -637,7 +641,7 @@ func restUpdateServiceOpStateById(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := updateServiceOpState(ds, newOs, w); err != nil {
+	if err = updateServiceOpState(ds, newOs, w); err != nil {
 		LoggingClient.Error(err.Error())
 		return
 	}
@@ -667,7 +671,7 @@ func restUpdateServiceOpStateByName(w http.ResponseWriter, r *http.Request) {
 
 	// Check if the device service exists
 	var ds models.DeviceService
-	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
+	if ds, err = dbClient.GetDeviceServiceByName(n); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
@@ -701,11 +705,12 @@ func restUpdateServiceAdminStateById(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	var id string = vars[ID]
 	var as string = vars[ADMINSTATE]
+	var err error
 
 	// Check the admin state
 	newAs, f := models.GetAdminState(as)
 	if !f {
-		err := errors.New("Invalid state: " + as + " Must be 'LOCKED' or 'UNLOCKED'")
+		err = errors.New("Invalid state: " + as + " Must be 'LOCKED' or 'UNLOCKED'")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		LoggingClient.Error(err.Error())
 		return
@@ -713,7 +718,7 @@ func restUpdateServiceAdminStateById(w http.ResponseWriter, r *http.Request) {
 
 	// Check if the device service exists
 	var ds models.DeviceService
-	if err := dbClient.GetDeviceServiceById(&ds, id); err != nil {
+	if ds, err = dbClient.GetDeviceServiceById(id); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -724,7 +729,7 @@ func restUpdateServiceAdminStateById(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update the admin state
-	if err := updateServiceAdminState(ds, newAs, w); err != nil {
+	if err = updateServiceAdminState(ds, newAs, w); err != nil {
 		LoggingClient.Error(err.Error())
 		return
 	}
@@ -754,7 +759,7 @@ func restUpdateServiceAdminStateByName(w http.ResponseWriter, r *http.Request) {
 
 	// Check if the device service exists
 	var ds models.DeviceService
-	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
+	if ds, err = dbClient.GetDeviceServiceByName(n); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -798,7 +803,7 @@ func restUpdateServiceLastReportedById(w http.ResponseWriter, r *http.Request) {
 
 	// Check if the devicde service exists
 	var ds models.DeviceService
-	if err = dbClient.GetDeviceServiceById(&ds, id); err != nil {
+	if ds, err = dbClient.GetDeviceServiceById(id); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {
@@ -835,7 +840,7 @@ func restUpdateServiceLastReportedByName(w http.ResponseWriter, r *http.Request)
 
 	// Check if the device service exists
 	var ds models.DeviceService
-	if err = dbClient.GetDeviceServiceByName(&ds, n); err != nil {
+	if ds, err = dbClient.GetDeviceServiceByName(n); err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, "Device service not found", http.StatusNotFound)
 		} else {

--- a/internal/pkg/db/mongo/device.go
+++ b/internal/pkg/db/mongo/device.go
@@ -130,7 +130,7 @@ func (md *mongoDevice) SetBSON(raw bson.Raw) error {
 
 	md.Addressable = a.ToContract()
 	md.Profile = mdp.DeviceProfile
-	md.Service = mds.DeviceService
+	md.Service = mds.DeviceService.ToContract()
 
 	return nil
 }

--- a/internal/pkg/db/mongo/models/addressable.go
+++ b/internal/pkg/db/mongo/models/addressable.go
@@ -17,7 +17,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 	"github.com/globalsign/mgo/bson"
-	"github.com/google/uuid"
 )
 
 type Addressable struct {
@@ -65,26 +64,12 @@ func (a Addressable) ToContract() contract.Addressable {
 }
 
 func (a *Addressable) FromContract(from contract.Addressable) error {
-	// In this first case, ID is empty so this must be an add.
-	// Generate new BSON/UUIDs
-	if from.Id == "" {
-		a.Id = bson.NewObjectId()
-		a.Uuid = uuid.New().String()
-	} else {
-		// In this case, we're dealing with an existing event
-		if !bson.IsObjectIdHex(from.Id) {
-			// EventID is not a BSON ID. Is it a UUID?
-			_, err := uuid.Parse(from.Id)
-			if err != nil { // It is some unsupported type of string
-				return db.ErrInvalidObjectId
-			}
-			// Leave model's ID blank for now. We will be querying based on the UUID.
-			a.Uuid = from.Id
-		} else {
-			// ID of pre-existing event is a BSON ID. We will query using the BSON ID.
-			a.Id = bson.ObjectIdHex(from.Id)
-		}
+	var err error
+	a.Id, a.Uuid, err = FromContractId(from.Id)
+	if err != nil {
+		return err
 	}
+
 	a.Name = from.Name
 	a.Protocol = from.Protocol
 	a.HTTPMethod = from.HTTPMethod

--- a/internal/pkg/db/mongo/models/describedobject.go
+++ b/internal/pkg/db/mongo/models/describedobject.go
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import contract "github.com/edgexfoundry/edgex-go/pkg/models"
+
+type DescribedObject struct {
+	Created  int64 `bson:"created"`
+	Modified int64 `bson:"modified"`
+	Origin   int64 `bson:"origin"`
+
+	Description string `bson:"description"`
+}
+
+func (do *DescribedObject) ToContract() contract.DescribedObject {
+	var to contract.DescribedObject
+
+	to.Created = do.Created
+	to.Modified = do.Modified
+	to.Origin = do.Origin
+	to.Description = do.Description
+
+	return to
+}
+
+func (do *DescribedObject) FromContract(from contract.DescribedObject) {
+	do.Created = from.Created
+	do.Modified = from.Modified
+	do.Origin = from.Origin
+	do.Description = from.Description
+}

--- a/internal/pkg/db/mongo/models/deviceservice.go
+++ b/internal/pkg/db/mongo/models/deviceservice.go
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import (
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
+)
+
+type DeviceService struct {
+	Service    `bson:",inline"`
+	AdminState contract.AdminState `bson:"adminState"` // Device Service Admin State
+}
+
+func (ds *DeviceService) ToContract() contract.DeviceService {
+	return contract.DeviceService{
+		Service:    ds.Service.ToContract(),
+		AdminState: ds.AdminState,
+	}
+}
+
+func (ds *DeviceService) FromContract(from contract.DeviceService) error {
+	var err error
+	if err = ds.Service.FromContract(from.Service); err != nil {
+		return err
+	}
+	ds.AdminState = from.AdminState
+	return nil
+}

--- a/internal/pkg/db/mongo/models/id.go
+++ b/internal/pkg/db/mongo/models/id.go
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/globalsign/mgo/bson"
+	"github.com/google/uuid"
+)
+
+func FromContractId(id string) (bson.ObjectId, string, error) {
+	// In this first case, ID is empty so this must be an add.
+	// Generate new BSON/UUIDs
+	if id == "" {
+		return bson.NewObjectId(), uuid.New().String(), nil
+	}
+
+	// In this case, we're dealing with an existing id
+	if !bson.IsObjectIdHex(id) {
+		// Id is not a BSON ID. Is it a UUID?
+		_, err := uuid.Parse(id)
+		if err != nil { // It is some unsupported type of string
+			return "", "", db.ErrInvalidObjectId
+		}
+		return "", id, nil
+	}
+
+	// ID of pre-existing event is a BSON ID. We will query using the BSON ID.
+	return bson.ObjectIdHex(id), "", nil
+}

--- a/internal/pkg/db/mongo/models/service.go
+++ b/internal/pkg/db/mongo/models/service.go
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import (
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+)
+
+type Service struct {
+	DescribedObject `bson:",inline"`
+	Id              bson.ObjectId           `bson:"_id,omitempty"`
+	Uuid            string                  `bson:"uuid,omitempty"`
+	Name            string                  `bson:"name"`           // time in milliseconds that the device last provided any feedback or responded to any request
+	LastConnected   int64                   `bson:"lastConnected"`  // time in milliseconds that the device last reported data to the core
+	LastReported    int64                   `bson:"lastReported"`   // operational state - either enabled or disabled
+	OperatingState  contract.OperatingState `bson:"operatingState"` // operational state - ether enabled or disableddc
+	Labels          []string                `bson:"labels"`         // tags or other labels applied to the device service for search or other identification needs
+	Addressable     Addressable
+	dbRefs          []mgo.DBRef `bson:"addressable"` // address (MQTT topic, HTTP address, serial bus, etc.) for reaching the service
+}
+
+func (s *Service) ToContract() contract.Service {
+	// Always hand back the UUID as the contract command ID unless it's blank (an old command, for example blackbox test scripts)
+	id := s.Uuid
+	if id == "" {
+		id = s.Id.Hex()
+	}
+
+	return contract.Service{
+		DescribedObject: s.DescribedObject.ToContract(),
+		Id:              id,
+		Name:            s.Name,
+		LastConnected:   s.LastConnected,
+		LastReported:    s.LastReported,
+		OperatingState:  s.OperatingState,
+		Labels:          s.Labels,
+		Addressable:     s.Addressable.ToContract(),
+	}
+}
+
+func (s *Service) FromContract(from contract.Service) error {
+	var err error
+	s.Id, s.Uuid, err = FromContractId(from.Id)
+	if err != nil {
+		return err
+	}
+
+	s.DescribedObject.FromContract(from.DescribedObject)
+	s.Name = from.Name
+	s.LastConnected = from.LastConnected
+	s.LastReported = from.LastReported
+	s.OperatingState = from.OperatingState
+	s.Labels = from.Labels
+	if err = s.Addressable.FromContract(from.Addressable); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/pkg/db/mongo/provision_watcher.go
+++ b/internal/pkg/db/mongo/provision_watcher.go
@@ -94,7 +94,7 @@ func (mpw *mongoProvisionWatcher) SetBSON(raw bson.Raw) error {
 	}
 
 	mpw.Profile = mdp.DeviceProfile
-	mpw.Service = mds.DeviceService
+	mpw.Service = mds.DeviceService.ToContract()
 
 	return nil
 }

--- a/pkg/models/deviceservice.go
+++ b/pkg/models/deviceservice.go
@@ -16,21 +16,18 @@ package models
 
 import (
 	"encoding/json"
-
-	"github.com/globalsign/mgo/bson"
 )
 
 type DeviceService struct {
 	Service
-	AdminState AdminState `bson:"adminState" json:"adminState"` // Device Service Admin State
+	AdminState AdminState `json:"adminState"` // Device Service Admin State
 }
 
 // Custom Marshaling to make empty strings null
 func (ds DeviceService) MarshalJSON() ([]byte, error) {
-
 	test := struct {
 		DescribedObject `json:",inline"`
-		Id              *bson.ObjectId `json:"id"`
+		Id              *string        `json:"id"`
 		Name            *string        `json:"name"`           // time in milliseconds that the device last provided any feedback or responded to any request
 		LastConnected   int64          `json:"lastConnected"`  // time in milliseconds that the device last reported data to the core
 		LastReported    int64          `json:"lastReported"`   // operational state - either enabled or disabled
@@ -64,7 +61,7 @@ func (ds DeviceService) MarshalJSON() ([]byte, error) {
 func (ds *DeviceService) UnmarshalJSON(data []byte) error {
 	type Alias struct {
 		DescribedObject `json:",inline"`
-		Id              bson.ObjectId  `json:"id"`
+		Id              string         `json:"id"`
 		Name            *string        `json:"name"`           // time in milliseconds that the device last provided any feedback or responded to any request
 		LastConnected   int64          `json:"lastConnected"`  // time in milliseconds that the device last reported data to the core
 		LastReported    int64          `json:"lastReported"`   // operational state - either enabled or disabled

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -16,31 +16,30 @@ package models
 
 import (
 	"encoding/json"
-	"github.com/globalsign/mgo/bson"
 )
 
 type Service struct {
-	DescribedObject `bson:",inline"`
-	Id              bson.ObjectId  `bson:"_id,omitempty" json:"id"`
-	Name            string         `bson:"name" json:"name"`                     // time in milliseconds that the device last provided any feedback or responded to any request
-	LastConnected   int64          `bson:"lastConnected" json:"lastConnected"`   // time in milliseconds that the device last reported data to the core
-	LastReported    int64          `bson:"lastReported" json:"lastReported"`     // operational state - either enabled or disabled
-	OperatingState  OperatingState `bson:"operatingState" json:"operatingState"` // operational state - ether enabled or disableddc
-	Labels          []string       `bson:"labels" json:"labels"`                 // tags or other labels applied to the device service for search or other identification needs
-	Addressable     Addressable    `bson:"addressable" json:"addressable"`       // address (MQTT topic, HTTP address, serial bus, etc.) for reaching the service
+	DescribedObject
+	Id             string         `json:"id"`
+	Name           string         `json:"name"`           // time in milliseconds that the device last provided any feedback or responded to any request
+	LastConnected  int64          `json:"lastConnected"`  // time in milliseconds that the device last reported data to the core
+	LastReported   int64          `json:"lastReported"`   // operational state - either enabled or disabled
+	OperatingState OperatingState `json:"operatingState"` // operational state - ether enabled or disableddc
+	Labels         []string       `json:"labels"`         // tags or other labels applied to the device service for search or other identification needs
+	Addressable    Addressable    `json:"addressable"`    // address (MQTT topic, HTTP address, serial bus, etc.) for reaching the service
 }
 
 // Custom Marshaling to make empty strings null
 func (s Service) MarshalJSON() ([]byte, error) {
 	test := struct {
-		DescribedObject `bson:",inline"`
-		Id              *bson.ObjectId `bson:"_id,omitempty" json:"id"`
-		Name            *string        `bson:"name" json:"name"`                     // time in milliseconds that the device last provided any feedback or responded to any request
-		LastConnected   int64          `bson:"lastConnected" json:"lastConnected"`   // time in milliseconds that the device last reported data to the core
-		LastReported    int64          `bson:"lastReported" json:"lastReported"`     // operational state - either enabled or disabled
-		OperatingState  OperatingState `bson:"operatingState" json:"operatingState"` // operational state - ether enabled or disableddc
-		Labels          []string       `bson:"labels" json:"labels"`                 // tags or other labels applied to the device service for search or other identification needs
-		Addressable     Addressable    `bson:"addressable" json:"addressable"`       // address (MQTT topic, HTTP address, serial bus, etc.) for reaching the service
+		DescribedObject
+		Id             *string        `json:"id"`
+		Name           *string        `json:"name"`           // time in milliseconds that the device last provided any feedback or responded to any request
+		LastConnected  int64          `json:"lastConnected"`  // time in milliseconds that the device last reported data to the core
+		LastReported   int64          `json:"lastReported"`   // operational state - either enabled or disabled
+		OperatingState OperatingState `json:"operatingState"` // operational state - ether enabled or disableddc
+		Labels         []string       `json:"labels"`         // tags or other labels applied to the device service for search or other identification needs
+		Addressable    Addressable    `json:"addressable"`    // address (MQTT topic, HTTP address, serial bus, etc.) for reaching the service
 	}{
 		DescribedObject: s.DescribedObject,
 		LastConnected:   s.LastConnected,


### PR DESCRIPTION
Issue 877 - core-metadata DeviceService: Eliminate Mongo Types from Models

* Updated contract to return uuid *string for Id and removed BSON annotations.
* Updated query methods to eliminated references and return result values instead.
* Updated AddDeviceService() to return Id.
* Collapsed common code that translates Id into bson.ObjectId or UUID.

Signed-off-by: Michael Estrin <m.estrin@dell.com>

#877 