### PR TITLE
Caching go module deps via Docker COPY

### DIFF
--- a/cmd/config-seed/Dockerfile
+++ b/cmd/config-seed/Dockerfile
@@ -19,17 +19,24 @@
 FROM golang:1.11.2-alpine3.7 AS build-env
 
 # environment variables
+ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:$PATH
 
 # set the working directory
 WORKDIR $GOPATH/src/github.com/edgexfoundry/edgex-go
 
+RUN apk update && apk add make git
+
 # copy go source files
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
 
 # build
-RUN apk update && apk add make git
 RUN make prepare
 RUN make cmd/config-seed/config-seed
 

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -8,6 +8,7 @@
 
 FROM golang:1.11.2-alpine3.7 AS builder
 
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -16,7 +17,14 @@ RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
     echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add make git
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
+
 RUN make cmd/core-command/core-command
 
 FROM scratch

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -8,6 +8,8 @@
 
 # Docker image for Golang Core Data micro service 
 FROM golang:1.11.2-alpine3.7 AS builder
+
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -17,7 +19,14 @@ RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
 
 
 RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base git
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
+
 RUN make cmd/core-data/core-data
 
 #Next image - Copy built Go binary into new workspace

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -7,6 +7,8 @@
 #
 
 FROM golang:1.11.2-alpine3.7 AS builder
+
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -16,6 +18,12 @@ RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
 
 
 RUN apk update && apk add make git
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
 RUN make cmd/core-metadata/core-metadata
 

--- a/cmd/export-client/Dockerfile
+++ b/cmd/export-client/Dockerfile
@@ -7,6 +7,8 @@
 #
 
 FROM golang:1.11.2-alpine3.7 AS builder
+
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -16,6 +18,12 @@ RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
 
 
 RUN apk update && apk add make git
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
 RUN make cmd/export-client/export-client
 

--- a/cmd/export-distro/Dockerfile
+++ b/cmd/export-distro/Dockerfile
@@ -7,6 +7,8 @@
 #
 
 FROM golang:1.11.2-alpine3.7 AS builder
+
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -16,6 +18,12 @@ RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
 
 
 RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base git
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
 RUN make cmd/export-distro/export-distro
 

--- a/cmd/support-logging/Dockerfile
+++ b/cmd/support-logging/Dockerfile
@@ -6,6 +6,8 @@
 #
 
 FROM golang:1.11.2-alpine3.7 AS builder
+
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -15,6 +17,12 @@ RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
 
 
 RUN apk update && apk add make && apk add bash git
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
 RUN make cmd/support-logging/support-logging
 

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -6,6 +6,8 @@
 #
 
 FROM golang:1.11.2-alpine3.7 AS builder
+
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -15,6 +17,12 @@ RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
 
 
 RUN apk update && apk add make && apk add bash git
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
 RUN make cmd/support-notifications/support-notifications
 

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -7,6 +7,8 @@
 #
 
 FROM golang:1.11.2-alpine3.7 AS builder
+
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -15,6 +17,12 @@ RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
     echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add make git
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
 RUN make cmd/support-scheduler/support-scheduler
 


### PR DESCRIPTION
#1112 

The use of `go mod download` allows Go module dependencies to be downloaded once and then Docker itself will cache the deps for re-use during the various COPY operations. Hoping this will save us quite a build of time in the build pipeline.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>