### PR TITLE
Utilizing golang:1.11-alpine as base Docker image

### DIFF
--- a/cmd/config-seed/Dockerfile
+++ b/cmd/config-seed/Dockerfile
@@ -16,7 +16,7 @@
 ###############################################################################
 
 # Docker image for building EdgeX Foundry Config Seed
-FROM golang:1.11.2-alpine3.7 AS build-env
+FROM golang:1.11-alpine AS build-env
 
 # environment variables
 ENV GO111MODULE=on
@@ -30,7 +30,7 @@ RUN apk update && apk add make git
 
 # copy go source files
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 
@@ -41,7 +41,7 @@ RUN make prepare
 RUN make cmd/config-seed/config-seed
 
 # Consul Docker image for EdgeX Foundry
-FROM golang:1.11.2-alpine3.7
+FROM golang:1.11-alpine
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2017: Samsung'

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -6,20 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
+
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk update && apk add make git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -7,21 +7,20 @@
 #
 
 # Docker image for Golang Core Data micro service 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 
@@ -30,16 +29,15 @@ COPY . .
 RUN make cmd/core-data/core-data
 
 #Next image - Copy built Go binary into new workspace
-FROM alpine:3.7
+FROM alpine
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Dell, Cavium'
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk --no-cache add zeromq
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-data/core-data /

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -6,21 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk update && apk add make git
 
 COPY go.mod .
-COPY go.sum .
+# COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/export-client/Dockerfile
+++ b/cmd/export-client/Dockerfile
@@ -6,21 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk update && apk add make git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 
@@ -30,7 +29,7 @@ RUN make cmd/export-client/export-client
 FROM scratch
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-      copyright='Copyright (c) 2017-2018: Mainflux, Cavium'
+      copyright='Copyright (c) 2017-2019: Mainflux, Cavium, Dell'
 
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/export-client/export-client /
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/export-client/res/docker/configuration.toml /res/docker/configuration.toml

--- a/cmd/export-distro/Dockerfile
+++ b/cmd/export-distro/Dockerfile
@@ -6,37 +6,35 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk update && apk add zeromq-dev libsodium-dev pkgconfig build-base git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 
 COPY . .
 RUN make cmd/export-distro/export-distro
 
-FROM alpine:3.7
+FROM alpine
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2017-2018: Mainflux, Cavium'
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk --no-cache add zeromq
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/export-distro/export-distro /

--- a/cmd/support-logging/Dockerfile
+++ b/cmd/support-logging/Dockerfile
@@ -5,21 +5,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk update && apk add make && apk add bash git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -5,21 +5,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
 
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk update && apk add make && apk add bash git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -6,20 +6,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-    echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
+
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk update && apk add make git
 
 COPY go.mod .
-COPY go.sum .
+#COPY go.sum .
 
 RUN go mod download
 


### PR DESCRIPTION
#1124 

NOTE: The `COPY go.sum .` is merely commented out on purpose. Please see my comment on the above issue for the reasoning.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>