### PR TITLE
Fixed NewPutCommand URL and Body bugs

### DIFF
--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -20,9 +20,8 @@ import (
 	"net/http"
 )
 
-func commandByDeviceID(deviceID string, commandID string, b string, isPutCommand bool, ctx context.Context) (string, int) {
+func commandByDeviceID(deviceID string, commandID string, body string, isPutCommand bool, ctx context.Context) (string, int) {
 	device, err := mdc.Device(deviceID, ctx)
-
 	if err != nil {
 		LoggingClient.Error(err.Error())
 
@@ -53,9 +52,8 @@ func commandByDeviceID(deviceID string, commandID string, b string, isPutCommand
 	}
 
 	var ex Executor
-
 	if isPutCommand {
-		ex, err = NewPutCommand(device, command, ctx, &http.Client{})
+		ex, err = NewPutCommand(device, command, body, ctx, &http.Client{})
 	} else {
 		ex, err = NewGetCommand(device, command, ctx, &http.Client{})
 	}
@@ -64,12 +62,12 @@ func commandByDeviceID(deviceID string, commandID string, b string, isPutCommand
 		return "", http.StatusInternalServerError
 	}
 
-	body, responseCode, err := ex.Execute()
-
+	responseBody, responseCode, err := ex.Execute()
 	if err != nil {
 		return "", http.StatusInternalServerError
 	}
-	return body, responseCode
+
+	return responseBody, responseCode
 }
 
 func putDeviceAdminState(did string, as string, ctx context.Context) (int, error) {

--- a/internal/core/command/get.go
+++ b/internal/core/command/get.go
@@ -26,7 +26,6 @@ import (
 func NewGetCommand(device models.Device, command models.Command, context context.Context, httpCaller internal.HttpCaller) (Executor, error) {
 	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
 	request, err := http.NewRequest(http.MethodGet, url, nil)
-
 	if err != nil {
 		return serviceCommand{}, err
 	}

--- a/internal/core/command/get_test.go
+++ b/internal/core/command/get_test.go
@@ -49,6 +49,11 @@ var testCommand = models.Command{
 			Path: "/some/uri",
 		},
 	},
+	Put: &models.Put{
+		Action: models.Action{
+			Path: "/another/uri",
+		},
+	},
 }
 
 func TestNewGetCommandWithCorrelationId(t *testing.T) {

--- a/internal/core/command/put.go
+++ b/internal/core/command/put.go
@@ -23,10 +23,9 @@ import (
 )
 
 // NewPutCommand creates and Executor which can be used to execute the PUT related command.
-func NewPutCommand(device models.Device, command models.Command, context context.Context, httpCaller internal.HttpCaller) (Executor, error) {
-	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
-	request, err := http.NewRequest(http.MethodPut, url, nil)
-
+func NewPutCommand(device models.Device, command models.Command, body string, context context.Context, httpCaller internal.HttpCaller) (Executor, error) {
+	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Put.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
+	request, err := http.NewRequest(http.MethodPut, url, strings.NewReader(body))
 	if err != nil {
 		return serviceCommand{}, err
 	}


### PR DESCRIPTION
This commit fixes issue #1252

Fixed NewPutCommand function in put.go to use the command.PUT URL rather
than command.GET

Added test to cover the bug which has been fixed in this commit

Cleaned up white-space and empty lines.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>