### PR TITLE
Add support-rulesengine back to the snap

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -19,7 +19,7 @@ ALL_SERVICES="$ALL_SERVICES core-command"
 ALL_SERVICES="$ALL_SERVICES support-notifications"
 ALL_SERVICES="$ALL_SERVICES support-logging"
 ALL_SERVICES="$ALL_SERVICES support-scheduler"
-# TODO: add support-rulesengine here when available
+ALL_SERVICES="$ALL_SERVICES support-rulesengine"
 
 # export services
 ALL_SERVICES="$ALL_SERVICES export-distro"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -39,6 +39,27 @@ cp ${SNAP}/config/device-mqtt/res/configuration-driver.toml "${SNAP_DATA}/config
 # handle device-random device profile
 cp ${SNAP}/config/device-random/res/device.random.yaml "${SNAP_DATA}/config/device-random/res/device.random.yaml"
 
+# also handle java services' application.properties
+for jsvc in edgex-support-rulesengine; do
+    if [ ! -f "${SNAP_DATA}/config/config-seed/res/properties/$jsvc/application.properties" ]; then
+        mkdir -p "${SNAP_DATA}/config/config-seed/res/properties/$jsvc"
+        cp "${SNAP}/config/config-seed/res/properties/$jsvc/application.properties" "${SNAP_DATA}/config/config-seed/res/properties/$jsvc/application.properties"
+        # also replace SNAP_DATA and SNAP_COMMON in the application files
+        sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" -e "s@\$SNAP_DATA@$SNAP_DATA@g" "${SNAP_DATA}/config/config-seed/res/properties/$jsvc/application.properties"
+    fi
+done
+
+# create support-rulesengine directories for templates/rules
+if [ ! -f "${SNAP_DATA}/support-rulesengine/templates" ]; then
+    mkdir -p "${SNAP_DATA}/support-rulesengine/templates"
+    cp "${SNAP}/jar/support-rulesengine/templates/rule-template.drl" "${SNAP_DATA}/support-rulesengine/templates/rule-template.drl"
+fi
+
+if [ ! -f "${SNAP_DATA}/support-rulesengine/rules" ]; then
+    mkdir -p "${SNAP_DATA}/support-rulesengine/rules"
+fi
+
+
 # for security-secret-store, copy the hcl config files used with vault
 for hclType in admin kong; do 
     if [ ! -f "${SNAP_DATA}/config/security-secret-store/res/vault-policy-${hclType}.hcl" ]; then
@@ -114,6 +135,6 @@ fi
 
 # finally, disable services in the snap that aren't meant to come up by default
 # by default, we want the export-*, support-*, and device-* services off.
-for svc in export-distro export-client support-notifications support-scheduler support-logging device-modbus device-mqtt device-random; do
+for svc in export-distro export-client support-notifications support-scheduler support-logging support-rulesengine device-modbus device-mqtt device-random; do
     snapctl stop --disable edgexfoundry.$svc
 done

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# stop edgex services
-$SNAP/bin/stop-edgex.sh

--- a/snap/local/runtime-helpers/bin/support-rulesengine-wrapper.sh
+++ b/snap/local/runtime-helpers/bin/support-rulesengine-wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+if [ "$(arch)" = "aarch64" ] ; then
+    ARCH="arm64"
+elif [ "$(arch)" = "x86_64" ] ; then
+    ARCH="amd64"
+else
+    echo "Unsupported architecture: $(arch)"
+    exit 1
+fi
+
+JAVA="$SNAP"/usr/lib/jvm/java-8-openjdk-"$ARCH"/jre/bin/java
+
+$JAVA -jar -Djava.security.egd=file:/dev/urandom -Xmx100M \
+            -Dspring.cloud.consul.enabled=true \
+            -Dspring.cloud.consul.host=localhost \
+            -Dlogging.file=$SNAP_COMMON/logs/edgex-support-rulesengine.log \
+            $SNAP/jar/support-rulesengine/support-rulesengine.jar

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -177,6 +177,16 @@ apps:
         - core-config-seed
         - mongo-worker
         - edgexproxy
+  support-rulesengine:
+    command: bin/support-rulesengine-wrapper.sh
+    daemon: simple
+    plugs: [network, network-bind]
+    passthrough:
+      after:
+        - export-client
+        - core-config-seed
+        - mongo-worker
+        - edgexproxy
   export-client:
     command: bin/fork-wrapper.sh $SNAP/bin/go-services-wrapper.sh export-client --registry
     daemon: forking
@@ -432,6 +442,14 @@ parts:
       install -d "$SNAPCRAFT_PART_INSTALL/config/support-scheduler/res/"
       install -d "$SNAPCRAFT_PART_INSTALL/config/sys-mgmt-agent/res/"
 
+      install -d "$SNAPCRAFT_PART_INSTALL/config/config-seed/res/properties/edgex-support-rulesengine/"
+
+      # handle application.properties for the remaining java services
+      cat "./cmd/config-seed/res/properties/edgex-support-rulesengine/application.properties" | \
+        sed -e s:edgex/rules:\$SNAP_DATA/support-rulesengine/rules: \
+            -e s:edgex/templates:\$SNAP_DATA/support-rulesengine/templates: > \
+       "$SNAPCRAFT_PART_INSTALL/config/config-seed/res/properties/edgex-support-rulesengine/application.properties"
+
       cat "./cmd/config-seed/res/configuration.toml" | \
         sed -e s:./logs/edgex-config-seed.log:\$SNAP_COMMON/config-seed.log: \
             -e s:'http\://localhost\:48061/api/v1/logs':: > \
@@ -531,6 +549,51 @@ parts:
       - pkg-config
     stage-packages:
       - libzmq3-dev
+
+  support-rulesengine:
+    source: https://github.com/edgexfoundry/support-rulesengine.git
+    source-branch: "master"
+    plugin: maven
+    maven-options: ["-Dmaven.test.skip=true"]
+    override-build: |
+      snapcraftctl build
+      echo "Installing support-rulesengine files"
+
+      # The logic following logic is all handled by DockerFile for
+      # the EdgeX support-rulesengine docker image.
+      install -d "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine"
+      mv "$SNAPCRAFT_PART_INSTALL"/jar/support-rulesengine-*-SNAPSHOT.jar \
+         "$SNAPCRAFT_PART_INSTALL"/jar/support-rulesengine/support-rulesengine.jar
+
+      # FIXME:
+      # copy service license into /usr/share/java/doc, because the
+      # jdk plugin has a bug which prevents any files from /usr/share/doc
+      # to be staged or primed.
+      install -DT "./Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/java/doc/support-rulesengine/Attribution.txt"
+      install -DT "./LICENSE-2.0.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/java/doc/support-rulesengine/LICENSE-2.0.txt"
+      install -DT "./src/main/resources/rule-template.drl" \
+         "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine/templates/rule-template.drl"
+    prime:
+      - -etc/fonts
+      - -etc/fonts/X11
+      - -usr/lib/jvm/*/ASSEMBLY_EXCEPTION
+      - -usr/lib/jvm/*/THIRD_PARTY_README
+      - -usr/lib/jvm/*/jre/ASSEMBLY_EXCEPTION
+      - -usr/lib/jvm/*/jre/THIRD_PARTY_README
+      - -usr/lib/jvm/*/man
+      - -usr/lib/jvm/*/jre/man
+      - -usr/lib/jvm/*/jre/lib/images
+      - -usr/lib/jvm/*/include
+      - -usr/lib/jvm/*/bin
+      - -usr/lib/jvm/*/lib
+      - -usr/lib/jvm/*/docs
+      - -usr/lib/jvm/*/src.zip
+      - -usr/share/X11
+      - -usr/share/man
+      - -usr/share/fonts
+      - -usr/share/alsa
 
   cassandra:
     plugin: ant


### PR DESCRIPTION
Also remove obsolete remove hook.

To test this, build the snap and install it.

1. Check that support-rulesengine doesn't start by default:

```
snap services edgexfoundry.support-rulesengine | grep disabled | grep inactive
```

2. Check that after starting `support-rulesengine` and `export-client` (which is also disabled by default), support-rulesengine starts up and registers itself with consul:

```
snap set edgexfoundry export-client=on
snap set edgexfoundry support-rulesengine=on
```

You can check the consul status by going to localhost:8500 and seeing that `edgex-support-rulesengine` shows up there.

Closes #552 for Edinburgh (again)