### PR TITLE
Make the critical severity notification be an asynchronous one.

### DIFF
--- a/internal/support/notifications/normal_distribution.go
+++ b/internal/support/notifications/normal_distribution.go
@@ -20,12 +20,9 @@ import (
 )
 
 func distributeAndMark(n models.Notification) error {
-	err := distribute(n)
-	if err != nil {
-		LoggingClient.Error("Trouble on distribution of notification: " + n.Slug)
-		return err
-	}
-	err = dbClient.MarkNotificationProcessed(n)
+	go distribute(n)
+
+	err := dbClient.MarkNotificationProcessed(n)
 	if err != nil {
 		LoggingClient.Error("Trouble updating notification to Processed for: " + n.Slug)
 		return err


### PR DESCRIPTION
- Make the critical severity notification asynchronous by making the call to the function distributeAndMark(n) a goroutine and, to indicate this process now being an asynchronous one, logging that the critical severity scheduler has been _triggered_ (instead of _completed_ as we used to do).
- This is to make the response time acceptable, performance-wise: The response time should be less than 200ms.
- This PR is per: [Issue-1187](https://github.com/edgexfoundry/edgex-go/issues/1187)