### PR TITLE
#1219 Updated core-command to include a correlation ID in the request headers when sending HTTP(s) requests

### DIFF
--- a/internal/core/command/get.go
+++ b/internal/core/command/get.go
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package command
+
+import (
+	"context"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"net/http"
+	"strings"
+)
+
+// NewGetCommand creates and Executor which can be used to execute the GET related command.
+func NewGetCommand(device models.Device, command models.Command, context context.Context, httpCaller internal.HttpCaller) (Executor, error) {
+	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+
+	if err != nil {
+		return serviceCommand{}, err
+	}
+
+	correlationID := context.Value(clients.CorrelationHeader)
+	if correlationID != nil {
+		request.Header.Set(clients.CorrelationHeader, correlationID.(string))
+	}
+
+	return serviceCommand{
+		Device:     device,
+		HttpCaller: httpCaller,
+		Request:    request,
+	}, nil
+}

--- a/internal/core/command/get_test.go
+++ b/internal/core/command/get_test.go
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package command
+
+import (
+	"context"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"testing"
+)
+
+const (
+	TestProtocol = "http"
+	TestDeviceId = "TestDeviceID"
+	TestAddress  = "example.com"
+	TestPort     = 8080
+)
+
+// Device which can be used as a basis for test setup. By default this is constructed for happy path testing.
+var testDevice = models.Device{
+	Id:         TestDeviceId,
+	AdminState: models.Unlocked,
+	Service: models.DeviceService{
+		Service: models.Service{
+			Addressable: models.Addressable{
+				Protocol: TestProtocol,
+				Address:  TestAddress,
+				Port:     TestPort,
+			},
+		},
+	},
+}
+
+// Command which can be used as a basis for test setup. By default this is constructed for happy path testing.
+var testCommand = models.Command{
+	Get: &models.Get{
+		Action: models.Action{
+			Path: "/some/uri",
+		},
+	},
+}
+
+func TestNewGetCommandWithCorrelationId(t *testing.T) {
+	expectedCorrelationIDHeaderValue := "Testing"
+	testContext := context.WithValue(context.Background(), clients.CorrelationHeader, expectedCorrelationIDHeaderValue)
+	getCommand, _ := NewGetCommand(testDevice, testCommand, testContext, nil)
+	actualCorrelationIDHeaderValue := getCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
+	if actualCorrelationIDHeaderValue == "" {
+		t.Errorf("The populated GetCommand's request should contain a correlation ID header value")
+	}
+
+	if actualCorrelationIDHeaderValue != expectedCorrelationIDHeaderValue {
+		t.Errorf("The populated GetCommand's request should contain the correct correlation ID")
+	}
+}
+
+func TestNewGetCommandNoCorrelationIDInContext(t *testing.T) {
+	getCommand, _ := NewGetCommand(testDevice, testCommand, context.Background(), nil)
+	actualCorrelationIDHeaderValue := getCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
+	if actualCorrelationIDHeaderValue != "" {
+		t.Errorf("No correlation ID should be specified")
+	}
+}
+
+func TestNewGetCommandInvalidBaseUrl(t *testing.T) {
+	device := testDevice
+	device.Service.Addressable.Address = "!@#$"
+	_, err := NewGetCommand(device, testCommand, context.Background(), nil)
+	if err != nil {
+		t.Errorf("The invalid URL error was not properly propegated to the caller")
+	}
+}

--- a/internal/core/command/interfaces.go
+++ b/internal/core/command/interfaces.go
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package command
+
+// Executor interface used to execute commands
+type Executor interface {
+	Execute() (string, int, error)
+}

--- a/internal/core/command/put.go
+++ b/internal/core/command/put.go
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package command
+
+import (
+	"context"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"net/http"
+	"strings"
+)
+
+// NewPutCommand creates and Executor which can be used to execute the PUT related command.
+func NewPutCommand(device models.Device, command models.Command, context context.Context, httpCaller internal.HttpCaller) (Executor, error) {
+	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
+	request, err := http.NewRequest(http.MethodPut, url, nil)
+
+	if err != nil {
+		return serviceCommand{}, err
+	}
+
+	correlationID := context.Value(clients.CorrelationHeader)
+	if correlationID != nil {
+		request.Header.Set(clients.CorrelationHeader, correlationID.(string))
+	}
+
+	return serviceCommand{
+		Device:     device,
+		HttpCaller: httpCaller,
+		Request:    request,
+	}, nil
+}

--- a/internal/core/command/put_test.go
+++ b/internal/core/command/put_test.go
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package command
+
+import (
+	"context"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"testing"
+)
+
+func TestNewPutCommandWithCorrelationId(t *testing.T) {
+	expectedCorrelationIDHeaderValue := "Testing"
+	testContext := context.WithValue(context.Background(), clients.CorrelationHeader, expectedCorrelationIDHeaderValue)
+
+	putCommand, _ := NewPutCommand(testDevice, testCommand, testContext, nil)
+
+	actualCorrelationIDHeaderValue := putCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
+	if actualCorrelationIDHeaderValue == "" {
+		t.Errorf("The populated PutCommand's request should contain a correlation ID header value")
+	}
+
+	if actualCorrelationIDHeaderValue != expectedCorrelationIDHeaderValue {
+		t.Errorf("The populated PutCommand's request should contain the correct correlation ID")
+	}
+}
+func TestNewPutCommandNoCorrelationIDInContext(t *testing.T) {
+	putCommand, _ := NewPutCommand(testDevice, testCommand, context.Background(), nil)
+
+	actualCorrelationIDHeaderValue := putCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
+	if actualCorrelationIDHeaderValue != "" {
+		t.Errorf("No correlation ID should be specified")
+	}
+}
+
+func TestNewPutCommandInvalidBaseUrl(t *testing.T) {
+	device := testDevice
+	device.Service.Addressable.Address = "!@#$"
+
+	_, err := NewPutCommand(device, testCommand, context.Background(), nil)
+
+	if err != nil {
+		t.Errorf("The invalid URL error was not properly propegated to the caller")
+	}
+}

--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -18,7 +18,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	mux "github.com/gorilla/mux"
+	"github.com/gorilla/mux"
 )
 
 func restGetDeviceCommandByCommandID(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +29,7 @@ func restPutDeviceCommandByCommandID(w http.ResponseWriter, r *http.Request) {
 	issueDeviceCommand(w, r, true)
 }
 
-func issueDeviceCommand(w http.ResponseWriter, r *http.Request, p bool) {
+func issueDeviceCommand(w http.ResponseWriter, r *http.Request, isPutCommand bool) {
 	defer r.Body.Close()
 
 	vars := mux.Vars(r)
@@ -42,7 +42,7 @@ func issueDeviceCommand(w http.ResponseWriter, r *http.Request, p bool) {
 	}
 
 	ctx := r.Context()
-	body, status := commandByDeviceID(did, cid, string(b), p, ctx)
+	body, status := commandByDeviceID(did, cid, string(b), isPutCommand, ctx)
 	if status != http.StatusOK {
 		w.WriteHeader(status)
 	} else {

--- a/internal/core/command/types.go
+++ b/internal/core/command/types.go
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package command
+
+import (
+	"bytes"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"net/http"
+)
+
+// DefaultErrorCode the default value used when an error has occurred and no response code was received.
+const DefaultErrorCode = 0
+
+// ErrDeviceLocked error indicating the locked state of a device
+type ErrDeviceLocked struct{}
+
+func (ErrDeviceLocked) Error() string {
+	return "The device is in admin locked state"
+}
+
+// serviceCommand type which encapsulates command information to be sent to the command service.
+type serviceCommand struct {
+	models.Device
+	internal.HttpCaller
+	*http.Request
+}
+
+// Execute sends the command to the command service
+func (sc serviceCommand) Execute() (string, int, error) {
+	if sc.AdminState == models.Locked {
+		LoggingClient.Error(sc.Name + " is in admin locked state")
+
+		return "", DefaultErrorCode, ErrDeviceLocked{}
+	}
+
+	LoggingClient.Info("Issuing" + sc.Request.Method + " command to: " + sc.Request.URL.String())
+	resp, reqErr := sc.HttpCaller.Do(sc.Request)
+	if reqErr != nil {
+		LoggingClient.Error(reqErr.Error())
+		return "", http.StatusInternalServerError, reqErr
+
+	}
+
+	buf := new(bytes.Buffer)
+	_, readErr := buf.ReadFrom(resp.Body)
+
+	if readErr != nil {
+		return "", DefaultErrorCode, readErr
+	}
+	return buf.String(), resp.StatusCode, nil
+}

--- a/internal/core/command/types_test.go
+++ b/internal/core/command/types_test.go
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package command
+
+import (
+	"errors"
+	"fmt"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// FailingMockHttpCaller a HttpCaller which always returns an error when executing a request.
+type FailingMockHttpCaller struct{}
+
+// Do always returns an empty http.Response and an error.
+func (FailingMockHttpCaller) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{}, errors.New("testing error handling")
+}
+
+// ReadFailMockHttpCaller an HttpCaller which returns a http.Response that will always fail when attempting to read the Body.
+type ReadFailMockHttpCaller struct{}
+
+// Do returns a http.Response which contains a Body that will return an error when attempting to read.
+func (ReadFailMockHttpCaller) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		Body: MockBody{},
+	}, nil
+}
+
+// MockBody a Body which will return 0 and an error when attempting to read.
+type MockBody struct{}
+
+// Read returns 0 and an error
+func (MockBody) Read(p []byte) (n int, err error) {
+	return 0, errors.New("testing read error")
+}
+
+// Close implementation not required
+func (MockBody) Close() error {
+	panic("implement me")
+}
+
+func TestExecute(t *testing.T) {
+	expectedResponseBody := "Sample Response Body"
+	expectedResponseCode := http.StatusOK
+	LoggingClient = logger.MockLogger{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, expectedResponseBody)
+		w.WriteHeader(expectedResponseCode)
+	}))
+	defer ts.Close()
+
+	request, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	sc := serviceCommand{
+		Device: models.Device{
+			AdminState: models.Unlocked,
+		},
+		HttpCaller: &http.Client{},
+		Request:    request,
+	}
+
+	body, responseCode, err := sc.Execute()
+	if err != nil {
+		t.Errorf("No error should be present for happy path")
+	}
+
+	if body != expectedResponseBody {
+		t.Errorf("The response body was not properly propegated to the caller")
+	}
+
+	if responseCode != expectedResponseCode {
+		t.Errorf("The response code was not properly propegated to the caller")
+	}
+}
+
+func TestExecuteHttpRequestError(t *testing.T) {
+	LoggingClient = logger.MockLogger{}
+	request, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	sc := serviceCommand{
+		Device: models.Device{
+			AdminState: models.Unlocked,
+		},
+		HttpCaller: &FailingMockHttpCaller{},
+		Request:    request,
+	}
+
+	_, _, err := sc.Execute()
+	if err == nil {
+		t.Errorf("No error should be present for happy path")
+	}
+}
+
+func TestExecuteHttpReadResponseError(t *testing.T) {
+	LoggingClient = logger.MockLogger{}
+	request, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	sc := serviceCommand{
+		Device: models.Device{
+			AdminState: models.Unlocked,
+		},
+		HttpCaller: &ReadFailMockHttpCaller{},
+		Request:    request,
+	}
+
+	_, responseCode, err := sc.Execute()
+	if err == nil {
+		t.Errorf("The error was not properly propegated to the caller")
+	}
+
+	if responseCode != DefaultErrorCode {
+		t.Errorf("The response code should be the default value for failing requests")
+	}
+}
+
+func TestExecuteWithLockedDevice(t *testing.T) {
+	LoggingClient = logger.MockLogger{}
+	request, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	sc := serviceCommand{
+		Device: models.Device{
+			AdminState: models.Locked,
+		},
+		HttpCaller: &http.Client{},
+		Request:    request,
+	}
+
+	_, _, err := sc.Execute()
+	if err == nil {
+		t.Errorf("No error should be present for happy path")
+	}
+}

--- a/internal/interface.go
+++ b/internal/interface.go
@@ -1,0 +1,7 @@
+package internal
+
+import "net/http"
+
+type HttpCaller interface{
+	Do(req *http.Request) (*http.Response, error)
+}


### PR DESCRIPTION
Refactored device.go command execution functionality to allow for easier
testing

Added tests to cover newly added functionality