### PR TITLE
Fix modbus/mqtt profile links in docs

### DIFF
--- a/docs/examples/Ch-ExamplesAddingMQTTDevice.rst
+++ b/docs/examples/Ch-ExamplesAddingMQTTDevice.rst
@@ -80,8 +80,8 @@ The DeviceProfile defines the device's values and operation method, which can be
         :scale: 50%
         :alt: Device profile
 
-You can download and use the provided :download:`modbus.test.device.profile.yml
-<modbus.test.device.profile.yml>`.
+You can download and use the provided :download:`mqtt.test.device.profile.yml
+<mqtt.test.device.profile.yml>`.
 
 
 Set Up Device Service Configuration

--- a/docs/examples/Ch-ExamplesAddingModbusDevice.rst
+++ b/docs/examples/Ch-ExamplesAddingModbusDevice.rst
@@ -73,8 +73,8 @@ Set Up Device Profile
 
 The DeviceProfile defines the device's values and operation method, which can be Read or Write. 
 
-You can download and use the provided :download:`mqtt.test.device.profile.yml
-<mqtt.test.device.profile.yml>`.
+You can download and use the provided :download:`modbus.test.device.profile.yml
+<modbus.test.device.profile.yml>`.
 
 In the Modbus protocol, we must define attributes: 
 


### PR DESCRIPTION
Fix swapped filenames for device profiles between MQTT and ModBus tutorials. Fixes #1095

Signed-off-by: Michael Hall <mhall119@gmail.com>