### PR TITLE
snapcraft.yaml, hooks: handle upgrades from previous revisions

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -119,10 +119,10 @@ done
 # the vault config needs to be generated with sed, replacing $SNAP_DATA in the file 
 # with the actual absolute directory
 # note that if anyone ever somehow has a "@" in their $SNAP_DATA this will likely break :-/
-if [ ! -f "${SNAP_DATA}/config/security-secret-store/vault-config.json" ]; then
+if [ ! -f "${SNAP_DATA}/config/security-secret-store/vault-config.hcl" ]; then
     mkdir -p ${SNAP_DATA}/config/security-secret-store
-    sed "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" ${SNAP}/config/security-secret-store/vault-config.json.in > ${SNAP_DATA}/config/security-secret-store/vault-config.json
-    chmod 644 ${SNAP_DATA}/config/security-secret-store/vault-config.json
+    sed "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" ${SNAP}/config/security-secret-store/vault-config.hcl.in > ${SNAP_DATA}/config/security-secret-store/vault-config.hcl
+    chmod 644 ${SNAP_DATA}/config/security-secret-store/vault-config.hcl
 fi
 
 # the kong config file needs to be generated with 3 changes from the default one included in the snap

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,25 +1,8 @@
 #!/bin/bash -e
 
-# LD_LIBRARY_PATH isn't properly initialized for hooks as snapcraft does for apps, so this 
-# has to be constructed manually
-# Note - the env var SNAP_LIBRARY_PATH is set by snapd for hooks, so it can be referenced here
-# This is mainly necessary so we can use jq from the snap which needs libs from inside the snap
-export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
-# for LD_LIBRARY_PATH, we need to handle the different architecture paths
-case $(arch) in
-    x86_64)
-        MULTI_ARCH_PATH="x86_64-linux-gnu";;
-    arm*)
-        MULTI_ARCH_PATH="arm-linux-gnueabihf";;
-    aarch64)
-        MULTI_ARCH_PATH="aarch64-linux-gnu";;
-    *)
-        echo "architecture $ARCH not supported"
-        exit 1
-        ;;
-esac
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$MULTI_ARCH_PATH:$SNAP/usr/lib/$MULTI_ARCH_PATH"
-export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+# load appropriate env vars so we can use jq here
+# shellcheck source=/dev/null
+source "$SNAP/bin/hooks-env-setup.sh"
 
 # currently $SNAP_DATA will evaluate to the absolute path including the 
 # explicit revision number, which will change after a refresh

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -21,6 +21,16 @@ esac
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$MULTI_ARCH_PATH:$SNAP/usr/lib/$MULTI_ARCH_PATH"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
+# currently $SNAP_DATA will evaluate to the absolute path including the 
+# explicit revision number, which will change after a refresh
+# this is problematic for storing file paths using $SNAP_DATA inside the 
+# config files, as they need absolute file paths and don't perform environment
+# variable substitution themselves
+# so what we want to do is instead change $SNAP_DATA to point to the current
+# symlink and use that in all of the config files we process here
+SNAP_DATA_CURRENT=${SNAP_DATA/%$SNAP_REVISION/current}
+SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
+
 # install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
 # into $SNAP_DATA/config
 mkdir -p ${SNAP_DATA}/config
@@ -30,8 +40,8 @@ for service in security-api-gateway security-secret-store core-command config-se
         cp ${SNAP}/config/${service}/res/configuration.toml "${SNAP_DATA}/config/${service}/res/configuration.toml"
         # do replacement of the $SNAP, $SNAP_DATA, $SNAP_COMMON environment variables in the config files
         sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
-            -e "s@\$SNAP_DATA@$SNAP_DATA@g" \
-            -e "s@\$SNAP@$SNAP@g" \
+            -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
+            -e "s@\$SNAP@$SNAP_CURRENT@g" \
             "${SNAP_DATA}/config/${service}/res/configuration.toml"
     fi
 done
@@ -45,7 +55,7 @@ for jsvc in edgex-support-rulesengine; do
         mkdir -p "${SNAP_DATA}/config/config-seed/res/properties/$jsvc"
         cp "${SNAP}/config/config-seed/res/properties/$jsvc/application.properties" "${SNAP_DATA}/config/config-seed/res/properties/$jsvc/application.properties"
         # also replace SNAP_DATA and SNAP_COMMON in the application files
-        sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" -e "s@\$SNAP_DATA@$SNAP_DATA@g" "${SNAP_DATA}/config/config-seed/res/properties/$jsvc/application.properties"
+        sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" "${SNAP_DATA}/config/config-seed/res/properties/$jsvc/application.properties"
     fi
 done
 
@@ -74,7 +84,7 @@ if [ ! -f "${SNAP_DATA}/config/security-secret-store/pkisetup-kong.json" ]; then
     mkdir -p ${SNAP_DATA}/config/security-secret-store
     CONFIG_FILE_PATH="config/security-secret-store/pkisetup-kong.json"
     # replace the hostname with localhost using jq
-    jq --arg WORKDIR "$SNAP_DATA/vault" \
+    jq --arg WORKDIR "$SNAP_DATA_CURRENT/vault" \
         '.x509_tls_server_parameters.tls_host = "localhost" | .pki_setup_dir = "pki" | .working_dir  = $WORKDIR' \
         "${SNAP}/${CONFIG_FILE_PATH}" > "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp"
     mv "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp" "${SNAP_DATA}/${CONFIG_FILE_PATH}"
@@ -87,7 +97,7 @@ if [ ! -f "${SNAP_DATA}/config/security-secret-store/pkisetup-vault.json" ]; the
     mkdir -p ${SNAP_DATA}/config/security-secret-store
     CONFIG_FILE_PATH="config/security-secret-store/pkisetup-vault.json"
     # modify the parameters using jq
-    jq --arg WORKDIR "$SNAP_DATA/vault" \
+    jq --arg WORKDIR "$SNAP_DATA_CURRENT/vault" \
         '.x509_tls_server_parameters.tls_host = "localhost" | .pki_setup_dir = "pki" | .working_dir  = $WORKDIR' \
         "${SNAP}/${CONFIG_FILE_PATH}" > "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp"
     mv "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp" "${SNAP_DATA}/${CONFIG_FILE_PATH}"
@@ -111,7 +121,7 @@ done
 # note that if anyone ever somehow has a "@" in their $SNAP_DATA this will likely break :-/
 if [ ! -f "${SNAP_DATA}/config/security-secret-store/vault-config.json" ]; then
     mkdir -p ${SNAP_DATA}/config/security-secret-store
-    sed "s@\$SNAP_DATA@$SNAP_DATA@g" ${SNAP}/config/security-secret-store/vault-config.json.in > ${SNAP_DATA}/config/security-secret-store/vault-config.json
+    sed "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" ${SNAP}/config/security-secret-store/vault-config.json.in > ${SNAP_DATA}/config/security-secret-store/vault-config.json
     chmod 644 ${SNAP_DATA}/config/security-secret-store/vault-config.json
 fi
 
@@ -124,7 +134,7 @@ if [ ! -f ${SNAP_DATA}/config/security-api-gateway/kong.conf ]; then
     cp "${SNAP}/config/security-api-gateway/kong.conf" "${SNAP_DATA}/config/security-api-gateway/kong.conf"
     # replace the default prefix setting with an absolute path using $SNAP_DATA
     # note that if anyone ever has a "@" in their $SNAP_DATA this will likely fail
-    sed -i "s@#prefix = /usr/local/kong/@prefix = ${SNAP_DATA}/kong@" ${SNAP_DATA}/config/security-api-gateway/kong.conf
+    sed -i "s@#prefix = /usr/local/kong/@prefix = ${SNAP_DATA_CURRENT}/kong@" ${SNAP_DATA}/config/security-api-gateway/kong.conf
 
     # also replace the default nginx user/group to be root
     sed -i "s@#nginx_user = nobody nobody@nginx_user = root root@" ${SNAP_DATA}/config/security-api-gateway/kong.conf

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+# load appropriate env vars so we can use jq here
+# shellcheck source=/dev/null
+source "$SNAP/bin/hooks-env-setup.sh"
+
 # the new revisions use vault-config.hcl as the vault config instead of 
 # vault-config.json as previously was used
 # so all we do is check if that file exists and the new hcl file doesn't exist

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,126 @@
+#!/bin/bash -e
+
+# the new revisions use vault-config.hcl as the vault config instead of 
+# vault-config.json as previously was used
+# so all we do is check if that file exists and the new hcl file doesn't exist
+# and if it does then we move it
+# see https://github.com/edgexfoundry/security-secret-store/issues/66
+VAULT_CONFIG_FILE="$SNAP_DATA/config/security-secret-store/vault-config"
+if [ -f "$VAULT_CONFIG_FILE.json" ] && [ ! -f "$VAULT_CONFIG_FILE.hcl" ] ; then
+    mv "$VAULT_CONFIG_FILE.json" "$VAULT_CONFIG_FILE.hcl"
+fi
+
+# if the lastrevision has a value, it means that the previous revision
+# was new enough to use the current symlink, and as such doesn't need
+# processing
+if [ -n "$(snapctl get lastrev)" ]; then
+    exit 0
+fi
+
+# if however the previous revision wasn't set, we know that the previous 
+# revision would have used absolute paths for things like $SNAP_DATA to
+# and are now incorrect, and so we should update relevant values to use the 
+# current symlink intead
+# see https://github.com/edgexfoundry/edgex-go/issues/799#issuecomment-480318857
+# for full details
+
+# the full set of previous config items that would have been set as verbatim 
+# $SNAP_DATA
+# * $SNAP_DATA/config/config-seed/res/properties/edgex-support-rulesengine/application.properties:
+#     $SNAP_DATA/support-rulesengine/rules
+#     $SNAP_DATA/support-rulesengine/templates
+# * $SNAP_DATA/config/security-secret-store/res/configuration.toml:
+#     $SNAP_DATA/vault/pki
+#     tokenfolderpath = "$SNAP_DATA/config/security-secret-store/res"
+# * $SNAP_DATA/config/security-api-gateway/res/configuration.toml:
+#     tokenpath = "$SNAP_DATA/config/security-api-gateway/res/kong-token.json"
+# * $SNAP_DATA/config/security-secret-store/vault-config.hcl
+#     tls_client_ca_file ="$SNAP_DATA/vault/pki/EdgeXFoundryCA/EdgeXFoundryTrustCA.pem"
+#     tls_cert_file ="$SNAP_DATA/vault/pki/EdgeXFoundryCA/localhost.pem"
+#     tls_key_file = "$SNAP_DATA/vault/pki/EdgeXFoundryCA/localhost.priv.key"
+# * $SNAP_DATA/config/security-api-gateway/kong.conf
+#     prefix = $SNAP_DATA/kong
+# * $SNAP_DATA/config/security-secret-store/pkisetup-kong.json
+#     working_dir: $SNAP_DATA/vault
+# * $SNAP_DATA/config/security-secret-store/pkisetup-vault.json
+#     working_dir: $SNAP_DATA/vault
+# * $SNAP_DATA/config/sys-mgmt-agent/configuration.toml:
+#     ExecutorPath = "$SNAP/bin/sys-mgmt-agent-snap-executor.sh"
+
+# snap setup dirs
+SNAP_DATA_CURRENT=${SNAP_DATA/%$SNAP_REVISION/current}
+SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
+SNAP_DATA_DIR=$(dirname "$SNAP_DATA")
+SNAP_DIR=$(dirname "$SNAP")
+
+RULES_ENGINE_PROP_FILE="$SNAP_DATA/config/config-seed/res/properties/edgex-support-rulesengine/application.properties"
+if [ -f "$RULES_ENGINE_PROP_FILE" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/support-rulesengine/rules@$SNAP_DATA_CURRENT/support-rulesengine/rules@" \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/support-rulesengine/templates@$SNAP_DATA_CURRENT/support-rulesengine/templates@" \
+        "$RULES_ENGINE_PROP_FILE"
+fi
+
+SECRET_STORE_CONFIG="$SNAP_DATA/config/security-secret-store/res/configuration.toml"
+if [ -f "$SECRET_STORE_CONFIG" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/vault/pki@$SNAP_DATA_CURRENT/vault/pki@" \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/config/security-secret-store/res@$SNAP_DATA_CURRENT/config/security-secret-store/res@" \
+        "$SECRET_STORE_CONFIG"
+fi
+
+SYS_MGMT_AGENT_CONFIG="$SNAP_DATA/config/sys-mgmt-agent/res/configuration.toml"
+if [ -f "$SYS_MGMT_AGENT_CONFIG" ]; then
+    sed -i \
+        -e "s@$SNAP_DIR/[0-9]*/bin/sys-mgmt-agent-snap-executor.sh@$SNAP_CURRENT/bin/sys-mgmt-agent-snap-executor.sh@" \
+        "$SYS_MGMT_AGENT_CONFIG"
+fi
+
+API_GATEWAY_CONFIG="$SNAP_DATA/config/security-api-gateway/res/configuration.toml"
+if [ -f "$API_GATEWAY_CONFIG" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/config/security-api-gateway/res/kong-token.json@$SNAP_DATA_CURRENT/config/security-api-gateway/res/kong-token.json@" \
+        "$API_GATEWAY_CONFIG"
+fi
+
+if [ -f "$VAULT_CONFIG_FILE.hcl" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/vault/pki/EdgeXFoundryCA/EdgeXFoundryTrustCA.pem@$SNAP_DATA_CURRENT/vault/pki/EdgeXFoundryCA/EdgeXFoundryTrustCA.pem@" \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/vault/pki/EdgeXFoundryCA/localhost.pem@$SNAP_DATA_CURRENT/vault/pki/EdgeXFoundryCA/localhost.pem@" \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/vault/pki/EdgeXFoundryCA/localhost.priv.key@$SNAP_DATA_CURRENT/vault/pki/EdgeXFoundryCA/localhost.priv.key@" \
+        "$VAULT_CONFIG_FILE.hcl"
+fi
+
+KONG_CONF="$SNAP_DATA/config/security-api-gateway/kong.conf"
+if [ -f "$KONG_CONF" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/kong@$SNAP_DATA_CURRENT/kong@" \
+        "$KONG_CONF"
+fi
+
+PKISETUP_CONFIG_DIR=$SNAP_DATA/config/security-secret-store
+PKI_VAULT_FILE="$PKISETUP_CONFIG_DIR/pkisetup-vault.json"
+if [ -f "$PKI_VAULT_FILE" ]; then
+    # with jq we can directly check if the setting for working_dir matches the
+    # regex for the previous revision $SNAP_DATA
+    # only then do we update it
+    if [ "$(jq -r --arg REGEX "$SNAP_DATA_DIR/[0-9]+/vault" '.working_dir | test($REGEX)' < "$PKI_VAULT_FILE" )"  = "true" ]; then
+        # modify the parameters using jq
+        jq --arg WORKDIR "$SNAP_DATA_CURRENT/vault" '.working_dir  = $WORKDIR' \
+            < "$PKI_VAULT_FILE" > "$PKI_VAULT_FILE.tmp"
+        mv "$PKI_VAULT_FILE.tmp" "$PKI_VAULT_FILE"
+    fi
+fi
+
+PKI_KONG_FILE="$PKISETUP_CONFIG_DIR/pkisetup-kong.json"
+if [ -f "$PKI_KONG_FILE" ]; then
+    # with jq we can directly check if the setting for working_dir matches the
+    # regex for the previous revision $SNAP_DATA
+    # only then do we update it
+    if [ "$(jq -r --arg REGEX "$SNAP_DATA_DIR/[0-9]+/vault" '.working_dir | test($REGEX)' < "$PKI_KONG_FILE" )"  = "true" ]; then
+        # update the working_dir
+        jq --arg WORKDIR "$SNAP_DATA_CURRENT/vault" '.working_dir  = $WORKDIR' \
+            < "$PKI_KONG_FILE" > "$PKI_KONG_FILE.tmp"
+        mv "$PKI_KONG_FILE.tmp" "$PKI_KONG_FILE"
+    fi
+fi

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+# save this revision for when we run again in the post-refresh
+snapctl set lastrev="$SNAP_REVISION"

--- a/snap/local/runtime-helpers/bin/hooks-env-setup.sh
+++ b/snap/local/runtime-helpers/bin/hooks-env-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+# This script is mainly necessary so from the hooks we can use jq (which is in
+# the snap) which requires libs from inside the snap, but hooks don't get the
+# same wrapper scripts as apps in snapcraft.yaml do
+
+# add things from the snap's $PATH to here
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+
+# setup LD_LIBRARY_PATH, we need to handle the different architecture paths -
+# this snippet is copied out of one of the generated snapcraft wrappers
+case $(arch) in
+    x86_64)
+        MULTI_ARCH_PATH="x86_64-linux-gnu";;
+    arm*)
+        MULTI_ARCH_PATH="arm-linux-gnueabihf";;
+    aarch64)
+        MULTI_ARCH_PATH="aarch64-linux-gnu";;
+    *)
+        echo "architecture $ARCH not supported"
+        exit 1
+        ;;
+esac
+
+# Note - the env var SNAP_LIBRARY_PATH is set by snapd for hooks, so it can be referenced here
+export LD_LIBRARY_PATH="$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$MULTI_ARCH_PATH:$SNAP/usr/lib/$MULTI_ARCH_PATH"

--- a/snap/local/runtime-helpers/config/security-secret-store/vault-config.hcl.in
+++ b/snap/local/runtime-helpers/config/security-secret-store/vault-config.hcl.in
@@ -3,7 +3,7 @@
 # this file maintains a number of changes, i.e. all
 # hostnames are localhost instead of the docker hostnames, 
 # the tls cert and key files reference localhost as the common name,
-# and the location of the files uses reference to $SNAP_DATA
+# and the location of the files uses reference to SNAP_DATA
 # (but note that these paths have to be absolute, so we process the env
 #  vars during the install hook)
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,7 +85,7 @@ apps:
   vault:
     command: bin/vault server --config="$VAULT_CONFIG"
     environment:
-      VAULT_CONFIG: "$SNAP_DATA/config/security-secret-store/vault-config.json"
+      VAULT_CONFIG: "$SNAP_DATA/config/security-secret-store/vault-config.hcl"
       VAULT_ADDR: "https://localhost:8200"
       VAULT_UI: "true"
     daemon: simple


### PR DESCRIPTION
This PR fixes #799 and generally allows snap refreshes to work seamlessly now. 

It also incorporates the snap version of the fix for https://github.com/edgexfoundry/security-secret-store/issues/66

I also finally have an easy way to run integration tests against the snap, using the scripts I provided to Canonical's certification team for running tests against the EdgeX snap. To run the tests build the snap then clone the `checkbox-provider-edgex` repo from launchpad and run the script:

```bash
$ cd $HOME
$ git clone -b feature/more-tests https://git.launchpad.net/checkbox-provider-edgex
$ cd $GOPATH/src/github.com/edgexfoundry/edgex-go
$ snapcraft
$ $HOME/checkbox-provider-edgex/bin/run-all-tests-locally.sh $(pwd)/*.snap
```

Note that this will take quite a while to run, upwards of 30 minutes on my laptop to download the stable channel snap, as well as install and then remove the snaps (with minimum 2 minute sleep in between) a number of times.

There are two specific scripts there that test for this PR to ensure that services startup properly after a refresh and that configuration files from a previous revision with explicit revision numbers in them are replaced with the current symlink. You can also manually inspect the files after the refresh, see the comments in the post-refresh script for a full listing of all of what needs to be changed.