### PR TITLE
snapcraft.yaml: stage Attribution.txt files for dev svcs into snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -910,12 +910,11 @@ parts:
       cat "./cmd/res/configuration.toml" | \
         sed -e s:\"./device-Modbus.log\":\'\$SNAP_COMMON/device-Modbus.log\': > \
         "$SNAPCRAFT_PART_INSTALL/config/device-modbus/res/configuration.toml"
-
-      # FIXME: no Attribution.txt for 3rd party licenses; probably needs to be
-      # an aggregation of SDK's and this device service...
-
+      install -DT "./cmd/Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/Attribution.txt"
       install -DT "./LICENSE" \
-         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mongo/LICENSE"
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/LICENSE"
+
   device-mqtt:
     source: https://github.com/edgexfoundry/device-mqtt-go.git
     source-depth: 1
@@ -944,11 +943,11 @@ parts:
       install -T "./cmd/res/configuration-driver.toml" \
         "$SNAPCRAFT_PART_INSTALL/config/device-mqtt/res/configuration-driver.toml"
 
-      # FIXME: no Attribution.txt for 3rd party licenses; probably needs to be
-      # an aggregation of SDK's and this device service...
-
+      install -DT "./cmd/Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt/Attribution.txt"
       install -DT "./LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-mqtt/LICENSE"
+
   device-random:
     source: https://github.com/edgexfoundry/device-random.git
     source-depth: 1
@@ -978,8 +977,8 @@ parts:
       install -T "./cmd/res/device.random.yaml" \
         "$SNAPCRAFT_PART_INSTALL/config/device-random/res/device.random.yaml"
 
-      # FIXME: no Attribution.txt for 3rd party licenses; probably needs to be
-      # an aggregation of SDK's and this device service...
-
+      install -DT "./cmd/Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-random/Attribution.txt"
       install -DT "./LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-random/LICENSE"
+


### PR DESCRIPTION
Duplicate of #905 but for master (thus Edinburgh) and also doesn't include the delhi branch).