### PR TITLE
Fixed issues in core-metadata DB test

### DIFF
--- a/internal/core/metadata/interfaces/db.go
+++ b/internal/core/metadata/interfaces/db.go
@@ -72,7 +72,7 @@ type DBClient interface {
 	GetDeviceProfilesByManufacturerModel(man string, mod string) ([]contract.DeviceProfile, error)
 	GetDeviceProfilesByManufacturer(man string) ([]contract.DeviceProfile, error)
 	GetDeviceProfileByName(n string) (contract.DeviceProfile, error)
-	GetDeviceProfilesUsingCommand(c contract.Command) ([]contract.DeviceProfile, error)
+	GetDeviceProfilesByCommandId(id string) ([]contract.DeviceProfile, error)
 
 	// Addressable
 	UpdateAddressable(a contract.Addressable) error

--- a/internal/core/metadata/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/interfaces/mocks/DBClient.go
@@ -836,13 +836,13 @@ func (_m *DBClient) GetDeviceProfilesByModel(m string) ([]models.DeviceProfile, 
 	return r0, r1
 }
 
-// GetDeviceProfilesUsingCommand provides a mock function with given fields: c
-func (_m *DBClient) GetDeviceProfilesUsingCommand(c models.Command) ([]models.DeviceProfile, error) {
-	ret := _m.Called(c)
+// GetDeviceProfilesByCommandId provides a mock function with given fields: c
+func (_m *DBClient) GetDeviceProfilesByCommandId(id string) ([]models.DeviceProfile, error) {
+	ret := _m.Called(id)
 
 	var r0 []models.DeviceProfile
-	if rf, ok := ret.Get(0).(func(models.Command) []models.DeviceProfile); ok {
-		r0 = rf(c)
+	if rf, ok := ret.Get(0).(func(string) []models.DeviceProfile); ok {
+		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]models.DeviceProfile)
@@ -850,8 +850,8 @@ func (_m *DBClient) GetDeviceProfilesUsingCommand(c models.Command) ([]models.De
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(models.Command) error); ok {
-		r1 = rf(c)
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/core/metadata/rest_command.go
+++ b/internal/core/metadata/rest_command.go
@@ -85,7 +85,7 @@ func restUpdateCommand(w http.ResponseWriter, r *http.Request) {
 
 	// Name is changed, make sure the new name doesn't conflict with device profile
 	if c.Name != "" {
-		dps, err := dbClient.GetDeviceProfilesUsingCommand(c)
+		dps, err := dbClient.GetDeviceProfilesByCommandId(c.Id)
 		if err != nil {
 			LoggingClient.Error(err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -163,7 +163,7 @@ func restDeleteCommandById(w http.ResponseWriter, r *http.Request) {
 	var id string = vars[ID]
 
 	// Check if the command exists
-	c, err := dbClient.GetCommandById(id)
+	_, err := dbClient.GetCommandById(id)
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusNotFound)
@@ -171,7 +171,7 @@ func restDeleteCommandById(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if the command is still in use by a device profile
-	isStillInUse, err := isCommandStillInUse(c)
+	isStillInUse, err := isCommandStillInUse(id)
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -199,8 +199,8 @@ func restDeleteCommandById(w http.ResponseWriter, r *http.Request) {
 }
 
 // Helper function to determine if the command is still in use by device profiles
-func isCommandStillInUse(c contract.Command) (bool, error) {
-	dp, err := dbClient.GetDeviceProfilesUsingCommand(c)
+func isCommandStillInUse(id string) (bool, error) {
+	dp, err := dbClient.GetDeviceProfilesByCommandId(id)
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/db/mongo/client_test.go
+++ b/internal/pkg/db/mongo/client_test.go
@@ -48,6 +48,13 @@ func TestMongoDB(t *testing.T) {
 		t.Fatalf("Could not connect: %v", err)
 	}
 	test.TestExportDB(t, mongo)
+
+	config.DatabaseName = "scheduler"
+	mongo, err = NewClient(config)
+	if err != nil {
+		t.Fatalf("Could not connect: %v", err)
+	}
+	test.TestSchedulerDB(t, mongo)
 }
 
 func BenchmarkMongoDB(b *testing.B) {

--- a/internal/pkg/db/mongo/metadata.go
+++ b/internal/pkg/db/mongo/metadata.go
@@ -17,11 +17,11 @@ package mongo
 import (
 	"errors"
 	"fmt"
-	"github.com/globalsign/mgo"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo/models"
 	contract "github.com/edgexfoundry/edgex-go/pkg/models"
+	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 )
 
@@ -323,13 +323,11 @@ func (mc MongoClient) GetAllDevices() ([]contract.Device, error) {
 }
 
 func (mc MongoClient) GetDevicesByProfileId(id string) ([]contract.Device, error) {
-	name, value, err := idToQueryParameters(id)
+	dp, err := mc.getDeviceProfileById(id)
 	if err != nil {
 		return []contract.Device{}, err
 	}
-
-	name = "profile." + name
-	return mc.getDevices(bson.M{name: value})
+	return mc.getDevices(bson.M{"profile.$id": dp.Id})
 }
 
 func (mc MongoClient) GetDeviceById(id string) (contract.Device, error) {
@@ -345,23 +343,19 @@ func (mc MongoClient) GetDeviceByName(n string) (contract.Device, error) {
 }
 
 func (mc MongoClient) GetDevicesByServiceId(id string) ([]contract.Device, error) {
-	name, value, err := idToQueryParameters(id)
+	ds, err := mc.getDeviceServiceById(id)
 	if err != nil {
 		return []contract.Device{}, err
 	}
-
-	name = "service." + name
-	return mc.getDevices(bson.M{name: value})
+	return mc.getDevices(bson.M{"service.$id": ds.Id})
 }
 
 func (mc MongoClient) GetDevicesByAddressableId(id string) ([]contract.Device, error) {
-	name, value, err := idToQueryParameters(id)
+	addr, err := mc.getAddressableById(id)
 	if err != nil {
 		return []contract.Device{}, err
 	}
-
-	name = "addressable." + name
-	return mc.getDevices(bson.M{name: value})
+	return mc.getDevices(bson.M{"addressable.$id": addr.Id})
 }
 
 func (mc MongoClient) GetDevicesWithLabel(l string) ([]contract.Device, error) {
@@ -789,13 +783,11 @@ func (mc MongoClient) GetAllDeviceServices() ([]contract.DeviceService, error) {
 }
 
 func (mc MongoClient) GetDeviceServicesByAddressableId(id string) ([]contract.DeviceService, error) {
-	name, value, err := idToQueryParameters(id)
+	addr, err := mc.getAddressableById(id)
 	if err != nil {
 		return []contract.DeviceService{}, err
 	}
-
-	name = "addressable." + name
-	return mc.getDeviceServices(bson.M{name: value})
+	return mc.getDeviceServices(bson.M{"addressable.$id": addr.Id})
 }
 
 func (mc MongoClient) GetDeviceServicesWithLabel(l string) ([]contract.DeviceService, error) {
@@ -899,33 +891,19 @@ func (mc MongoClient) GetProvisionWatchersByIdentifier(k string, v string) (pw [
 }
 
 func (mc MongoClient) GetProvisionWatchersByServiceId(id string) (pw []contract.ProvisionWatcher, err error) {
-	name, value, err := idToQueryParameters(id)
+	ds, err := mc.getDeviceServiceById(id)
 	if err != nil {
 		return []contract.ProvisionWatcher{}, err
 	}
-
-	name = "service." + name
-	pw, err = mc.getProvisionWatchers(bson.M{name: value})
-	if err != nil {
-		return []contract.ProvisionWatcher{}, err
-	}
-
-	return pw, nil
+	return mc.getProvisionWatchers(bson.M{"service.$id": ds.Id})
 }
 
 func (mc MongoClient) GetProvisionWatchersByProfileId(id string) (pw []contract.ProvisionWatcher, err error) {
-	name, value, err := idToQueryParameters(id)
+	dp, err := mc.getDeviceProfileById(id)
 	if err != nil {
 		return []contract.ProvisionWatcher{}, err
 	}
-
-	name = "profile." + name
-	pw, err = mc.getProvisionWatchers(bson.M{name: value})
-	if err != nil {
-		return []contract.ProvisionWatcher{}, err
-	}
-
-	return pw, nil
+	return mc.getProvisionWatchers(bson.M{"profile.$id": dp.Id})
 }
 
 func (mc MongoClient) GetProvisionWatcherById(id string) (pw contract.ProvisionWatcher, err error) {

--- a/internal/pkg/db/mongo/metadata.go
+++ b/internal/pkg/db/mongo/metadata.go
@@ -74,17 +74,10 @@ func (mc MongoClient) GetScheduleEventsByScheduleName(se *[]contract.ScheduleEve
 }
 
 func (mc MongoClient) GetScheduleEventsByAddressableId(se *[]contract.ScheduleEvent, id string) error {
-	_, err := mc.getAddressableById(id)
-	if err != nil {
-		return err
+	if bson.IsObjectIdHex(id) {
+		return mc.getScheduleEvents(se, bson.M{"addressable" + ".$id": bson.ObjectIdHex(id)})
 	}
-	return err //mc.getDeviceServices(bson.M{"addressable.$id": addr.Id})
-
-	/*
-		if bson.IsObjectIdHex(id) {
-			return mc.getScheduleEvents(se, bson.M{"addressable" + ".$id": bson.ObjectIdHex(id)})
-		}
-		return errors.New("mgoGetScheduleEventsByAddressableId Invalid Object ID" + id)*/
+	return errors.New("mgoGetScheduleEventsByAddressableId Invalid Object ID" + id)
 }
 
 func (mc MongoClient) GetScheduleEventsByServiceName(se *[]contract.ScheduleEvent, n string) error {

--- a/internal/pkg/db/mongo/metadata.go
+++ b/internal/pkg/db/mongo/metadata.go
@@ -74,10 +74,17 @@ func (mc MongoClient) GetScheduleEventsByScheduleName(se *[]contract.ScheduleEve
 }
 
 func (mc MongoClient) GetScheduleEventsByAddressableId(se *[]contract.ScheduleEvent, id string) error {
-	if bson.IsObjectIdHex(id) {
-		return mc.getScheduleEvents(se, bson.M{"addressable" + ".$id": bson.ObjectIdHex(id)})
+	_, err := mc.getAddressableById(id)
+	if err != nil {
+		return err
 	}
-	return errors.New("mgoGetScheduleEventsByAddressableId Invalid Object ID" + id)
+	return err //mc.getDeviceServices(bson.M{"addressable.$id": addr.Id})
+
+	/*
+		if bson.IsObjectIdHex(id) {
+			return mc.getScheduleEvents(se, bson.M{"addressable" + ".$id": bson.ObjectIdHex(id)})
+		}
+		return errors.New("mgoGetScheduleEventsByAddressableId Invalid Object ID" + id)*/
 }
 
 func (mc MongoClient) GetScheduleEventsByServiceName(se *[]contract.ScheduleEvent, n string) error {
@@ -550,8 +557,8 @@ func (mc MongoClient) UpdateDeviceProfile(dp contract.DeviceProfile) error {
 }
 
 // Get the device profiles that are currently using the command
-func (mc MongoClient) GetDeviceProfilesUsingCommand(c contract.Command) ([]contract.DeviceProfile, error) {
-	command, err := mc.getCommandById(c.Id)
+func (mc MongoClient) GetDeviceProfilesByCommandId(id string) ([]contract.DeviceProfile, error) {
+	command, err := mc.getCommandById(id)
 	if err != nil {
 		return []contract.DeviceProfile{}, err
 	}

--- a/internal/pkg/db/test/db_metadata.go
+++ b/internal/pkg/db/test/db_metadata.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
+	dataBase "github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
 	"github.com/globalsign/mgo/bson"
 	"github.com/google/uuid"
@@ -684,7 +685,7 @@ func testDBDeviceService(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 deviceServices instead of %d", len(deviceServices))
 	}
 	deviceServices, err = db.GetDeviceServicesByAddressableId(uuid.New().String())
-	if err != nil {
+	if err != dataBase.ErrNotFound {
 		t.Fatalf("Error getting deviceServices by addressable id")
 	}
 
@@ -1254,7 +1255,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 	}
 
 	devices, err = db.GetDevicesByProfileId(uuid.New().String())
-	if err != nil {
+	if err != dataBase.ErrNotFound {
 		t.Fatalf("Error getting devices %v", err)
 	}
 	if len(devices) != 0 {
@@ -1270,7 +1271,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 	}
 
 	devices, err = db.GetDevicesByServiceId(uuid.New().String())
-	if err != nil {
+	if err != dataBase.ErrNotFound {
 		t.Fatalf("Error getting devices %v", err)
 	}
 	if len(devices) != 0 {
@@ -1286,7 +1287,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 	}
 
 	devices, err = db.GetDevicesByAddressableId(uuid.New().String())
-	if err != nil {
+	if err != dataBase.ErrNotFound {
 		t.Fatalf("Error getting devices %v", err)
 	}
 	if len(devices) != 0 {
@@ -1393,7 +1394,7 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 	}
 
 	provisionWatchers, err = db.GetProvisionWatchersByServiceId(uuid.New().String())
-	if err != nil {
+	if err != dataBase.ErrNotFound {
 		t.Fatalf("Error getting provisionWatchers %v", err)
 	}
 	if len(provisionWatchers) != 0 {
@@ -1409,7 +1410,7 @@ func testDBProvisionWatcher(t *testing.T, db interfaces.DBClient) {
 	}
 
 	provisionWatchers, err = db.GetProvisionWatchersByProfileId(uuid.New().String())
-	if err != nil {
+	if err != dataBase.ErrNotFound {
 		t.Fatalf("Error getting provisionWatchers %v", err)
 	}
 	if len(provisionWatchers) != 0 {

--- a/internal/pkg/db/test/db_metadata.go
+++ b/internal/pkg/db/test/db_metadata.go
@@ -1147,10 +1147,7 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 0 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	c := models.Command{}
-	c.Id = dp.Commands[0].Id
-
-	deviceProfiles, err = db.GetDeviceProfilesUsingCommand(c)
+	deviceProfiles, err = db.GetDeviceProfilesByCommandId(dp.Commands[0].Id)
 	if err != nil {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
@@ -1158,9 +1155,8 @@ func testDBDeviceProfile(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 deviceProfiles instead of %d", len(deviceProfiles))
 	}
 
-	c.Id = uuid.New().String()
-	deviceProfiles, err = db.GetDeviceProfilesUsingCommand(c)
-	if err != nil {
+	deviceProfiles, err = db.GetDeviceProfilesByCommandId(uuid.New().String())
+	if err != dataBase.ErrNotFound {
 		t.Fatalf("Error getting deviceProfiles %v", err)
 	}
 	if len(deviceProfiles) != 0 {

--- a/internal/pkg/db/test/db_scheduler.go
+++ b/internal/pkg/db/test/db_scheduler.go
@@ -1,0 +1,288 @@
+//
+// Copyright (c) 2018 Cavium
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/interfaces"
+	contract "github.com/edgexfoundry/edgex-go/pkg/models"
+)
+
+func TestSchedulerDB(t *testing.T, db interfaces.DBClient) {
+	testDBInterval(t, db)
+	testDBIntervalAction(t, db)
+
+	db.CloseSession()
+	// Calling CloseSession twice to test that there is no panic when closing an
+	// already closed db
+	db.CloseSession()
+}
+
+func populateIntervals(db interfaces.DBClient, count int) (string, error) {
+	var id string
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("name%d", i)
+		mi := contract.Interval{}
+		mi.Name = name
+		var err error
+		id, err = db.AddInterval(mi)
+		if err != nil {
+			return id, err
+		}
+	}
+	return id, nil
+}
+
+func populateIntervalActions(db interfaces.DBClient, count int) (string, error) {
+	var id string
+	for i := 0; i < count; i++ {
+		mi := contract.IntervalAction{}
+		mi.Name = fmt.Sprintf("name%d", i)
+		mi.Target = fmt.Sprintf("target%d", i)
+		mi.Interval = fmt.Sprintf("interval%d", i)
+		var err error
+		id, err = db.AddIntervalAction(mi)
+		if err != nil {
+			return id, err
+		}
+	}
+	return id, nil
+}
+
+func testDBInterval(t *testing.T, db interfaces.DBClient) {
+	_, err := db.ScrubAllIntervals()
+	if err != nil {
+		t.Fatalf("Error removing all intervals")
+	}
+
+	mis, err := db.Intervals()
+	if err != nil {
+		t.Fatalf("Error getting intervals %v", err)
+	}
+	if len(mis) != 0 {
+		t.Fatalf("There should be 0 mis instead of %d", len(mis))
+	}
+
+	id, err := populateIntervals(db, 110)
+	if err != nil {
+		t.Fatalf("Error populating db: %v\n", err)
+	}
+
+	_, err = populateIntervals(db, 110)
+	if err == nil {
+		t.Fatalf("Should be an error adding a new interval with the same name\n")
+	}
+
+	mis, err = db.Intervals()
+	if err != nil {
+		t.Fatalf("Error getting intervals %v", err)
+	}
+	if len(mis) != 110 {
+		t.Fatalf("There should be 110 intervals instead of %d", len(mis))
+	}
+
+	mis, err = db.IntervalsWithLimit(50)
+	if err != nil {
+		t.Fatalf("Error getting intervals with limit: %v", err)
+	}
+	if len(mis) != 50 {
+		t.Fatalf("There should be 50 intervals, not %d", len(mis))
+	}
+
+	mi, err := db.IntervalById(id)
+	if err != nil {
+		t.Fatalf("Error getting interval by id %v", err)
+	}
+	if mi.ID != id {
+		t.Fatalf("Id does not match %s - %s", mi.ID, id)
+	}
+
+	_, err = db.IntervalById("INVALID")
+	if err == nil {
+		t.Fatalf("Interval should not be found")
+	}
+
+	mi, err = db.IntervalByName("name1")
+	if err != nil {
+		t.Fatalf("Error getting interval by id %v", err)
+	}
+	if mi.Name != "name1" {
+		t.Fatalf("Name does not match %s - name1", mi.Name)
+	}
+	_, err = db.IntervalByName("INVALID")
+	if err == nil {
+		t.Fatalf("Interval should not be found")
+	}
+
+	mi = contract.Interval{}
+	mi.ID = id
+	mi.Name = "name"
+	err = db.UpdateInterval(mi)
+	if err != nil {
+		t.Fatalf("Error updating interval %v", err)
+	}
+	mi2, err := db.IntervalById(mi.ID)
+	if err != nil {
+		t.Fatalf("Error getting interval by id %v", err)
+	}
+	if mi2.Name != mi.Name {
+		t.Fatalf("Did not update interval correctly: %s %s", mi.Name, mi2.Name)
+	}
+
+	err = db.DeleteIntervalById("INVALID")
+	if err == nil {
+		t.Fatalf("Interval should not be deleted")
+	}
+
+	err = db.DeleteIntervalById(id)
+	if err != nil {
+		t.Fatalf("Interval should be deleted: %v", err)
+	}
+
+	err = db.UpdateInterval(mi)
+	if err == nil {
+		t.Fatalf("Update should return error")
+	}
+
+	_, err = db.ScrubAllIntervals()
+	if err != nil {
+		t.Fatalf("Error removing all intervals")
+	}
+}
+
+func testDBIntervalAction(t *testing.T, db interfaces.DBClient) {
+	_, err := db.ScrubAllIntervalActions()
+	if err != nil {
+		t.Fatalf("Error removing all IntervalActions")
+	}
+
+	ias, err := db.IntervalActions()
+	if err != nil {
+		t.Fatalf("Error getting IntervalActions %v", err)
+	}
+	if len(ias) != 0 {
+		t.Fatalf("There should be 0 ias instead of %d", len(ias))
+	}
+
+	id, err := populateIntervalActions(db, 110)
+	if err != nil {
+		t.Fatalf("Error populating db: %v\n", err)
+	}
+
+	_, err = populateIntervalActions(db, 110)
+	if err == nil {
+		t.Fatalf("Should be an error adding a new IntervalAction with the same name\n")
+	}
+
+	ias, err = db.IntervalActions()
+	if err != nil {
+		t.Fatalf("Error getting IntervalActions %v", err)
+	}
+	if len(ias) != 110 {
+		t.Fatalf("There should be 110 IntervalActions instead of %d", len(ias))
+	}
+
+	ias, err = db.IntervalActionsWithLimit(50)
+	if err != nil {
+		t.Fatalf("Error getting IntervalActions with limit: %v", err)
+	}
+	if len(ias) != 50 {
+		t.Fatalf("There should be 50 IntervalActions, not %d", len(ias))
+	}
+
+	ia, err := db.IntervalActionById(id)
+	if err != nil {
+		t.Fatalf("Error getting IntervalAction by id %v", err)
+	}
+	if ia.ID != id {
+		t.Fatalf("Id does not match %s - %s", ia.ID, id)
+	}
+
+	_, err = db.IntervalActionById("INVALID")
+	if err == nil {
+		t.Fatalf("IntervalAction should not be found")
+	}
+
+	ia, err = db.IntervalActionByName("name1")
+	if err != nil {
+		t.Fatalf("Error getting IntervalAction by id %v", err)
+	}
+	if ia.Name != "name1" {
+		t.Fatalf("Name does not match %s - name1", ia.Name)
+	}
+	_, err = db.IntervalActionByName("INVALID")
+	if err == nil {
+		t.Fatalf("IntervalAction should not be found")
+	}
+
+	ias, err = db.IntervalActionsByTarget("target1")
+	if err != nil {
+		t.Fatalf("Error getting IntervalActionsByTarget: %v", err)
+	}
+	if len(ias) != 1 {
+		t.Fatalf("There should be 1 IntervalActions, not %d", len(ias))
+	}
+	ias, err = db.IntervalActionsByTarget("INVALID")
+	if err != nil {
+		t.Fatalf("Error getting IntervalActionsByTarget: %v", err)
+	}
+	if len(ias) != 0 {
+		t.Fatalf("There should be 0 IntervalActions, not %d", len(ias))
+	}
+
+	ias, err = db.IntervalActionsByIntervalName("interval1")
+	if err != nil {
+		t.Fatalf("Error getting IntervalActionsByIntervalName: %v", err)
+	}
+	if len(ias) != 1 {
+		t.Fatalf("There should be 1 IntervalActions, not %d", len(ias))
+	}
+	ias, err = db.IntervalActionsByIntervalName("INVALID")
+	if err != nil {
+		t.Fatalf("Error getting IntervalActionsByIntervalName: %v", err)
+	}
+	if len(ias) != 0 {
+		t.Fatalf("There should be 0 IntervalActions, not %d", len(ias))
+	}
+
+	ia = contract.IntervalAction{}
+	ia.ID = id
+	ia.Name = "name"
+	err = db.UpdateIntervalAction(ia)
+	if err != nil {
+		t.Fatalf("Error updating IntervalAction %v", err)
+	}
+	ia2, err := db.IntervalActionById(ia.ID)
+	if err != nil {
+		t.Fatalf("Error getting IntervalAction by id %v", err)
+	}
+	if ia2.Name != ia.Name {
+		t.Fatalf("Did not update IntervalAction correctly: %s %s", ia.Name, ia2.Name)
+	}
+
+	err = db.DeleteIntervalActionById("INVALID")
+	if err == nil {
+		t.Fatalf("IntervalAction should not be deleted")
+	}
+
+	err = db.DeleteIntervalActionById(id)
+	if err != nil {
+		t.Fatalf("IntervalAction should be deleted: %v", err)
+	}
+
+	err = db.UpdateIntervalAction(ia)
+	if err == nil {
+		t.Fatalf("Update should return error")
+	}
+
+	_, err = db.ScrubAllIntervalActions()
+	if err != nil {
+		t.Fatalf("Error removing all IntervalActions")
+	}
+}


### PR DESCRIPTION
This PR fixes several issues in data base test (related with #977).
Anyway, MongoDB test still fails in core-metadata:
```
$ go test -tags mongoRunning
--- FAIL: TestMongoDB (0.20s)
    client_test.go:24: This test needs to have a running mongo on localhost
    db_metadata.go:684: There should be 1 deviceServices instead of 0
FAIL
exit status 1
FAIL	github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo	0.198s
```
This seems to be a bad implementation in `GetDeviceServicesByAddressableId()` and several similar functions (`GetScheduleEventsByAddressableId()` or `GetDevicesByProfileId()`) 

Signed-off-by: Joan Duran <jduran@circutor.com>