### PR TITLE
Fix SMA's ExecutorPath; implement snap-specific executor

### DIFF
--- a/cmd/sys-mgmt-agent/res/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/configuration.toml
@@ -5,6 +5,8 @@
 # In the first release of the SMA, the manifest will be static.
 # In the future, the manifest may be more dynamic or even provided by some 3rd party orchestrator.
 
+ExecutorPath = '/path/to/the/file'
+
 [Writable]
 ResendLimit = 2
 LogLevel = 'INFO'
@@ -20,7 +22,6 @@ ReadMaxLimit = 100
 StartupMsg = 'This is the System Management Agent Service'
 Timeout = 5000
 FormatSpecifier = '%(\\d+\\$)?([-#+ 0(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])'
-ExecutorPath = '/path/to/the/file'
 
 [Registry]
 Host = 'localhost'

--- a/internal/system/agent/execution_engine.go
+++ b/internal/system/agent/execution_engine.go
@@ -13,8 +13,6 @@ func runExec(service string, operation string) error {
 	// Preparing the call to the executor app.
 	cmd := exec.Command(Configuration.ExecutorPath, service, operation)
 
-	cmd.Dir = Configuration.ExecutorPath
-
 	_, err := cmd.CombinedOutput()
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("an error occurred in calling executor on service %s where requested operation was %s: %v ", service, operation, err.Error()))

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -100,6 +100,7 @@ func Init(useRegistry bool) bool {
 	if Configuration == nil {
 		return false
 	}
+	executorClient = &ExecuteApp{}
 
 	if useRegistry && registryClient != nil {
 		chErrors = make(chan error)

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -28,8 +28,11 @@ for service in security-api-gateway security-secret-store core-command config-se
     if [ ! -f "${SNAP_DATA}/config/${service}/res/configuration.toml" ]; then
         mkdir -p "${SNAP_DATA}/config/${service}/res"
         cp ${SNAP}/config/${service}/res/configuration.toml "${SNAP_DATA}/config/${service}/res/configuration.toml"
-        # do replacement of the SNAP_DATA and SNAP_COMMON environment variables in the config files
-        sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" -e "s@\$SNAP_DATA@$SNAP_DATA@g" "${SNAP_DATA}/config/${service}/res/configuration.toml"
+        # do replacement of the $SNAP, $SNAP_DATA, $SNAP_COMMON environment variables in the config files
+        sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
+            -e "s@\$SNAP_DATA@$SNAP_DATA@g" \
+            -e "s@\$SNAP@$SNAP@g" \
+            "${SNAP_DATA}/config/${service}/res/configuration.toml"
     fi
 done
 

--- a/snap/local/runtime-helpers/bin/sys-mgmt-agent-snap-executor.sh
+++ b/snap/local/runtime-helpers/bin/sys-mgmt-agent-snap-executor.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+# the first argument is the service
+# the second argument is the operation, one of "stop", "start", "restart"
+# TODO: handle enable/disable when those paramaters are provided
+
+if [ "$#" -ne 2 ]; then
+    echo "invalid number of arguments"
+fi
+
+case "$#" in
+    0)
+        echo "the service and the operation must be provided"
+        exit 1
+        ;;
+    1)
+        echo "the operation must be provided"
+        exit 1
+        ;;
+    2)
+        # correct - do nothing
+        ;;
+    *)
+        echo "too many arguments provided"
+        echo "only the service and the operation must be provided"
+        exit 1
+        ;;
+esac
+
+
+# note this prefix is in edgex-go, as go code, and if it changes we don't have
+# a good way to pull that here so if this breaks go look for changes there
+svcName=${1#"edgex-"}
+
+# the operation type maps 1:1 to the snapctl service operations
+snapctl "$2" "$SNAP_NAME.$svcName"
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -206,7 +206,7 @@ apps:
         - mongo-worker
         - edgexproxy
   sys-mgmt-agent:
-    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh sys-mgmt-agent
+    command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh sys-mgmt-agent --registry
     daemon: forking
     plugs: [network, network-bind, daemon-notify]
     passthrough:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -498,7 +498,7 @@ parts:
       # for sys-mgmt-agent we also need to specify the operations type as "snap"
       cat "./cmd/sys-mgmt-agent/res/configuration.toml" | \
         sed -e s:./logs/edgex-sys-mgmt-agent.log:\$SNAP_COMMON/sys-mgmt-agent.log: \
-            -e s:"OperationsType = 'docker'":"OperationsType = 'snap'": \
+            -e s:"ExecutorPath = '/path/to/the/file'":"ExecutorPath = '\$SNAP/bin/sys-mgmt-agent-snap-executor.sh'": \
             -e s:'http\://localhost\:48061/api/v1/logs':: > \
        "$SNAPCRAFT_PART_INSTALL/config/sys-mgmt-agent/res/configuration.toml"
 


### PR DESCRIPTION
* Fixes SMA support for using the interfaces defined for each operation 
* Has SMA use consul now that it has support for it
* Add snap specific SMA executor that uses `snapctl` to start/stop/restart services

To test this, build the snap and after installing, run:

```
$ curl --header "Content-Type: application/json" --request POST --data '{"action":"stop","services":["edgex-core-command"]}' localhost:48090/api/v1/operation
Done. Started the requested services.
```

you should then see `core-command` go down is inactive:

```
$ snap services edgexfoundry.core-command
Service                    Startup  Current   Notes
edgexfoundry.core-command  enabled  inactive  -
```

Then start the service with:

```
$ curl --header "Content-Type: application/json" --request POST --data '{"action":"start","services":["edgex-core-command"]}' localhost:48090/api/v1/operation; echo
Done. Started the requested services.
```

and core-command should be alive again:

```
$ snap services edgexfoundry.core-command
Service                    Startup  Current  Notes
edgexfoundry.core-command  enabled  active   -
```

Finally, test `restart` with:
```
$ curl --header "Content-Type: application/json" --request POST --data '{"action":"restart","services":["edgex-core-command"]}' localhost:48090/api/v1/operation; echo
Done. Restarted the requested services.
```
and see that core-command is running again:

```
$ snap services edgexfoundry.core-command
Service                    Startup  Current  Notes
edgexfoundry.core-command  enabled  active   -
```

Closes #1132 
Closes #1159 