### PR TITLE
snap/build.sh: fix typo in job name for snap release job

### DIFF
--- a/snap/build.sh
+++ b/snap/build.sh
@@ -21,7 +21,7 @@ if [ ! -z "$JENKINS_URL" ]; then
     JOB_TYPE="build"
     if [[ "$JOB_NAME" =~ edgex-go-snap-.*-stage-snap.* ]]; then
         JOB_TYPE="stage"
-    elif [[ "$JOB_NAME" =~ edgex-go-snap-.*-release-snap.* ]]; then
+    elif [[ "$JOB_NAME" =~ edgex-go-snap-release-snap ]]; then
         JOB_TYPE="release"
     fi
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -637,7 +637,7 @@ parts:
       - -usr/share/alsa
   cassandra:
     plugin: dump
-    source: http://apache.claz.org/cassandra/3.11.3/apache-cassandra-3.11.3-bin.tar.gz
+    source: http://apache.claz.org/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz
     source-type: tar
     build-packages:
       - ant-optional


### PR DESCRIPTION
This regex would never match the verbatim "edgex-go-snap-release-snap", so just make it check for that exact job name to trigger a release build in the script

This will unblock https://github.com/edgexfoundry/ci-management/pull/281 as per https://github.com/edgexfoundry/ci-management/pull/281#issuecomment-462889828

Also since now building the snap is broken due to the removal of cassandra 3.11.3 download link, I have fixed that by just updating the URL here, however we should look for a more long term solution than just updating the link everytime they change it. This issue is filed as https://github.com/edgexfoundry/edgex-go/issues/1103