### PR TITLE
Replace device.DeviceProfile with device.ProfileName

### DIFF
--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -39,6 +39,7 @@ import (
 var Configuration *ConfigurationStruct
 var LoggingClient logger.LoggingClient
 var mdc metadata.DeviceClient
+var mdpc metadata.DeviceProfileClient
 var cc metadata.CommandClient
 var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
@@ -228,6 +229,9 @@ func initializeClients(useRegistry bool) {
 	params.Path = clients.ApiCommandRoute
 	params.Url = Configuration.Clients["Metadata"].Url() + clients.ApiCommandRoute
 	cc = metadata.NewCommandClient(params, startup.Endpoint{RegistryClient: &registryClient})
+	params.Path = clients.ApiDeviceProfileRoute
+	params.Url = Configuration.Clients["Metadata"].Url() + clients.ApiDeviceProfileRoute
+	mdpc = metadata.NewDeviceProfileClient(params, startup.Endpoint{RegistryClient: &registryClient})
 }
 
 func setLoggingTarget() string {

--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -105,39 +105,37 @@ func restGetCommandsByDeviceID(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	did := vars[ID]
 	ctx := r.Context()
-	status, device, err := getCommandsByDeviceID(did, ctx)
+	status, cmds, err := getCommandsByDeviceID(did, ctx)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, "Device not found", http.StatusNotFound)
+		http.Error(w, err.Error(), status)
 		return
 	} else if status != http.StatusOK {
 		w.WriteHeader(status)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(&device)
+	json.NewEncoder(w).Encode(&cmds)
 }
 
 func restGetCommandsByDeviceName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	dn := vars[NAME]
 	ctx := r.Context()
-	status, devices, err := getCommandsByDeviceName(dn, ctx)
+	status, cmds, err := getCommandsByDeviceName(dn, ctx)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, "Device not found", http.StatusNotFound)
+		http.Error(w, err.Error(), status)
 		return
 	} else if status != http.StatusOK {
 		w.WriteHeader(status)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(&devices)
+	json.NewEncoder(w).Encode(&cmds)
 }
 
 func restGetAllCommands(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	status, devices, err := getCommands(ctx)
+	status, cmds, err := getCommands(ctx)
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		w.WriteHeader(status)
@@ -146,5 +144,5 @@ func restGetAllCommands(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(devices)
+	json.NewEncoder(w).Encode(cmds)
 }

--- a/internal/core/data/device_test.go
+++ b/internal/core/data/device_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata/mocks"
+	mdMocks "github.com/edgexfoundry/go-mod-core-contracts/clients/metadata/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/edgexfoundry/go-mod-messaging/messaging"
@@ -26,13 +28,17 @@ import (
 )
 
 var testEvent contract.Event
+var testDevice contract.Device
+var testDeviceProfile contract.DeviceProfile
 var testRoutes *mux.Router
 
 const (
-	testDeviceName string = "Test Device"
-	testOrigin     int64  = 123456789
-	testBsonString string = "57e59a71e4b0ca8e6d6d4cc2"
-	testUUIDString string = "ca93c8fa-9919-4ec5-85d3-f81b2b6a7bc1"
+	testDeviceName          string = "Test Device"
+	testOrigin              int64  = 123456789
+	testBsonString          string = "57e59a71e4b0ca8e6d6d4cc2"
+	testUUIDString          string = "ca93c8fa-9919-4ec5-85d3-f81b2b6a7bc1"
+	testDeviceProfileName   string = "Test DeviceProfile Name"
+	testValueDescriptorName string = "RandomValue_Bool"
 )
 
 func TestCheckMaxLimit(t *testing.T) {
@@ -63,6 +69,7 @@ func TestMain(m *testing.M) {
 	testRoutes = LoadRestRoutes()
 	LoggingClient = logger.NewMockClient()
 	mdc = newMockDeviceClient()
+	mdpc = newMockDeviceProfileClient()
 	// no need to mock this since it's all in process
 	msgClient, _ = messaging.NewMessageClient(msgTypes.MessageBusConfig{
 		PublishHost: msgTypes.HostInfo{
@@ -84,6 +91,19 @@ func reset() {
 	testEvent.Device = testDeviceName
 	testEvent.Origin = testOrigin
 	testEvent.Readings = buildReadings()
+	testDevice.ProfileName = testDeviceProfileName
+
+}
+
+func newMockDeviceProfileClient() *mdMocks.DeviceProfileClient {
+	dpClient := &mdMocks.DeviceProfileClient{}
+
+	testDeviceProfileGenerator := `{"created":1551711642676,"modified":1551711642676,"origin":0,"description":"Example of Device-Virtual","id":"b06e124f-3e46-483d-b18b-fc1f93f835c6","name":"Test DeviceProfile Name","manufacturer":"IOTech","model":"Device-Virtual-01","labels":["device-virtual-example"],"objects":null,"deviceResources":[{"description":"used to decide whether to re-generate a random value","name":"Enable_Randomization","tag":null,"properties":{"value":{"type":"Bool","readWrite":"W","minimum":null,"maximum":null,"defaultValue":"true","size":null,"word":"2","lsb":null,"mask":"0x00","shift":"0","scale":"1.0","offset":"0.0","base":"0","assertion":null,"signed":true,"precision":null},"units":{"type":"String","readWrite":"R","defaultValue":"Random"}},"attributes":null}],"resources":[{"name":"RandomValue_Bool","get":[{"index":null,"operation":"get","object":"RandomValue_Bool","property":null,"parameter":"RandomValue_Bool","resource":null,"secondary":[],"mappings":{}}],"set":[{"index":null,"operation":"set","object":"RandomValue_Bool","property":null,"parameter":"RandomValue_Bool","resource":"RandomValue_Bool","secondary":[],"mappings":{}}]}],"commands":[{"created":1551711642676,"modified":0,"origin":0,"id":"ed0d88b8-e202-4bdd-a941-606b5c7f40d4","name":"RandomValue_Bool","get":{"path":"/api/v1/device/{deviceId}/RandomValue_Bool","responses":[{"code":"200","description":null,"expectedValues":["RandomValue_Bool"]},{"code":"503","description":"service unavailable","expectedValues":[]}]},"put":{"path":"/api/v1/device/{deviceId}/RandomValue_Bool","responses":[{"code":"200","description":null,"expectedValues":[]},{"code":"503","description":"service unavailable","expectedValues":[]}],"parameterNames":["RandomValue_Bool"]}}]}`
+	json.Unmarshal([]byte(testDeviceProfileGenerator), &testDeviceProfile)
+
+	dpClient.On("DeviceProfileForName", testDeviceProfileName, context.Background()).Return(testDeviceProfile, nil)
+
+	return dpClient
 }
 
 func newMockDeviceClient() *mocks.DeviceClient {
@@ -93,9 +113,9 @@ func newMockDeviceClient() *mocks.DeviceClient {
 
 	mockDeviceResultFn := func(id string, ctx context.Context) contract.Device {
 		if bson.IsObjectIdHex(id) {
-			return contract.Device{Id: id, Name: testDeviceName, Protocols: protocols}
+			return contract.Device{Id: id, Name: testDeviceName, ProfileName: testDeviceProfileName, Protocols: protocols}
 		}
-		return contract.Device{}
+		return contract.Device{ProfileName: testDeviceProfileName}
 	}
 	client.On("Device", "valid", context.Background()).Return(mockDeviceResultFn, nil)
 	client.On("Device", "404", context.Background()).Return(mockDeviceResultFn,
@@ -103,7 +123,7 @@ func newMockDeviceClient() *mocks.DeviceClient {
 	client.On("Device", mock.Anything, context.Background()).Return(mockDeviceResultFn, fmt.Errorf("some error"))
 
 	mockDeviceForNameResultFn := func(name string, ctx context.Context) contract.Device {
-		device := contract.Device{Id: uuid.New().String(), Name: name, Protocols: protocols}
+		device := contract.Device{Id: uuid.New().String(), Name: name, ProfileName: testDeviceProfileName, Protocols: protocols}
 
 		return device
 	}

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -56,6 +56,7 @@ var chUpdates chan interface{} //A channel for "config updates" sourced from Reg
 var msgClient messaging.MessageClient
 var mdc metadata.DeviceClient
 var msc metadata.DeviceServiceClient
+var mdpc metadata.DeviceProfileClient
 
 func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
@@ -306,6 +307,9 @@ func initializeClients(useRegistry bool) {
 		},
 		Type: Configuration.MessageQueue.Type,
 	})
+	params.Path = clients.ApiDeviceProfileRoute
+	params.Url = Configuration.Clients["Metadata"].Url() + clients.ApiDeviceProfileRoute
+	mdpc = metadata.NewDeviceProfileClient(params, startup.Endpoint{RegistryClient: &registryClient})
 
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("failed to create messaging client: %s", err.Error()))

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -129,10 +129,11 @@ func getValueDescriptorsByType(typ string) (vdList []contract.ValueDescriptor, e
 	return vdList, nil
 }
 
-func getValueDescriptorsByDevice(device contract.Device) (vdList []contract.ValueDescriptor, err error) {
+
+func getValueDescriptorsByDeviceProfile(profile contract.DeviceProfile) (vdList []contract.ValueDescriptor, err error) {
 	// Get the names of the value descriptors
 	vdNames := []string{}
-	device.AllAssociatedValueDescriptors(&vdNames)
+	profile.AllAssociatedValueDescriptors(&vdNames)
 
 	// Get the value descriptors
 	vdList = []contract.ValueDescriptor{}
@@ -162,8 +163,12 @@ func getValueDescriptorsByDeviceName(name string, ctx context.Context) (vdList [
 		LoggingClient.Error("Problem getting device from metadata: " + err.Error())
 		return []contract.ValueDescriptor{}, err
 	}
-
-	return getValueDescriptorsByDevice(device)
+	dp, err := mdpc.DeviceProfileForName(device.ProfileName, ctx)
+	if err != nil {
+		LoggingClient.Error("Problem getting device profile from metadata: " + err.Error())
+		return []contract.ValueDescriptor{}, err
+	}
+	return getValueDescriptorsByDeviceProfile(dp)
 }
 
 func getValueDescriptorsByDeviceId(id string, ctx context.Context) (vdList []contract.ValueDescriptor, err error) {
@@ -173,8 +178,12 @@ func getValueDescriptorsByDeviceId(id string, ctx context.Context) (vdList []con
 		LoggingClient.Error("Problem getting device from metadata: " + err.Error())
 		return []contract.ValueDescriptor{}, err
 	}
-
-	return getValueDescriptorsByDevice(device)
+	dp, err := mdpc.DeviceProfileForName(device.ProfileName, ctx)
+	if err != nil {
+		LoggingClient.Error("Problem getting device profile from metadata: " + err.Error())
+		return []contract.ValueDescriptor{}, err
+	}
+	return getValueDescriptorsByDeviceProfile(dp)
 }
 
 func getAllValueDescriptors() (vd []contract.ValueDescriptor, err error) {

--- a/internal/core/data/valuedescriptor_test.go
+++ b/internal/core/data/valuedescriptor_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
-
 	"github.com/stretchr/testify/mock"
 )
 
@@ -50,6 +49,7 @@ func TestGetValueDescriptorByName(t *testing.T) {
 
 	valueDescriptor, err := getValueDescriptorByName("valid")
 
+	fmt.Println("uu", valueDescriptor)
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by name")
 	}
@@ -327,11 +327,18 @@ func TestGetValueDescriptorsByTypeError(t *testing.T) {
 func TestGetValueDescriptorsByDeviceName(t *testing.T) {
 	reset()
 	dbClient = nil
+	myMock := &mocks.DBClient{}
+	myMock.On("ValueDescriptorByName", mock.Anything).Return(models.ValueDescriptor{}, nil)
 
-	_, err := getValueDescriptorsByDeviceName(testDeviceName, context.Background())
+	dbClient = myMock
+
+	vds, err := getValueDescriptorsByDeviceName(testDeviceName, context.Background())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by device name")
+	}
+	if len(vds) != 1 {
+		t.Errorf("Expected 1 Value Descriptor, returned %v", len(vds))
 	}
 }
 
@@ -372,11 +379,17 @@ func TestGetValueDescriptorsByDeviceNameError(t *testing.T) {
 func TestGetValueDescriptorsByDeviceId(t *testing.T) {
 	reset()
 	dbClient = nil
+	myMock := &mocks.DBClient{}
+	myMock.On("ValueDescriptorByName", mock.Anything).Return(models.ValueDescriptor{Name: testValueDescriptorName}, nil)
 
-	_, err := getValueDescriptorsByDeviceId("valid", context.Background())
+	dbClient = myMock
+	vds, err := getValueDescriptorsByDeviceId("valid", context.Background())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by device id")
+	}
+	if len(vds) != 1 {
+		t.Errorf("Expected 1 Value Descriptor, returned %v", len(vds))
 	}
 }
 

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -149,12 +149,10 @@ func updateDeviceProfileFields(from models.DeviceProfile, to *models.DeviceProfi
 	if from.Origin != 0 {
 		to.Origin = from.Origin
 	}
-	if from.Name != "" {
-		to.Name = from.Name
-		// Names must be unique for each device profile
-		if err := checkDuplicateProfileNames(*to, w); err != nil {
-			return err
-		}
+	if from.Name != "" && to.Name != from.Name{
+		//DeviceName must be unique and cannot be updated
+		err := errors.New("DeviceProfile's Name cannot be updated.")
+		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
 	if from.DeviceResources != nil {
 		to.DeviceResources = from.DeviceResources

--- a/internal/pkg/db/mongo/metadata.go
+++ b/internal/pkg/db/mongo/metadata.go
@@ -247,6 +247,16 @@ func (mc MongoClient) DBRefToDeviceProfile(dbRef mgo.DBRef) (a models.DeviceProf
 	return
 }
 
+func (mc MongoClient) NameToDeviceProfile(name string) (a models.DeviceProfile, err error) {
+	s := mc.session.Copy()
+	defer s.Close()
+
+	if err = s.DB(mc.database.Name).C(db.DeviceProfile).Find(bson.M{"name": name}).One(&a); err != nil {
+		return models.DeviceProfile{}, errorMap(err)
+	}
+	return
+}
+
 func (mc MongoClient) DeviceProfileToDBRef(model models.DeviceProfile) (dbRef mgo.DBRef, err error) {
 	// validate model with identity provided in contract actually exists
 	if model.Id.Valid() {

--- a/internal/pkg/db/mongo/models/device.go
+++ b/internal/pkg/db/mongo/models/device.go
@@ -98,10 +98,7 @@ func (d *Device) ToContract(dsTransform deviceServiceTransform, dpTransform devi
 	if err != nil {
 		return
 	}
-	result.Profile, err = dpModel.ToContract(cTransform)
-	if err != nil {
-		return
-	}
+	result.ProfileName = dpModel.Name
 
 	c = result
 	return
@@ -144,13 +141,14 @@ func (d *Device) FromContract(from contract.Device, dsTransform deviceServiceTra
 		return
 	}
 
-	var dpModel DeviceProfile
-	if _, err = dpModel.FromContract(from.Profile, cTransform); err != nil {
+	dpModel, err := dpTransform.NameToDeviceProfile(from.ProfileName)
+	if err != nil {
 		return
 	}
 	if d.Profile, err = dpTransform.DeviceProfileToDBRef(dpModel); err != nil {
 		return
 	}
+
 	id = toContractId(d.Id, d.Uuid)
 	return
 }

--- a/internal/pkg/db/mongo/models/deviceprofile.go
+++ b/internal/pkg/db/mongo/models/deviceprofile.go
@@ -23,6 +23,7 @@ import (
 
 type deviceProfileTransform interface {
 	DBRefToDeviceProfile(dbRef mgo.DBRef) (model DeviceProfile, err error)
+	NameToDeviceProfile(name string) (model DeviceProfile, err error)
 	DeviceProfileToDBRef(model DeviceProfile) (dbRef mgo.DBRef, err error)
 }
 

--- a/internal/pkg/db/redis/device.go
+++ b/internal/pkg/db/redis/device.go
@@ -49,7 +49,7 @@ func marshalDevice(d contract.Device) (out []byte, err error) {
 		Labels:          d.Labels,
 		Location:        d.Location,
 		Service:         d.Service.Id,
-		Profile:         d.Profile.Id,
+		Profile:         d.ProfileName,
 	}
 
 	return marshalObject(s)
@@ -76,6 +76,7 @@ func unmarshalDevice(o []byte, d interface{}) (err error) {
 		x.LastReported = s.LastReported
 		x.Labels = s.Labels
 		x.Location = s.Location
+		x.ProfileName = s.Profile
 
 		conn, err := getConnection()
 		if err != nil {
@@ -84,11 +85,6 @@ func unmarshalDevice(o []byte, d interface{}) (err error) {
 		defer conn.Close()
 
 		err = getObjectById(conn, s.Service, unmarshalDeviceService, &x.Service)
-		if err != nil {
-			return err
-		}
-
-		err = getObjectById(conn, s.Profile, unmarshalDeviceProfile, &x.Profile)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/db/redis/metadata.go
+++ b/internal/pkg/db/redis/metadata.go
@@ -351,7 +351,7 @@ func addDevice(conn redis.Conn, d contract.Device) (string, error) {
 	conn.Send("ZADD", db.Device, 0, id)
 	conn.Send("HSET", db.Device+":name", d.Name, id)
 	conn.Send("SADD", db.Device+":service:"+d.Service.Id, id)
-	conn.Send("SADD", db.Device+":profile:"+d.Profile.Id, id)
+	conn.Send("SADD", db.Device+":profileName:"+d.ProfileName, id)
 	for _, label := range d.Labels {
 		conn.Send("SADD", db.Device+":label:"+label, id)
 	}
@@ -375,7 +375,7 @@ func deleteDevice(conn redis.Conn, id string) error {
 	_ = conn.Send("ZREM", db.Device, id)
 	_ = conn.Send("HDEL", db.Device+":name", d.Name)
 	_ = conn.Send("SREM", db.Device+":service:"+d.Service.Id, id)
-	_ = conn.Send("SREM", db.Device+":profile:"+d.Profile.Id, id)
+	_ = conn.Send("SREM", db.Device+":profileName:"+d.ProfileName, id)
 	for _, label := range d.Labels {
 		conn.Send("SREM", db.Device+":label:"+label, id)
 	}

--- a/internal/pkg/db/test/db_metadata.go
+++ b/internal/pkg/db/test/db_metadata.go
@@ -204,11 +204,12 @@ func populateDevice(db interfaces.DBClient, count int) (string, error) {
 			return id, fmt.Errorf("Error creating DeviceService: %v", err)
 		}
 
-		d.Profile, err = getDeviceProfile(db, i)
+		dp, err := getDeviceProfile(db, i)
 		if err != nil {
 			return id, fmt.Errorf("Error getting DeviceProfile: %v", err)
 		}
-		d.Profile.Id, err = db.AddDeviceProfile(d.Profile)
+		d.ProfileName = dp.Name
+		_, err = db.AddDeviceProfile(dp)
 		if err != nil {
 			return id, fmt.Errorf("Error creating DeviceProfile: %v", err)
 		}
@@ -987,8 +988,12 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 	if err == nil {
 		t.Fatalf("Device should not be found")
 	}
+	dp, err := db.GetDeviceProfileByName(d.ProfileName)
+	if err != nil {
+		t.Fatalf("Error getting Device Profile %v", err)
+	}
 
-	devices, err = db.GetDevicesByProfileId(d.Profile.Id)
+	devices, err = db.GetDevicesByProfileId(dp.Id)
 	if err != nil {
 		t.Fatalf("Error getting devices %v", err)
 	}


### PR DESCRIPTION
Remove the embedded DeviceProfile struct from the Device.
The Device struct will keep just the ProfileName as a reference.
The Device SDK have a cache of Device Profiles, so they will be retrieved from the cache.
All other services will make a call to metadata in order to get a Device Profile.

It decreases the Device SDK cache size, and descrease the debug and error log messages.

Resolves/Fixes edgexfoundry/go-mod-core-contracts#27

Signed-off-by: Diana Atanasova <dianaa@vmware.com>