### PR TITLE
Fix update command and other issues

### DIFF
--- a/internal/core/data/errors/types.go
+++ b/internal/core/data/errors/types.go
@@ -15,6 +15,7 @@ package errors
 
 import (
 	"fmt"
+
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
@@ -89,6 +90,18 @@ func (e ErrValueDescriptorInUse) Error() string {
 
 func NewErrValueDescriptorInUse(name string) error {
 	return &ErrValueDescriptorInUse{name: name}
+}
+
+type ErrDuplicateValueDescriptorName struct {
+	name string
+}
+
+func (e ErrDuplicateValueDescriptorName) Error() string {
+	return fmt.Sprintf("duplicate name for value descriptor: %s", e.name)
+}
+
+func NewErrDuplicateValueDescriptorName(name string) error {
+	return &ErrDuplicateValueDescriptorName{name: name}
 }
 
 type ErrLimitExceeded struct {

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -210,7 +210,7 @@ func addValueDescriptor(vd contract.ValueDescriptor) (id string, err error) {
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		if err == db.ErrNotUnique {
-			return "", errors.NewErrValueDescriptorInUse(vd.Name)
+			return "", errors.NewErrDuplicateValueDescriptorName(vd.Name)
 		} else {
 			return "", err
 		}
@@ -285,7 +285,7 @@ func updateValueDescriptor(from contract.ValueDescriptor) error {
 	if err != nil {
 		if err == db.ErrNotUnique {
 			LoggingClient.Error("Value descriptor name is not unique")
-			return errors.NewErrValueDescriptorInUse(to.Name)
+			return errors.NewErrDuplicateValueDescriptorName(to.Name)
 		} else {
 			LoggingClient.Error(err.Error())
 			return err

--- a/internal/core/data/valuedescriptor_test.go
+++ b/internal/core/data/valuedescriptor_test.go
@@ -463,7 +463,7 @@ func TestAddValueDescriptor(t *testing.T) {
 	}
 }
 
-func TestAddValueDescriptorInUse(t *testing.T) {
+func TestAddDuplicateValueDescriptor(t *testing.T) {
 	reset()
 	myMock := &mocks.DBClient{}
 
@@ -475,10 +475,10 @@ func TestAddValueDescriptorInUse(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrValueDescriptorInUse:
+		case *errors.ErrDuplicateValueDescriptorName:
 			return
 		default:
-			t.Errorf("Unexpected error getting value descriptor by UOM label missing in DB")
+			t.Errorf("Unexpected error adding value descriptor that already exists")
 		}
 	}
 

--- a/internal/core/metadata/addressable.go
+++ b/internal/core/metadata/addressable.go
@@ -14,10 +14,11 @@
 package metadata
 
 import (
+	"net/http"
+
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-	"net/http"
 )
 
 func getAllAddressables() ([]contract.Addressable, error) {
@@ -85,15 +86,33 @@ func updateAddressable(addressable contract.Addressable) error {
 		}
 	}
 
-	dest.Name = addressable.Name
-	dest.Protocol = addressable.Protocol
-	dest.Address = addressable.Address
-	dest.Port = addressable.Port
-	dest.Path = addressable.Path
-	dest.Publisher = addressable.Publisher
-	dest.User = addressable.User
-	dest.Password = addressable.Password
-	dest.Topic = addressable.Topic
+	if addressable.Name != "" {
+		dest.Name = addressable.Name
+	}
+	if addressable.Protocol != "" {
+		dest.Protocol = addressable.Protocol
+	}
+	if addressable.Address != "" {
+		dest.Address = addressable.Address
+	}
+	if addressable.Port != 0 {
+		dest.Port = addressable.Port
+	}
+	if addressable.Path != "" {
+		dest.Path = addressable.Path
+	}
+	if addressable.Publisher != "" {
+		dest.Publisher = addressable.Publisher
+	}
+	if addressable.User != "" {
+		dest.User = addressable.User
+	}
+	if addressable.Password != "" {
+		dest.Password = addressable.Password
+	}
+	if addressable.Topic != "" {
+		dest.Topic = addressable.Topic
+	}
 
 	if err := dbClient.UpdateAddressable(dest); err != nil {
 		LoggingClient.Error(err.Error())

--- a/internal/core/metadata/rest_command.go
+++ b/internal/core/metadata/rest_command.go
@@ -33,7 +33,7 @@ func restGetAllCommands(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	if len(results) > Configuration.Service.ReadMaxLimit {
-		LoggingClient.Error(err.Error())
+		LoggingClient.Error("Max limit exceeded")
 		http.Error(w, errors.New("Max limit exceeded").Error(), http.StatusRequestEntityTooLarge)
 		return
 	}

--- a/internal/core/metadata/rest_command.go
+++ b/internal/core/metadata/rest_command.go
@@ -76,7 +76,7 @@ func restUpdateCommand(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if command exists (By ID)
-	c, err := dbClient.GetCommandById(c.Id)
+	former, err := dbClient.GetCommandById(c.Id)
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusNotFound)
@@ -103,6 +103,17 @@ func restUpdateCommand(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+	}
+
+	// Update the fields
+	if c.Name != "" {
+		former.Name = c.Name
+	}
+	if (c.Get.String() != contract.Get{}.String()) {
+		former.Get = c.Get
+	}
+	if (c.Put.String() != contract.Put{}.String()) {
+		former.Put = c.Put
 	}
 
 	if err := dbClient.UpdateCommand(c); err != nil {


### PR DESCRIPTION
This PR fixes #1130 and also:
* Makes update addressable database independent
* Fixed panic error when trying to get commands and max limit is reached
* When trying to add an existing value descriptor, now the error is "duplicate name for value descriptor" instead of "value descriptor still referenced by readings"

And ok, maybe I should create different PR for each of those issues, but at least there is one commit for each one :smiley: 
