### PR TITLE
Use golang:1.11-alpine as the base image. Ingore go.sum for the moment.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
 docs
+
+# Ignoring the go.sum file. There are checksum issues with
+# different versions of Golang. Remove once all Go versions
+# are in sync
+go.sum

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ glide.lock
 docker/docker-compose.yml
 .project
 .vscode/
+go.sum
 
 # binary files
 cmd/config-seed/config-seed

--- a/cmd/config-seed/Dockerfile
+++ b/cmd/config-seed/Dockerfile
@@ -16,7 +16,7 @@
 ###############################################################################
 
 # Docker image for building EdgeX Foundry Config Seed
-FROM golang:1.11.2-alpine3.7 AS build-env
+FROM golang:1.11-alpine AS build-env
 
 # environment variables
 ENV GO111MODULE=on
@@ -30,7 +30,7 @@ RUN apk update && apk add make git
 
 # copy go source files
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 
@@ -41,7 +41,7 @@ RUN make prepare
 RUN make cmd/config-seed/config-seed
 
 # Consul Docker image for EdgeX Foundry
-FROM golang:1.11.2-alpine3.7
+FROM golang:1.11-alpine
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2017: Samsung'

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -6,20 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
+# RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+#   echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add make git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -7,21 +7,20 @@
 #
 
 # Docker image for Golang Core Data micro service 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
-
+# RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+#   echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -6,21 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
-
+# RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+#   echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add make git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/export-client/Dockerfile
+++ b/cmd/export-client/Dockerfile
@@ -6,21 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
-
+# RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+#   echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add make git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/export-distro/Dockerfile
+++ b/cmd/export-distro/Dockerfile
@@ -6,21 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
-
+# RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+#   echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/support-logging/Dockerfile
+++ b/cmd/support-logging/Dockerfile
@@ -5,21 +5,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
-
+# RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+#   echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add make && apk add bash git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -5,21 +5,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
-
+# RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+#   echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add make && apk add bash git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -6,20 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
+# RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
+#   echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
 RUN apk update && apk add make git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 


### PR DESCRIPTION
Changes made:
  - Ignore go.sum. Currently there is an issue with the way checksums are computed across patch versions of Go. We have observed that if a go.sum is generated from Go 1.11.2 it may not work with Go 1.11.5. Typically this is seen as a checksum mismatch error on specific modules (github.com/hashicorp/go-rootcerts for example). Until we can get some resolution on this, go.sum will be ignored.
  - Changed the base image to be golang:1.11-alpine as was discussed in the DevOps WG call.
  - Commented out APK repo pinning.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>