### PR TITLE
build cassandra from source in snap for delhi

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -618,9 +618,14 @@ parts:
       - -usr/share/fonts
       - -usr/share/alsa
   cassandra:
-    plugin: dump
-    source: http://apache.claz.org/cassandra/3.11.3/apache-cassandra-3.11.3-bin.tar.gz
-    source-type: tar
+    plugin: ant
+    ant-properties:
+      dist.dir: $SNAPCRAFT_PART_INSTALL
+    ant-build-targets:
+      - artifacts
+    source: https://github.com/apache/cassandra
+    source-tag: cassandra-3.11.4
+    source-type: git
     build-packages:
       - ant-optional
       - build-essential


### PR DESCRIPTION
Duplicate of #1151 but for Delhi.

Closes #1103 for Delhi

Note this is to fix failing edge builds such as https://jenkins.edgexfoundry.org/view/Snap/job/edgex-go-snap-delhi-stage-snap/134/ in the unlikely event we need to do another Delhi release