### PR TITLE
Issue #1223 Supports both GET/PUT, restructured to used same executio…

### DIFF
--- a/api/raml/core-command.raml
+++ b/api/raml/core-command.raml
@@ -169,7 +169,50 @@ schemas:
                 description: if no device exists by the name provided.
             "500": 
                 description: for unanticipated or unknown issues encountered.
-/device/name/{name}/opstate/{opState}: 
+/device/name/{name}/command/{command}:
+    displayName: Issue command
+    description: Example - http://localhost:48082/api/v1/device/name/RPIMotionDetector/command/Set_Green_Led
+    uriParameters:
+        name:
+            displayName: name
+            type: string
+            required: false
+            repeat: false
+        command:
+            displayName: commandname
+            type: string
+            required: false
+            repeat: false
+    get:
+        description: Issue the get command referenced by the command name to the device/sensor (also referenced by name) it is associated to via the device service. ServiceException (HTTP 500) for unanticipated or unknown issues encountered. Throws NotFoundException (HTTP 404) if no device exists by the name provided. Throws LockedException (HTTP 423) if the device is locked (admin state).
+        responses:
+            "200":
+                description: String as returned by the device/sensor via the device service.
+            "400":
+                description: if the request is malformed or unparsable
+            "404":
+                description: if no device exists by the name provided
+            "423":
+                description: if the device is locked (admin state).
+            "500":
+                description: for unanticipated or unknown issues encountered.
+    put:
+        description: Issue the get command referenced by the command name to the device/sensor (also referenced by name) it is associated to via the device service. ServiceException (HTTP 500) for unanticipated or unknown issues encountered. Throws NotFoundException (HTTP 404) if no device exists by the name provided. Throws LockedException (HTTP 423) if the device is locked (admin state).
+        body:
+            application/json:
+                example: '{"temp":72}'
+        responses:
+            "200":
+                description: String as returned by the device/sensor via the device service.
+            "400":
+                description: if the request is malformed or unparsable
+            "404":
+                description: if no device exists by the name provided
+            "423":
+                description: if the device is locked (admin state)
+            "500":
+                description: for unanticipated or unknown issues encountered.
+/device/name/{name}/opstate/{opState}:
     displayName: Op state by name
     description: Example - http://localhost:48082/api/v1/device/name/livingroomthermostat/opstate/disabled
     uriParameters: 

--- a/internal/core/command/errors/types.go
+++ b/internal/core/command/errors/types.go
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package errors
+
+import (
+	"fmt"
+)
+
+type ErrInvalidName struct {
+	name string
+}
+
+func (e ErrInvalidName) Error() string {
+	return fmt.Sprintf("invalid Name: %s", e.name)
+}
+
+func NewErrInvalidName(name string) error {
+	return &ErrInvalidName{name: name}
+}

--- a/internal/core/command/rest.go
+++ b/internal/core/command/rest.go
@@ -65,6 +65,8 @@ func loadDeviceRoutes(b *mux.Router) {
 
 	dn.HandleFunc("/{"+NAME+"}", restGetCommandsByDeviceName).Methods(http.MethodGet)
 	dn.HandleFunc("/{"+NAME+"}/"+URLADMINSTATE+"/{"+ADMINSTATE+"}", restPutDeviceAdminStateByDeviceName).Methods(http.MethodPut)
+	dn.HandleFunc("/{"+NAME+"}/"+COMMAND+"/{"+COMMAND+"}", restGetDeviceCommandByNames).Methods(http.MethodGet)
+	dn.HandleFunc("/{"+NAME+"}/"+COMMAND+"/{"+COMMAND+"}", restPutDeviceCommandByNames).Methods(http.MethodPut)
 	dn.HandleFunc("/{"+NAME+"}/"+OPSTATE+"/{"+OPSTATE+"}", restPutDeviceOpStateByDeviceName).Methods(http.MethodPut)
 }
 

--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -74,7 +74,7 @@ func convertDeviceCommandToIDs(w http.ResponseWriter, r *http.Request) (did stri
 	}
 
 	//	Match command name with commands associated with Device Profile.
-	for _, one := range d.Profile.Commands {
+	for _, one := range d.Profile.CoreCommands {
 		if cn == one.Name {
 			return d.Id, one.Id, nil
 		}


### PR DESCRIPTION
Added matching RESTful call /device/api/v1/device/name/{device-name}/command/{command-name}, finding the corresponding device and command ids and passing them to the methods that operate off of IDs used by /device/api/v1/device/{device-id}/command/{command-id}.

To convert command name into appropriate ID for the device, used the device's profile and iterate through names looking for a match.  Unless the number of commands is substantial - and not sure how large that would be - seemed that overhead of creating the map would be more than just walking through the array.  Not opposed to making a map but didn't seem necessary (but remember, I'm new here).

Tested by following camera control example in docs https://docs.edgexfoundry.org/Ch-WalkthroughData.html and trying various combinations of commands or invalid commands.  Also updated .raml with new calls (basically cut-and-paste of existing ID calls with changes to reflect the use of names).