### PR TITLE
addressing issue_1060  support scheduler not removing intervalAction in memory references

### DIFF
--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -71,7 +71,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	scheduler.LoggingClient = logger.NewClient(internal.CoreCommandServiceKey, false, "", logger.InfoLog)
+	scheduler.LoggingClient = logger.NewClient(internal.SupportSchedulerServiceKey, false, "", logger.InfoLog)
 	scheduler.LoggingClient.Error(err.Error())
 }
 

--- a/internal/support/scheduler/schedule.go
+++ b/internal/support/scheduler/schedule.go
@@ -75,6 +75,7 @@ func deleteIntervalOperation(interval contract.Interval, intervalContext *Interv
 	intervalIdToContextMap[interval.ID] = intervalContext
 	intervalNameToContextMap[interval.Name] = intervalContext
 	delete(intervalIdToContextMap, interval.ID)
+	delete(intervalNameToContextMap, interval.Name)
 }
 
 func addIntervalActionOperation(interval contract.Interval, intervalAction contract.IntervalAction) {
@@ -382,8 +383,13 @@ func(qc *QueueClient)  RemoveIntervalActionQueue(intervalActionId string) error 
 		return errors.New(logMsg)
 	}
 
-	delete(intervalContext.IntervalActionsMap, intervalActionId)
+	action, exists := intervalContext.IntervalActionsMap[intervalActionId]
+	if exists {
+		delete(intervalActionNameToIntervalMap,action.Name)
+	}
 
+	delete(intervalContext.IntervalActionsMap, intervalActionId)
+	
 	LoggingClient.Info(fmt.Sprintf("removed the intervalAction with id: %s", intervalActionId))
 
 	return nil


### PR DESCRIPTION
Addressed issue in support-scheduler where the intervalAction was not being removed fully from scheduler in memory map references.

This was discovered when executing the black box tests in the intervalAction area. 
Fix:  Removed the intervalAction name reference from in memory helper map.  This map was used in validation to determine if an instance of the intervalAction existed without hitting the queue directly. 

Note: a logging key used in main.go was incorrectly logging data using the wrong key.  That as been fixed as well in main.go.

Signed-off-by: xmlviking <ecotter@gmail.com>