### PR TITLE
#1019 Fix Import DeviceProfile crash on Commands with empty Put/Get

### DIFF
--- a/internal/pkg/db/mongo/models/command.go
+++ b/internal/pkg/db/mongo/models/command.go
@@ -78,14 +78,19 @@ func (c *Command) FromContract(from contract.Command) (contractId string, err er
 
 	c.Name = from.Name
 	c.Get = &Get{}
-	err = c.Get.FromContract(*from.Get)
-	if err != nil {
-		return
+	if from.Get != nil {
+		err = c.Get.FromContract(*from.Get)
+		if err != nil {
+			return
+		}
 	}
+
 	c.Put = &Put{}
-	err = c.Put.FromContract(*from.Put)
-	if err != nil {
-		return
+	if from.Put != nil {
+		err = c.Put.FromContract(*from.Put)
+		if err != nil {
+			return
+		}
 	}
 
 	c.Created = from.Created


### PR DESCRIPTION
#1019 Guard against a null pointer dereference in internal/pkg/db/mongo/models/command.go

Signed-off-by: Daniel Harms <jdharms@gmail.com>