### PR TITLE
Propogating correlation-id through EventPublisher

### DIFF
--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
-	"github.com/edgexfoundry/edgex-go/pkg/models"
 
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/export/distro"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 )

--- a/internal/core/data/device_test.go
+++ b/internal/core/data/device_test.go
@@ -12,19 +12,20 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/messaging"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 
 	"github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/metadata/mocks"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/mock"
 )
 
-var testEvent models.Event
+var testEvent contract.Event
 var testRoutes *mux.Router
 
 const (
@@ -91,25 +92,25 @@ func reset() {
 func newMockDeviceClient() *mocks.DeviceClient {
 	client := &mocks.DeviceClient{}
 
-	mockAddressable := models.Addressable{
+	mockAddressable := contract.Addressable{
 		Address:  "localhost",
 		Name:     "Test Addressable",
 		Port:     3000,
 		Protocol: "http"}
 
-	mockDeviceResultFn := func(id string, ctx context.Context) models.Device {
+	mockDeviceResultFn := func(id string, ctx context.Context) contract.Device {
 		if bson.IsObjectIdHex(id) {
-			return models.Device{Id: id, Name: testDeviceName, Addressable: mockAddressable}
+			return contract.Device{Id: id, Name: testDeviceName, Addressable: mockAddressable}
 		}
-		return models.Device{}
+		return contract.Device{}
 	}
 	client.On("Device", "valid", context.Background()).Return(mockDeviceResultFn, nil)
 	client.On("Device", "404", context.Background()).Return(mockDeviceResultFn,
 		types.NewErrServiceClient(http.StatusNotFound, []byte{}))
 	client.On("Device", mock.Anything, context.Background()).Return(mockDeviceResultFn, fmt.Errorf("some error"))
 
-	mockDeviceForNameResultFn := func(name string, ctx context.Context) models.Device {
-		device := models.Device{Id: uuid.New().String(), Name: name, Addressable: mockAddressable}
+	mockDeviceForNameResultFn := func(name string, ctx context.Context) contract.Device {
+		device := contract.Device{Id: uuid.New().String(), Name: name, Addressable: mockAddressable}
 
 		return device
 	}
@@ -122,9 +123,9 @@ func newMockDeviceClient() *mocks.DeviceClient {
 	return client
 }
 
-func buildReadings() []models.Reading {
+func buildReadings() []contract.Reading {
 	ticks := db.MakeTimestamp()
-	r1 := models.Reading{Id: bson.NewObjectId().Hex(),
+	r1 := contract.Reading{Id: bson.NewObjectId().Hex(),
 		Name:     "Temperature",
 		Value:    "45",
 		Origin:   testOrigin,
@@ -133,7 +134,7 @@ func buildReadings() []models.Reading {
 		Pushed:   ticks,
 		Device:   testDeviceName}
 
-	r2 := models.Reading{Id: bson.NewObjectId().Hex(),
+	r2 := contract.Reading{Id: bson.NewObjectId().Hex(),
 		Name:     "Pressure",
 		Value:    "1.01325",
 		Origin:   testOrigin,
@@ -141,7 +142,7 @@ func buildReadings() []models.Reading {
 		Modified: ticks,
 		Pushed:   ticks,
 		Device:   testDeviceName}
-	readings := []models.Reading{}
+	readings := []contract.Reading{}
 	readings = append(readings, r1, r2)
 	return readings
 }

--- a/internal/core/data/messaging/eventpublisher.go
+++ b/internal/core/data/messaging/eventpublisher.go
@@ -14,7 +14,7 @@
 package messaging
 
 import (
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
 )
 
 // Configuration struct for PubSub

--- a/internal/core/data/messaging/zeromq.go
+++ b/internal/core/data/messaging/zeromq.go
@@ -17,7 +17,7 @@ import (
 	"encoding/json"
 	"sync"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
 	zmq "github.com/pebbe/zmq4"
 )
 

--- a/internal/export/distro/filter.go
+++ b/internal/export/distro/filter.go
@@ -9,14 +9,14 @@ package distro
 import (
 	"fmt"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
 type devIdFilterDetails struct {
 	deviceIDs []string
 }
 
-func newDevIdFilter(filter models.Filter) filterer {
+func newDevIdFilter(filter contract.Filter) filterer {
 
 	filterer := devIdFilterDetails{
 		deviceIDs: filter.DeviceIDs,
@@ -24,7 +24,7 @@ func newDevIdFilter(filter models.Filter) filterer {
 	return filterer
 }
 
-func (filter devIdFilterDetails) Filter(event *models.Event) (bool, *models.Event) {
+func (filter devIdFilterDetails) Filter(event *contract.Event) (bool, *contract.Event) {
 
 	if event == nil {
 		return false, nil
@@ -43,26 +43,26 @@ type valueDescFilterDetails struct {
 	valueDescIDs []string
 }
 
-func newValueDescFilter(filter models.Filter) filterer {
+func newValueDescFilter(filter contract.Filter) filterer {
 	filterer := valueDescFilterDetails{
 		valueDescIDs: filter.ValueDescriptorIDs,
 	}
 	return filterer
 }
 
-func (filter valueDescFilterDetails) Filter(event *models.Event) (bool, *models.Event) {
+func (filter valueDescFilterDetails) Filter(event *contract.Event) (bool, *contract.Event) {
 
 	if event == nil {
 		return false, nil
 	}
 
-	auxEvent := &models.Event{
+	auxEvent := &contract.Event{
 		Pushed:   event.Pushed,
 		Device:   event.Device,
 		Created:  event.Created,
 		Modified: event.Modified,
 		Origin:   event.Origin,
-		Readings: []models.Reading{},
+		Readings: []contract.Reading{},
 	}
 
 	for _, filterId := range filter.valueDescIDs {

--- a/internal/export/distro/filter_test.go
+++ b/internal/export/distro/filter_test.go
@@ -9,7 +9,7 @@ package distro
 import (
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
 const (
@@ -22,15 +22,15 @@ const (
 
 func TestFilterDevice(t *testing.T) {
 	// Filter only accepting events from device 1
-	f := models.Filter{}
+	f := contract.Filter{}
 	f.DeviceIDs = append(f.DeviceIDs, "DEV1")
 
 	// Event from device 1
-	eventDev1 := models.Event{
+	eventDev1 := contract.Event{
 		Device: deviceID1,
 	}
 	// Event from device 2
-	eventDev2 := models.Event{
+	eventDev2 := contract.Event{
 		Device: deviceID2,
 	}
 
@@ -53,10 +53,10 @@ func TestFilterDevice(t *testing.T) {
 }
 
 func TestFilterValue(t *testing.T) {
-	f1 := models.Filter{}
+	f1 := contract.Filter{}
 	f1.ValueDescriptorIDs = append(f1.ValueDescriptorIDs, descriptor1)
 
-	f12 := models.Filter{}
+	f12 := contract.Filter{}
 	f12.ValueDescriptorIDs = append(f12.ValueDescriptorIDs, descriptor1)
 	f12.ValueDescriptorIDs = append(f12.ValueDescriptorIDs, descriptor2)
 
@@ -66,17 +66,17 @@ func TestFilterValue(t *testing.T) {
 	filter12 := newValueDescFilter(f12)
 
 	// event with a value descriptor 1
-	event1 := models.Event{}
-	event1.Readings = append(event1.Readings, models.Reading{Name: descriptor1})
+	event1 := contract.Event{}
+	event1.Readings = append(event1.Readings, contract.Reading{Name: descriptor1})
 
 	// event with a value descriptor 2
-	event2 := models.Event{}
-	event2.Readings = append(event2.Readings, models.Reading{Name: descriptor2})
+	event2 := contract.Event{}
+	event2.Readings = append(event2.Readings, contract.Reading{Name: descriptor2})
 
 	// event with a value descriptor 1 and another 2
-	event12 := models.Event{}
-	event12.Readings = append(event12.Readings, models.Reading{Name: descriptor1})
-	event12.Readings = append(event12.Readings, models.Reading{Name: descriptor2})
+	event12 := contract.Event{}
+	event12.Readings = append(event12.Readings, contract.Reading{Name: descriptor1})
+	event12.Readings = append(event12.Readings, contract.Reading{Name: descriptor2})
 
 	accepted, res := filter1.Filter(nil)
 	if accepted {

--- a/internal/export/distro/format.go
+++ b/internal/export/distro/format.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 	"github.com/google/uuid"
 )
 
@@ -33,7 +33,7 @@ const (
 	full
 )
 
-func (jsonTr jsonFormatter) Format(event *models.Event) []byte {
+func (jsonTr jsonFormatter) Format(event *contract.Event) []byte {
 
 	b, err := json.Marshal(event)
 	if err != nil {
@@ -46,7 +46,7 @@ func (jsonTr jsonFormatter) Format(event *models.Event) []byte {
 type xmlFormatter struct {
 }
 
-func (xmlTr xmlFormatter) Format(event *models.Event) []byte {
+func (xmlTr xmlFormatter) Format(event *contract.Event) []byte {
 	b, err := xml.Marshal(event)
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("Error parsing XML. Error: %s", err.Error()))
@@ -60,7 +60,7 @@ type thingsboardJSONFormatter struct {
 
 // ThingsBoard JSON formatter
 // https://thingsboard.io/docs/reference/gateway-mqtt-api/#telemetry-upload-api
-func (thingsboardjsonTr thingsboardJSONFormatter) Format(event *models.Event) []byte {
+func (thingsboardjsonTr thingsboardJSONFormatter) Format(event *contract.Event) []byte {
 
 	type Device struct {
 		Ts     int64             `json:"ts"`
@@ -142,7 +142,7 @@ type azureFormatter struct {
 }
 
 // Format method does all foramtting job.
-func (af azureFormatter) Format(event *models.Event) []byte {
+func (af azureFormatter) Format(event *contract.Event) []byte {
 	am, err := newAzureMessage()
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("Error creating a new Azure message: %s", err))
@@ -168,7 +168,7 @@ func (af azureFormatter) Format(event *models.Event) []byte {
 type awsFormatter struct {
 }
 
-func (af awsFormatter) Format(event *models.Event) []byte {
+func (af awsFormatter) Format(event *contract.Event) []byte {
 	reported := map[string]interface{}{}
 
 	for _, reading := range event.Readings {
@@ -210,7 +210,7 @@ func (af awsFormatter) Format(event *models.Event) []byte {
 type noopFormatter struct {
 }
 
-func (noopFmt noopFormatter) Format(event *models.Event) []byte {
+func (noopFmt noopFormatter) Format(event *contract.Event) []byte {
 	return []byte{}
 }
 
@@ -254,7 +254,7 @@ type biotFormatter struct {
 }
 
 // Format method does all foramtting job.
-func (af biotFormatter) Format(event *models.Event) []byte {
+func (af biotFormatter) Format(event *contract.Event) []byte {
 	bm, err := newBIoTMessage()
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("error creating a new BIoT message: %s", err))

--- a/internal/export/distro/format_test.go
+++ b/internal/export/distro/format_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
 const (
@@ -24,7 +24,7 @@ const (
 )
 
 func TestJson(t *testing.T) {
-	eventIn := models.Event{
+	eventIn := contract.Event{
 		Device: devID1,
 	}
 
@@ -34,7 +34,7 @@ func TestJson(t *testing.T) {
 		t.Fatal("out should not be nil")
 	}
 
-	var eventOut models.Event
+	var eventOut contract.Event
 	if err := json.Unmarshal(out, &eventOut); err != nil {
 		t.Fatalf("Error unmarshalling event: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestJson(t *testing.T) {
 }
 
 func TestXml(t *testing.T) {
-	eventIn := models.Event{
+	eventIn := contract.Event{
 		Device: devID1,
 	}
 
@@ -54,7 +54,7 @@ func TestXml(t *testing.T) {
 		t.Fatal("out should not be nil")
 	}
 
-	var eventOut models.Event
+	var eventOut contract.Event
 	if err := xml.Unmarshal(out, &eventOut); err != nil {
 		t.Fatalf("Error unmarshalling event: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestXml(t *testing.T) {
 }
 
 func TestThingsBoardJson(t *testing.T) {
-	eventIn := models.Event{
+	eventIn := contract.Event{
 		Device: devID1,
 	}
 
@@ -81,7 +81,7 @@ func TestThingsBoardJson(t *testing.T) {
 }
 
 func TestNoop(t *testing.T) {
-	eventIn := models.Event{
+	eventIn := contract.Event{
 		Device: devID1,
 	}
 
@@ -98,9 +98,9 @@ func TestNoop(t *testing.T) {
 }
 
 func TestAWSIoTJson(t *testing.T) {
-	eventIn := models.Event{}
+	eventIn := contract.Event{}
 
-	eventIn.Readings = append(eventIn.Readings, models.Reading{Device: devID1, Name: readingName1, Value: readingValue1})
+	eventIn.Readings = append(eventIn.Readings, contract.Reading{Device: devID1, Name: readingName1, Value: readingValue1})
 
 	af := awsFormatter{}
 	out := af.Format(&eventIn)
@@ -130,9 +130,9 @@ func TestAWSIoTJson(t *testing.T) {
 }
 
 func TestBIoT(t *testing.T) {
-	eventIn := models.Event{}
+	eventIn := contract.Event{}
 
-	eventIn.Readings = append(eventIn.Readings, models.Reading{Device: devID1, Name: readingName1, Value: readingValue1})
+	eventIn.Readings = append(eventIn.Readings, contract.Reading{Device: devID1, Name: readingName1, Value: readingValue1})
 
 	xf := biotFormatter{}
 	out := xf.Format(&eventIn)

--- a/internal/export/distro/httpsender.go
+++ b/internal/export/distro/httpsender.go
@@ -11,11 +11,16 @@ package distro
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	"github.com/edgexfoundry/edgex-go/pkg/clients"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
 type httpSender struct {
@@ -26,7 +31,7 @@ type httpSender struct {
 const mimeTypeJSON = "application/json"
 
 // newHTTPSender - create http sender
-func newHTTPSender(addr models.Addressable) sender {
+func newHTTPSender(addr contract.Addressable) sender {
 
 	sender := httpSender{
 		url:    addr.Protocol + "://" + addr.Address + ":" + strconv.Itoa(addr.Port) + addr.Path,
@@ -35,17 +40,29 @@ func newHTTPSender(addr models.Addressable) sender {
 	return sender
 }
 
+// Send will send the optionally filtered, compressed, encypted contract.Event via HTTP POST
+// The model.Event is provided in order to obtain the necessary correlation-id.
 func (sender httpSender) Send(data []byte, event *models.Event) bool {
 
 	switch sender.method {
 	case http.MethodPost:
-		response, err := http.Post(sender.url, mimeTypeJSON, bytes.NewReader(data))
+		ctx := context.WithValue(context.Background(), clients.CorrelationHeader, event.CorrelationId)
+		req, err := http.NewRequest(http.MethodPost, sender.url, bytes.NewReader(data))
 		if err != nil {
-			LoggingClient.Error(err.Error())
+			return false
+		}
+		req.Header.Set("Content-Type", mimeTypeJSON)
+
+		c := clients.NewCorrelatedRequest(req, ctx)
+		client := &http.Client{}
+		begin := time.Now()
+		response, err := client.Do(c.Request)
+		if err != nil {
+			LoggingClient.Error(err.Error(), clients.CorrelationHeader, event.CorrelationId, internal.LogDurationKey, time.Since(begin).String())
 			return false
 		}
 		defer response.Body.Close()
-		LoggingClient.Info(fmt.Sprintf("Response: %s", response.Status))
+		LoggingClient.Info(fmt.Sprintf("Response: %s", response.Status), clients.CorrelationHeader, event.CorrelationId, internal.LogDurationKey, time.Since(begin).String())
 	default:
 		LoggingClient.Info(fmt.Sprintf("Unsupported method: %s", sender.method))
 		return false

--- a/internal/export/distro/httpsender_test.go
+++ b/internal/export/distro/httpsender_test.go
@@ -16,7 +16,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
 func TestHttpSender(t *testing.T) {
@@ -27,27 +28,27 @@ func TestHttpSender(t *testing.T) {
 
 	var tests = []struct {
 		name string
-		addr models.Addressable
+		addr contract.Addressable
 	}{
-		{"noMethod", models.Addressable{
+		{"noMethod", contract.Addressable{
 			Protocol: "http",
 			Path:     path}},
-		{"get", models.Addressable{
+		{"get", contract.Addressable{
 			Protocol:   "http",
 			HTTPMethod: http.MethodGet,
 			Path:       path}},
-		{"post", models.Addressable{
+		{"post", contract.Addressable{
 			Protocol:   "http",
 			HTTPMethod: http.MethodPost,
 			Path:       path}},
-		{"postInvalidPort", models.Addressable{
+		{"postInvalidPort", contract.Addressable{
 			Protocol:   "http",
 			HTTPMethod: http.MethodPost,
 			Path:       path,
 			Port:       -1}},
 	}
 
-	var addressableTest models.Addressable
+	var addressableTest contract.Addressable
 	var msg = []byte(msgStr)
 
 	for _, tt := range tests {
@@ -99,7 +100,9 @@ func TestHttpSender(t *testing.T) {
 				addressableTest.Port = port
 			}
 			sender := newHTTPSender(addressableTest)
-			sender.Send(msg, nil)
+
+			e := models.Event{CorrelationId: "test"}
+			sender.Send(msg, &e)
 		})
 	}
 }

--- a/internal/export/distro/influxdb.go
+++ b/internal/export/distro/influxdb.go
@@ -11,7 +11,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 
 	"github.com/influxdata/influxdb/client/v2"
 )
@@ -26,7 +27,7 @@ type influxdbSender struct {
 	database string
 }
 
-func newInfluxDBSender(addr models.Addressable) sender {
+func newInfluxDBSender(addr contract.Addressable) sender {
 	connStr := "http://" + addr.Address + ":" + strconv.Itoa(addr.Port)
 
 	influxdbHTTPInfo := client.HTTPConfig{

--- a/internal/export/distro/mqtt.go
+++ b/internal/export/distro/mqtt.go
@@ -16,7 +16,8 @@ import (
 	"strings"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
 type mqttSender struct {
@@ -25,7 +26,7 @@ type mqttSender struct {
 }
 
 // newMqttSender - create new mqtt sender
-func newMqttSender(addr models.Addressable, cert string, key string) sender {
+func newMqttSender(addr contract.Addressable, cert string, key string) sender {
 	protocol := strings.ToLower(addr.Protocol)
 
 	opts := MQTT.NewClientOptions()

--- a/internal/export/distro/registrations_test.go
+++ b/internal/export/distro/registrations_test.go
@@ -9,15 +9,16 @@ package distro
 import (
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
-func validRegistration() models.Registration {
-	r := models.Registration{}
-	r.Format = models.FormatJSON
-	r.Compression = models.CompNone
-	r.Destination = models.DestMQTT
-	r.Encryption.Algo = models.EncNone
+func validRegistration() contract.Registration {
+	r := contract.Registration{}
+	r.Format = contract.FormatJSON
+	r.Compression = contract.CompNone
+	r.Destination = contract.DestMQTT
+	r.Encryption.Algo = contract.EncNone
 	r.Filter.DeviceIDs = append(r.Filter.DeviceIDs, "dummy1")
 	r.Filter.ValueDescriptorIDs = append(r.Filter.DeviceIDs, "dummy1")
 	return r
@@ -29,7 +30,7 @@ func TestRegistrationInfoUpdate(t *testing.T) {
 		t.Fatal("RegistrationInfo should not be nil")
 	}
 
-	r := models.Registration{}
+	r := contract.Registration{}
 	if ri.update(r) {
 		t.Fatal("An empty registration is not valid")
 	}
@@ -75,7 +76,7 @@ func (sender *dummyStruct) Send(data []byte, event *models.Event) bool {
 	return true
 }
 
-func (sender *dummyStruct) Format(ev *models.Event) []byte {
+func (sender *dummyStruct) Format(ev *contract.Event) []byte {
 	return []byte("")
 }
 
@@ -101,16 +102,20 @@ func TestRegistrationInfoEvent(t *testing.T) {
 	ri.compression = dummy
 
 	// Filter only accepting events from dummyDev
-	f := models.Filter{}
+	f := contract.Filter{}
 	f.DeviceIDs = append(f.DeviceIDs, dummyDev)
 	filter := newDevIdFilter(f)
 
 	ri.filter = append(ri.filter, filter)
 
-	ri.processEvent(&models.Event{
-		Device: dummyDev})
-	ri.processEvent(&models.Event{
-		Device: filterOutDev})
+	e1 := &models.Event{}
+	e1.Device = dummyDev
+	ri.processEvent(e1)
+
+	e2 := &models.Event{}
+	e2.Device = filterOutDev
+	ri.processEvent(e2)
+
 	if dummy.count != 1 {
 		t.Fatal("It should send an event")
 	}
@@ -172,19 +177,19 @@ func TestRegistrationInfoLoop(t *testing.T) {
 func TestUpdateRunningRegistrations(t *testing.T) {
 	running := make(map[string]*registrationInfo)
 
-	if updateRunningRegistrations(running, models.NotifyUpdate{}) == nil {
+	if updateRunningRegistrations(running, contract.NotifyUpdate{}) == nil {
 		t.Error("Err should not be nil")
 	}
-	if updateRunningRegistrations(running, models.NotifyUpdate{
-		Operation: models.NotifyUpdateDelete}) == nil {
+	if updateRunningRegistrations(running, contract.NotifyUpdate{
+		Operation: contract.NotifyUpdateDelete}) == nil {
 		t.Error("Err should not be nil")
 	}
-	if updateRunningRegistrations(running, models.NotifyUpdate{
-		Operation: models.NotifyUpdateUpdate}) == nil {
+	if updateRunningRegistrations(running, contract.NotifyUpdate{
+		Operation: contract.NotifyUpdateUpdate}) == nil {
 		t.Error("Err should not be nil")
 	}
-	if updateRunningRegistrations(running, models.NotifyUpdate{
-		Operation: models.NotifyUpdateAdd}) == nil {
+	if updateRunningRegistrations(running, contract.NotifyUpdate{
+		Operation: contract.NotifyUpdateAdd}) == nil {
 		t.Error("Err should not be nil")
 	}
 

--- a/internal/export/distro/types.go
+++ b/internal/export/distro/types.go
@@ -9,7 +9,10 @@
 
 package distro
 
-import "github.com/edgexfoundry/edgex-go/pkg/models"
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
+)
 
 // Sender - Send interface
 type sender interface {
@@ -18,7 +21,7 @@ type sender interface {
 
 // Formatter - Format interface
 type formatter interface {
-	Format(event *models.Event) []byte
+	Format(event *contract.Event) []byte
 }
 
 // Transformer - Transform interface
@@ -28,5 +31,5 @@ type transformer interface {
 
 // Filter - Filter interface
 type filterer interface {
-	Filter(event *models.Event) (bool, *models.Event)
+	Filter(event *contract.Event) (bool, *contract.Event)
 }

--- a/internal/export/distro/xmpp.go
+++ b/internal/export/distro/xmpp.go
@@ -13,7 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
 
 	"github.com/mattn/go-xmpp"
 )
@@ -28,7 +29,7 @@ type xmppSender struct {
 	stamp   time.Time
 }
 
-func newXMPPSender(addr models.Addressable) sender {
+func newXMPPSender(addr contract.Addressable) sender {
 	protocol := strings.ToLower(addr.Protocol)
 
 	if protocol == "tls" {

--- a/internal/export/distro/zeromq.go
+++ b/internal/export/distro/zeromq.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
 	zmq "github.com/pebbe/zmq4"
 )
 

--- a/internal/pkg/correlation/models/event.go
+++ b/internal/pkg/correlation/models/event.go
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import (
+	"encoding/json"
+
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
+)
+
+type Event struct {
+	CorrelationId string `json:"correlation-id"`
+	contract.Event
+}
+
+// Returns an instance of just the public contract portion of the model Event.
+// I don't like returning a pointer from this method but I have to in order to
+// satisfy the Filter, Format interfaces.
+func (e Event) ToContract() *contract.Event {
+	event := contract.Event{
+		ID:       e.ID,
+		Pushed:   e.Pushed,
+		Device:   e.Device,
+		Created:  e.Created,
+		Modified: e.Modified,
+		Origin:   e.Origin,
+		Event:    e.Event.Event,
+	}
+
+	for _, r := range e.Readings {
+		event.Readings = append(event.Readings, r)
+	}
+	return &event
+}
+
+func (e Event) MarshalJSON() ([]byte, error) {
+	test := struct {
+		CorrelationId *string            `json:"correlation-id,omitempty"`
+		ID            *string            `json:"id,omitempty"`
+		Pushed        int64              `json:"pushed,omitempty"`
+		Device        *string            `json:"device,omitempty"` // Device identifier (name or id)
+		Created       int64              `json:"created,omitempty"`
+		Modified      int64              `json:"modified,omitempty"`
+		Origin        int64              `json:"origin,omitempty"`
+		Schedule      *string            `json:"schedule,omitempty"` // Schedule identifier
+		Event         *string            `json:"event,omitempty"`    // Schedule event identifier
+		Readings      []contract.Reading `json:"readings,omitempty"` // List of readings
+	}{
+		Pushed:   e.Pushed,
+		Created:  e.Created,
+		Modified: e.Modified,
+		Origin:   e.Origin,
+	}
+
+	// Empty strings are null
+	if e.CorrelationId != "" {
+		test.CorrelationId = &e.CorrelationId
+	}
+
+	if e.ID != "" {
+		test.ID = &e.ID
+	}
+	if e.Device != "" {
+		test.Device = &e.Device
+	}
+	if e.Event.Event != "" { //good lord, this is terrible. An Event property on an Event type...
+		test.Event = &e.Event.Event
+	}
+
+	// Empty arrays are null
+	if len(e.Readings) > 0 {
+		test.Readings = e.Readings
+	}
+
+	return json.Marshal(test)
+}

--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -44,7 +44,6 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		Created  int64     `json:"created,omitempty"`
 		Modified int64     `json:"modified,omitempty"`
 		Origin   int64     `json:"origin,omitempty"`
-		Schedule *string   `json:"schedule,omitempty"` // Schedule identifier
 		Event    *string   `json:"event,omitempty"`    // Schedule event identifier
 		Readings []Reading `json:"readings,omitempty"` // List of readings
 	}{


### PR DESCRIPTION
#1089 

Note the following:
* Aliased all imports from `github.com/edgexfoundry/pkg/models` as `contract`
* Introduction of internal/pkg/correlation/model/event.go which wraps the contract event adding a CorrelationID property.
* The above model is sent through the EventPublisher to export-distro
* Export-distro continues to export the regular contract model, as it should, however if exporting via HTTP the correlation-id header is passed to the next endpoint.
* In the case of HTTP export, a log entry is written showing the correlation-id and duration of the call

I have also tested this using a small export client that I've written and I confirmed receipt of the same correlation-id that was generated when the event was ingested by core-data.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>