### PR TITLE
Correct doc typo issue for device-modbus example

### DIFF
--- a/docs/examples/Ch-ExamplesAddingModbusDevice.rst
+++ b/docs/examples/Ch-ExamplesAddingModbusDevice.rst
@@ -147,7 +147,7 @@ In the RTU protocol, address is defined in five comma-separated parts:
       MaxCmdValueLen = 256
       RemoveCmd = ""
       RemoveCmdArgs = ""
-      ProfileDir = "/custom-config"
+      ProfilesDir = "/custom-config"
 
     # Pre-define Devices
     [[DeviceList]]


### PR DESCRIPTION
Change ProfileDir to ProfilesDir for config example