### PR TITLE
Create "floatEncoding" field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690 // indirect
 	github.com/BurntSushi/toml v0.3.1
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190318194656-589fa6ca0c45
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190321073831-5d4d0afdbef0
 	github.com/edgexfoundry/go-mod-registry v0.0.0-20190221211212-171439dc16f8
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0

--- a/internal/pkg/db/mongo/models/deviceprofile.go
+++ b/internal/pkg/db/mongo/models/deviceprofile.go
@@ -27,19 +27,20 @@ type deviceProfileTransform interface {
 }
 
 type PropertyValue struct {
-	Type         string `bson:"type"`         // ValueDescriptor Type of property after transformations
-	ReadWrite    string `bson:"readWrite"`    // Read/Write Permissions set for this property
-	Minimum      string `bson:"minimum"`      // Minimum value that can be get/set from this property
-	Maximum      string `bson:"maximum"`      // Maximum value that can be get/set from this property
-	DefaultValue string `bson:"defaultValue"` // Default value set to this property if no argument is passed
-	Size         string `bson:"size"`         // Size of this property in its type  (i.e. bytes for numeric types, characters for string types)
-	Mask         string `bson:"mask"`         // Mask to be applied prior to get/set of property
-	Shift        string `bson:"shift"`        // Shift to be applied after masking, prior to get/set of property
-	Scale        string `bson:"scale"`        // Multiplicative factor to be applied after shifting, prior to get/set of property
-	Offset       string `bson:"offset"`       // Additive factor to be applied after multiplying, prior to get/set of property
-	Base         string `bson:"base"`         // Base for property to be applied to, leave 0 for no power operation (i.e. base ^ property: 2 ^ 10)
-	Assertion    string `bson:"assertion"`    // Required value of the property, set for checking error state.  Failing an assertion condition will mark the device with an error state
-	Precision    string `bson:"precision"`
+	Type          string `bson:"type"`          // ValueDescriptor Type of property after transformations
+	ReadWrite     string `bson:"readWrite"`     // Read/Write Permissions set for this property
+	Minimum       string `bson:"minimum"`       // Minimum value that can be get/set from this property
+	Maximum       string `bson:"maximum"`       // Maximum value that can be get/set from this property
+	DefaultValue  string `bson:"defaultValue"`  // Default value set to this property if no argument is passed
+	Size          string `bson:"size"`          // Size of this property in its type  (i.e. bytes for numeric types, characters for string types)
+	Mask          string `bson:"mask"`          // Mask to be applied prior to get/set of property
+	Shift         string `bson:"shift"`         // Shift to be applied after masking, prior to get/set of property
+	Scale         string `bson:"scale"`         // Multiplicative factor to be applied after shifting, prior to get/set of property
+	Offset        string `bson:"offset"`        // Additive factor to be applied after multiplying, prior to get/set of property
+	Base          string `bson:"base"`          // Base for property to be applied to, leave 0 for no power operation (i.e. base ^ property: 2 ^ 10)
+	Assertion     string `bson:"assertion"`     // Required value of the property, set for checking error state.  Failing an assertion condition will mark the device with an error state
+	Precision     string `bson:"precision"`
+	FloatEncoding string `bson:"floatEncoding"` // FloatEncoding indicates the representation of floating value of reading.  It should be 'Base64' or 'eNotation'
 }
 
 type Units struct {
@@ -129,6 +130,7 @@ func (dp *DeviceProfile) ToContract(transform commandTransform) (c contract.Devi
 		cdo.Properties.Value.Base = dr.Properties.Value.Base
 		cdo.Properties.Value.Assertion = dr.Properties.Value.Assertion
 		cdo.Properties.Value.Precision = dr.Properties.Value.Precision
+		cdo.Properties.Value.FloatEncoding = dr.Properties.Value.FloatEncoding
 
 		cdo.Properties.Units.Type = dr.Properties.Units.Type
 		cdo.Properties.Units.ReadWrite = dr.Properties.Units.ReadWrite
@@ -216,6 +218,7 @@ func (dp *DeviceProfile) FromContract(from contract.DeviceProfile, transform com
 		do.Properties.Value.Base = dr.Properties.Value.Base
 		do.Properties.Value.Assertion = dr.Properties.Value.Assertion
 		do.Properties.Value.Precision = dr.Properties.Value.Precision
+		do.Properties.Value.FloatEncoding = dr.Properties.Value.FloatEncoding
 
 		do.Properties.Units.Type = dr.Properties.Units.Type
 		do.Properties.Units.ReadWrite = dr.Properties.Units.ReadWrite

--- a/internal/pkg/db/mongo/models/value_descriptor.go
+++ b/internal/pkg/db/mongo/models/value_descriptor.go
@@ -20,20 +20,22 @@ import (
 )
 
 type ValueDescriptor struct {
-	Id           bson.ObjectId `bson:"_id,omitempty"`
-	Uuid         string        `bson:"uuid"`
-	Created      int64         `bson:"created"`
-	Description  string        `bson:"description,omitempty"`
-	Modified     int64         `bson:"modified"`
-	Origin       int64         `bson:"origin"`
-	Name         string        `bson:"name"`
-	Min          interface{}   `bson:"min,omitempty"`
-	Max          interface{}   `bson:"max,omitempty"`
-	DefaultValue interface{}   `bson:"defaultValue,omitempty"`
-	Type         string        `bson:"type,omitempty"`
-	UomLabel     string        `bson:"uomLabel,omitempty"`
-	Formatting   string        `bson:"formatting,omitempty"`
-	Labels       []string      `bson:"labels,omitempty"`
+	Id            bson.ObjectId `bson:"_id,omitempty"`
+	Uuid          string        `bson:"uuid"`
+	Created       int64         `bson:"created"`
+	Description   string        `bson:"description,omitempty"`
+	Modified      int64         `bson:"modified"`
+	Origin        int64         `bson:"origin"`
+	Name          string        `bson:"name"`
+	Min           interface{}   `bson:"min,omitempty"`
+	Max           interface{}   `bson:"max,omitempty"`
+	DefaultValue  interface{}   `bson:"defaultValue,omitempty"`
+	Type          string        `bson:"type,omitempty"`
+	UomLabel      string        `bson:"uomLabel,omitempty"`
+	Formatting    string        `bson:"formatting,omitempty"`
+	Labels        []string      `bson:"labels,omitempty"`
+	MediaType     string        `bson:"mediaType,omitempty"`
+	FloatEncoding string        `bson:"floatEncoding,omitempty"`
 }
 
 func (v *ValueDescriptor) ToContract() contract.ValueDescriptor {
@@ -43,19 +45,21 @@ func (v *ValueDescriptor) ToContract() contract.ValueDescriptor {
 		id = v.Id.Hex()
 	}
 	to := contract.ValueDescriptor{
-		Id:           id,
-		Created:      v.Created,
-		Description:  v.Description,
-		Modified:     v.Modified,
-		Origin:       v.Origin,
-		Name:         v.Name,
-		Min:          v.Min,
-		Max:          v.Max,
-		DefaultValue: v.DefaultValue,
-		Type:         v.Type,
-		UomLabel:     v.UomLabel,
-		Formatting:   v.Formatting,
-		Labels:       []string{},
+		Id:            id,
+		Created:       v.Created,
+		Description:   v.Description,
+		Modified:      v.Modified,
+		Origin:        v.Origin,
+		Name:          v.Name,
+		Min:           v.Min,
+		Max:           v.Max,
+		DefaultValue:  v.DefaultValue,
+		Type:          v.Type,
+		UomLabel:      v.UomLabel,
+		Formatting:    v.Formatting,
+		Labels:        []string{},
+		MediaType:     v.MediaType,
+		FloatEncoding: v.FloatEncoding,
 	}
 	for _, l := range v.Labels {
 		to.Labels = append(to.Labels, l)
@@ -81,6 +85,8 @@ func (v *ValueDescriptor) FromContract(from contract.ValueDescriptor) (id string
 	v.UomLabel = from.UomLabel
 	v.Formatting = from.Formatting
 	v.Labels = []string{}
+	v.MediaType = from.MediaType
+	v.FloatEncoding = from.FloatEncoding
 
 	for _, l := range from.Labels {
 		v.Labels = append(v.Labels, l)


### PR DESCRIPTION
Create "floatEncoding" field to "PropertyValue" and "ValueDescriptor"
struct in Mongo db models
fix #1188

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>