### PR TITLE
mongo-worker-wrapper.sh: stop after 10 tries

### DIFF
--- a/snap/local/runtime-helpers/bin/mongo-worker-wrapper.sh
+++ b/snap/local/runtime-helpers/bin/mongo-worker-wrapper.sh
@@ -1,7 +1,14 @@
-#!/bin/bash -e
+#!/bin/bash
 
-
-while true; do
-  mongo $SNAP/mongo/init_mongo.js && break
-  sleep 5
+# try to initialize mongo, giving up after a reasonable number of tries
+MAX_TRIES=10
+num_tries=0
+until mongo $SNAP/mongo/init_mongo.js; do
+    sleep 5
+    # increment number of tries
+    num_tries=$((num_tries+1))
+    if (( num_tries >= MAX_TRIES )); then
+        echo "unable to init mongod from mongo-worker after $MAX_TRIES attempts"
+        exit 1
+    fi
 done


### PR DESCRIPTION
This prevents us from getting into an infinite loop if mongod is not startable for some reason in the snap.

For example, this could happen if there's another mongod running on the system that makes it unable to listen on the default port number, with this change mongo-worker will at least die after 10 times (or 50 seconds), leading to either an abort of the snap installation (if installing) or explicitly failed services if happening on a snap restart/system reboot.

To test this:
1. Build the snap and install it normally, it should install and have services come up normally.
2. First, listen on mongodb port 27017 with a super simple http server such that mongo-worker will get an invalid response and be unable to initialize mongod:
```bash
RESPONSE="HTTP/1.1 200 OK\r\nConnection: keep-alive\r\n\r\n${2:-"OK"}\r\n"
while { echo -en "$RESPONSE"; } | nc -l 27017; do echo "RESPONDED"; done
```
Then in another terminal, attempt to install the snap. mongod will fail to start after 5 attempts, and then systemd marks it as failed, but goes on to attempt starting dependent services like mongo-worker. You should then see mongo-worker fail 10 times then systemd will give up on the snap and abort installation.

You should see output similar to this if you follow the system journal while doing this test (`journalctl -ef`):

```
Mar 11 20:44:33 systemd[1]: Started Service for snap application edgexfoundry.mongod.
Mar 11 20:44:35 systemd[1]: snap.edgexfoundry.mongod.service: Main process exited, code=exited, status=48/n/a
Mar 11 20:44:35 edgexfoundry.mongod[20856]: There doesn't seem to be a server running with dbpath: /var/snap/edgexfoundry/x1/mongo/db
Mar 11 20:44:35 systemd[1]: snap.edgexfoundry.mongod.service: Control process exited, code=exited status=1
Mar 11 20:44:35 systemd[1]: snap.edgexfoundry.mongod.service: Unit entered failed state.
Mar 11 20:44:35 systemd[1]: snap.edgexfoundry.mongod.service: Failed with result 'exit-code'.
Mar 11 20:44:35 systemd[1]: snap.edgexfoundry.mongod.service: Service hold-off time over, scheduling restart.
Mar 11 20:44:35 systemd[1]: Stopped Service for snap application edgexfoundry.mongod.
Mar 11 20:44:35 systemd[1]: Started Service for snap application edgexfoundry.mongod.
Mar 11 20:44:35 edgexfoundry.mongod[20885]: 2019-03-11T20:44:35.852-0500 I CONTROL  [main] log file "/var/snap/edgexfoundry/common/mongodb.log" exists; moved to "/var/snap/edgexfoundry/common/mongodb.log.2019-03-12T01-44-35".
Mar 11 20:44:35 systemd[1]: snap.edgexfoundry.mongod.service: Main process exited, code=exited, status=48/n/a
Mar 11 20:44:35 edgexfoundry.mongod[20908]: There doesn't seem to be a server running with dbpath: /var/snap/edgexfoundry/x1/mongo/db
Mar 11 20:44:35 systemd[1]: snap.edgexfoundry.mongod.service: Control process exited, code=exited status=1
Mar 11 20:44:35 systemd[1]: snap.edgexfoundry.mongod.service: Unit entered failed state.
Mar 11 20:44:35 systemd[1]: snap.edgexfoundry.mongod.service: Failed with result 'exit-code'.
Mar 11 20:44:36 systemd[1]: snap.edgexfoundry.mongod.service: Service hold-off time over, scheduling restart.
Mar 11 20:44:36 systemd[1]: Stopped Service for snap application edgexfoundry.mongod.
Mar 11 20:44:36 systemd[1]: Started Service for snap application edgexfoundry.mongod.
Mar 11 20:44:36 edgexfoundry.mongod[20929]: 2019-03-11T20:44:36.546-0500 I CONTROL  [main] log file "/var/snap/edgexfoundry/common/mongodb.log" exists; moved to "/var/snap/edgexfoundry/common/mongodb.log.2019-03-12T01-44-36".
Mar 11 20:44:36 systemd[1]: snap.edgexfoundry.mongod.service: Main process exited, code=exited, status=48/n/a
Mar 11 20:44:36 edgexfoundry.mongod[20952]: There doesn't seem to be a server running with dbpath: /var/snap/edgexfoundry/x1/mongo/db
Mar 11 20:44:36 systemd[1]: snap.edgexfoundry.mongod.service: Control process exited, code=exited status=1
Mar 11 20:44:36 systemd[1]: snap.edgexfoundry.mongod.service: Unit entered failed state.
Mar 11 20:44:36 systemd[1]: snap.edgexfoundry.mongod.service: Failed with result 'exit-code'.
Mar 11 20:44:36 systemd[1]: snap.edgexfoundry.mongod.service: Service hold-off time over, scheduling restart.
Mar 11 20:44:36 systemd[1]: Stopped Service for snap application edgexfoundry.mongod.
Mar 11 20:44:36 systemd[1]: Started Service for snap application edgexfoundry.mongod.
Mar 11 20:44:36 edgexfoundry.mongod[20974]: 2019-03-11T20:44:36.881-0500 I CONTROL  [main] log file "/var/snap/edgexfoundry/common/mongodb.log" exists; moved to "/var/snap/edgexfoundry/common/mongodb.log.2019-03-12T01-44-36".
Mar 11 20:44:36 systemd[1]: snap.edgexfoundry.mongod.service: Main process exited, code=exited, status=48/n/a
Mar 11 20:44:37 edgexfoundry.mongod[20997]: There doesn't seem to be a server running with dbpath: /var/snap/edgexfoundry/x1/mongo/db
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Control process exited, code=exited status=1
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Unit entered failed state.
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Failed with result 'exit-code'.
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Service hold-off time over, scheduling restart.
Mar 11 20:44:37 systemd[1]: Stopped Service for snap application edgexfoundry.mongod.
Mar 11 20:44:37 systemd[1]: Started Service for snap application edgexfoundry.mongod.
Mar 11 20:44:37 edgexfoundry.mongod[21018]: 2019-03-11T20:44:37.375-0500 I CONTROL  [main] log file "/var/snap/edgexfoundry/common/mongodb.log" exists; moved to "/var/snap/edgexfoundry/common/mongodb.log.2019-03-12T01-44-37".
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Main process exited, code=exited, status=48/n/a
Mar 11 20:44:37 edgexfoundry.mongod[21042]: There doesn't seem to be a server running with dbpath: /var/snap/edgexfoundry/x1/mongo/db
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Control process exited, code=exited status=1
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Unit entered failed state.
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Failed with result 'exit-code'.
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Service hold-off time over, scheduling restart.
Mar 11 20:44:37 systemd[1]: Stopped Service for snap application edgexfoundry.mongod.
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Start request repeated too quickly.
Mar 11 20:44:37 systemd[1]: Failed to start Service for snap application edgexfoundry.mongod.
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Unit entered failed state.
Mar 11 20:44:37 systemd[1]: snap.edgexfoundry.mongod.service: Failed with result 'start-limit-hit'.
Mar 11 20:45:04 systemd[1]: Starting Service for snap application edgexfoundry.mongo-worker...
Mar 11 20:45:05 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:05 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:05 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:05.572-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:05 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:05.600-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:05 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:05 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:05 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:10 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:10 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:10 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:10.681-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:10 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:10.682-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:10 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:10 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:10 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:15 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:15 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:15 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:15.751-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:15 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:15.752-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:15 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:15 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:15 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:20 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:20 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:20 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:20.826-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:20 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:20.826-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:20 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:20 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:20 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:25 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:25 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:25 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:25.905-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:25 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:25.905-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:25 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:25 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:25 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:30 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:30 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:30 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:30.990-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:30 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:30.991-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:30 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:30 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:30 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:36 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:36 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:36 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:36.058-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:36 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:36.059-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:36 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:36 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:36 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:41 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:41 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:41 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:41.105-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:41 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:41.106-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:41 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:41 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:41 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:46 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:46 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:46 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:46.186-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:46 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:46.187-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:46 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:46 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:46 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:51 edgexfoundry.mongo-worker[21073]: MongoDB shell version v3.4.10
Mar 11 20:45:51 edgexfoundry.mongo-worker[21073]: connecting to: mongodb://127.0.0.1:27017
Mar 11 20:45:51 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:51.271-0500 I NETWORK  [thread1] recv(): message len 1347703880 is invalid. Min 16 Max: 48000000
Mar 11 20:45:51 edgexfoundry.mongo-worker[21073]: 2019-03-11T20:45:51.271-0500 E QUERY    [thread1] Error: network error while attempting to run command 'isMaster' on host '127.0.0.1:27017'  :
Mar 11 20:45:51 edgexfoundry.mongo-worker[21073]: connect@src/mongo/shell/mongo.js:237:13
Mar 11 20:45:51 edgexfoundry.mongo-worker[21073]: @(connect):1:6
Mar 11 20:45:51 edgexfoundry.mongo-worker[21073]: exception: connect failed
Mar 11 20:45:56 edgexfoundry.mongo-worker[21073]: unable to init mongod from mongo-worker after 10 attempts
Mar 11 20:45:56 systemd[1]: snap.edgexfoundry.mongo-worker.service: Main process exited, code=exited, status=1/FAILURE
Mar 11 20:45:56 systemd[1]: Failed to start Service for snap application edgexfoundry.mongo-worker.
Mar 11 20:45:56 systemd[1]: snap.edgexfoundry.mongo-worker.service: Unit entered failed state.
Mar 11 20:45:56 systemd[1]: snap.edgexfoundry.mongo-worker.service: Failed with result 'exit-code'.
Mar 11 20:45:56 systemd[1]: Stopped Service for snap application edgexfoundry.export-client.
Mar 11 20:45:56 systemd[1]: Stopped Service for snap application edgexfoundry.device-modbus.
Mar 11 20:45:56 systemd[1]: Stopped Service for snap application edgexfoundry.device-mqtt.
Mar 11 20:45:57 systemd[1]: Stopped Service for snap application edgexfoundry.export-distro.
Mar 11 20:45:57 systemd[1]: Stopped Service for snap application edgexfoundry.core-data.
Mar 11 20:45:57 systemd[1]: Stopped Service for snap application edgexfoundry.core-command.
Mar 11 20:45:57 systemd[1]: Stopped Service for snap application edgexfoundry.support-notifications.
Mar 11 20:45:58 systemd[1]: Stopped Service for snap application edgexfoundry.core-metadata.
Mar 11 20:45:58 systemd[1]: Stopped Service for snap application edgexfoundry.device-random.
Mar 11 20:45:58 systemd[1]: Stopped Service for snap application edgexfoundry.sys-mgmt-agent.
Mar 11 20:45:59 systemd[1]: Stopped Service for snap application edgexfoundry.support-logging.
Mar 11 20:45:59 systemd[1]: Stopped Service for snap application edgexfoundry.support-scheduler.
Mar 11 20:45:59 systemd[1]: Stopped Service for snap application edgexfoundry.edgexproxy.
Mar 11 20:45:59 systemd[1]: Stopped Service for snap application edgexfoundry.mongo-worker.
Mar 11 20:46:00 systemd[1]: Stopped Service for snap application edgexfoundry.vault-worker.
Mar 11 20:46:00 systemd[1]: Stopped Service for snap application edgexfoundry.mongod.
Mar 11 20:46:00 systemd[1]: Stopping Service for snap application edgexfoundry.vault...
```

Performing this test before without the timeout would just have `mongo-worker` loop indefinitely trying to connect and failing every time. The installation I had presumably at some point getting killed though in my testing it still hadn't been aborted/killed in over 5 minutes of snapd waiting for the service to finish. I had to manually stop `mongo-worker` with `systemctl stop snap.edgexfoundry.mongo-worker` in order to abort the installation.

Close #944 