### PR TITLE
404s should be wrapped by ErrServiceClient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190206111100-148998445693
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190220165850-ed0acaf07725
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0
 	github.com/go-stack/stack v1.8.0 // indirect

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -139,7 +139,7 @@ func eventCountByDeviceIdHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), err.StatusCode)
 			return
 		default: //return an error on everything else.
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}
@@ -456,7 +456,7 @@ func deleteByDeviceIdHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), err.StatusCode)
 			return
 		default: //return an error on everything else.
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}
@@ -572,7 +572,7 @@ func readingByDeviceFilteredValueDescriptor(w http.ResponseWriter, r *http.Reque
 				http.Error(w, err.Error(), err.StatusCode)
 				return
 			default: //return an error on everything else.
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 		}
@@ -677,7 +677,7 @@ func readingHandler(w http.ResponseWriter, r *http.Request) {
 					http.Error(w, err.Error(), err.StatusCode)
 					return
 				default: //return an error on everything else.
-					http.Error(w, err.Error(), http.StatusServiceUnavailable)
+					http.Error(w, err.Error(), http.StatusInternalServerError)
 					return
 				}
 			}
@@ -755,7 +755,7 @@ func getReadingByIdHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			default: //return an error on everything else.
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 		}
@@ -802,7 +802,7 @@ func deleteReadingByIdHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			default: //return an error on everything else.
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 		}
@@ -853,7 +853,7 @@ func readingByDeviceHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), err.StatusCode)
 				return
 			default:
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 		}
@@ -1132,7 +1132,7 @@ func readingByValueDescriptorAndDeviceHandler(w http.ResponseWriter, r *http.Req
 			http.Error(w, err.Error(), err.StatusCode)
 			return
 		default: //return an error on everything else.
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}


### PR DESCRIPTION
#1115 

- Note the actual fix is in go-mod-core-contracts from this PR https://github.com/edgexfoundry/go-mod-core-contracts/pull/9
- Updated go.mod to point to above commit
- Replaced a few occurrences of `StatusServiceUnavailable` with standard `StatusInternalServerError`

Signed-off-by: Trevor Conn <trevor_conn@dell.com>