### PR TITLE
PR for Issue 788 - Redis updated for UUID, contracts, and propagated across services

### DIFF
--- a/bin/edgex-docker-launch.sh
+++ b/bin/edgex-docker-launch.sh
@@ -31,11 +31,8 @@ fi
 
 EDGEX_CORE_DB=${EDGEX_CORE_DB:-"mongo"}
 
-echo "Starting Mongo"
-docker-compose -f $COMPOSE_FILE up -d mongo
-
 if [ ${EDGEX_CORE_DB} != mongo ]; then
-  echo "Starting $EDGEX_CORE_DB for Core Data Services"
+  echo "Starting $EDGEX_CORE_DB for Core Data Services and Support Services"
   docker-compose -f $COMPOSE_FILE up -d $EDGEX_CORE_DB
 fi
 

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,12 @@ require (
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.7.0
 	github.com/hashicorp/consul v1.4.2
+	github.com/imdario/mergo v0.3.6
 	github.com/influxdata/influxdb v1.7.4
 	github.com/influxdata/platform v0.0.0-20190117200541-d500d3cf5589 // indirect
 	github.com/magiconair/properties v1.8.0

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -37,6 +37,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 )
@@ -137,28 +138,35 @@ func Destruct() {
 func connectToDatabase() error {
 	// Create a database client
 	var err error
-	dbConfig := db.Configuration{
-		Host:         Configuration.Databases["Primary"].Host,
-		Port:         Configuration.Databases["Primary"].Port,
-		Timeout:      Configuration.Databases["Primary"].Timeout,
-		DatabaseName: Configuration.Databases["Primary"].Name,
-		Username:     Configuration.Databases["Primary"].Username,
-		Password:     Configuration.Databases["Primary"].Password,
-	}
-	dbClient, err = newDBClient(Configuration.Databases["Primary"].Type, dbConfig)
+
+	dbClient, err = newDBClient(Configuration.Databases["Primary"].Type)
 	if err != nil {
 		dbClient = nil
 		return fmt.Errorf("couldn't create database client: %v", err.Error())
 	}
 
-	return err
+	return nil
 }
 
 // Return the dbClient interface
-func newDBClient(dbType string, config db.Configuration) (interfaces.DBClient, error) {
+func newDBClient(dbType string) (interfaces.DBClient, error) {
 	switch dbType {
 	case db.MongoDB:
-		return mongo.NewClient(config)
+		dbConfig := db.Configuration{
+			Host:         Configuration.Databases["Primary"].Host,
+			Port:         Configuration.Databases["Primary"].Port,
+			Timeout:      Configuration.Databases["Primary"].Timeout,
+			DatabaseName: Configuration.Databases["Primary"].Name,
+			Username:     Configuration.Databases["Primary"].Username,
+			Password:     Configuration.Databases["Primary"].Password,
+		}
+		return mongo.NewClient(dbConfig)
+	case db.RedisDB:
+		dbConfig := db.Configuration{
+			Host: Configuration.Databases["Primary"].Host,
+			Port: Configuration.Databases["Primary"].Port,
+		}
+		return redis.NewClient(dbConfig) //TODO: Verify this also connects to Redis
 	default:
 		return nil, db.ErrUnsupportedDatabase
 	}

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -336,7 +336,12 @@ func restDeleteProfileByName(w http.ResponseWriter, r *http.Request) {
 func deleteDeviceProfile(dp models.DeviceProfile, w http.ResponseWriter) error {
 	// Check if the device profile is still in use by devices
 	d, err := dbClient.GetDevicesByProfileId(dp.Id)
-	if err != nil {
+
+	// XXX ErrNotFound should always be returned but this is not consistent in the implementations
+	if err == db.ErrNotFound {
+		err = nil
+		d = []models.Device{}
+	} else if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 )
@@ -115,28 +116,35 @@ func Destruct() {
 func connectToDatabase() error {
 	// Create a database client
 	var err error
-	dbConfig := db.Configuration{
-		Host:         Configuration.Databases["Primary"].Host,
-		Port:         Configuration.Databases["Primary"].Port,
-		Timeout:      Configuration.Databases["Primary"].Timeout,
-		DatabaseName: Configuration.Databases["Primary"].Name,
-		Username:     Configuration.Databases["Primary"].Username,
-		Password:     Configuration.Databases["Primary"].Password,
-	}
-	dbClient, err = newDBClient(Configuration.Databases["Primary"].Type, dbConfig)
+
+	dbClient, err = newDBClient(Configuration.Databases["Primary"].Type)
 	if err != nil {
 		dbClient = nil
 		return fmt.Errorf("couldn't create database client: %v", err.Error())
 	}
 
-	return err
+	return nil
 }
 
 // Return the dbClient interface
-func newDBClient(dbType string, config db.Configuration) (export.DBClient, error) {
+func newDBClient(dbType string) (export.DBClient, error) {
 	switch dbType {
 	case db.MongoDB:
-		return mongo.NewClient(config)
+		dbConfig := db.Configuration{
+			Host:         Configuration.Databases["Primary"].Host,
+			Port:         Configuration.Databases["Primary"].Port,
+			Timeout:      Configuration.Databases["Primary"].Timeout,
+			DatabaseName: Configuration.Databases["Primary"].Name,
+			Username:     Configuration.Databases["Primary"].Username,
+			Password:     Configuration.Databases["Primary"].Password,
+		}
+		return mongo.NewClient(dbConfig)
+	case db.RedisDB:
+		dbConfig := db.Configuration{
+			Host: Configuration.Databases["Primary"].Host,
+			Port: Configuration.Databases["Primary"].Port,
+		}
+		return redis.NewClient(dbConfig) //TODO: Verify this also connects to Redis
 	default:
 		return nil, db.ErrUnsupportedDatabase
 	}

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -22,6 +22,7 @@ import (
 const (
 	// Databases
 	MongoDB  = "mongodb"
+	RedisDB  = "redisdb"
 
 	// Data
 	EventsCollection          = "event"

--- a/internal/pkg/db/redis/CONFIGURATION.md
+++ b/internal/pkg/db/redis/CONFIGURATION.md
@@ -1,0 +1,112 @@
+# Configuring Microservices to use Redis
+
+As of Delhi 0.7.1, Core Data, Core Metadata, and Export Client all support using Redis as their persistence layer. The microservices can be configured via Consul or in a development environment, via the respective TOML files.
+
+## Requirements
+
+### Redis
+
+Redis can be run locally or as a Docker container. This document assumes the default port of 6379 is being used. If you are using a different port, massage these instructions appropriately.
+
+### EdgeX
+
+Follow the EdgeX build instructions or the EdgeX Docker Compose instructions to set yourself up for success.
+
+## Configure via Consul
+
+### Start EdgeX
+
+```sh
+export EDGEX_CORE_DB=redis
+make run_docker
+```
+
+This will start all the microservices along with both Redis and Mongo
+
+### Configure Microservices to use Redis
+
+1. Point your browser at Consul. For example `http://localhost:8500/ui`
+2. Modify the primary database service key for each of edgex-core-data, edgex-core-metadata, and edgex-export-client
+
+- edgex-core-data
+
+<table align="center">
+    <tr>
+        <td align="left">Consul Path</td>
+        <td align="left">edgex-core-data</td>
+    </tr>
+    <tr>
+        <td align="left">Host</td>
+        <td align="left">edgex-redis</td>
+    </tr>
+    <tr>
+        <td align="left">Port</td>
+        <td align="left">6379</td>
+    </tr>
+    <tr>
+        <td align="left">Type</td>
+        <td align="left">redisdb</td>
+    </tr>
+</table>
+
+- edgex-core-metadata
+
+  <table align="center">
+      <tr>
+          <td align="left">Consul Path</td>
+          <td align="left">edgex-core-meadata</td>
+      </tr>
+      <tr>
+          <td align="left">Host</td>
+          <td align="left">edgex-redis</td>
+      </tr>
+      <tr>
+          <td align="left">Port</td>
+          <td align="left">6379</td>
+      </tr>
+      <tr>
+          <td align="left">Type</td>
+          <td align="left">redisdb</td>
+      </tr>
+  </table>
+
+- edgex-export-client
+  <table align="center">
+      <tr>
+          <td align="left">Consul Path</td>
+          <td align="left">edgex-core-meadata</td>
+      </tr>
+      <tr>
+          <td align="left">Host</td>
+          <td align="left">edgex-redis</td>
+      </tr>
+      <tr>
+          <td align="left">Port</td>
+          <td align="left">6379</td>
+      </tr>
+      <tr>
+          <td align="left">Type</td>
+          <td align="left">redisdb</td>
+      </tr>
+  </table>
+
+3. Restart the Microservices
+
+```sh
+docker restart edgex-core-data
+docker restart edgex-core-metadata
+docker restart edgex-export-client
+```
+
+## Configure via TOML files
+
+The `configuration.toml` files for edgex-core-data, edgex-core-metadata, and edgex-export-client are found in their respective `cmd/<SERVICE>/res` directory
+
+For each of the microservices update the keys in the `Databases.Primary` table
+
+| Key  | Value   |
+| ---- | ------- |
+| Port | 6379    |
+| Type | redisdb |
+
+Redis does not use the other keys in that table

--- a/internal/pkg/db/redis/README.md
+++ b/internal/pkg/db/redis/README.md
@@ -1,0 +1,60 @@
+# Redis Implementation Notes
+
+`pkg/models/event` is stored as a marshalled value using the event id as the key. Sorted sets are used to track events sorted by most recently added, created timestamp (both relative to all events and scoped to the source device), and the pushed timestamp. Readings are stored are stored similarly in their own sorted sets.
+
+Given
+
+```
+var e Event
+```
+and
+
+```
+var e models.Event = models.Event{
+  ID: "57ba04a1189b95b8afcdafd7",
+  Pushed: 1471806399999,
+  Device: "123456789",
+  Created: 1464039917100,
+  Modified: 1474774741088,
+  Origin: 1471806386919,
+  Event: "",
+  Reading: []Reading{
+  Reading {
+    ID: "57b9fe08189b95b8afcdafd4",
+    Pushed: 0,
+    Created: 1471806984866,
+    Modified: 1471807130870,
+    Origin: 1471806386919,
+    Name: "temperature",
+    Value: "39"
+  },
+  Reading {
+    ID: "57e745efe4b0ca8e6d7116d7",
+    Pushed: 0,
+    Created: 1474774511737,
+    Modified: 1474774511737,
+    Origin: 1471806386919,
+    Name: "power",
+    Value: "38"
+  },
+  ...
+  }
+}
+```
+
+then 
+
+| Sorted Set Key | Score  | Member |
+|---|---|---|
+| event | 0 | 57ba04a1189b95b8afcdafd7 |
+| event:created | 1464039917100 | 57ba04a1189b95b8afcdafd7 |
+| event:pushed | 1471806399999 | 57ba04a1189b95b8afcdafd7 |
+| event:device:123456789 | 1464039917100 | 57ba04a1189b95b8afcdafd7 |
+| reading | 0 | 57b9fe08189b95b8afcdafd4 |
+| reading:created | 1471806984866 | 57b9fe08189b95b8afcdafd4 |
+| reading:device:123456789 | 1471806984866 | 57b9fe08189b95b8afcdafd4 |
+| reading:name:temperature | 1471806984866 | 57b9fe08189b95b8afcdafd4 |
+| reading | 0 | 57e745efe4b0ca8e6d7116d7 |
+| reading:created | 1474774511737 | 57e745efe4b0ca8e6d7116d7 |
+| reading:device:123456789 | 1474774511737 | 57e745efe4b0ca8e6d7116d7 |
+| reading:name:power | 1474774511737 | 57e745efe4b0ca8e6d7116d7 |

--- a/internal/pkg/db/redis/client.go
+++ b/internal/pkg/db/redis/client.go
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/gomodule/redigo/redis"
+)
+
+var currClient *Client // a singleton so Readings can be de-referenced
+var once sync.Once
+
+// Client represents a Redis client
+type Client struct {
+	Pool *redis.Pool // A thread-safe pool of connections to Redis
+}
+
+// Return a pointer to the Redis client
+func NewClient(config db.Configuration) (*Client, error) {
+	once.Do(func() {
+		connectionString := fmt.Sprintf("%s:%d", config.Host, config.Port)
+		opts := []redis.DialOption{
+			redis.DialPassword(config.Password),
+			redis.DialConnectTimeout(time.Duration(config.Timeout) * time.Millisecond),
+		}
+
+		dialFunc := func() (redis.Conn, error) {
+			conn, err := redis.Dial(
+				"tcp", connectionString, opts...,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("Could not dial Redis: %s", err)
+			}
+			return conn, nil
+		}
+
+		currClient = &Client{
+			Pool: &redis.Pool{
+				IdleTimeout: 0,
+				/* The current implementation processes nested structs using concurrent connections.
+				 * With the deepest nesting level being 3, three shall be the number of maximum open
+				 * idle connections in the pool, to allow reuse.
+				 * TODO: Once we have a concurrent benchmark, this should be revisited.
+				 * TODO: Longer term, once the objects are clean of external dependencies, the use
+				 * of another serializer should make this moot.
+				 */
+				MaxIdle: 10,
+				Dial:    dialFunc,
+			},
+		}
+	})
+	return currClient, nil
+}
+
+// Connect connects to Redis
+func (c *Client) Connect() error {
+	return nil
+}
+
+// CloseSession closes the connections to Redis
+func (c *Client) CloseSession() {
+	c.Pool.Close()
+	currClient = nil
+	once = sync.Once{}
+}
+
+// getConnection gets a connection from the pool
+func getConnection() (conn redis.Conn, err error) {
+	if currClient == nil {
+		return nil, errors.New("No current Redis client: create a new client before getting a connection from it")
+	}
+
+	conn = currClient.Pool.Get()
+	return conn, nil
+}

--- a/internal/pkg/db/redis/client_test.go
+++ b/internal/pkg/db/redis/client_test.go
@@ -1,0 +1,87 @@
+// +build redisRunning
+
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// This test will only be executed if the tag redisRunning is added when running
+// the tests with a command like:
+// LD_LIBRARY_PATH=$GOROOT/src/github.com/redislab/eredis/redis/src go test -tags redisRunning
+
+// To test Redis, specify the a `Host` value as follows:
+// * TCP connection: use the IP address or host name
+// * Unix domain socket: use the path to the socket file (e.g. /tmp/redis.sock)
+// * Embedded: leave empty
+
+package redis
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/test"
+)
+
+const (
+	redisHost = "0.0.0.0"
+	redisPort = 6379
+)
+
+func TestRedisDB(t *testing.T) {
+
+	t.Log("This test needs to have a running Redis on localhost")
+
+	config := db.Configuration{
+		Host: redisHost,
+		Port: redisPort,
+	}
+
+	rc, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("Could not connect with Redis: %v", err)
+	}
+	test.TestDataDB(t, rc)
+	rc.CloseSession()
+
+	rc, err = NewClient(config)
+	if err != nil {
+		t.Fatalf("Could not connect with Redis: %v", err)
+	}
+	test.TestMetadataDB(t, rc)
+	rc.CloseSession()
+
+	rc, err = NewClient(config)
+	if err != nil {
+		t.Fatalf("Could not connect with Redis: %v", err)
+	}
+	test.TestExportDB(t, rc)
+	rc.CloseSession()
+
+}
+
+func BenchmarkRedisDB(b *testing.B) {
+
+	b.Log("This benchmark needs to have a running Redis on localhost")
+
+	config := db.Configuration{
+		Host: redisHost,
+		Port: redisPort,
+	}
+
+	rc, err := NewClient(config)
+	if err != nil {
+		b.Fatalf("Could not connect with Redis: %v", err)
+	}
+
+	test.BenchmarkDB(b, rc)
+}

--- a/internal/pkg/db/redis/data.go
+++ b/internal/pkg/db/redis/data.go
@@ -1,0 +1,975 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/gomodule/redigo/redis"
+	"github.com/google/uuid"
+	"github.com/imdario/mergo"
+)
+
+// ******************************* EVENTS **********************************
+
+// ********************** EVENT FUNCTIONS *******************************
+// Return all the events
+// Sort the events in descending order by ID
+// UnexpectedError - failed to retrieve events from the database
+func (c *Client) Events() (events []contract.Event, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.EventsCollection, 0, -1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return events, err
+		}
+	}
+	events = make([]contract.Event, len(objects))
+	err = unmarshalEvents(objects, events)
+	if err != nil {
+		return events, err
+	}
+
+	return events, nil
+}
+
+// Return events up to the number specified
+// UnexpectedError - failed to retrieve events from the database
+func (c *Client) EventsWithLimit(limit int) (events []contract.Event, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.EventsCollection, 0, limit-1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return events, err
+		}
+	}
+	events = make([]contract.Event, len(objects))
+	err = unmarshalEvents(objects, events)
+	if err != nil {
+		return events, err
+	}
+
+	return events, nil
+}
+
+// Add a new event
+// UnexpectedError - failed to add to database
+// NoValueDescriptor - no existing value descriptor for a reading in the event
+func (c *Client) AddEvent(e contract.Event) (id string, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	if e.ID != "" {
+		_, err = uuid.Parse(e.ID)
+		if err != nil {
+			return "", db.ErrInvalidObjectId
+		}
+	}
+	return addEvent(conn, e)
+}
+
+// Update an event - do NOT update readings
+// UnexpectedError - problem updating in database
+// NotFound - no event with the ID was found
+func (c *Client) UpdateEvent(e contract.Event) (err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	id := e.ID
+
+	o, err := eventByID(conn, id)
+	if err != nil {
+		if err == redis.ErrNil {
+			return db.ErrNotFound
+		}
+		return err
+	}
+
+	e.Modified = db.MakeTimestamp()
+	err = mergo.Merge(&e, o)
+	if err != nil {
+		return err
+	}
+
+	err = deleteEvent(conn, id)
+	if err != nil {
+		return err
+	}
+
+	_, err = addEvent(conn, e)
+	return err
+}
+
+// Get an event by id
+func (c *Client) EventById(id string) (event contract.Event, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	event, err = eventByID(conn, id)
+	if err != nil {
+		if err == redis.ErrNil {
+			return event, db.ErrNotFound
+		}
+		return event, err
+	}
+
+	return event, nil
+}
+
+// Get the number of events in Core Data
+func (c *Client) EventCount() (count int, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	count, err = redis.Int(conn.Do("ZCARD", db.EventsCollection))
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// Get the number of events in Core Data for the device specified by id
+func (c *Client) EventCountByDeviceId(id string) (count int, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	count, err = redis.Int(conn.Do("ZCARD", db.EventsCollection+":device:"+id))
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// Delete an event by ID. Readings are not deleted as this should be handled by the contract layer
+// 404 - Event not found
+// 503 - Unexpected problems
+func (c *Client) DeleteEventById(id string) (err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err = deleteEvent(conn, id)
+	if err != nil {
+		if err == redis.ErrNil {
+			return db.ErrNotFound
+		}
+		return err
+	}
+
+	return nil
+}
+
+// Get a list of events based on the device id and limit
+func (c *Client) EventsForDeviceLimit(id string, limit int) (events []contract.Event, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.EventsCollection+":device:"+id, 0, limit-1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return events, err
+		}
+	}
+
+	events = make([]contract.Event, len(objects))
+	err = unmarshalEvents(objects, events)
+	if err != nil {
+		return events, err
+	}
+
+	return events, nil
+}
+
+// Get a list of events based on the device id
+func (c *Client) EventsForDevice(id string) (events []contract.Event, err error) {
+	events, err = c.EventsForDeviceLimit(id, 0)
+	if err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+// Delete all of the events by the device id (and the readings)
+//DeleteEventsByDeviceId(id string) error
+
+// Return a list of events whos creation time is between startTime and endTime
+// Limit the number of results by limit
+func (c *Client) EventsByCreationTime(startTime, endTime int64, limit int) (events []contract.Event, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByScore(conn, db.EventsCollection+":created", startTime, endTime, limit)
+	if err != nil {
+		if err != redis.ErrNil {
+			return events, err
+		}
+	}
+
+	events = make([]contract.Event, len(objects))
+	err = unmarshalEvents(objects, events)
+	if err != nil {
+		return events, err
+	}
+
+	return events, nil
+}
+
+// Return a list of readings for a device filtered by the value descriptor and limited by the limit
+// The readings are linked to the device through an event
+func (c *Client) ReadingsByDeviceAndValueDescriptor(deviceId, valueDescriptor string, limit int) (readings []contract.Reading, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	if limit == 0 {
+		return readings, nil
+	}
+
+	objects, err := getObjectsByRangeFilter(conn,
+		db.ReadingsCollection+":device:"+deviceId,
+		db.ReadingsCollection+":name:"+valueDescriptor,
+		0, limit-1)
+	if err != nil {
+		return readings, err
+	}
+
+	readings = make([]contract.Reading, len(objects))
+	for i, in := range objects {
+		err = unmarshalObject(in, &readings[i])
+		if err != nil {
+			return readings, err
+		}
+	}
+
+	return readings, nil
+
+}
+
+// Remove all the events that are older than the given age
+// Return the number of events removed
+//RemoveEventByAge(age int64) (int, error)
+
+// Get events that are older than a age
+func (c *Client) EventsOlderThanAge(age int64) ([]contract.Event, error) {
+	expireDate := db.MakeTimestamp() - age
+
+	return c.EventsByCreationTime(0, expireDate, 0)
+}
+
+// Remove all the events that have been pushed
+//func (dbc *DBClient) ScrubEvents()(int, error)
+
+// Get events that have been pushed (pushed field is not 0)
+func (c *Client) EventsPushed() (events []contract.Event, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByScore(conn, db.EventsCollection+":pushed", 1, -1, 0)
+	if err != nil {
+		return events, err
+	}
+
+	events = make([]contract.Event, len(objects))
+	err = unmarshalEvents(objects, events)
+	if err != nil {
+		return events, err
+	}
+
+	return events, nil
+}
+
+// Delete all readings and events
+func (c *Client) ScrubAllEvents() (err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err = unlinkCollection(conn, db.EventsCollection)
+	if err != nil {
+		return err
+	}
+
+	err = unlinkCollection(conn, db.ReadingsCollection)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ********************* READING FUNCTIONS *************************
+// Return a list of readings sorted by reading id
+func (c *Client) Readings() (readings []contract.Reading, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.ReadingsCollection, 0, -1)
+	if err != nil {
+		return readings, err
+	}
+
+	readings = make([]contract.Reading, len(objects))
+	for i, in := range objects {
+		err = unmarshalObject(in, &readings[i])
+		if err != nil {
+			return readings, err
+		}
+	}
+
+	return readings, nil
+}
+
+// Post a new reading
+// Check if valuedescriptor exists in the database
+func (c *Client) AddReading(r contract.Reading) (id string, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	if r.Id != "" {
+		_, err = uuid.Parse(r.Id)
+		if err != nil {
+			return "", db.ErrInvalidObjectId
+		}
+	}
+	return addReading(conn, true, r)
+}
+
+// Update a reading
+// 404 - reading cannot be found
+// 409 - Value descriptor doesn't exist
+// 503 - unknown issues
+func (c *Client) UpdateReading(r contract.Reading) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	id := r.Id
+	o := contract.Reading{}
+	err := getObjectById(conn, id, unmarshalObject, &o)
+	if err != nil {
+		if err == redis.ErrNil {
+			return db.ErrNotFound
+		}
+		return err
+	}
+
+	r.Modified = db.MakeTimestamp()
+	err = mergo.Merge(&r, o)
+	if err != nil {
+		return err
+	}
+
+	err = deleteReading(conn, id)
+	if err != nil {
+		return err
+	}
+
+	if r.Id != "" {
+		_, err = uuid.Parse(r.Id)
+		if err != nil {
+			return db.ErrInvalidObjectId
+		}
+	}
+	_, err = addReading(conn, true, r)
+	return err
+}
+
+// Get a reading by ID
+func (c *Client) ReadingById(id string) (reading contract.Reading, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err = getObjectById(conn, id, unmarshalObject, &reading)
+	if err != nil {
+		if err == redis.ErrNil {
+			return reading, db.ErrNotFound
+		}
+		return reading, err
+	}
+
+	return reading, nil
+}
+
+// Get the number of readings in core data
+func (c *Client) ReadingCount() (int, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	count, err := redis.Int(conn.Do("ZCARD", db.ReadingsCollection))
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// Delete a reading by ID
+// 404 - can't find the reading with the given id
+func (c *Client) DeleteReadingById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteReading(conn, id)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Return a list of readings for the given device (id or name)
+// 404 - meta data checking enabled and can't find the device
+// Sort the list of readings on creation date
+func (c *Client) ReadingsByDevice(id string, limit int) (readings []contract.Reading, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.ReadingsCollection+":device:"+id, 0, limit-1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return readings, err
+		}
+	}
+
+	readings = make([]contract.Reading, len(objects))
+	for i, in := range objects {
+		err = unmarshalObject(in, &readings[i])
+		if err != nil {
+			return readings, err
+		}
+	}
+
+	return readings, nil
+}
+
+// Return a list of readings for the given value descriptor
+// 413 - the number exceeds the current max limit
+func (c *Client) ReadingsByValueDescriptor(name string, limit int) (readings []contract.Reading, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.ReadingsCollection+":name:"+name, 0, limit-1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return readings, err
+		}
+	}
+
+	readings = make([]contract.Reading, len(objects))
+	for i, in := range objects {
+		err = unmarshalObject(in, &readings[i])
+		if err != nil {
+			return readings, err
+		}
+	}
+
+	return readings, nil
+}
+
+// Return a list of readings whose name is in the list of value descriptor names
+func (c *Client) ReadingsByValueDescriptorNames(names []string, limit int) (readings []contract.Reading, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	if limit == 0 {
+		return readings, nil
+	}
+	limit--
+
+	for _, name := range names {
+		objects, err := getObjectsByRange(conn, db.ReadingsCollection+":name:"+name, 0, limit)
+		if err != nil {
+			if err != redis.ErrNil {
+				return readings, err
+			}
+		}
+
+		t := make([]contract.Reading, len(objects))
+		for i, in := range objects {
+			err = unmarshalObject(in, &t[i])
+			if err != nil {
+				return readings, err
+			}
+		}
+
+		readings = append(readings, t...)
+
+		limit -= len(objects)
+		if limit < 0 {
+			break
+		}
+	}
+
+	return readings, nil
+}
+
+// Return a list of readings whos created time is between the start and end times
+func (c *Client) ReadingsByCreationTime(start, end int64, limit int) (readings []contract.Reading, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	if limit == 0 {
+		return readings, nil
+	}
+
+	objects, err := getObjectsByScore(conn, db.ReadingsCollection+":created", start, end, limit)
+	if err != nil {
+		return readings, err
+	}
+
+	readings = make([]contract.Reading, len(objects))
+	for i, in := range objects {
+		err = unmarshalObject(in, &readings[i])
+		if err != nil {
+			return readings, err
+		}
+	}
+
+	return readings, nil
+}
+
+// ************************** VALUE DESCRIPTOR FUNCTIONS ***************************
+// Add a value descriptor
+// 409 - Formatting is bad or it is not unique
+// 503 - Unexpected
+// TODO: Check for valid printf formatting
+func (c *Client) AddValueDescriptor(v contract.ValueDescriptor) (id string, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	if v.Id != "" {
+		_, err = uuid.Parse(v.Id)
+		if err != nil {
+			return "", db.ErrInvalidObjectId
+		}
+	}
+	return addValue(conn, v)
+}
+
+// Return a list of all the value descriptors
+// 513 Service Unavailable - database problems
+func (c *Client) ValueDescriptors() (values []contract.ValueDescriptor, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.ValueDescriptorCollection, 0, -1)
+	if err != nil {
+		return values, err
+	}
+
+	values = make([]contract.ValueDescriptor, len(objects))
+	for i, in := range objects {
+		err = unmarshalObject(in, &values[i])
+		if err != nil {
+			return values, err
+		}
+	}
+
+	return values, nil
+}
+
+// Update a value descriptor
+// First use the ID for identification, then the name
+// TODO: Check for the valid printf formatting
+// 404 not found if the value descriptor cannot be found by the identifiers
+func (c *Client) UpdateValueDescriptor(v contract.ValueDescriptor) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	id := v.Id
+	o, err := valueByName(conn, v.Name)
+	if err != nil && err != redis.ErrNil {
+		return err
+	}
+	if err == nil && o.Id != v.Id {
+		// IDs are different -> name not unique
+		return db.ErrNotUnique
+	}
+
+	v.Modified = db.MakeTimestamp()
+	err = mergo.Merge(&v, o)
+	if err != nil {
+		return err
+	}
+
+	err = deleteValue(conn, id)
+	if err != nil {
+		return err
+	}
+
+	_, err = addValue(conn, v)
+	return err
+}
+
+// Delete a value descriptor based on the ID
+func (c *Client) DeleteValueDescriptorById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteValue(conn, id)
+	if err != nil {
+		if err == redis.ErrNil {
+			return db.ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// Return a value descriptor based on the name
+func (c *Client) ValueDescriptorByName(name string) (value contract.ValueDescriptor, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	value, err = valueByName(conn, name)
+	if err != nil {
+		if err == redis.ErrNil {
+			return value, db.ErrNotFound
+		}
+		return value, err
+	}
+
+	return value, nil
+}
+
+// Return value descriptors based on the names
+func (c *Client) ValueDescriptorsByName(names []string) (values []contract.ValueDescriptor, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	for _, name := range names {
+		value, err := valueByName(conn, name)
+		if err != nil && err != redis.ErrNil {
+			return nil, err
+		}
+
+		if err == nil {
+			values = append(values, value)
+		}
+	}
+
+	return values, nil
+}
+
+// Delete a valuedescriptor based on the name
+//DeleteValueDescriptorByName(name string) error
+
+// Return a value descriptor based on the id
+func (c *Client) ValueDescriptorById(id string) (value contract.ValueDescriptor, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err = getObjectById(conn, id, unmarshalObject, &value)
+	if err == redis.ErrNil {
+		return value, db.ErrNotFound
+	}
+	if err != nil {
+		return value, err
+	}
+
+	return value, nil
+}
+
+// Return value descriptors based on the unit of measure label
+func (c *Client) ValueDescriptorsByUomLabel(uomLabel string) (values []contract.ValueDescriptor, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.ValueDescriptorCollection+":uomlabel:"+uomLabel, 0, -1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return values, err
+		}
+	}
+
+	values = make([]contract.ValueDescriptor, len(objects))
+	for i, in := range objects {
+		err = unmarshalObject(in, &values[i])
+		if err != nil {
+			return values, err
+		}
+	}
+
+	return values, nil
+}
+
+// Return value descriptors based on the label
+func (c *Client) ValueDescriptorsByLabel(label string) (values []contract.ValueDescriptor, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.ValueDescriptorCollection+":label:"+label, 0, -1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return values, err
+		}
+	}
+
+	values = make([]contract.ValueDescriptor, len(objects))
+	for i, in := range objects {
+		err = unmarshalObject(in, &values[i])
+		if err != nil {
+			return values, err
+		}
+	}
+
+	return values, nil
+}
+
+// Return a list of value descriptors based on their type
+func (c *Client) ValueDescriptorsByType(t string) (values []contract.ValueDescriptor, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.ValueDescriptorCollection+":type:"+t, 0, -1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return values, err
+		}
+	}
+
+	values = make([]contract.ValueDescriptor, len(objects))
+	for i, in := range objects {
+		err = unmarshalObject(in, &values[i])
+		if err != nil {
+			return values, err
+		}
+	}
+
+	return values, nil
+}
+
+// Delete all value descriptors
+func (c *Client) ScrubAllValueDescriptors() error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := unlinkCollection(conn, db.ValueDescriptorCollection)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ************************** HELPER FUNCTIONS ***************************
+func addEvent(conn redis.Conn, e contract.Event) (id string, err error) {
+	if e.Created == 0 {
+		e.Created = db.MakeTimestamp()
+	}
+
+	if e.ID == "" {
+		e.ID = uuid.New().String()
+	}
+
+	m, err := marshalEvent(e)
+	if err != nil {
+		return "", err
+	}
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("SET", e.ID, m)
+	_ = conn.Send("ZADD", db.EventsCollection, 0, e.ID)
+	_ = conn.Send("ZADD", db.EventsCollection+":created", e.Created, e.ID)
+	_ = conn.Send("ZADD", db.EventsCollection+":pushed", e.Pushed, e.ID)
+	_ = conn.Send("ZADD", db.EventsCollection+":device:"+e.Device, e.Created, e.ID)
+
+	rids := make([]interface{}, len(e.Readings)*2+1)
+	rids[0] = db.EventsCollection + ":readings:" + e.ID
+	for i, r := range e.Readings {
+		r.Created = e.Created
+		r.Device = e.Device
+
+		if r.Id != "" {
+			_, err = uuid.Parse(r.Id)
+			if err != nil {
+				return "", db.ErrInvalidObjectId
+			}
+		}
+		id, err = addReading(conn, false, r)
+		if err != nil {
+			return id, err
+		}
+		rids[i*2+1] = 0
+		rids[i*2+2] = id
+	}
+	if len(rids) > 1 {
+		_ = conn.Send("ZADD", rids...)
+	}
+
+	_, err = conn.Do("EXEC")
+	return e.ID, err
+}
+
+func deleteEvent(conn redis.Conn, id string) error {
+	_ = conn.Send("MULTI")
+	_ = conn.Send("UNLINK", id)
+	_ = conn.Send("ZRANGE", db.EventsCollection+":readings:"+id, 0, -1)
+	_ = conn.Send("UNLINK", db.EventsCollection+":readings:"+id)
+	_ = conn.Send("ZREM", db.EventsCollection, id)
+	_ = conn.Send("ZREM", db.EventsCollection+":created", id)
+	res, err := redis.Values(conn.Do("EXEC"))
+	if err != nil {
+		return err
+	}
+	exists, _ := redis.Bool(res[0], nil)
+	if !exists {
+		return redis.ErrNil
+	}
+
+	// The Contract is responsible for data coherency thus there is no cleanup of specific readings
+
+	return nil
+}
+
+func eventByID(conn redis.Conn, id string) (event contract.Event, err error) {
+	obj, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return event, db.ErrNotFound
+	}
+	if err != nil {
+		return event, err
+	}
+
+	event, err = unmarshalEvent(obj)
+	if err != nil {
+		return event, err
+	}
+
+	return event, err
+}
+
+// Add a reading to the database
+func addReading(conn redis.Conn, tx bool, r contract.Reading) (id string, err error) {
+	if r.Created == 0 {
+		r.Created = db.MakeTimestamp()
+	}
+
+	if r.Id == "" {
+		r.Id = uuid.New().String()
+	}
+
+	m, err := marshalObject(r)
+	if err != nil {
+		return r.Id, err
+	}
+
+	if tx {
+		_ = conn.Send("MULTI")
+	}
+	_ = conn.Send("SET", r.Id, m)
+	_ = conn.Send("ZADD", db.ReadingsCollection, 0, r.Id)
+	_ = conn.Send("ZADD", db.ReadingsCollection+":created", r.Created, r.Id)
+	_ = conn.Send("ZADD", db.ReadingsCollection+":device:"+r.Device, r.Created, r.Id)
+	_ = conn.Send("ZADD", db.ReadingsCollection+":name:"+r.Name, r.Created, r.Id)
+	if tx {
+		_, err = conn.Do("EXEC")
+	}
+
+	return r.Id, err
+}
+
+func deleteReading(conn redis.Conn, id string) error {
+	r := contract.Reading{}
+	err := getObjectById(conn, id, unmarshalObject, &r)
+	if err != nil {
+		return err
+	}
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("UNLINK", id)
+	_ = conn.Send("ZREM", db.ReadingsCollection, id)
+	_ = conn.Send("ZREM", db.ReadingsCollection+":created", id)
+	_ = conn.Send("ZREM", db.ReadingsCollection+":device:"+r.Device, id)
+	_ = conn.Send("ZREM", db.ReadingsCollection+":name:"+r.Name, id)
+	_, err = conn.Do("EXEC")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addValue(conn redis.Conn, v contract.ValueDescriptor) (id string, err error) {
+	if v.Created == 0 {
+		v.Created = db.MakeTimestamp()
+	}
+
+	if v.Id == "" {
+		v.Id = uuid.New().String()
+	}
+
+	exists, err := redis.Bool(conn.Do("HEXISTS", db.ValueDescriptorCollection+":name", v.Name))
+	if err != nil {
+		return "", err
+	} else if exists {
+		return "", db.ErrNotUnique
+	}
+
+	m, err := marshalObject(v)
+	if err != nil {
+		return "", err
+	}
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("SET", v.Id, m)
+	_ = conn.Send("ZADD", db.ValueDescriptorCollection, 0, v.Id)
+	_ = conn.Send("HSET", db.ValueDescriptorCollection+":name", v.Name, v.Id)
+	_ = conn.Send("ZADD", db.ValueDescriptorCollection+":uomlabel:"+v.UomLabel, 0, v.Id)
+	_ = conn.Send("ZADD", db.ValueDescriptorCollection+":type:"+v.Type, 0, v.Id)
+	for _, label := range v.Labels {
+		_ = conn.Send("ZADD", db.ValueDescriptorCollection+":label:"+label, 0, v.Id)
+	}
+	_, err = conn.Do("EXEC")
+	return v.Id, err
+}
+
+func deleteValue(conn redis.Conn, id string) error {
+	v := contract.ValueDescriptor{}
+	err := getObjectById(conn, id, unmarshalObject, &v)
+	if err != nil {
+		return err
+	}
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("UNLINK", id)
+	_ = conn.Send("ZREM", db.ValueDescriptorCollection, id)
+	_ = conn.Send("HDEL", db.ValueDescriptorCollection+":name", v.Name)
+	_ = conn.Send("ZREM", db.ValueDescriptorCollection+":uomlabel:"+v.UomLabel, id)
+	_ = conn.Send("ZREM", db.ValueDescriptorCollection+":type:"+v.Type, id)
+	for _, label := range v.Labels {
+		_ = conn.Send("ZREM", db.ValueDescriptorCollection+":label:"+label, 0, id)
+	}
+	_, err = conn.Do("EXEC")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func valueByName(conn redis.Conn, name string) (value contract.ValueDescriptor, err error) {
+	id, err := redis.String(conn.Do("HGET", db.ValueDescriptorCollection+":name", name))
+	if err != nil {
+		return value, err
+	}
+
+	err = getObjectById(conn, id, unmarshalObject, &value)
+	if err != nil {
+		return value, err
+	}
+
+	return value, nil
+}

--- a/internal/pkg/db/redis/device.go
+++ b/internal/pkg/db/redis/device.go
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"fmt"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type redisDevice struct {
+	contract.DescribedObject
+	Id             string
+	Name           string
+	AdminState     contract.AdminState
+	OperatingState contract.OperatingState
+	Protocols      map[string]contract.ProtocolProperties
+	AutoEvents     []contract.AutoEvent
+	LastConnected  int64
+	LastReported   int64
+	Labels         []string
+	Location       interface{}
+	Service        string
+	Profile        string
+}
+
+func marshalDevice(d contract.Device) (out []byte, err error) {
+	s := redisDevice{
+		DescribedObject: d.DescribedObject,
+		Id:              d.Id,
+		Name:            d.Name,
+		AdminState:      d.AdminState,
+		OperatingState:  d.OperatingState,
+		Protocols:       d.Protocols,
+		AutoEvents:      d.AutoEvents,
+		LastConnected:   d.LastConnected,
+		LastReported:    d.LastReported,
+		Labels:          d.Labels,
+		Location:        d.Location,
+		Service:         d.Service.Id,
+		Profile:         d.Profile.Id,
+	}
+
+	return marshalObject(s)
+}
+
+func unmarshalDevice(o []byte, d interface{}) (err error) {
+	var s redisDevice
+
+	err = unmarshalObject(o, &s)
+	if err != nil {
+		return err
+	}
+
+	switch x := d.(type) {
+	case *contract.Device:
+		x.DescribedObject = s.DescribedObject
+		x.Id = s.Id
+		x.Name = s.Name
+		x.AdminState = s.AdminState
+		x.Protocols = s.Protocols
+		x.AutoEvents = s.AutoEvents
+		x.OperatingState = s.OperatingState
+		x.LastConnected = s.LastConnected
+		x.LastReported = s.LastReported
+		x.Labels = s.Labels
+		x.Location = s.Location
+
+		conn, err := getConnection()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		err = getObjectById(conn, s.Service, unmarshalDeviceService, &x.Service)
+		if err != nil {
+			return err
+		}
+
+		err = getObjectById(conn, s.Profile, unmarshalDeviceProfile, &x.Profile)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("Can only unmarshal into a *Device, got %T", x)
+	}
+}

--- a/internal/pkg/db/redis/device_profile.go
+++ b/internal/pkg/db/redis/device_profile.go
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"fmt"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/gomodule/redigo/redis"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type redisDeviceProfile struct {
+	contract.DescribedObject
+	Id              string
+	Name            string
+	Manufacturer    string
+	Model           string
+	Labels          []string
+	DeviceResources []contract.DeviceResource
+	Resources       []contract.ProfileResource
+}
+
+func marshalDeviceProfile(dp contract.DeviceProfile) (out []byte, err error) {
+	s := redisDeviceProfile{
+		DescribedObject: dp.DescribedObject,
+		Id:              dp.Id,
+		Name:            dp.Name,
+		Manufacturer:    dp.Manufacturer,
+		Model:           dp.Model,
+		Labels:          dp.Labels,
+		DeviceResources: dp.DeviceResources,
+		Resources:       dp.Resources,
+	}
+
+	return marshalObject(s)
+}
+
+func unmarshalDeviceProfile(o []byte, dp interface{}) (err error) {
+	var s redisDeviceProfile
+
+	err = unmarshalObject(o, &s)
+	if err != nil {
+		return err
+	}
+
+	switch x := dp.(type) {
+	case *contract.DeviceProfile:
+		x.DescribedObject = s.DescribedObject
+		x.Id = s.Id
+		x.Name = s.Name
+		x.Manufacturer = s.Manufacturer
+		x.Model = s.Model
+		x.Labels = s.Labels
+		x.DeviceResources = s.DeviceResources
+		x.Resources = s.Resources
+		conn, err := getConnection()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		objects, err := getObjectsByValue(conn, db.DeviceProfile+":commands:"+s.Id)
+		if err != nil {
+			if err != redis.ErrNil {
+				return err
+			}
+		}
+
+		x.Commands = make([]contract.Command, len(objects))
+		for i, in := range objects {
+			err = unmarshalObject(in, &x.Commands[i])
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("Can only unmarshal into a *DeviceProfile, got %T", x)
+	}
+}

--- a/internal/pkg/db/redis/device_service.go
+++ b/internal/pkg/db/redis/device_service.go
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"fmt"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type redisDeviceService struct {
+	contract.DescribedObject
+	Id             string
+	Name           string
+	LastConnected  int64
+	LastReported   int64
+	OperatingState contract.OperatingState
+	Addressable    string
+	Labels         []string
+	AdminState     contract.AdminState
+}
+
+func marshalDeviceService(ds contract.DeviceService) (out []byte, err error) {
+	s := redisDeviceService{
+		DescribedObject: ds.Service.DescribedObject,
+		Id:              ds.Service.Id,
+		Name:            ds.Service.Name,
+		LastConnected:   ds.Service.LastConnected,
+		LastReported:    ds.Service.LastReported,
+		OperatingState:  ds.Service.OperatingState,
+		Addressable:     ds.Addressable.Id,
+		Labels:          ds.Labels,
+		AdminState:      ds.AdminState,
+	}
+
+	return marshalObject(s)
+}
+
+func unmarshalDeviceService(o []byte, ds interface{}) (err error) {
+	var s redisDeviceService
+
+	err = unmarshalObject(o, &s)
+	if err != nil {
+		return err
+	}
+
+	switch x := ds.(type) {
+	case *contract.DeviceService:
+		x.DescribedObject = s.DescribedObject
+		x.Id = s.Id
+		x.Name = s.Name
+		x.LastConnected = s.LastConnected
+		x.LastReported = s.LastReported
+		x.OperatingState = s.OperatingState
+		x.Labels = s.Labels
+		x.AdminState = s.AdminState
+		conn, err := getConnection()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		err = getObjectById(conn, s.Addressable, unmarshalObject, &x.Addressable)
+		return err
+	default:
+		return fmt.Errorf("Can only unmarshal into a *DeviceService, got %T", x)
+	}
+}

--- a/internal/pkg/db/redis/event.go
+++ b/internal/pkg/db/redis/event.go
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"encoding/json"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/gomodule/redigo/redis"
+)
+
+type redisEvent struct {
+	ID       string
+	Pushed   int64
+	Device   string
+	Created  int64
+	Modified int64
+	Origin   int64
+}
+
+func marshalEvent(event contract.Event) (out []byte, err error) {
+	s := redisEvent{
+		ID:       event.ID,
+		Pushed:   event.Pushed,
+		Device:   event.Device,
+		Created:  event.Created,
+		Modified: event.Modified,
+		Origin:   event.Origin,
+	}
+
+	return marshalObject(s)
+}
+
+func unmarshalEvents(objects [][]byte, events []contract.Event) (err error) {
+	for i, o := range objects {
+		if len(o) > 0 {
+			events[i], err = unmarshalEvent(o)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func unmarshalEvent(o []byte) (event contract.Event, err error) {
+	var s redisEvent
+
+	err = json.Unmarshal(o, &s)
+	if err != nil {
+		return contract.Event{}, err
+	}
+
+	event.ID = s.ID
+	event.Pushed = s.Pushed
+	event.Device = s.Device
+	event.Created = s.Created
+	event.Modified = s.Modified
+	event.Origin = s.Origin
+
+	conn, err := getConnection()
+	if err != nil {
+		return event, err
+	}
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.EventsCollection+":readings:"+s.ID, 0, -1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return event, err
+		}
+	}
+
+	event.Readings = make([]contract.Reading, len(objects))
+
+	for i, in := range objects {
+		err = unmarshalObject(in, &event.Readings[i])
+		if err != nil {
+			return event, err
+		}
+	}
+
+	return event, nil
+}

--- a/internal/pkg/db/redis/export.go
+++ b/internal/pkg/db/redis/export.go
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"encoding/json"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/gomodule/redigo/redis"
+	"github.com/google/uuid"
+)
+
+// ********************** REGISTRATION FUNCTIONS *****************************
+// Return all the registrations
+// UnexpectedError - failed to retrieve registrations from the database
+func (c *Client) Registrations() (r []contract.Registration, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.ExportCollection, 0, -1)
+	if err != nil {
+		return nil, err
+	}
+
+	r = make([]contract.Registration, len(objects))
+	for i, object := range objects {
+		err = json.Unmarshal(object, &r[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return r, err
+}
+
+// Add a new registration
+// UnexpectedError - failed to add to database
+func (c *Client) AddRegistration(reg contract.Registration) (id string, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	if reg.ID != "" {
+		_, err = uuid.Parse(reg.ID)
+		if err != nil {
+			return "", db.ErrInvalidObjectId
+		}
+	}
+
+	return addRegistration(conn, reg)
+}
+
+// Update a registration
+// UnexpectedError - problem updating in database
+// NotFound - no registration with the ID was found
+func (c *Client) UpdateRegistration(reg contract.Registration) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteRegistration(conn, reg.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = addRegistration(conn, reg)
+	return err
+}
+
+// Get a registration by ID
+// UnexpectedError - problem getting in database
+// NotFound - no registration with the ID was found
+func (c *Client) RegistrationById(id string) (r contract.Registration, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err = getObjectById(conn, id, unmarshalObject, &r)
+	return r, err
+}
+
+// Get a registration by name
+// UnexpectedError - problem getting in database
+// NotFound - no registration with the name was found
+func (c *Client) RegistrationByName(name string) (r contract.Registration, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err = getObjectByHash(conn, db.ExportCollection+":name", name, unmarshalObject, &r)
+	return r, err
+}
+
+// Delete a registration by ID
+// UnexpectedError - problem getting in database
+// NotFound - no registration with the ID was found
+func (c *Client) DeleteRegistrationById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return deleteRegistration(conn, id)
+}
+
+// Delete a registration by name
+// UnexpectedError - problem getting in database
+// NotFound - no registration with the name was found
+func (c *Client) DeleteRegistrationByName(name string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	id, err := redis.String(conn.Do("HGET", db.ExportCollection+":name", name))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	return deleteRegistration(conn, id)
+}
+
+//  ScrubAllRegistrations deletes all export related data
+func (c *Client) ScrubAllRegistrations() (err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return unlinkCollection(conn, db.ExportCollection)
+}
+
+func addRegistration(conn redis.Conn, r contract.Registration) (id string, err error) {
+	if r.ID == "" {
+		r.ID = uuid.New().String()
+	}
+
+	ts := db.MakeTimestamp()
+	if r.Created == 0 {
+		r.Created = ts
+	}
+	r.Modified = ts
+
+	m, err := marshalObject(r)
+	if err != nil {
+		return r.ID, err
+	}
+
+	conn.Send("MULTI")
+	conn.Send("SET", r.ID, m)
+	conn.Send("ZADD", db.ExportCollection, 0, r.ID)
+	conn.Send("HSET", db.ExportCollection+":name", r.Name, r.ID)
+	_, err = conn.Do("EXEC")
+	return r.ID, err
+}
+
+func deleteRegistration(conn redis.Conn, id string) error {
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	r := contract.Registration{}
+	_ = unmarshalObject(object, &r)
+
+	conn.Send("MULTI")
+	conn.Send("DEL", id)
+	conn.Send("ZREM", db.ExportCollection, id)
+	conn.Send("HDEL", db.ExportCollection+":name", r.Name)
+	_, err = conn.Do("EXEC")
+	return err
+}

--- a/internal/pkg/db/redis/metadata.go
+++ b/internal/pkg/db/redis/metadata.go
@@ -1,0 +1,1329 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	dataBase "github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/gomodule/redigo/redis"
+	"github.com/google/uuid"
+)
+
+// /* ----------------------Device Report --------------------------*/
+func (c *Client) GetAllDeviceReports() ([]contract.DeviceReport, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.DeviceReport, 0, -1)
+	if err != nil {
+		return []contract.DeviceReport{}, err
+	}
+
+	d := make([]contract.DeviceReport, len(objects))
+	for i, object := range objects {
+		err = unmarshalObject(object, &d[i])
+		if err != nil {
+			return []contract.DeviceReport{}, err
+		}
+	}
+
+	return d, nil
+}
+
+func (c *Client) GetDeviceReportByName(n string) (contract.DeviceReport, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	d := contract.DeviceReport{}
+	err := getObjectByHash(conn, db.DeviceReport+":name", n, unmarshalObject, &d)
+
+	return d, err
+}
+
+func (c *Client) GetDeviceReportByDeviceName(n string) ([]contract.DeviceReport, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, db.DeviceReport+":device:"+n)
+	if err != nil {
+		return []contract.DeviceReport{}, err
+	}
+
+	d := make([]contract.DeviceReport, len(objects))
+	for i, object := range objects {
+		err = unmarshalObject(object, &d[i])
+		if err != nil {
+			return []contract.DeviceReport{}, err
+		}
+	}
+
+	return d, nil
+}
+
+func (c *Client) GetDeviceReportById(id string) (contract.DeviceReport, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var d contract.DeviceReport
+	err := getObjectById(conn, id, unmarshalObject, &d)
+	return d, err
+}
+
+func (c *Client) GetDeviceReportsByScheduleEventName(n string) ([]contract.DeviceReport, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, db.DeviceReport+":scheduleevent:"+n)
+	if err != nil {
+		return []contract.DeviceReport{}, err
+	}
+
+	d := make([]contract.DeviceReport, len(objects))
+	for i, object := range objects {
+		err = unmarshalObject(object, &d[i])
+		if err != nil {
+			return []contract.DeviceReport{}, err
+		}
+	}
+
+	return d, nil
+}
+
+func (c *Client) GetDeviceReportsByAction(n string) ([]contract.DeviceReport, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, db.DeviceReport+":action:"+n)
+	if err != nil {
+		return []contract.DeviceReport{}, err
+	}
+
+	d := make([]contract.DeviceReport, len(objects))
+	for i, object := range objects {
+		err = unmarshalObject(object, &d[i])
+		if err != nil {
+			return []contract.DeviceReport{}, err
+		}
+	}
+
+	return d, nil
+}
+
+func (c *Client) AddDeviceReport(d contract.DeviceReport) (string, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return addDeviceReport(conn, d)
+}
+
+func (c *Client) UpdateDeviceReport(dr contract.DeviceReport) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteDeviceReport(conn, dr.Id)
+	if err != nil {
+		return err
+	}
+
+	_, err = addDeviceReport(conn, dr)
+	return err
+}
+
+func (c *Client) DeleteDeviceReportById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return deleteDeviceReport(conn, id)
+}
+
+func addDeviceReport(conn redis.Conn, dr contract.DeviceReport) (string, error) {
+	exists, err := redis.Bool(conn.Do("HEXISTS", db.DeviceReport+":name", dr.Name))
+	if err != nil {
+		return "", err
+	} else if exists {
+		return "", db.ErrNotUnique
+	}
+
+	_, err = uuid.Parse(dr.Id)
+	if err != nil {
+		dr.Id = uuid.New().String()
+	}
+	id := dr.Id
+
+	ts := db.MakeTimestamp()
+	if dr.Created == 0 {
+		dr.Created = ts
+	}
+	dr.Modified = ts
+
+	m, err := marshalObject(dr)
+	if err != nil {
+		return "", err
+	}
+
+	conn.Send("MULTI")
+	conn.Send("SET", id, m)
+	conn.Send("ZADD", db.DeviceReport, 0, id)
+	conn.Send("SADD", db.DeviceReport+":device:"+dr.Device, id)
+	conn.Send("SADD", db.DeviceReport+":action:"+dr.Action, id)
+	conn.Send("HSET", db.DeviceReport+":name", dr.Name, id)
+	_, err = conn.Do("EXEC")
+	return id, err
+}
+
+func deleteDeviceReport(conn redis.Conn, id string) error {
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	dr := contract.DeviceReport{}
+	_ = unmarshalObject(object, &dr)
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("DEL", id)
+	_ = conn.Send("ZREM", db.DeviceReport, id)
+	_ = conn.Send("SREM", db.DeviceReport+":device:"+dr.Device, id)
+	_ = conn.Send("SREM", db.DeviceReport+":action:"+dr.Action, id)
+	_ = conn.Send("HDEL", db.DeviceReport+":name", dr.Name)
+	_, err = conn.Do("EXEC")
+	return err
+}
+
+// /* ----------------------------- Device ---------------------------------- */
+func (c *Client) AddDevice(d contract.Device) (string, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return addDevice(conn, d)
+}
+
+func (c *Client) UpdateDevice(d contract.Device) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteDevice(conn, d.Id)
+	if err != nil {
+		return err
+	}
+
+	_, err = addDevice(conn, d)
+	return err
+}
+
+func (c *Client) DeleteDeviceById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return deleteDevice(conn, id)
+}
+
+func (c *Client) GetAllDevices() ([]contract.Device, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.Device, 0, -1)
+	if err != nil {
+		return []contract.Device{}, err
+	}
+
+	d := make([]contract.Device, len(objects))
+	for i, object := range objects {
+		err = unmarshalDevice(object, &d[i])
+		if err != nil {
+			return []contract.Device{}, err
+		}
+	}
+
+	return d, nil
+}
+
+func (c *Client) GetDevicesByProfileId(id string) ([]contract.Device, error) {
+	d, err := c.getDevicesByValue(db.Device + ":profile:" + id)
+
+	// XXX This is here only because test/db_metadata.go is inconsistent when testing for _not found_. It
+	// should always be checking for database.ErrNotFound but too often it is checking for nil
+	if len(d) == 0 {
+		err = dataBase.ErrNotFound
+	}
+
+	return d, err
+}
+
+func (c *Client) GetDeviceById(id string) (contract.Device, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var d contract.Device
+	err := getObjectById(conn, id, unmarshalDevice, &d)
+	return d, err
+}
+
+func (c *Client) GetDeviceByName(n string) (contract.Device, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var d contract.Device
+	err := getObjectByHash(conn, db.Device+":name", n, unmarshalDevice, &d)
+	return d, err
+}
+
+func (c *Client) GetDevicesByServiceId(id string) ([]contract.Device, error) {
+	d, err := c.getDevicesByValue(db.Device + ":service:" + id)
+
+	// XXX This is here only because test/db_metadata.go is inconsistent when testing for _not found_. It
+	// should always be checking for database.ErrNotFound but too often it is checking for nil
+	if len(d) == 0 {
+		err = dataBase.ErrNotFound
+	}
+
+	return d, err
+}
+
+func (c *Client) GetDevicesWithLabel(l string) ([]contract.Device, error) {
+	return c.getDevicesByValue(db.Device + ":label:" + l)
+}
+
+func (c *Client) getDevicesByValue(v string) ([]contract.Device, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, v)
+	if err != nil {
+		return []contract.Device{}, err
+	}
+
+	d := make([]contract.Device, len(objects))
+	for i, object := range objects {
+		err = unmarshalDevice(object, &d[i])
+		if err != nil {
+			return []contract.Device{}, err
+		}
+	}
+
+	return d, nil
+}
+
+func addDevice(conn redis.Conn, d contract.Device) (string, error) {
+	exists, err := redis.Bool(conn.Do("HEXISTS", db.Device+":name", d.Name))
+	if err != nil {
+		return "", err
+	} else if exists {
+		return "", db.ErrNotUnique
+	}
+
+	_, err = uuid.Parse(d.Id)
+	if err != nil {
+		d.Id = uuid.New().String()
+	}
+	id := d.Id
+
+	ts := db.MakeTimestamp()
+	if d.Created == 0 {
+		d.Created = ts
+	}
+	d.Modified = ts
+
+	m, err := marshalDevice(d)
+	if err != nil {
+		return "", err
+	}
+
+	conn.Send("MULTI")
+	conn.Send("SET", id, m)
+	conn.Send("ZADD", db.Device, 0, id)
+	conn.Send("HSET", db.Device+":name", d.Name, id)
+	conn.Send("SADD", db.Device+":service:"+d.Service.Id, id)
+	conn.Send("SADD", db.Device+":profile:"+d.Profile.Id, id)
+	for _, label := range d.Labels {
+		conn.Send("SADD", db.Device+":label:"+label, id)
+	}
+	_, err = conn.Do("EXEC")
+	return id, err
+}
+
+func deleteDevice(conn redis.Conn, id string) error {
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	d := contract.Device{}
+	_ = unmarshalDevice(object, &d)
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("DEL", id)
+	_ = conn.Send("ZREM", db.Device, id)
+	_ = conn.Send("HDEL", db.Device+":name", d.Name)
+	_ = conn.Send("SREM", db.Device+":service:"+d.Service.Id, id)
+	_ = conn.Send("SREM", db.Device+":profile:"+d.Profile.Id, id)
+	for _, label := range d.Labels {
+		conn.Send("SREM", db.Device+":label:"+label, id)
+	}
+	_, err = conn.Do("EXEC")
+	return err
+}
+
+// /* -----------------------------Device Profile -----------------------------*/
+func (c *Client) GetDeviceProfileById(id string) (contract.DeviceProfile, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var d contract.DeviceProfile
+	err := getObjectById(conn, id, unmarshalDeviceProfile, &d)
+	return d, err
+}
+
+func (c *Client) GetAllDeviceProfiles() ([]contract.DeviceProfile, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.DeviceProfile, 0, -1)
+	if err != nil {
+		return []contract.DeviceProfile{}, err
+	}
+
+	dp := make([]contract.DeviceProfile, len(objects))
+	for i, object := range objects {
+		err = unmarshalDeviceProfile(object, &dp[i])
+		if err != nil {
+			return []contract.DeviceProfile{}, err
+		}
+	}
+
+	return dp, nil
+}
+
+func (c *Client) GetDeviceProfilesByModel(model string) ([]contract.DeviceProfile, error) {
+	return c.getDeviceProfilesByValues(db.DeviceProfile + ":model:" + model)
+}
+
+func (c *Client) GetDeviceProfilesWithLabel(l string) ([]contract.DeviceProfile, error) {
+	return c.getDeviceProfilesByValues(db.DeviceProfile + ":label:" + l)
+}
+
+func (c *Client) GetDeviceProfilesByManufacturerModel(man string, mod string) ([]contract.DeviceProfile, error) {
+	return c.getDeviceProfilesByValues(db.DeviceProfile+":manufacturer:"+man, db.DeviceProfile+":model:"+mod)
+}
+
+func (c *Client) GetDeviceProfilesByManufacturer(man string) ([]contract.DeviceProfile, error) {
+	return c.getDeviceProfilesByValues(db.DeviceProfile + ":manufacturer:" + man)
+}
+
+func (c *Client) GetDeviceProfileByName(n string) (contract.DeviceProfile, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var dp contract.DeviceProfile
+	err := getObjectByHash(conn, db.DeviceProfile+":name", n, unmarshalDeviceProfile, &dp)
+	return dp, err
+}
+
+func (c *Client) GetDeviceProfilesByCommandId(id string) ([]contract.DeviceProfile, error) {
+	dp, err := c.getDeviceProfilesByValues(db.DeviceProfile + ":command:" + id)
+
+	// XXX This is here only because test/db_metadata.go is inconsistent when testing for _not found_. It
+	// should always be checking for database.ErrNotFound but too often it is checking for nil
+	if len(dp) == 0 {
+		err = dataBase.ErrNotFound
+	}
+
+	return dp, err
+}
+
+// Get device profiles with the passed query
+func (c *Client) getDeviceProfilesByValues(vals ...string) ([]contract.DeviceProfile, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValues(conn, vals...)
+	if err != nil {
+		return []contract.DeviceProfile{}, err
+	}
+
+	dp := make([]contract.DeviceProfile, len(objects))
+	for i, object := range objects {
+		err = unmarshalDeviceProfile(object, &dp[i])
+		if err != nil {
+			return []contract.DeviceProfile{}, err
+		}
+	}
+
+	return dp, nil
+}
+
+func (c *Client) AddDeviceProfile(dp contract.DeviceProfile) (string, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return addDeviceProfile(conn, dp)
+}
+
+func (c *Client) UpdateDeviceProfile(dp contract.DeviceProfile) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteDeviceProfile(conn, dp.Id)
+	if err != nil {
+		return err
+	}
+
+	_, err = addDeviceProfile(conn, dp)
+	return err
+}
+
+func (c *Client) DeleteDeviceProfileById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return deleteDeviceProfile(conn, id)
+}
+
+func addDeviceProfile(conn redis.Conn, dp contract.DeviceProfile) (string, error) {
+	exists, err := redis.Bool(conn.Do("HEXISTS", db.DeviceProfile+":name", dp.Name))
+	if err != nil {
+		return "", err
+	} else if exists {
+		return "", db.ErrNotUnique
+	}
+
+	_, err = uuid.Parse(dp.Id)
+	if err != nil {
+		dp.Id = uuid.New().String()
+	}
+	id := dp.Id
+
+	ts := db.MakeTimestamp()
+	if dp.Created == 0 {
+		dp.Created = ts
+	}
+	dp.Modified = ts
+
+	m, err := marshalDeviceProfile(dp)
+	if err != nil {
+		return "", err
+	}
+
+	conn.Send("MULTI")
+	conn.Send("SET", id, m)
+	conn.Send("ZADD", db.DeviceProfile, 0, id)
+	conn.Send("HSET", db.DeviceProfile+":name", dp.Name, id)
+	conn.Send("SADD", db.DeviceProfile+":manufacturer:"+dp.Manufacturer, id)
+	conn.Send("SADD", db.DeviceProfile+":model:"+dp.Model, id)
+	for _, label := range dp.Labels {
+		conn.Send("SADD", db.DeviceProfile+":label:"+label, id)
+	}
+	if len(dp.Commands) > 0 {
+		cids := redis.Args{}.Add(db.DeviceProfile + ":commands:" + id)
+		for _, c := range dp.Commands {
+			cid, err := addCommand(conn, false, c)
+			if err != nil {
+				return "", err
+			}
+			conn.Send("SADD", db.DeviceProfile+":command:"+cid, id)
+			cids = cids.Add(cid)
+		}
+		conn.Send("SADD", cids...)
+	}
+	_, err = conn.Do("EXEC")
+	return id, err
+}
+
+func deleteDeviceProfile(conn redis.Conn, id string) error {
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	dp := contract.DeviceProfile{}
+	_ = unmarshalObject(object, &dp)
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("DEL", id)
+	_ = conn.Send("ZREM", db.DeviceProfile, id)
+	_ = conn.Send("HDEL", db.DeviceProfile+":name", dp.Name)
+	_ = conn.Send("SREM", db.DeviceProfile+":manufacturer:"+dp.Manufacturer, id)
+	_ = conn.Send("SREM", db.DeviceProfile+":model:"+dp.Model, id)
+	for _, label := range dp.Labels {
+		conn.Send("SREM", db.DeviceProfile+":label:"+label, id)
+	}
+	// TODO: should commands be also removed?
+	for _, c := range dp.Commands {
+		conn.Send("SREM", db.DeviceProfile+":command:"+c.Id, id)
+	}
+	conn.Send("DEL", db.DeviceProfile+":commands:"+id)
+	_, err = conn.Do("EXEC")
+	return err
+}
+
+/* -----------------------------------Addressable -------------------------- */
+//func (c *Client) UpdateAddressable(updated *contract.Addressable, orig *contract.Addressable) error {
+func (c *Client) UpdateAddressable(a contract.Addressable) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteAddressable(conn, a.Id)
+	if err != nil {
+		return err
+	}
+
+	_, err = addAddressable(conn, a)
+	return err
+}
+
+func (c *Client) AddAddressable(a contract.Addressable) (string, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return addAddressable(conn, a)
+}
+
+func (c *Client) GetAddressableById(id string) (contract.Addressable, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var a contract.Addressable
+	err := getObjectById(conn, id, unmarshalObject, &a)
+	return a, err
+}
+
+func (c *Client) GetAddressableByName(n string) (contract.Addressable, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var a contract.Addressable
+	err := getObjectByHash(conn, db.Addressable+":name", n, unmarshalObject, &a)
+	return a, err
+}
+
+func (c *Client) GetAddressablesByTopic(t string) ([]contract.Addressable, error) {
+	return c.getAddressablesByValue(db.Addressable + ":topic:" + t)
+}
+
+func (c *Client) GetAddressablesByPort(p int) ([]contract.Addressable, error) {
+	return c.getAddressablesByValue(db.Addressable + ":port:" + strconv.Itoa(p))
+}
+
+func (c *Client) GetAddressablesByPublisher(p string) ([]contract.Addressable, error) {
+	return c.getAddressablesByValue(db.Addressable + ":publisher:" + p)
+}
+
+func (c *Client) GetAddressablesByAddress(add string) ([]contract.Addressable, error) {
+	return c.getAddressablesByValue(db.Addressable + ":address:" + add)
+}
+
+func (c *Client) GetAddressables() ([]contract.Addressable, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.Addressable, 0, -1)
+	if err != nil {
+		return []contract.Addressable{}, err
+	}
+
+	d := make([]contract.Addressable, len(objects))
+	for i, object := range objects {
+		err = unmarshalObject(object, &d[i])
+		if err != nil {
+			return []contract.Addressable{}, err
+		}
+	}
+
+	return d, nil
+}
+
+func (c *Client) DeleteAddressableById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return deleteAddressable(conn, id)
+}
+
+func (c *Client) getAddressablesByValue(v string) ([]contract.Addressable, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, v)
+	if err != nil {
+		return []contract.Addressable{}, err
+	}
+
+	a := make([]contract.Addressable, len(objects))
+	for i, object := range objects {
+		err = unmarshalObject(object, &a[i])
+		if err != nil {
+			return []contract.Addressable{}, err
+		}
+	}
+
+	return a, nil
+}
+
+func addAddressable(conn redis.Conn, a contract.Addressable) (string, error) {
+	exists, err := redis.Bool(conn.Do("HEXISTS", db.Addressable+":name", a.Name))
+	if err != nil {
+		return a.Id, err
+	} else if exists {
+		return a.Id, db.ErrNotUnique
+	}
+
+	_, err = uuid.Parse(a.Id)
+	if err != nil {
+		a.Id = uuid.New().String()
+	}
+	id := a.Id
+
+	ts := db.MakeTimestamp()
+	if a.Created == 0 {
+		a.Created = ts
+	}
+	a.Modified = ts
+
+	m, err := marshalObject(a)
+	if err != nil {
+		return a.Id, err
+	}
+
+	conn.Send("MULTI")
+	conn.Send("SET", id, m)
+	conn.Send("ZADD", db.Addressable, 0, id)
+	conn.Send("SADD", db.Addressable+":topic:"+a.Topic, id)
+	conn.Send("SADD", db.Addressable+":port:"+strconv.Itoa(a.Port), id)
+	conn.Send("SADD", db.Addressable+":publisher:"+a.Publisher, id)
+	conn.Send("SADD", db.Addressable+":address:"+a.Address, id)
+	conn.Send("HSET", db.Addressable+":name", a.Name, id)
+	_, err = conn.Do("EXEC")
+	if err != nil {
+		return a.Id, err
+	}
+
+	return a.Id, err
+}
+
+func deleteAddressable(conn redis.Conn, id string) error {
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	// TODO: ??? check if addressable is used by DeviceServices
+
+	a := contract.Addressable{}
+	_ = unmarshalObject(object, &a)
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("DEL", id)
+	_ = conn.Send("ZREM", db.Addressable, id)
+	_ = conn.Send("SREM", db.Addressable+":topic:"+a.Topic, id)
+	_ = conn.Send("SREM", db.Addressable+":port:"+strconv.Itoa(a.Port), id)
+	_ = conn.Send("SREM", db.Addressable+":publisher:"+a.Publisher, id)
+	_ = conn.Send("SREM", db.Addressable+":address:"+a.Address, id)
+	_ = conn.Send("HDEL", db.Addressable+":name", a.Name)
+	_, err = conn.Do("EXEC")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// /* ----------------------------- Device Service ----------------------------------*/
+func (c *Client) GetDeviceServiceByName(n string) (contract.DeviceService, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var d contract.DeviceService
+	err := getObjectByHash(conn, db.DeviceService+":name", n, unmarshalDeviceService, &d)
+	return d, err
+}
+
+func (c *Client) GetDeviceServiceById(id string) (contract.DeviceService, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var d contract.DeviceService
+	err := getObjectById(conn, id, unmarshalDeviceService, &d)
+	return d, err
+}
+
+func (c *Client) GetAllDeviceServices() ([]contract.DeviceService, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.DeviceService, 0, -1)
+	if err != nil {
+		return []contract.DeviceService{}, err
+	}
+
+	d := make([]contract.DeviceService, len(objects))
+	for i, object := range objects {
+		err = unmarshalDeviceService(object, &d[i])
+		if err != nil {
+			return []contract.DeviceService{}, err
+		}
+	}
+
+	return d, nil
+}
+
+func (c *Client) GetDeviceServicesByAddressableId(id string) ([]contract.DeviceService, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, db.DeviceService+":addressable:"+id)
+	if err != nil {
+		return []contract.DeviceService{}, err
+	}
+
+	// XXX This should really return an ErrNotFound. It's not to be consistent with existing code
+	// assumptions
+	//
+	// if len(objects) == 0 {
+	// 	return []contract.DeviceService{}, dataBase.ErrNotFound
+	// }
+
+	d := make([]contract.DeviceService, len(objects))
+	for i, object := range objects {
+		err = unmarshalDeviceService(object, &d[i])
+		if err != nil {
+			return []contract.DeviceService{}, err
+		}
+	}
+	return d, nil
+}
+
+func (c *Client) GetDeviceServicesWithLabel(l string) ([]contract.DeviceService, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, db.DeviceService+":label:"+l)
+	if err != nil {
+		return []contract.DeviceService{}, err
+	}
+
+	d := make([]contract.DeviceService, len(objects))
+	for i, object := range objects {
+		err = unmarshalDeviceService(object, &d[i])
+		if err != nil {
+			return []contract.DeviceService{}, err
+		}
+	}
+	return d, nil
+}
+
+func (c *Client) AddDeviceService(ds contract.DeviceService) (string, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return addDeviceService(conn, ds)
+}
+
+func (c *Client) UpdateDeviceService(ds contract.DeviceService) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteDeviceService(conn, ds.Id)
+	if err != nil {
+		return err
+	}
+
+	ds.Modified = db.MakeTimestamp()
+
+	_, err = addDeviceService(conn, ds)
+
+	return err
+}
+
+func (c *Client) DeleteDeviceServiceById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return deleteDeviceService(conn, id)
+}
+
+func addDeviceService(conn redis.Conn, ds contract.DeviceService) (string, error) {
+	aid := ds.Addressable.Id
+	conn.Send("MULTI")
+	conn.Send("HEXISTS", db.DeviceService+":name", ds.Name)
+	conn.Send("EXISTS", aid)
+	conn.Send("HGET", db.Addressable+":name", ds.Addressable.Name)
+	rep, err := redis.Values(conn.Do("EXEC"))
+	if err != nil {
+		return ds.Id, err
+	}
+
+	// Verify uniquness of name
+	nex, err := redis.Bool(rep[0], nil)
+	if err != nil {
+		return "", err
+	} else if nex {
+		return "", db.ErrNotUnique
+	}
+
+	// Verify existence of an addressable by ID or name
+	idex, err := redis.Bool(rep[1], nil)
+	if err != nil {
+		return ds.Id, err
+	} else if !idex {
+		aid, err = redis.String(rep[2], nil)
+		if err == redis.ErrNil {
+			return "", errors.New("Invalid addressable")
+		} else if err != nil {
+			return "", err
+		}
+		ds.Addressable.Id = aid // XXX This seems redundant
+	}
+
+	_, err = uuid.Parse(ds.Id)
+	if err != nil {
+		ds.Id = uuid.New().String()
+	}
+	id := ds.Id
+
+	ts := db.MakeTimestamp()
+	if ds.Created == 0 {
+		ds.Created = ts
+	}
+	ds.Modified = ts
+
+	m, err := marshalDeviceService(ds)
+	if err != nil {
+		return "", err
+	}
+
+	conn.Send("MULTI")
+	conn.Send("SET", id, m)
+	conn.Send("ZADD", db.DeviceService, 0, id)
+	conn.Send("HSET", db.DeviceService+":name", ds.Name, id)
+	conn.Send("SADD", db.DeviceService+":addressable:"+aid, id)
+	for _, label := range ds.Labels {
+		conn.Send("SADD", db.DeviceService+":label:"+label, id)
+	}
+	_, err = conn.Do("EXEC")
+	if err != nil {
+		return "", err
+	}
+
+	return ds.Id, err
+}
+
+func deleteDeviceService(conn redis.Conn, id string) error {
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	ds := contract.DeviceService{}
+	_ = unmarshalDeviceService(object, &ds)
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("DEL", id)
+	_ = conn.Send("ZREM", db.DeviceService, id)
+	_ = conn.Send("HDEL", db.DeviceService+":name", ds.Name)
+	_ = conn.Send("SREM", db.DeviceService+":addressable:"+ds.Addressable.Id, id)
+	for _, label := range ds.Labels {
+		conn.Send("SREM", db.DeviceService+":label:"+label, id)
+	}
+	_, err = conn.Do("EXEC")
+	return err
+}
+
+//  ----------------------Provision Watcher -----------------------------*/
+func (c *Client) GetAllProvisionWatchers() ([]contract.ProvisionWatcher, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.ProvisionWatcher, 0, -1)
+	if err != nil {
+		return []contract.ProvisionWatcher{}, err
+	}
+
+	pw := make([]contract.ProvisionWatcher, len(objects))
+	for i, object := range objects {
+		err = unmarshalProvisionWatcher(object, &pw[i])
+		if err != nil {
+			return []contract.ProvisionWatcher{}, err
+		}
+	}
+
+	return pw, nil
+}
+
+func (c *Client) GetProvisionWatcherByName(n string) (contract.ProvisionWatcher, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var pw contract.ProvisionWatcher
+	err := getObjectByHash(conn, db.ProvisionWatcher+":name", n, unmarshalProvisionWatcher, &pw)
+	return pw, err
+}
+
+func (c *Client) GetProvisionWatchersByIdentifier(k string, v string) (pw []contract.ProvisionWatcher, err error) {
+	return c.getProvisionWatchersByValue(db.ProvisionWatcher + ":identifier:" + k + ":" + v)
+}
+
+func (c *Client) GetProvisionWatchersByServiceId(id string) ([]contract.ProvisionWatcher, error) {
+	pw, err := c.getProvisionWatchersByValue(db.ProvisionWatcher + ":service:" + id)
+
+	// XXX This is here only because test/db_metadata.go is inconsistent when testing for _not found_. It
+	// should always be checking for database.ErrNotFound but too often it is checking for nil
+	if len(pw) == 0 {
+		err = dataBase.ErrNotFound
+	}
+
+	return pw, err
+}
+
+func (c *Client) GetProvisionWatchersByProfileId(id string) ([]contract.ProvisionWatcher, error) {
+	pw, err := c.getProvisionWatchersByValue(db.ProvisionWatcher + ":profile:" + id)
+
+	// XXX This is here only because test/db_metadata.go is inconsistent when testing for _not found_. It
+	// should always be checking for database.ErrNotFound but too often it is checking for nil
+	if len(pw) == 0 {
+		err = dataBase.ErrNotFound
+	}
+
+	return pw, err
+}
+
+func (c *Client) GetProvisionWatcherById(id string) (contract.ProvisionWatcher, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var pw contract.ProvisionWatcher
+	err := getObjectById(conn, id, unmarshalProvisionWatcher, &pw)
+	return pw, err
+}
+
+func (c *Client) getProvisionWatchersByValue(v string) ([]contract.ProvisionWatcher, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, v)
+	if err != nil {
+		return []contract.ProvisionWatcher{}, err
+	}
+
+	pw := make([]contract.ProvisionWatcher, len(objects))
+	for i, object := range objects {
+		err = unmarshalProvisionWatcher(object, &pw[i])
+		if err != nil {
+			return []contract.ProvisionWatcher{}, err
+		}
+	}
+
+	return pw, nil
+}
+
+func (c *Client) AddProvisionWatcher(pw contract.ProvisionWatcher) (string, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return addProvisionWatcher(conn, pw)
+}
+
+func (c *Client) UpdateProvisionWatcher(pw contract.ProvisionWatcher) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteProvisionWatcher(conn, pw.Id)
+	if err != nil {
+		return err
+	}
+
+	_, err = addProvisionWatcher(conn, pw)
+	return err
+}
+
+func (c *Client) DeleteProvisionWatcherById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return deleteProvisionWatcher(conn, id)
+}
+
+func addProvisionWatcher(conn redis.Conn, pw contract.ProvisionWatcher) (string, error) {
+	pid := pw.Profile.Id
+	sid := pw.Service.Id
+	conn.Send("MULTI")
+	conn.Send("HEXISTS", db.ProvisionWatcher+":name", pw.Name)
+	conn.Send("EXISTS", pid)
+	conn.Send("HGET", db.DeviceProfile+":name", pw.Profile.Name)
+	conn.Send("EXISTS", sid)
+	conn.Send("HGET", db.DeviceService+":name", pw.Service.Name)
+	rep, err := redis.Values(conn.Do("EXEC"))
+	if err != nil {
+		return "", err
+	}
+
+	// Verify uniquness of name
+	nex, err := redis.Bool(rep[0], nil)
+	if err != nil {
+		return "", err
+	} else if nex {
+		return "", db.ErrNotUnique
+	}
+
+	// Verify existence of a device profile by ID or name
+	idex, err := redis.Bool(rep[1], nil)
+	if err != nil {
+		return "", err
+	} else if !idex {
+		pid, err = redis.String(rep[2], nil)
+		if err == redis.ErrNil {
+			return "", errors.New("Invalid Device Profile")
+		} else if err != nil {
+			return "", err
+		}
+		pw.Profile.Id = pid
+	}
+
+	// Verify existence of a device profile by ID or name
+	idex, err = redis.Bool(rep[3], nil)
+	if err != nil {
+		return "", err
+	} else if !idex {
+		sid, err = redis.String(rep[4], nil)
+		if err == redis.ErrNil {
+			return "", errors.New("Invalid Device Service")
+		} else if err != nil {
+			return "", err
+		}
+		pw.Service.Id = sid
+	}
+
+	_, err = uuid.Parse(pw.Id)
+	if err != nil {
+		pw.Id = uuid.New().String()
+	}
+	id := pw.Id
+
+	ts := db.MakeTimestamp()
+	if pw.Created == 0 {
+		pw.Created = ts
+	}
+	pw.Modified = ts
+
+	m, err := marshalProvisionWatcher(pw)
+	if err != nil {
+		return "", err
+	}
+
+	conn.Send("MULTI")
+	conn.Send("SET", id, m)
+	conn.Send("ZADD", db.ProvisionWatcher, 0, id)
+	conn.Send("HSET", db.ProvisionWatcher+":name", pw.Name, id)
+	conn.Send("SADD", db.ProvisionWatcher+":service:"+pw.Service.Id, id)
+	conn.Send("SADD", db.ProvisionWatcher+":profile:"+pw.Profile.Id, id)
+	for k, v := range pw.Identifiers {
+		conn.Send("SADD", db.ProvisionWatcher+":identifier:"+k+":"+v, id)
+	}
+	_, err = conn.Do("EXEC")
+	if err != nil {
+		return "", err
+	}
+
+	return id, nil
+}
+
+func deleteProvisionWatcher(conn redis.Conn, id string) error {
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	pw := contract.ProvisionWatcher{}
+	_ = unmarshalProvisionWatcher(object, &pw)
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("DEL", id)
+	_ = conn.Send("ZREM", db.ProvisionWatcher, id)
+	_ = conn.Send("HDEL", db.ProvisionWatcher+":name", pw.Name)
+	_ = conn.Send("SREM", db.ProvisionWatcher+":service:"+pw.Service.Id, id)
+	_ = conn.Send("SREM", db.ProvisionWatcher+":profile:"+pw.Profile.Id, id)
+	for k, v := range pw.Identifiers {
+		conn.Send("SREM", db.ProvisionWatcher+":identifier:"+k+":"+v, id)
+	}
+	_, err = conn.Do("EXEC")
+	return err
+}
+
+//  ------------------------Command -------------------------------------*/
+func (c *Client) GetAllCommands() ([]contract.Command, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, db.Command, 0, -1)
+	if err != nil {
+		return []contract.Command{}, err
+	}
+
+	d := make([]contract.Command, len(objects))
+	for i, object := range objects {
+		err = unmarshalObject(object, &d[i])
+		if err != nil {
+			return []contract.Command{}, err
+		}
+	}
+
+	return d, nil
+}
+
+func (c *Client) GetCommandById(id string) (contract.Command, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	var d contract.Command
+	err := getObjectById(conn, id, unmarshalObject, &d)
+	return d, err
+}
+
+func (c *Client) GetCommandByName(n string) ([]contract.Command, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, db.Command+":name:"+n)
+	if err != nil {
+		return []contract.Command{}, err
+	}
+
+	cmd := make([]contract.Command, len(objects))
+	for i, object := range objects {
+		err = unmarshalObject(object, &cmd[i])
+		if err != nil {
+			return []contract.Command{}, err
+		}
+	}
+
+	return cmd, nil
+}
+
+func (c *Client) AddCommand(cmd contract.Command) (string, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	return addCommand(conn, true, cmd)
+}
+
+// Update command uses the ID of the command for identification
+func (c *Client) UpdateCommand(cmd contract.Command) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err := deleteCommand(conn, cmd.Id)
+	if err != nil {
+		return err
+	}
+
+	_, err = addCommand(conn, true, cmd)
+	return err
+}
+
+// Delete the command by ID
+func (c *Client) DeleteCommandById(id string) error {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	// TODO: ??? Check if the command is still in use by device profiles
+
+	return deleteCommand(conn, id)
+}
+
+func addCommand(conn redis.Conn, tx bool, cmd contract.Command) (string, error) {
+	_, err := uuid.Parse(cmd.Id)
+	if err != nil {
+		cmd.Id = uuid.New().String()
+	}
+	id := cmd.Id
+
+	ts := db.MakeTimestamp()
+	if cmd.Created == 0 {
+		cmd.Created = ts
+	}
+	cmd.Modified = ts
+
+	m, err := marshalObject(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	if tx {
+		conn.Send("MULTI")
+	}
+	conn.Send("SET", id, m)
+	conn.Send("ZADD", db.Command, 0, id)
+	conn.Send("SADD", db.Command+":name:"+cmd.Name, id)
+	if tx {
+		_, err = conn.Do("EXEC")
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return id, nil
+}
+
+func deleteCommand(conn redis.Conn, id string) error {
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	cmd := contract.Command{}
+	_ = unmarshalObject(object, &cmd)
+
+	_ = conn.Send("MULTI")
+	_ = conn.Send("DEL", id)
+	_ = conn.Send("ZREM", db.Command, id)
+	_ = conn.Send("SREM", db.Command+":name:"+cmd.Name, id)
+	_, err = conn.Do("EXEC")
+	return err
+}
+
+func (c *Client) ScrubMetadata() (err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	cols := []string{
+		db.Addressable, db.Command, db.DeviceService, db.DeviceReport, db.DeviceProfile,
+		db.Device, db.ProvisionWatcher,
+	}
+
+	for _, col := range cols {
+		err = unlinkCollection(conn, col)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/db/redis/models/db_command.go
+++ b/internal/pkg/db/redis/models/db_command.go
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+type Adder interface {
+	Add() []DbCommand
+}
+
+type Remover interface {
+	Remove() []DbCommand
+}
+
+// DbCommand is used to represent information about a specific Redis command
+// If this strategy works, this type is called "DbCommand" in order to differentiate
+// from the EdgeX model Command
+type DbCommand struct {
+	Command string //The actual Redis API command
+	Hash    string //Indicates which hash index the command should be applied toward
+	Key     string //Indicates the key that will be targeted in the given Hash
+	Value   string //If applicable the value to be assigned to the key
+	Rank    int64  //If applicable, the rank to be assigned to a given key
+}

--- a/internal/pkg/db/redis/models/interval.go
+++ b/internal/pkg/db/redis/models/interval.go
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+const (
+	IntervalKey     = db.Interval
+	IntervalNameKey = db.Interval + ":name"
+)
+
+var intervalKeys = []string{IntervalKey, IntervalNameKey}
+
+type Interval struct {
+	contract.Interval
+}
+
+func NewInterval(from contract.Interval) (i Interval) {
+	i.Interval = from
+	return
+}
+
+func (i Interval) Add() (cmds []DbCommand) {
+	cmds = make([]DbCommand, len(intervalKeys))
+	for _, key := range intervalKeys {
+		switch key {
+		case IntervalKey:
+			cmds = append(cmds, DbCommand{Command: "ZADD", Hash: key, Key: i.ID, Rank: i.Modified})
+		case IntervalNameKey:
+			cmds = append(cmds, DbCommand{Command: "HSET", Hash: key, Key: i.Name, Value: i.ID})
+		}
+	}
+	return cmds
+}
+
+func (i Interval) Remove() (cmds []DbCommand) {
+	cmds = make([]DbCommand, len(intervalKeys))
+	for _, key := range intervalKeys {
+		switch key {
+		case IntervalKey:
+			cmds = append(cmds, DbCommand{Command: "ZREM", Hash: key, Key: i.ID})
+		case IntervalNameKey:
+			cmds = append(cmds, DbCommand{Command: "HDEL", Key: i.Name})
+		}
+	}
+	return cmds
+}

--- a/internal/pkg/db/redis/models/interval_action.go
+++ b/internal/pkg/db/redis/models/interval_action.go
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package models
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+const (
+	IntervalActionKey       = db.IntervalAction
+	IntervalActionNameKey   = db.IntervalAction + ":name"
+	IntervalActionParentKey = db.IntervalAction + ":parent"
+	IntervalActionTargetKey = db.IntervalAction + ":target"
+)
+
+var intervalActionKeys = []string{IntervalActionKey, IntervalActionNameKey, IntervalActionParentKey, IntervalActionTargetKey}
+
+type IntervalAction struct {
+	contract.IntervalAction
+}
+
+func NewIntervalAction(from contract.IntervalAction) (ia IntervalAction) {
+	ia.IntervalAction = from
+	return
+}
+
+func (ia IntervalAction) Add() (cmds []DbCommand) {
+	cmds = make([]DbCommand, len(intervalActionKeys))
+	for _, key := range intervalActionKeys {
+		switch key {
+		case IntervalActionKey:
+			cmds = append(cmds, DbCommand{Command: "ZADD", Hash: key, Key: ia.ID, Rank: ia.Modified})
+		case IntervalActionNameKey:
+			cmds = append(cmds, DbCommand{Command: "HSET", Hash: key, Key: ia.Name, Value: ia.ID})
+		case IntervalActionParentKey:
+			cmds = append(cmds, DbCommand{Command: "SADD", Hash: key + ":" + ia.Interval, Key: ia.ID})
+		case IntervalActionTargetKey:
+			cmds = append(cmds, DbCommand{Command: "SADD", Hash: key + ":" + ia.Target, Key: ia.ID})
+		}
+	}
+	return cmds
+}
+
+func (ia IntervalAction) Remove() (cmds []DbCommand) {
+	cmds = make([]DbCommand, len(intervalActionKeys))
+	for _, key := range intervalKeys {
+		switch key {
+		case IntervalActionKey:
+			cmds = append(cmds, DbCommand{Command: "ZREM", Hash: key, Key: ia.ID})
+		case IntervalActionNameKey:
+			cmds = append(cmds, DbCommand{Command: "HDEL", Hash: key, Key: ia.Name})
+		case IntervalActionParentKey:
+			cmds = append(cmds, DbCommand{Command: "SREM", Hash: key + ":" + ia.Interval, Key: ia.ID})
+		case IntervalActionTargetKey:
+			cmds = append(cmds, DbCommand{Command: "SREM", Hash: key + ":" + ia.Target, Key: ia.ID})
+		}
+	}
+	return cmds
+}

--- a/internal/pkg/db/redis/object.go
+++ b/internal/pkg/db/redis/object.go
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"encoding/json"
+)
+
+type marshalFunc func(in interface{}) (out []byte, err error)
+type unmarshalFunc func(in []byte, out interface{}) (err error)
+
+func marshalObject(in interface{}) (out []byte, err error) {
+	return json.Marshal(in)
+}
+
+func unmarshalObject(in []byte, out interface{}) (err error) {
+	return json.Unmarshal(in, out)
+}

--- a/internal/pkg/db/redis/provision_watcher.go
+++ b/internal/pkg/db/redis/provision_watcher.go
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"fmt"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type redisProvisionWatcher struct {
+	contract.BaseObject
+	Id             string
+	Name           string
+	Identifiers    map[string]string
+	Profile        string
+	Service        string
+	OperatingState contract.OperatingState
+}
+
+func marshalProvisionWatcher(pw contract.ProvisionWatcher) (out []byte, err error) {
+	s := redisProvisionWatcher{
+		BaseObject:     pw.BaseObject,
+		Id:             pw.Id,
+		Name:           pw.Name,
+		Identifiers:    pw.Identifiers,
+		Profile:        pw.Profile.Id,
+		Service:        pw.Service.Id,
+		OperatingState: pw.OperatingState,
+	}
+
+	return marshalObject(s)
+}
+
+func unmarshalProvisionWatcher(o []byte, pw interface{}) (err error) {
+	var s redisProvisionWatcher
+
+	err = unmarshalObject(o, &s)
+	if err != nil {
+		return err
+	}
+
+	switch x := pw.(type) {
+	case *contract.ProvisionWatcher:
+		x.BaseObject = s.BaseObject
+		x.Id = s.Id
+		x.Name = s.Name
+		x.Identifiers = s.Identifiers
+		x.OperatingState = s.OperatingState
+
+		conn, err := getConnection()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+
+		err = getObjectById(conn, s.Profile, unmarshalDeviceProfile, &x.Profile)
+		if err != nil {
+			return err
+		}
+
+		err = getObjectById(conn, s.Service, unmarshalDeviceService, &x.Service)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("Can only unmarshal into a *ProvisionWatcher, got %T", x)
+	}
+}

--- a/internal/pkg/db/redis/queries.go
+++ b/internal/pkg/db/redis/queries.go
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import (
+	"encoding/json"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis/models"
+	"github.com/gomodule/redigo/redis"
+)
+
+func getObjectById(conn redis.Conn, id string, unmarshal unmarshalFunc, out interface{}) error {
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	return unmarshal(object, out)
+}
+
+//TODO: Discuss this with Andre as a possibly replacement for getObjectByHash
+// 1.) key/value seems clearer to me than hash/field for equivalent concepts. However the latter
+//     may be more consistently used in the Redis community. If so, revert.
+// 2.) Not sure the custom "unmarshal" function is necessary when no domain logic is encapsulated
+//     within the Redis-based models. If the signatures of the Redis models are the same as contract
+//     then just use contract. However we have the capability to specialize the Redis models as
+//     needed now should a future requirement arise.
+func getObjectByKey(conn redis.Conn, key string, value string, out interface{}) error {
+	id, err := redis.String(conn.Do("HGET", key, value))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(object, out)
+}
+
+func getObjectByHash(conn redis.Conn, hash string, field string, unmarshal unmarshalFunc, out interface{}) error {
+	id, err := redis.String(conn.Do("HGET", hash, field))
+	if err == redis.ErrNil {
+		return db.ErrNotFound
+	} else if err != nil {
+		return err
+	}
+
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err != nil {
+		return err
+	}
+
+	return unmarshal(object, out)
+}
+
+func getObjectsByValue(conn redis.Conn, v string) (objects [][]byte, err error) {
+	ids, err := redis.Values(conn.Do("SMEMBERS", v))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	objects, err = redis.ByteSlices(conn.Do("MGET", ids...))
+	if err != nil {
+		return nil, err
+	}
+
+	return objects, nil
+}
+
+func getObjectsByValues(conn redis.Conn, vals ...string) (objects [][]byte, err error) {
+	args := redis.Args{}
+	for _, v := range vals {
+		args = args.Add(v)
+	}
+	ids, err := redis.Values(conn.Do("SINTER", args...))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	objects, err = redis.ByteSlices(conn.Do("MGET", ids...))
+	if err != nil {
+		return nil, err
+	}
+
+	return objects, nil
+}
+
+func getObjectsByRange(conn redis.Conn, key string, start, end int) (objects [][]byte, err error) {
+	ids, err := redis.Values(conn.Do("ZRANGE", key, start, end))
+	if err != nil && err != redis.ErrNil {
+		return nil, err
+	}
+
+	if len(ids) > 0 {
+		objects, err = redis.ByteSlices(conn.Do("MGET", ids...))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return objects, nil
+}
+
+// Return objects by a score from a zset
+// if limit is 0, all are returned
+// if end is negative, it is considered as positive infinity
+func getObjectsByRangeFilter(conn redis.Conn, key string, filter string, start, end int) (objects [][]byte, err error) {
+	ids, err := redis.Values(conn.Do("ZRANGE", key, start, end))
+	if err != nil && err != redis.ErrNil {
+		return nil, err
+	}
+
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	fids := ids[:0]
+	if len(ids) > 0 {
+		for _, id := range ids {
+			err := conn.Send("ZSCORE", filter, id)
+			if err != nil {
+				return nil, err
+			}
+		}
+		scores, err := redis.Strings(conn.Do(""))
+		if err != nil {
+			return nil, err
+		}
+
+		for i, score := range scores {
+			if score != "" {
+				fids = append(fids, ids[i])
+			}
+		}
+
+		objects, err = redis.ByteSlices(conn.Do("MGET", fids...))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return objects, nil
+}
+
+func getObjectsByScore(conn redis.Conn, key string, start, end int64, limit int) (objects [][]byte, err error) {
+	args := []interface{}{key, start}
+	if end < 0 {
+		args = append(args, "+inf")
+	} else {
+		args = append(args, end)
+	}
+	if limit != 0 {
+		args = append(args, "LIMIT")
+		args = append(args, 0)
+		args = append(args, limit)
+	}
+	ids, err := redis.Values(conn.Do("ZRANGEBYSCORE", args...))
+	if err != nil && err != redis.ErrNil {
+		return nil, err
+	}
+
+	if len(ids) > 0 {
+		objects, err = redis.ByteSlices(conn.Do("MGET", ids...))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return objects, nil
+}
+
+// addObject is responsible for setting the object's primary record and then sending the appropriate
+// follow-on commands as provided by the caller.
+
+// Transactions are managed outside of this function.
+func addObject(data []byte, adder models.Adder, id string, conn redis.Conn) {
+	conn.Send("SET", id, data)
+
+	for _, cmd := range adder.Add() {
+		switch cmd.Command {
+		case "ZADD":
+			conn.Send(cmd.Command, cmd.Hash, cmd.Rank, cmd.Key)
+		case "SADD":
+			conn.Send(cmd.Command, cmd.Hash, cmd.Key)
+		case "HSET":
+			conn.Send(cmd.Command, cmd.Hash, cmd.Key, cmd.Value)
+		}
+	}
+}
+
+// deleteObject is responsible for removing the object's primary record and then sending the appropriate
+// follow-on commands as provided by the caller.
+//
+// Transactions are managed outside of this function.
+func deleteObject(remover models.Remover, id string, conn redis.Conn) {
+	conn.Send("DEL", id)
+
+	for _, cmd := range remover.Remove() {
+		switch cmd.Command {
+		case "ZREM":
+		case "SREM":
+		case "HDEL":
+			conn.Send(cmd.Command, cmd.Hash, cmd.Key)
+		}
+	}
+}

--- a/internal/pkg/db/redis/scheduler.go
+++ b/internal/pkg/db/redis/scheduler.go
@@ -1,0 +1,428 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package redis
+
+import (
+	"encoding/json"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis/models"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/gomodule/redigo/redis"
+	"github.com/google/uuid"
+	"github.com/imdario/mergo"
+)
+
+// Return all the schedule interval(s)
+func (c *Client) Intervals() (intervals []contract.Interval, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, models.IntervalKey, 0, -1)
+	if err != nil {
+		return []contract.Interval{}, err
+	}
+
+	intervals = make([]contract.Interval, len(objects))
+	for i, object := range objects {
+		err = json.Unmarshal(object, &intervals[i])
+		if err != nil {
+			return []contract.Interval{}, err
+		}
+	}
+
+	return intervals, nil
+}
+
+// Return schedule interval(s) up to the number specified
+func (c *Client) IntervalsWithLimit(limit int) (intervals []contract.Interval, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, models.IntervalKey, 0, limit-1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return intervals, err
+		}
+	}
+
+	intervals = make([]contract.Interval, len(objects))
+	for i, object := range objects {
+		err = json.Unmarshal(object, &intervals[i])
+		if err != nil {
+			return []contract.Interval{}, err
+		}
+	}
+
+	return intervals, nil
+}
+
+// Return schedule interval by name
+func (c *Client) IntervalByName(name string) (interval contract.Interval, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err = getObjectByKey(conn, models.IntervalNameKey, name, &interval)
+	return interval, err
+}
+
+// Return schedule interval by ID
+func (c *Client) IntervalById(id string) (interval contract.Interval, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return contract.Interval{}, db.ErrNotFound
+	} else if err != nil {
+		return contract.Interval{}, err
+	}
+
+	err = json.Unmarshal(object, &interval)
+	if err != nil {
+		return contract.Interval{}, err
+	}
+
+	return interval, err
+}
+
+// Add a new schedule interval
+func (c *Client) AddInterval(from contract.Interval) (id string, err error) {
+	interval := models.NewInterval(from)
+	if interval.ID != "" {
+		_, err = uuid.Parse(interval.ID)
+		if err != nil {
+			return "", db.ErrInvalidObjectId
+		}
+	} else {
+		interval.ID = uuid.New().String()
+	}
+
+	if interval.Created == 0 {
+		ts := db.MakeTimestamp()
+		interval.Created = ts
+		interval.Modified = ts
+	}
+
+	data, err := json.Marshal(interval)
+	if err != nil {
+		return "", err
+	}
+
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	conn.Send("MULTI")
+	addObject(data, interval, interval.ID, conn)
+	_, err = conn.Do("EXEC")
+
+	return interval.ID, err
+}
+
+// Update a schedule interval
+func (c *Client) UpdateInterval(from contract.Interval) (err error) {
+	check, err := c.IntervalByName(from.Name)
+	if err != nil && err != redis.ErrNil {
+		return err
+	}
+	if err == nil && from.ID != check.ID {
+		// IDs are different -> name not unique
+		return db.ErrNotUnique
+	}
+
+	from.Modified = db.MakeTimestamp()
+	err = mergo.Merge(&from, check)
+	if err != nil {
+		return err
+	}
+
+	interval := models.NewInterval(from)
+	data, err := json.Marshal(interval)
+	if err != nil {
+		return err
+	}
+
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	conn.Send("MULTI")
+	deleteObject(interval, interval.ID, conn)
+	addObject(data, interval, interval.ID, conn)
+	_, err = conn.Do("EXEC")
+
+	return err
+}
+
+// Remove schedule interval by ID
+func (c *Client) DeleteIntervalById(id string) (err error) {
+	check, err := c.IntervalById(id)
+	if err != nil {
+		if err == db.ErrNotFound {
+			return nil
+		}
+		return
+	}
+
+	interval := models.NewInterval(check)
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	conn.Send("MULTI")
+	deleteObject(interval, id, conn)
+
+	_, err = conn.Do("EXEC")
+
+	return err
+}
+
+// Scrub all scheduler intervals from the database (only used in test)
+func (c *Client) ScrubAllIntervals() (count int, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	cols := []string{models.IntervalKey}
+
+	for _, col := range cols {
+		err = unlinkCollection(conn, col)
+		if err != nil {
+			return -1, err
+		}
+	}
+
+	return 0, nil
+}
+
+// Get all schedule interval action(s)
+func (c *Client) IntervalActions() (actions []contract.IntervalAction, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, models.IntervalActionKey, 0, -1)
+	if err != nil {
+		return []contract.IntervalAction{}, err
+	}
+
+	actions = make([]contract.IntervalAction, len(objects))
+	for i, object := range objects {
+		err = json.Unmarshal(object, &actions[i])
+		if err != nil {
+			return []contract.IntervalAction{}, err
+		}
+	}
+
+	return actions, nil
+}
+
+// Return schedule interval action(s) up to the number specified
+func (c *Client) IntervalActionsWithLimit(limit int) (actions []contract.IntervalAction, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByRange(conn, models.IntervalActionKey, 0, limit-1)
+	if err != nil {
+		if err != redis.ErrNil {
+			return actions, err
+		}
+	}
+
+	actions = make([]contract.IntervalAction, len(objects))
+	for i, object := range objects {
+		err = json.Unmarshal(object, &actions[i])
+		if err != nil {
+			return []contract.IntervalAction{}, err
+		}
+	}
+
+	return actions, nil
+}
+
+// Get all schedule interval action(s) by interval name
+func (c *Client) IntervalActionsByIntervalName(name string) (actions []contract.IntervalAction, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, models.IntervalActionParentKey+":"+name)
+	if err != nil {
+		if err != redis.ErrNil {
+			return actions, err
+		}
+	}
+
+	actions = make([]contract.IntervalAction, len(objects))
+	for i, action := range objects {
+		err = unmarshalObject(action, &actions[i])
+		if err != nil {
+			return actions, err
+		}
+	}
+	return actions, err
+}
+
+// Get all schedule interval action(s) by target name
+func (c *Client) IntervalActionsByTarget(name string) (actions []contract.IntervalAction, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValue(conn, models.IntervalActionTargetKey+":"+name)
+	if err != nil {
+		if err != redis.ErrNil {
+			return actions, err
+		}
+	}
+
+	actions = make([]contract.IntervalAction, len(objects))
+	for i, action := range objects {
+		err = unmarshalObject(action, &actions[i])
+		if err != nil {
+			return actions, err
+		}
+	}
+	return actions, err
+}
+
+// Get schedule interval action by id
+func (c *Client) IntervalActionById(id string) (action contract.IntervalAction, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	object, err := redis.Bytes(conn.Do("GET", id))
+	if err == redis.ErrNil {
+		return contract.IntervalAction{}, db.ErrNotFound
+	} else if err != nil {
+		return contract.IntervalAction{}, err
+	}
+
+	err = json.Unmarshal(object, &action)
+	if err != nil {
+		return contract.IntervalAction{}, err
+	}
+
+	return action, err
+}
+
+// Get schedule interval action by name
+func (c *Client) IntervalActionByName(name string) (action contract.IntervalAction, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err = getObjectByKey(conn, models.IntervalActionNameKey, name, &action)
+	return action, err
+}
+
+// Add schedule interval action
+func (c *Client) AddIntervalAction(from contract.IntervalAction) (id string, err error) {
+	action := models.NewIntervalAction(from)
+	if action.ID != "" {
+		_, err = uuid.Parse(action.ID)
+		if err != nil {
+			return "", db.ErrInvalidObjectId
+		}
+	} else {
+		action.ID = uuid.New().String()
+	}
+
+	if action.Created == 0 {
+		ts := db.MakeTimestamp()
+		action.Created = ts
+		action.Modified = ts
+	}
+
+	data, err := json.Marshal(action)
+	if err != nil {
+		return "", err
+	}
+
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	conn.Send("MULTI")
+	addObject(data, action, action.ID, conn)
+	_, err = conn.Do("EXEC")
+
+	return action.ID, err
+}
+
+// Update schedule interval action
+func (c *Client) UpdateIntervalAction(from contract.IntervalAction) (err error) {
+	check, err := c.IntervalActionByName(from.Name)
+	if err != nil && err != redis.ErrNil {
+		return err
+	}
+	if err == nil && from.ID != check.ID {
+		// IDs are different -> name not unique
+		return db.ErrNotUnique
+	}
+
+	from.Modified = db.MakeTimestamp()
+	err = mergo.Merge(&from, check)
+	if err != nil {
+		return err
+	}
+
+	action := models.NewIntervalAction(from)
+	data, err := json.Marshal(action)
+	if err != nil {
+		return err
+	}
+
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	conn.Send("MULTI")
+	deleteObject(action, action.ID, conn)
+	addObject(data, action, action.ID, conn)
+	_, err = conn.Do("EXEC")
+
+	return err
+}
+
+// Remove schedule interval action by id
+func (c *Client) DeleteIntervalActionById(id string) (err error) {
+	check, err := c.IntervalActionById(id)
+	if err != nil {
+		if err == db.ErrNotFound {
+			return nil
+		}
+		return
+	}
+
+	action := models.NewIntervalAction(check)
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	conn.Send("MULTI")
+	deleteObject(action, id, conn)
+
+	_, err = conn.Do("EXEC")
+
+	return err
+}
+
+// Scrub all scheduler interval actions from the database data (only used in test)
+func (c *Client) ScrubAllIntervalActions() (count int, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	cols := []string{models.IntervalActionKey}
+
+	for _, col := range cols {
+		err = unlinkCollection(conn, col)
+		if err != nil {
+			return -1, err
+		}
+	}
+
+	return 0, nil
+}

--- a/internal/pkg/db/redis/scripts.go
+++ b/internal/pkg/db/redis/scripts.go
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import "github.com/gomodule/redigo/redis"
+
+/***********************
+ * Lua scripts notes:
+ * magic number 4096 is less < 8000 (redis:/deps/lua/lapi.c:LUAI_MAXCSTACK -> unpack error)
+ * assumes a single instance
+ * `get*` scripts are implementations for range operations. Can be used when the server is
+ * remote in order to reduce latency.
+ */
+
+const (
+	scriptGetObjectsByRange = `
+	local magic = 4096
+	local ids = redis.call('ZRANGE', KEYS[1], ARGV[1], ARGV[2])
+	local rep = {}
+	if #ids > 0 then
+		for i = 1, #ids, magic do
+			local temp = redis.call('MGET', unpack(ids, i, i+magic < #ids and i+magic or #ids))
+			for _, o in ipairs(temp) do
+				table.insert(rep, o)
+			end
+		end
+		return rep
+	else
+		return nil
+	end
+	`
+	scriptGetObjectsByRangeFilter = `
+	local magic = 4096
+	local ids = redis.call('ZRANGE', KEYS[1], ARGV[1], ARGV[2])
+	local rep = {}
+	if #ids > 0 then
+		for i, id in ipairs(ids) do
+			local v = redis.call('ZSCORE', KEYS[2], id)
+			if v == nil then
+				ids[i] = nil
+			end
+		end
+		for i = 1, #ids, magic do
+			local temp = redis.call('MGET', unpack(ids, i, i+magic < #ids and i+magic or #ids))
+			for _, o in ipairs(temp) do
+				table.insert(rep, o)
+			end
+		end
+	else
+		return nil
+	end
+	return rep
+	`
+	scriptGetObjectsByScore = `
+	local magic = 4096
+	local cmd = {
+		'ZRANGEBYSCORE', KEYS[1], ARGV[1],
+		tonumber(ARGV[2]) < 0 and '+inf' or ARGV[2],
+	}
+	if tonumber(ARGV[3]) ~= 0 then
+		table.insert(cmd, 'LIMIT')
+		table.insert(cmd, 0)
+		table.insert(cmd, ARGV[3])
+	end
+	local ids = redis.call(unpack(cmd))
+	local rep = {}
+	if #ids > 0 then
+		for i = 1, #ids, magic do
+			local temp = redis.call('MGET', unpack(ids, i, i+magic < #ids and i+magic or #ids))
+			for _, o in ipairs(temp) do
+				table.insert(rep, o)
+			end
+		end
+	else
+		return nil
+	end
+	return rep
+	`
+	scriptUnlinkZsetMembers = `
+	local magic = 4096
+	local ids = redis.call('ZRANGE', KEYS[1], 0, -1)
+	if #ids > 0 then
+		for i = 1, #ids, magic do
+			redis.call('UNLINK', unpack(ids, i, i+magic < #ids and i+magic or #ids))
+		end
+	end
+	`
+	scriptUnlinkCollection = `
+	local magic = 4096
+	redis.replicate_commands()
+	local c = 0
+	repeat
+		local s = redis.call('SCAN', c, 'MATCH', ARGV[1] .. '*')
+		c = tonumber(s[1])
+		if #s[2] > 0 then
+			redis.call('UNLINK', unpack(s[2]))
+		end
+	until c == 0
+	`
+)
+
+var scripts = map[string]redis.Script{
+	"getObjectsByRange":       *redis.NewScript(1, scriptGetObjectsByRange),
+	"getObjectsByRangeFilter": *redis.NewScript(2, scriptGetObjectsByRangeFilter),
+	"getObjectsByScore":       *redis.NewScript(1, scriptGetObjectsByScore),
+	"unlinkZsetMembers":       *redis.NewScript(1, scriptUnlinkZsetMembers),
+	"unlinkCollection":        *redis.NewScript(0, scriptUnlinkCollection),
+}
+
+func getObjectsByRangeLua(conn redis.Conn, key string, start, end int) (objects [][]byte, err error) {
+	s := scripts["getObjectsByRange"]
+	objects, err = redis.ByteSlices(s.Do(conn, key, start, end))
+	if err != nil {
+		return nil, err
+	}
+
+	return objects, nil
+}
+
+func getObjectsByRangeFilterLua(conn redis.Conn, key string, filter string, start, end int) (objects [][]byte, err error) {
+	s := scripts["getObjectsByRangeFilter"]
+	objects, err = redis.ByteSlices(s.Do(conn, key, filter, start, end))
+	if err != nil {
+		return nil, err
+	}
+
+	return objects, nil
+}
+
+// Return objects by a score from a zset
+// if limit is 0, all are returned
+// if end is negative, it is considered as positive infinity
+func getObjectsByScoreLua(conn redis.Conn, key string, start, end int64, limit int) (objects [][]byte, err error) {
+	s := scripts["getObjectsByScore"]
+	objects, err = redis.ByteSlices(s.Do(conn, key, start, end, limit))
+	if err != nil {
+		return nil, err
+	}
+
+	return objects, nil
+}

--- a/internal/pkg/db/redis/util.go
+++ b/internal/pkg/db/redis/util.go
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright 2018 Redis Labs Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package redis
+
+import "github.com/gomodule/redigo/redis"
+
+func unlinkCollection(conn redis.Conn, col string) error {
+	conn.Send("MULTI")
+	s := scripts["unlinkZsetMembers"]
+	_ = s.Send(conn, col)
+	s = scripts["unlinkCollection"]
+	_ = s.Send(conn, col)
+	_, err := conn.Do("EXEC")
+	return err
+}


### PR DESCRIPTION
This brings Redis to Core Data, Core MetaData, Export Client, and Scheduler. The notification service will be merged separately. There is no plan to support the Logger which defaults to using a file.

Please note changes to `metadata/rest_command.go` and `metadata/rest_deviceprofile.go`; there are inconsistencies with how `err == ErrNotFound` and `err == nil` are treated and this is my proposed workaround. At some point we should make a decision on what the right way is and propagate those changes.

There are a few Black Box tests that are failing from what I believe are minor bugs in the tests. I will need to revisit that.