### PR TITLE
Added go.mod to config-seed properties folder

### DIFF
--- a/cmd/config-seed/res/properties/go.mod
+++ b/cmd/config-seed/res/properties/go.mod
@@ -1,0 +1,1 @@
+module github.com/edgexfoundry/edgex-go/cmd/config-seed/res/properties


### PR DESCRIPTION
#1030 

This is a preparatory effort and does not have a material effect on the build since GO111MODULE is not explicitly set. Per the issue above, we need to add this file to get the device-sdk-go module to ignore the config-seed/res/properties directories containing semi-colons. Device-sdk-go is our target first module project.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>