### PR TITLE
Registry Abstraction with Consul implementation and use in config-seed/core-data

### DIFF
--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -37,8 +37,8 @@ func main() {
 	flag.StringVar(&dirProperties, "r", "./res/properties", "Specify alternate properties location as absolute path")
 	flag.StringVar(&dirCmd, "cmd", "../cmd", "Specify alternate cmd location as absolute path")
 	flag.StringVar(&dirCmd, "c", "../cmd", "Specify alternate cmd location as absolute path")
-	flag.BoolVar(&overwriteConfig, "overwrite", false, "Overwrite configuration in Consul")
-	flag.BoolVar(&overwriteConfig, "o", false, "Overwrite configuration in Consul")
+	flag.BoolVar(&overwriteConfig, "overwrite", false, "Overwrite configuration in Registry")
+	flag.BoolVar(&overwriteConfig, "o", false, "Overwrite configuration in Registry")
 
 	flag.Usage = usage.HelpCallbackConfigSeed
 	flag.Parse()
@@ -50,11 +50,8 @@ func main() {
 		os.Exit(1)
 	}
 	config.LoggingClient.Info("Service dependencies resolved...")
-	err := config.ImportProperties(dirProperties)
-	if err != nil {
-		config.LoggingClient.Error(err.Error())
-	}
-	err = config.ImportConfiguration(dirCmd, useProfile, overwriteConfig)
+
+	err := config.ImportConfiguration(dirCmd, useProfile, overwriteConfig)
 	if err != nil {
 		config.LoggingClient.Error(err.Error())
 	}

--- a/cmd/config-seed/res/configuration.toml
+++ b/cmd/config-seed/res/configuration.toml
@@ -1,8 +1,5 @@
 ConfigPath = './config'
 GlobalPrefix = 'config'
-ConsulProtocol = 'http'
-ConsulHost = 'localhost'
-ConsulPort = 8500
 IsReset = true
 FailLimit = 30
 FailWaitTime = 3
@@ -13,3 +10,8 @@ EnableRemoteLogging = false
 LoggingFile = './logs/edgex-config-seed.log'
 LoggingRemoteURL = 'http://localhost:48061/api/v1/logs'
 LoggingLevel = 'INFO'
+
+[Registry]
+Host = 'localhost'
+Port = 8500
+Type = 'consul'

--- a/cmd/config-seed/res/docker/configuration.toml
+++ b/cmd/config-seed/res/docker/configuration.toml
@@ -1,8 +1,5 @@
 ConfigPath = './config'
 GlobalPrefix = 'config'
-ConsulProtocol = 'http'
-ConsulHost = 'edgex-core-consul'
-ConsulPort = 8500
 IsReset = true
 FailLimit = 30
 FailWaitTime = 3
@@ -12,3 +9,8 @@ TomlExtensions = ['.toml']
 EnableRemoteLogging = false
 LoggingFile = '/edgex/logs/edgex-config-seed.log'
 LoggingRemoteURL = 'http://edgex-support-logging:48061/api/v1/logs'
+
+[Registry]
+Host = 'edgex-core-consul'
+Port = 8500
+Type = 'consul'

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2017 Dell Inc.
+ * Copyright (c) 2019 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -35,20 +36,21 @@ import (
 
 func main() {
 	start := time.Now()
-	var useConsul bool
+	var useRegistry bool
 	var useProfile string
 
-	flag.BoolVar(&useConsul, "consul", false, "Indicates the service should use consul.")
-	flag.BoolVar(&useConsul, "c", false, "Indicates the service should use consul.")
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
 	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
 	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseConsul: useConsul, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	// TODO: Rename UseConsul to UseRegistry as part of consul cleanup once all services are using Registry abstraction
+	params := startup.BootParams{UseConsul: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
 	startup.Bootstrap(params, data.Retry, logBeforeInit)
 
-	ok := data.Init(useConsul)
+	ok := data.Init(useRegistry)
 	if !ok {
 		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.CoreDataServiceKey))
 		os.Exit(1)

--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -19,6 +19,7 @@ import (
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/mitchellh/consulstructure"
 	"strconv"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/registry/types"
 )
 
 // Configuration struct for consul - used to initialize the service
@@ -30,12 +31,6 @@ type ConsulConfig struct {
 	ServicePort    int
 	CheckAddress   string
 	CheckInterval  string
-}
-
-type ServiceEndpoint struct {
-	Key     string
-	Address string
-	Port    int
 }
 
 var consul *consulapi.Client = nil // Call consulInit to initialize this variable
@@ -101,13 +96,13 @@ func ConsulInit(config ConsulConfig) error {
 	return nil
 }
 
-func GetServiceEndpoint(serviceKey string) (ServiceEndpoint, error) {
+func GetServiceEndpoint(serviceKey string) (types.ServiceEndpoint, error) {
 	services, err := consul.Agent().Services()
 	if err != nil {
-		return ServiceEndpoint{}, err
+		return types.ServiceEndpoint{}, err
 	}
 
-	endpoint := ServiceEndpoint{}
+	endpoint := types.ServiceEndpoint{}
 	for key, service := range services {
 		if key == serviceKey {
 			endpoint.Port = service.Port

--- a/internal/pkg/registry/README.md
+++ b/internal/pkg/registry/README.md
@@ -1,0 +1,107 @@
+# README #
+Registry client library for the Go implementation of EdgeX micro services.  This project contains the abstract Registry interface and an implementation for Consul.
+These interface functions initialize a connection to the Registry service, registering the service for discovery and  health checks, push and pull configuration values to/from the Registry service and pull dependent service endpoint information and status.
+
+### What is this repository for? ###
+* Initialize connection to a Registry service
+* Register the service with the Registry service for discovery, health status and health check callback
+* Push a service's configuration in to the Registry
+* Pull service's configuration from the Registry into its configuration struct
+* Pull service endpoint information from the Registry for dependent services.
+* Check the health status of dependent services via the Registry.
+
+### Installation ###
+TBD once Go Modules is in full use.
+
+### How to Use ###
+This library is used by Go programs for interacting with the configured Registry service (i.e. Consul) and requires that a Registry service be running somewhere that the Registry Client can connect.  The Registry service connection information as well as which registry implementation to use is stored in the service's toml configuration as:
+
+        [Registry]
+        Host = 'localhost'
+        Port = 8500
+        Type = 'consul'
+
+The following code snippets demonstrate how a service uses this Registry module to register, load configuration, listen to for configuration updates and to get dependent service endpoint information.
+
+This code snippet shows how to connect to the Registry and register the service for discovery and health checks. Note that the expected health check callback URL path is "/api/v1/ping" which your service must implement. 
+```
+func connectToRegistry(conf *ConfigurationStruct) (error) {
+	var err error
+
+	registryClient, err := registry.NewRegistryClient(conf.Registry, &conf.Service, internal.CoreDataServiceKey)
+	if err != nil {
+		return fmt.Errorf("connection to Registry could not be made: %v", err.Error())
+	}
+
+	// Register the service with Registry
+	err = registryClient.Register()
+	if err != nil {
+		return fmt.Errorf("could not register service with Registry: %v", err.Error())
+	}
+
+	return nil
+}
+```
+This code snippet shows how to load the service's configuration from the Registry after connecting and registering above.
+```
+    if useRegistry {
+      err = connectToRegistry(configuration)
+      if err != nil {
+        return nil, err
+      }
+
+      rawConfig, err := registry.Client.GetConfiguration(configuration)
+      if err != nil {
+        return configuration, fmt.Errorf("could not get configuration from Registry: %v", err.Error())
+      }
+
+      actual, ok := rawConfig.(*ConfigurationStruct)
+      if !ok {
+        return configuration, fmt.Errorf("configuration from Registry failed type check")
+      }
+
+      configuration = actual
+    }
+```
+This code snippet shows how to listen for configuration changes from the Registry after connecting and registering above.
+Note the reference to the RegistryClient was saved in registry.Client and used here.
+```
+    registry.Client.WatchForChanges(updateChannel, errChannel, &WritableInfo{}, internal.WritableKey)
+
+    for {
+      select {
+      case ex := <-errChannel:
+        LoggingClient.Error(ex.Error())
+
+      case raw, ok := <-updateChannel:
+        if !ok {
+          return
+        }
+
+        actual, ok := raw.(*WritableInfo)
+        if !ok {
+          LoggingClient.Error("listenForConfigChanges() type check failed")
+          return
+        }
+
+        Configuration.Writable = *actual
+
+        LoggingClient.Info("Writeable configuration has been updated. Setting log level to " +
+          Configuration.Writable.LogLevel)
+        LoggingClient.SetLogLevel(Configuration.Writable.LogLevel)
+      }
+    }
+```
+This code snippet shows how to get dependent service endpoint information and check status of the dependent service.
+```
+    ...
+    if registry.Client != nil {
+        endpoint, err = registry.Client.GetServiceEndpoint(params.ServiceKey)
+        url := fmt.Sprintf("http://%s:%v%s", endpoint.Address, endpoint.Port, params.Path)
+        ...
+        if registry.Client.IsServiceAvailable(params.ServiceKey) {
+           ...
+        }
+    } 
+    ...
+```

--- a/internal/pkg/registry/consul/client.go
+++ b/internal/pkg/registry/consul/client.go
@@ -1,0 +1,328 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package consul
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/mitchellh/consulstructure"
+	"github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
+	"strings"
+	"time"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/registry/types"
+)
+
+const consulStatusPath = "/v1/agent/self"
+
+type consulClient struct {
+	ConsulAddress  string
+	ConsulPort     int
+	ServiceName    string
+	ServiceAddress string
+	ServicePort    int
+	CheckAddress   string
+	CheckInterval  string
+	consulClient   *consulapi.Client
+	consulUrl      string
+	consulBasePath string
+}
+
+// Create new Consul Client. Service information is optional, not needed just for configuration, but required if registering
+func NewConsulClient(registryInfo config.RegistryInfo, serviceInfo *config.ServiceInfo, serviceKey string) (*consulClient, error) {
+	client := consulClient{
+		ServiceName:    serviceKey,
+		ConsulAddress:  registryInfo.Host,
+		ConsulPort:     registryInfo.Port,
+		consulUrl:      registryInfo.Host + ":" + strconv.Itoa(registryInfo.Port),
+		consulBasePath: internal.ConfigRegistryStem + serviceKey,
+	}
+
+	// Service Info will be nil when client isn't registering the service
+	if serviceInfo != nil {
+		client.ServicePort = serviceInfo.Port
+		client.ServiceAddress = serviceInfo.Host
+		client.CheckAddress = serviceInfo.HealthCheck()
+		client.CheckInterval = serviceInfo.CheckInterval
+	}
+
+	var err error
+
+	consulConfig := consulapi.DefaultConfig()
+	consulConfig.Address = client.consulUrl
+	client.consulClient, err = consulapi.NewClient(consulConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable for create new Consul Client: %v", err)
+	}
+
+	return &client, nil
+}
+
+// Registers the current service with Consul for discover and health check
+func (client *consulClient) Register() error {
+	if client.ServiceName == "" || client.ServiceAddress == "" {
+		return fmt.Errorf("unable to register service with consul: Service information not set")
+	}
+
+	// Register for service discovery
+	err := client.consulClient.Agent().ServiceRegister(&consulapi.AgentServiceRegistration{
+		Name:    client.ServiceName,
+		Address: client.ServiceAddress,
+		Port:    client.ServicePort,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Register for Health Check
+	err = client.consulClient.Agent().CheckRegister(&consulapi.AgentCheckRegistration{
+		Name:      "Health Check: " + client.ServiceName,
+		Notes:     "Check the health of the API",
+		ServiceID: client.ServiceName,
+		AgentServiceCheck: consulapi.AgentServiceCheck{
+			HTTP:     client.CheckAddress,
+			Interval: client.CheckInterval,
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Puts a full toml configuration into Consul
+func (client *consulClient) PutConfiguration(configuration *toml.Tree, overwrite bool) error {
+
+	configurationMap := configuration.ToMap()
+	keyValues := convertInterfaceToConsulPairs("", configurationMap)
+
+	// Put config properties into Consul.
+	for _, keyValue := range keyValues {
+		exists, _ := client.ConfigurationValueExists(keyValue.Key)
+		if !exists || overwrite {
+			if err := client.PutConfigurationValue(keyValue.Key, []byte(keyValue.Value)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Gets the full configuration from Consul into the target configuration struct.
+// Passed in struct is only a reference for decoder, empty struct is ok
+// Returns the configuration in the target struct as interface{}, which caller must cast
+func (client *consulClient) GetConfiguration(configStruct interface{}) (interface{}, error) {
+	var err error
+	var configuration interface{}
+
+	// Update configuration data from Consul using decoder
+	updateChannel := make(chan interface{})
+	errorChannel := make(chan error)
+	decoder := client.newConsulDecoder()
+	decoder.Target = configStruct
+	decoder.Prefix = client.consulBasePath
+	decoder.ErrCh = errorChannel
+	decoder.UpdateCh = updateChannel
+
+	defer decoder.Close()
+	defer close(updateChannel)
+	defer close(errorChannel)
+	go decoder.Run()
+
+	select {
+	case <-time.After(5 * time.Second):
+		err = errors.New("timeout loading config from client")
+	case ex := <-errorChannel:
+		err = errors.New(ex.Error())
+	case raw := <-updateChannel:
+		configuration = raw
+	}
+
+	return configuration, err
+}
+
+// Sets up a Consul watch for the target key and send back updates on the update channel.
+// Passed in struct is only a reference for decoder, empty struct is ok
+// Sends the configuration in the target struct as interface{} on updateChannel, which caller must cast
+func (client *consulClient) WatchForChanges(updateChannel chan<- interface{}, errorChannel chan<- error, configuration interface{}, watchKey string) {
+
+	// some watch keys may already have the "/", add it for those that don't
+	if !strings.Contains(watchKey, "/") {
+		watchKey = "/" + watchKey
+	}
+
+	decoder := client.newConsulDecoder()
+	decoder.Target = configuration
+	decoder.Prefix = client.consulBasePath + watchKey
+	decoder.ErrCh = errorChannel
+	decoder.UpdateCh = updateChannel
+
+	defer decoder.Close()
+
+	go decoder.Run()
+}
+
+// Simply checks if Consul is up and running at the configured URL
+func (client *consulClient) IsRegistryRunning() bool {
+
+	resp, err := http.Get("http://" + client.consulUrl + consulStatusPath)
+	if err != nil {
+		return false
+	}
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return true
+	}
+
+	return false
+}
+
+// Checks if a configuration value exists in Consul
+func (client *consulClient) ConfigurationValueExists(name string) (bool, error) {
+	keyPair, _, err := client.consulClient.KV().Get(client.fullPath(name), nil)
+	if err != nil {
+		return false, fmt.Errorf("unable to check existence of %s in Consul: %v", client.fullPath(name), err)
+	}
+	return keyPair != nil, nil
+}
+
+// Gets a specific configuration value from Consul
+func (client *consulClient) GetConfigurationValue(name string) ([]byte, error) {
+	keyPair, _, err := client.consulClient.KV().Get(client.fullPath(name), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get value for %s from Consul: %v", client.fullPath(name), err)
+	}
+
+	if keyPair == nil {
+		return nil, nil
+	}
+
+	return keyPair.Value, nil
+}
+
+// Puts a specific configuration value into Consul
+func (client *consulClient) PutConfigurationValue(name string, value []byte) error {
+	keyPair := &consulapi.KVPair{
+		Key:   client.fullPath(name),
+		Value: value,
+	}
+
+	_, err := client.consulClient.KV().Put(keyPair, nil)
+	if err != nil {
+		return fmt.Errorf("unable to put value for %s into Consul: %v", client.fullPath(name), err)
+	}
+	return nil
+}
+
+// Gets the service endpoint information for the target ID from Consul
+func (client *consulClient) GetServiceEndpoint(serviceID string) (types.ServiceEndpoint, error) {
+	services, err := client.consulClient.Agent().Services()
+	if err != nil {
+		return types.ServiceEndpoint{}, err
+	}
+
+	endpoint := types.ServiceEndpoint{}
+	if service, ok := services[serviceID]; ok {
+		endpoint.Port = service.Port
+		endpoint.Key = serviceID
+		endpoint.Address = service.Address
+	}
+
+	return endpoint, nil
+}
+
+// Checks with Consul if the target service is available, i.e. registered and healthy
+func (client *consulClient) IsServiceAvailable(serviceID string) bool {
+	services, err := client.consulClient.Agent().Services()
+	if err != nil {
+		return false
+	}
+	if _, ok := services[serviceID]; !ok {
+		return false
+	}
+	return true
+}
+
+func (client *consulClient) fullPath(name string) string {
+	return client.consulBasePath + "/" + name
+}
+
+type pair struct {
+	Key   string
+	Value string
+}
+
+func convertInterfaceToConsulPairs(path string, interfaceMap interface{}) []*pair {
+	pairs := make([]*pair, 0)
+
+	pathPre := ""
+	if path != "" {
+		pathPre = path + "/"
+	}
+
+	switch interfaceMap.(type) {
+	case []interface{}:
+		for index, item := range interfaceMap.([]interface{}) {
+			nextPairs := convertInterfaceToConsulPairs(pathPre+strconv.Itoa(index), item)
+			pairs = append(pairs, nextPairs...)
+		}
+
+	case map[string]interface{}:
+		for index, item := range interfaceMap.(map[string]interface{}) {
+			nextPairs := convertInterfaceToConsulPairs(pathPre+index, item)
+			pairs = append(pairs, nextPairs...)
+		}
+
+	case int:
+		pairs = append(pairs, &pair{Key: path, Value: strconv.Itoa(interfaceMap.(int))})
+
+	case int64:
+		var value = int(interfaceMap.(int64))
+		pairs = append(pairs, &pair{Key: path, Value: strconv.Itoa(value)})
+
+	case float64:
+		pairs = append(pairs, &pair{Key: path, Value: strconv.FormatFloat(interfaceMap.(float64), 'f', -1, 64)})
+
+	case bool:
+		pairs = append(pairs, &pair{Key: path, Value: strconv.FormatBool(interfaceMap.(bool))})
+
+	case nil:
+		pairs = append(pairs, &pair{Key: path, Value: ""})
+
+	default:
+		pairs = append(pairs, &pair{Key: path, Value: interfaceMap.(string)})
+	}
+
+	return pairs
+}
+
+func (client *consulClient) newConsulDecoder() *consulstructure.Decoder {
+	return &consulstructure.Decoder{
+		Consul: &consulapi.Config{
+			Address: client.ConsulAddress + ":" + strconv.Itoa(client.ConsulPort),
+		},
+	}
+}

--- a/internal/pkg/registry/consul/client_test.go
+++ b/internal/pkg/registry/consul/client_test.go
@@ -1,0 +1,608 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package consul
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/hashicorp/consul/api"
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/registry/types"
+)
+
+const (
+	serviceName        = "consulUnitTest"
+	serviceHost        = "localhost"
+	defaultServicePort = 8000
+	consulBasePath     = internal.ConfigRegistryStem + serviceName + "/"
+)
+
+// change values to localhost and 8500 if you need to run tests against real Consul service running locally
+var (
+	testHost = ""
+	port     = 0
+)
+
+type MyConfig struct {
+	Logging  config.LoggingInfo
+	Service  types.ServiceEndpoint
+	Port     int
+	Host     string
+	LogLevel string
+}
+
+func TestMain(m *testing.M) {
+
+	var testMockServer *httptest.Server
+	if testHost == "" || port != 8500 {
+		mockConsul := NewMockConsul()
+		testMockServer = mockConsul.Start()
+
+		URL, _ := url.Parse(testMockServer.URL)
+		testHost = URL.Hostname()
+		port, _ = strconv.Atoi(URL.Port())
+	}
+
+	exitCode := m.Run()
+	if testMockServer != nil {
+		defer testMockServer.Close()
+	}
+	os.Exit(exitCode)
+}
+
+func TestRegistryRunning(t *testing.T) {
+	client := makeConsulClient(t, defaultServicePort, true)
+	if !client.IsRegistryRunning() {
+		t.Fatal("Consul not running")
+	}
+}
+
+func TestRegisterWithPingCallback(t *testing.T) {
+	doneChan := make(chan bool)
+	expectedHealthCheckPath := "api/v1/ping"
+	receivedPing := false
+
+	// Setup a server to simulate the service for the health check callback
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.Contains(request.URL.Path, expectedHealthCheckPath) {
+
+			switch request.Method {
+			case "GET":
+				fmt.Println("Received ping")
+				receivedPing = true
+
+				writer.Header().Set("Content-Type", "text/plain")
+				writer.Write([]byte("pong"))
+
+				doneChan <- true
+			}
+		}
+	}))
+	defer server.Close()
+
+	fmt.Println("Click this link if running actual Consul in docker container which unable to route back to real localhost:  " + server.URL)
+
+	// Figure out which port the simulated service is running on.
+	serverUrl, _ := url.Parse(server.URL)
+	serverPort, _ := strconv.Atoi(serverUrl.Port())
+
+	client := makeConsulClient(t, serverPort, true)
+	// Make sure service is not already registered.
+	client.consulClient.Agent().ServiceDeregister(client.ServiceName)
+	client.consulClient.Agent().CheckDeregister(client.ServiceName)
+
+	// Try to clean-up after test
+	defer func(client *consulClient) {
+		client.consulClient.Agent().ServiceDeregister(client.ServiceName)
+		client.consulClient.Agent().CheckDeregister(client.ServiceName)
+	}(client)
+
+	// Register the service endpoint and health check callback
+	err := client.Register()
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	go func() {
+		time.Sleep(10 * time.Second)
+		doneChan <- false
+	}()
+
+	<-doneChan
+	assert.True(t, receivedPing, "Never received health check ping")
+}
+
+func TestGetServiceEndpoint(t *testing.T) {
+	expectedNotFoundEndpoint := types.ServiceEndpoint{}
+	expectedFoundEndpoint := types.ServiceEndpoint{
+		Key:     serviceName,
+		Address: serviceHost,
+		Port:    defaultServicePort,
+	}
+
+	client := makeConsulClient(t, defaultServicePort, true)
+	// Make sure service is not already registered.
+	client.consulClient.Agent().ServiceDeregister(client.ServiceName)
+	client.consulClient.Agent().CheckDeregister(client.ServiceName)
+
+	// Try to clean-up after test
+	defer func(client *consulClient) {
+		client.consulClient.Agent().ServiceDeregister(client.ServiceName)
+		client.consulClient.Agent().CheckDeregister(client.ServiceName)
+	}(client)
+
+	// Test for endpoint not found
+	actualEndpoint, err := client.GetServiceEndpoint(client.ServiceName)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.Equal(t, expectedNotFoundEndpoint, actualEndpoint, "Test for endpoint not found result not as expected") {
+		t.Fatal()
+	}
+
+	// Register the service endpoint
+	err = client.Register()
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	// Test endpoint found
+	actualEndpoint, err = client.GetServiceEndpoint(client.ServiceName)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.Equal(t, expectedFoundEndpoint, actualEndpoint, "Test for endpoint found result not as expected") {
+		t.Fatal()
+	}
+}
+
+func TestIsServiceAvailable(t *testing.T) {
+
+	expected := false
+
+	client := makeConsulClient(t, defaultServicePort, true)
+	// Make sure service is not already registered.
+	client.consulClient.Agent().ServiceDeregister(client.ServiceName)
+	client.consulClient.Agent().CheckDeregister(client.ServiceName)
+
+	// Try to clean-up after test
+	defer func(client *consulClient) {
+		client.consulClient.Agent().ServiceDeregister(client.ServiceName)
+		client.consulClient.Agent().CheckDeregister(client.ServiceName)
+	}(client)
+
+	// Test before registering
+	actual := client.IsServiceAvailable(client.ServiceName)
+	if !assert.Equal(t, expected, actual, "IsServiceAvailable result not as expected") {
+		t.Fatal()
+	}
+
+	// Register the service endpoint
+	err := client.Register()
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	// Test before registering
+	expected = true
+	actual = client.IsServiceAvailable(client.ServiceName)
+	if !assert.Equal(t, expected, actual, "IsServiceAvailable result not as expected") {
+		t.Fatal()
+	}
+}
+
+func TestRegisterNoServiceInfoError(t *testing.T) {
+	// Don't set the service info so check for info results in error
+	client := makeConsulClient(t, defaultServicePort, false)
+
+	err := client.Register()
+	if !assert.Error(t, err, "Expected error due to no service info") {
+		t.Fatal()
+	}
+}
+
+func TestConfigurationValueExists(t *testing.T) {
+	key := "Foo"
+	value := []byte("bar")
+	fullKey := consulBasePath + key
+
+	client := makeConsulClient(t, defaultServicePort, true)
+	expected := false
+
+	// Make sure the target key/value doesn't already exists
+	_, err := client.consulClient.KV().Delete(fullKey, nil)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	actual, err := client.ConfigurationValueExists(key)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.Equal(t, expected, actual) {
+		t.Fatal()
+	}
+
+	keyPair := api.KVPair{
+		Key:   fullKey,
+		Value: value,
+	}
+
+	_, err = client.consulClient.KV().Put(&keyPair, nil)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	expected = true
+	actual, err = client.ConfigurationValueExists(key)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.Equal(t, expected, actual) {
+		t.Fatal()
+	}
+}
+
+func TestGetConfigurationValue(t *testing.T) {
+	key := "Foo"
+	expected := []byte("bar")
+	fullKey := consulBasePath + key
+	client := makeConsulClient(t, defaultServicePort, true)
+
+	// Make sure the target key/value exists
+	keyPair := api.KVPair{
+		Key:   fullKey,
+		Value: expected,
+	}
+
+	_, err := client.consulClient.KV().Put(&keyPair, nil)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	actual, err := client.GetConfigurationValue(key)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.Equal(t, expected, actual) {
+		t.Fatal()
+	}
+}
+
+func TestPutConfigurationValue(t *testing.T) {
+	key := "Foo"
+	expected := []byte("bar")
+	expectedFullKey := consulBasePath + key
+	client := makeConsulClient(t, defaultServicePort, true)
+
+	//clean up the the key, if it exists
+	client.consulClient.KV().Delete(expectedFullKey, nil)
+
+	err := client.PutConfigurationValue(key, expected)
+	assert.NoError(t, err)
+
+	keyValue, _, err := client.consulClient.KV().Get(expectedFullKey, nil)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.NotNil(t, keyValue, "%s value not found", expectedFullKey) {
+		t.Fatal()
+	}
+
+	actual := keyValue.Value
+
+	assert.Equal(t, expected, actual)
+
+}
+
+func TestGetConfiguration(t *testing.T) {
+	expected := MyConfig{
+		Logging: config.LoggingInfo{
+			EnableRemote: true,
+			File:         "NONE",
+		},
+		Service: types.ServiceEndpoint{
+			Key:     "Dummy",
+			Address: "10.6.7.8",
+			Port:    8080,
+		},
+		Port:     8000,
+		Host:     "localhost",
+		LogLevel: "debug",
+	}
+
+	client := makeConsulClient(t, defaultServicePort, true)
+
+	client.PutConfigurationValue("Logging/EnableRemote", []byte(strconv.FormatBool(expected.Logging.EnableRemote)))
+	client.PutConfigurationValue("Logging/File", []byte(expected.Logging.File))
+	client.PutConfigurationValue("Service/Key", []byte(expected.Service.Key))
+	client.PutConfigurationValue("Service/Address", []byte(expected.Service.Address))
+	client.PutConfigurationValue("Service/Port", []byte(strconv.Itoa(expected.Service.Port)))
+	client.PutConfigurationValue("Port", []byte(strconv.Itoa(expected.Port)))
+	client.PutConfigurationValue("Host", []byte(expected.Host))
+	client.PutConfigurationValue("LogLevel", []byte(expected.LogLevel))
+
+	result, err := client.GetConfiguration(&MyConfig{})
+	configuration := result.(*MyConfig)
+
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+	if !assert.NotNil(t, configuration) {
+		t.Fatal()
+	}
+
+	assert.Equal(t, expected.Logging.EnableRemote, configuration.Logging.EnableRemote, "Logging.EnableRemote not as expected")
+	assert.Equal(t, expected.Logging.File, configuration.Logging.File, "Logging.File not as expected")
+	assert.Equal(t, expected.Service.Port, configuration.Service.Port, "Service.Port not as expected")
+	assert.Equal(t, expected.Service.Address, configuration.Service.Address, "Service.Address not as expected")
+	assert.Equal(t, expected.Service.Key, configuration.Service.Key, "Service.Key not as expected")
+	assert.Equal(t, expected.Port, configuration.Port, "Port not as expected")
+	assert.Equal(t, expected.Host, configuration.Host, "Host not as expected")
+	assert.Equal(t, expected.LogLevel, configuration.LogLevel, "LogLevel not as expected")
+}
+
+func TestPutConfigurationNoPreviousValues(t *testing.T) {
+	client := makeConsulClient(t, defaultServicePort, true)
+
+	// Make sure the tree of values doesn't exist.
+	client.consulClient.KV().DeleteTree(consulBasePath, nil)
+
+	defer func() {
+		// Clean up
+		client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	}()
+
+	configMap := createKeyValueMap()
+	configuration, err := toml.TreeFromMap(configMap)
+	if err != nil {
+		log.Fatalf("unable to create TOML Tree from map: %v", err)
+	}
+	err = client.PutConfiguration(configuration, false)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	keyValues := convertInterfaceToConsulPairs("", configMap)
+	for _, keyValue := range keyValues {
+		expected := string(keyValue.Value)
+		value, err := client.GetConfigurationValue(keyValue.Key)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		actual := string(value)
+		if !assert.Equal(t, expected, actual, "Values for %s are not equal", keyValue.Key) {
+			t.Fatal()
+		}
+	}
+}
+
+func TestPutConfigurationWithoutOverWrite(t *testing.T) {
+	client := makeConsulClient(t, defaultServicePort, true)
+
+	// Make sure the tree of values doesn't exist.
+	client.consulClient.KV().DeleteTree(consulBasePath, nil)
+
+	defer func() {
+		// Clean up
+		client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	}()
+
+	configMap := createKeyValueMap()
+
+	configuration, _ := toml.TreeFromMap(configMap)
+	err := client.PutConfiguration(configuration, false)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	//Update map with new value and try to overwrite it
+	configMap["int"] = 2
+	configMap["int64"] = 164
+	configMap["float64"] = 2.4
+	configMap["string"] = "bye"
+	configMap["bool"] = false
+
+	// Try to put new values with overwrite = false
+	configuration, _ = toml.TreeFromMap(configMap)
+	err = client.PutConfiguration(configuration, false)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	keyValues := convertInterfaceToConsulPairs("", configMap)
+	for _, keyValue := range keyValues {
+		expected := string(keyValue.Value)
+		value, err := client.GetConfigurationValue(keyValue.Key)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		actual := string(value)
+		if !assert.NotEqual(t, expected, actual, "Values for %s are equal, expected not equal", keyValue.Key) {
+			t.Fatal()
+		}
+	}
+}
+
+func TestPutConfigurationOverWrite(t *testing.T) {
+	client := makeConsulClient(t, defaultServicePort, true)
+
+	// Make sure the tree of values doesn't exist.
+	client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	// Clean up after unit test
+	defer func() {
+		client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	}()
+
+	configMap := createKeyValueMap()
+
+	configuration, _ := toml.TreeFromMap(configMap)
+	err := client.PutConfiguration(configuration, false)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	//Update map with new value and try to overwrite it
+	configMap["int"] = 2
+	configMap["float64"] = 2.4
+	configMap["string"] = "bye"
+	configMap["bool"] = false
+
+	// Try to put new values with overwrite = True
+	configuration, _ = toml.TreeFromMap(configMap)
+	err = client.PutConfiguration(configuration, true)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	keyValues := convertInterfaceToConsulPairs("", configMap)
+	for _, keyValue := range keyValues {
+		expected := string(keyValue.Value)
+		value, err := client.GetConfigurationValue(keyValue.Key)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+		actual := string(value)
+		if !assert.Equal(t, expected, actual, "Values for %s are not equal", keyValue.Key) {
+			t.Fatal()
+		}
+	}
+}
+
+func TestWatchForChanges(t *testing.T) {
+	expectedConfig := MyConfig{
+		Logging: config.LoggingInfo{
+			EnableRemote: true,
+			File:         "NONE",
+		},
+		Service: types.ServiceEndpoint{
+			Key:     "Dummy",
+			Address: "10.6.7.8",
+			Port:    8080,
+		},
+		Port:     8000,
+		Host:     "localhost",
+		LogLevel: "debug",
+	}
+
+	expectedChange := "random"
+
+	client := makeConsulClient(t, defaultServicePort, false)
+
+	// Make sure the tree of values doesn't exist.
+	client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	// Clean up after unit test
+	defer func() {
+		client.consulClient.KV().DeleteTree(consulBasePath, nil)
+	}()
+
+	client.PutConfigurationValue("Logging/EnableRemote", []byte(strconv.FormatBool(expectedConfig.Logging.EnableRemote)))
+	client.PutConfigurationValue("Logging/File", []byte(expectedConfig.Logging.File))
+	client.PutConfigurationValue("Service/Key", []byte(expectedConfig.Service.Key))
+	client.PutConfigurationValue("Service/Address", []byte(expectedConfig.Service.Address))
+	client.PutConfigurationValue("Service/Port", []byte(strconv.Itoa(expectedConfig.Service.Port)))
+	client.PutConfigurationValue("Port", []byte(strconv.Itoa(expectedConfig.Port)))
+	client.PutConfigurationValue("Host", []byte(expectedConfig.Host))
+	client.PutConfigurationValue("LogLevel", []byte(expectedConfig.LogLevel))
+
+	updateChannel := make(chan interface{})
+	errorChannel := make(chan error)
+
+	client.WatchForChanges(updateChannel, errorChannel, &config.LoggingInfo{}, "Logging")
+
+	pass := 1
+	for {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timeout waiting on configuration changes")
+
+		case changes := <-updateChannel:
+			assert.NotNil(t, changes)
+			logInfo := changes.(*config.LoggingInfo)
+
+			// first pass is for Consul Decoder always sending data once watch has been setup. It hasn't actually changed
+			if pass == 1 {
+				if !assert.Equal(t, logInfo.File, expectedConfig.Logging.File) {
+					t.Fatal()
+				}
+
+				// Make a change to logging
+				client.PutConfigurationValue("Logging/File", []byte(expectedChange))
+
+				pass--
+				continue
+			}
+
+			// Now the data should have changed
+			assert.Equal(t, logInfo.File, expectedChange)
+			return
+
+		case waitError := <-errorChannel:
+			t.Fatalf("received WatchForChanges error: %v", waitError)
+		}
+	}
+}
+
+func makeConsulClient(t *testing.T, servicePort int, setServiceInfo bool) *consulClient {
+	registryInfo := config.RegistryInfo{
+		Host: testHost,
+		Port: port,
+	}
+
+	var serviceInfo *config.ServiceInfo = nil
+
+	if setServiceInfo {
+		serviceInfo = &config.ServiceInfo{
+			CheckInterval: "1s",
+			ClientMonitor: 1000,
+			Host:          serviceHost,
+			Port:          servicePort,
+			Protocol:      "http",
+		}
+	}
+
+	client, err := NewConsulClient(registryInfo, serviceInfo, serviceName)
+	if assert.NoError(t, err) == false {
+		t.Fatal()
+	}
+
+	return client
+}
+
+func createKeyValueMap() map[string]interface{} {
+	configMap := make(map[string]interface{})
+
+	configMap["int"] = int(1)
+	configMap["int64"] = int64(64)
+	configMap["float64"] = float64(1.4)
+	configMap["string"] = "hello"
+	configMap["bool"] = true
+
+	return configMap
+}

--- a/internal/pkg/registry/consul/mock_consul.go
+++ b/internal/pkg/registry/consul/mock_consul.go
@@ -1,0 +1,301 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package consul
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"time"
+
+	consulapi "github.com/hashicorp/consul/api"
+)
+
+type MockConsul struct {
+	keyValueStore map[string]*consulapi.KVPair
+	serviceStore  map[string]consulapi.AgentService
+}
+
+func NewMockConsul() *MockConsul {
+	mock := MockConsul{}
+	mock.keyValueStore = make(map[string]*consulapi.KVPair)
+	mock.serviceStore = make(map[string]consulapi.AgentService)
+	return &mock
+}
+
+var keyChannels map[string]chan bool
+var PrefixChannels map[string]chan bool
+
+func (mock *MockConsul) Start() *httptest.Server {
+	keyChannels = make(map[string]chan bool)
+	var consulIndex = 1
+	PrefixChannels = make(map[string]chan bool)
+
+	testMockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.Contains(request.URL.Path, "/v1/kv/") {
+			key := strings.Replace(request.URL.Path, "/v1/kv/", "", 1)
+
+			switch request.Method {
+			case "PUT":
+				body := make([]byte, request.ContentLength)
+				if _, err := io.ReadFull(request.Body, body); err != nil {
+					log.Printf("error reading request body: %s", err.Error())
+				}
+
+				keyValuePair, found := mock.keyValueStore[key]
+				if found {
+					keyValuePair.ModifyIndex++
+					keyValuePair.Value = body
+				} else {
+					keyValuePair = &consulapi.KVPair{
+						Key:         key,
+						Value:       body,
+						ModifyIndex: 1,
+						CreateIndex: 1,
+						Flags:       0,
+						LockIndex:   0,
+					}
+				}
+
+				mock.keyValueStore[key] = keyValuePair
+
+				log.Printf("PUTing new value for %s", key)
+				channel, found := keyChannels[key]
+				if found {
+					channel <- true
+				}
+				for prefix, channel := range PrefixChannels {
+					if strings.HasPrefix(key, prefix) {
+						consulIndex++
+						if channel != nil {
+							channel <- true
+						}
+					}
+				}
+			case "GET":
+				// this is what the wait query parameters will look like "index=1&wait=600000ms"
+				var pairs consulapi.KVPairs
+				var prefixFound bool
+				query := request.URL.Query()
+				waitTime := query.Get("wait")
+				// Recurse parameters are usually set when prefix is monitored,
+				// if found we need to find all keys with prefix set in URL.
+				_, recursefound := query["recurse"]
+				if recursefound {
+					pairs, prefixFound = mock.checkForPrefix(key)
+					if !prefixFound {
+						http.NotFound(writer, request)
+						return
+					}
+					//Default waitime is 30 minutes, overiding it for unit test purpose
+					waitTime = "2s"
+					if waitTime != "" {
+						waitForNextPutPrefix(key, waitTime)
+					}
+					writer.Header().Set("X-Consul-Index", strconv.Itoa(consulIndex))
+				} else {
+					keyValuePair, found := mock.keyValueStore[key]
+					pairs = consulapi.KVPairs{keyValuePair}
+					if !found {
+						http.NotFound(writer, request)
+						return
+					}
+					if waitTime != "" {
+						waitForNextPut(key, waitTime)
+					}
+
+				}
+
+				jsonData, _ := json.MarshalIndent(&pairs, "", "  ")
+
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
+				if _, err := writer.Write(jsonData); err != nil {
+					log.Printf("error writing data response: %s", err.Error())
+				}
+			}
+		} else if strings.HasSuffix(request.URL.Path, "/v1/agent/service/register") {
+			switch request.Method {
+			case "PUT":
+				body := make([]byte, request.ContentLength)
+				if _, err := io.ReadFull(request.Body, body); err != nil {
+					log.Printf("error reading request body: %s", err.Error())
+				}
+				//AgentServiceRegistration struct represents how service registration information is recieved
+				var mockServiceRegister consulapi.AgentServiceRegistration
+
+				//AgentService struct represent how service information is store internally
+				var mockService consulapi.AgentService
+				// unmarshal request body
+				if err := json.Unmarshal(body, &mockServiceRegister); err != nil {
+					log.Printf("error reading request body: %s", err.Error())
+				}
+
+				//Copying over basic fields required for current test cases.
+				mockService.ID = mockServiceRegister.Name
+				mockService.Service = mockServiceRegister.Name
+				mockService.Address = mockServiceRegister.Address
+				mockService.Port = mockServiceRegister.Port
+
+				mock.serviceStore[mockService.ID] = mockService
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
+
+			}
+		} else if strings.HasSuffix(request.URL.Path, "/v1/agent/services") {
+			switch request.Method {
+			case "GET":
+				jsonData, _ := json.MarshalIndent(&mock.serviceStore, "", "  ")
+
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
+				if _, err := writer.Write(jsonData); err != nil {
+					log.Printf("error writing data response: %s", err.Error())
+				}
+
+			}
+		} else if strings.Contains(request.URL.Path, "/v1/agent/service/deregister/") {
+			key := strings.Replace(request.URL.Path, "/v1/agent/service/deregister/", "", 1)
+			switch request.Method {
+			case "PUT":
+				_, ok := mock.serviceStore[key]
+				if ok {
+					delete(mock.serviceStore, key)
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
+
+			}
+		} else if strings.Contains(request.URL.Path, "/v1/agent/self") {
+			switch request.Method {
+			case "GET":
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
+
+			}
+
+		} else if strings.Contains(request.URL.Path, "/agent/check/register") {
+			switch request.Method {
+			case "PUT":
+				//TODO: Need to put in the logic how this data needs to be handled
+				body := make([]byte, request.ContentLength)
+				if _, err := io.ReadFull(request.Body, body); err != nil {
+					log.Printf("error reading request body: %s", err.Error())
+				}
+
+				var healthCheck consulapi.AgentCheckRegistration
+				if err := json.Unmarshal(body, &healthCheck); err != nil {
+					log.Printf("error reading request body: %s", err.Error())
+				}
+
+				//if endpoint for healthcheck is set, then try call the endpoint once after interval.
+				if healthCheck.AgentServiceCheck.HTTP != "" && healthCheck.AgentServiceCheck.Interval != "" {
+					timeout, err := time.ParseDuration(healthCheck.AgentServiceCheck.Interval)
+					if err != nil {
+						log.Printf("Error parsing waitTime %s into a duration: %s", timeout, err.Error())
+					}
+					go func() {
+						time.Sleep(timeout)
+						_, err := http.Get(healthCheck.AgentServiceCheck.HTTP + consulStatusPath)
+						if err != nil {
+							log.Print("Not able to reach health check endpoint")
+						}
+						log.Print("Health check endpoint is reachable!")
+					}()
+
+				}
+
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusOK)
+
+			}
+
+		}
+
+	}))
+
+	return testMockServer
+}
+
+func waitForNextPut(key string, waitTime string) {
+	timeout, err := time.ParseDuration(waitTime)
+	if err != nil {
+		log.Printf("Error parsing waitTime %s into a duration: %s", waitTime, err.Error())
+	}
+	channel := make(chan bool)
+	keyChannels[key] = channel
+	timedOut := false
+	go func() {
+		time.Sleep(timeout)
+		timedOut = true
+		if keyChannels[key] != nil {
+			keyChannels[key] <- true
+			log.Printf("Timed out watching for change on %s", key)
+		}
+	}()
+
+	log.Printf("Watching for change on %s", key)
+	<-channel
+	close(channel)
+	keyChannels[key] = nil
+	if !timedOut {
+		log.Printf("%s changed", key)
+	}
+}
+func waitForNextPutPrefix(key string, waitTime string) {
+	timeout, err := time.ParseDuration(waitTime)
+	if err != nil {
+		log.Printf("Error parsing waitTime %s into a duration: %s", waitTime, err.Error())
+	}
+	channel := make(chan bool)
+	PrefixChannels[key] = channel
+	timedOut := false
+	go func() {
+		time.Sleep(timeout)
+		timedOut = true
+		if PrefixChannels[key] != nil {
+			PrefixChannels[key] <- true
+			log.Printf("Timed out watching for change on %s", key)
+		}
+	}()
+
+	log.Printf("Watching for change on %s", key)
+	<-channel
+	close(channel)
+	PrefixChannels[key] = nil
+	if !timedOut {
+		log.Printf("%s changed", key)
+	}
+}
+
+func (mock *MockConsul) checkForPrefix(prefix string) (consulapi.KVPairs, bool) {
+	var pairs consulapi.KVPairs
+	for k, v := range mock.keyValueStore {
+		if strings.HasPrefix(k, prefix) {
+			pairs = append(pairs, v)
+		}
+	}
+	if len(pairs) == 0 {
+		return nil, false
+	}
+	return pairs, true
+
+}

--- a/internal/pkg/registry/factory.go
+++ b/internal/pkg/registry/factory.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package registry
+
+import (
+	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/registry/consul"
+)
+
+var Client RegistryClient
+
+func NewRegistryClient(registryInfo config.RegistryInfo, serviceInfo *config.ServiceInfo, serviceKey string) (RegistryClient, error) {
+	switch registryInfo.Type {
+	case "consul":
+		var err error
+		Client, err = consul.NewConsulClient(registryInfo, serviceInfo, serviceKey)
+		return Client, err
+	default:
+		return nil, fmt.Errorf("Unknown registry type '%s' requested", registryInfo.Type)
+	}
+}

--- a/internal/pkg/registry/factory_test.go
+++ b/internal/pkg/registry/factory_test.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package registry
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewRegistryClientConsul(t *testing.T) {
+	registryInfo := config.RegistryInfo{Type: "consul", Host: "localhost", Port: 8500}
+	serviceInfo := config.ServiceInfo{Host: "localhost", Port: 8080}
+	serviceKey := "edgex-registry-tests"
+
+	client, err := NewRegistryClient(registryInfo, &serviceInfo, serviceKey)
+	if assert.Nil(t, err, "New consul client failed: ", err) == false {
+		t.Fatal()
+	}
+
+	assert.True(t, client.IsRegistryRunning(), "Consul client should be running")
+}

--- a/internal/pkg/registry/factory_test.go
+++ b/internal/pkg/registry/factory_test.go
@@ -32,5 +32,5 @@ func TestNewRegistryClientConsul(t *testing.T) {
 		t.Fatal()
 	}
 
-	assert.True(t, client.IsRegistryRunning(), "Consul client should be running")
+	assert.False(t, client.IsRegistryRunning(), "Consul service not expected be running")
 }

--- a/internal/pkg/registry/interface.go
+++ b/internal/pkg/registry/interface.go
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package registry
+
+import (
+	"github.com/pelletier/go-toml"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/registry/types"
+)
+
+type RegistryClient interface {
+	// Registers the current service with Registry for discover and health check
+	Register() error
+
+	// Puts a full toml configuration into the Registry
+	PutConfiguration(configuration *toml.Tree, overwrite bool) error
+
+	// Gets the full configuration from Consul into the target configuration struct.
+	// Passed in struct is only a reference for Registry. Empty struct is fine
+	// Returns the configuration in the target struct as interface{}, which caller must cast
+	GetConfiguration(configStruct interface{}) (interface{}, error)
+
+	// Sets up a Consul watch for the target key and send back updates on the update channel.
+	// Passed in struct is only a reference for Registry, empty struct is ok
+	// Sends the configuration in the target struct as interface{} on updateChannel, which caller must cast
+	WatchForChanges(updateChannel chan<- interface{}, errorChannel chan<- error, configuration interface{}, waitKey string)
+
+	// Simply checks if Registry is up and running at the configured URL
+	IsRegistryRunning() bool
+
+	// Checks if a configuration value exists in the Registry
+	ConfigurationValueExists(name string) (bool, error)
+
+	// Gets a specific configuration value from the Registry
+	GetConfigurationValue(name string) ([]byte, error)
+
+	// Puts a specific configuration value into the Registry
+	PutConfigurationValue(name string, value []byte) error
+
+	// Gets the service endpoint information for the target ID from the Registry
+	GetServiceEndpoint(serviceId string) (types.ServiceEndpoint, error)
+
+	// Checks with the Registry if the target service is available, i.e. registered and healthy
+	IsServiceAvailable(serviceID string) bool
+}

--- a/internal/pkg/registry/types/serviceEndpoint.go
+++ b/internal/pkg/registry/types/serviceEndpoint.go
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package types
+
+type ServiceEndpoint struct {
+	Key     string
+	Address string
+	Port    int
+}

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -18,6 +18,7 @@ import (
 	"os"
 )
 
+// TODO: rename consul to registry during consul cleanup once all services have changed to use Registry abstraction
 var usageStr = `
 Usage: %s [options]
 Server Options:

--- a/internal/seed/config/init.go
+++ b/internal/seed/config/init.go
@@ -85,7 +85,7 @@ func initializeConfiguration(useProfile string) (*ConfigurationStruct, error) {
 func initRegistryClient(serviceKey string) (registry.RegistryClient, error) {
 	registryClient, err := registry.NewRegistryClient(Configuration.Registry, nil, serviceKey)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create New Registry: ", err)
+		return nil, fmt.Errorf("unable to create New Registry: %v", err)
 	}
 
 	 if !registryClient.IsRegistryRunning() {

--- a/internal/seed/config/types.go
+++ b/internal/seed/config/types.go
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package config
 
+import "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+
 type ConfigurationStruct struct {
 	ConfigPath                   string
 	GlobalPrefix                 string
 	ConsulProtocol               string
-	ConsulHost                   string
-	ConsulPort                   int
 	IsReset                      bool
 	FailLimit                    int
 	FailWaitTime                 int
@@ -29,4 +29,5 @@ type ConfigurationStruct struct {
 	LoggingFile                  string
 	LoggingRemoteURL             string
 	LoggingLevel                 string
+	Registry                     config.RegistryInfo
 }


### PR DESCRIPTION
This PR is a preview of the new Registry Abstraction interface with Consul implementation and usage in config-seed and core-data. 

Looking for feed back while the Registry module repo is being created and use of Go Modules is completed.