### PR TITLE
Fix issues with commands in device profile service

### DIFF
--- a/internal/core/metadata/rest_command.go
+++ b/internal/core/metadata/rest_command.go
@@ -95,7 +95,7 @@ func restUpdateCommand(w http.ResponseWriter, r *http.Request) {
 		// Loop through matched device profiles to ensure the name isn't duplicate
 		for _, profile := range dps {
 			for _, command := range profile.Commands {
-				if command.Name == c.Name && command.Id != c.Id {
+				if command.Name == c.Name {
 					err = errors.New("Error updating command: duplicate command name in device profile")
 					LoggingClient.Error(err.Error())
 					http.Error(w, err.Error(), http.StatusConflict)

--- a/internal/pkg/db/mongo/metadata.go
+++ b/internal/pkg/db/mongo/metadata.go
@@ -557,12 +557,12 @@ func (mc MongoClient) UpdateDeviceProfile(dp contract.DeviceProfile) error {
 
 // Get the device profiles that are currently using the command
 func (mc MongoClient) GetDeviceProfilesUsingCommand(c contract.Command) ([]contract.DeviceProfile, error) {
-	query, err := idToBsonM(c.Id)
+	command, err := mc.getCommandById(c.Id)
 	if err != nil {
 		return []contract.DeviceProfile{}, err
 	}
 
-	dps, err := mc.getDeviceProfiles(bson.M{"commands": bson.M{"$elemMatch": query}})
+	dps, err := mc.getDeviceProfiles(bson.M{"commands.$id": command.Id})
 	if err != nil {
 		return []contract.DeviceProfile{}, err
 	}


### PR DESCRIPTION
This PR addresses two issues and two issues #986 and #987:

First, the logic for determining if a command was associated with a device profile was broken and would always return that there were no commands associated with a device profile.

Second, the logic for determining whether to update a command was out of sync with the RAML and included an unpublished requirement that the ID of the updated command be different. This has been removed.