### PR TITLE
snapcraft.yaml: fix architectures key

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,8 +14,8 @@ icon: snap/local/assets/edgex-snap-icon.png
 
 # TODO: add armhf here when that's supported
 architectures: 
-  - arm64
-  - amd64
+  - build-on: arm64
+  - build-on: amd64
 
 # TODO: upgrade to stable before releasing to beta/candidate/stable
 grade: devel


### PR DESCRIPTION
The current architectures key worked with the old snapcraft, but this
is now interpreted as the snap being a multiarch snap.

Currently, if the snap is built it with a recent version of snapcraft it shows up as "edgexfoundry_..._multi.snap", which is wrong.