### PR TITLE
Core-Command Refactor: Change the interface of CommandResponseFrom…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/BurntSushi/toml v0.3.1
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190408185438-838c1e45fef1
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190418185811-6fa3b1fed53b
 	github.com/edgexfoundry/go-mod-messaging v0.0.0-20190327144236-4222ae1edb0b
 	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8

--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -142,7 +142,7 @@ func getCommands(ctx context.Context) (int, []models.CommandResponse, error) {
 	}
 	var cr []models.CommandResponse
 	for _, d := range devices {
-		cr = append(cr, models.CommandResponseFromDevice(d, Configuration.Service.Url()))
+		cr = append(cr, models.CommandResponseFromDevice(d, d.Profile.CoreCommands, Configuration.Service.Url()))
 	}
 	return http.StatusOK, cr, err
 
@@ -158,7 +158,7 @@ func getCommandsByDeviceID(did string, ctx context.Context) (int, models.Command
 			return http.StatusInternalServerError, models.CommandResponse{}, err
 		}
 	}
-	return http.StatusOK, models.CommandResponseFromDevice(d, Configuration.Service.Url()), err
+	return http.StatusOK, models.CommandResponseFromDevice(d, d.Profile.CoreCommands, Configuration.Service.Url()), err
 }
 
 func getCommandsByDeviceName(dn string, ctx context.Context) (int, models.CommandResponse, error) {
@@ -171,5 +171,5 @@ func getCommandsByDeviceName(dn string, ctx context.Context) (int, models.Comman
 			return http.StatusInternalServerError, models.CommandResponse{}, err
 		}
 	}
-	return http.StatusOK, models.CommandResponseFromDevice(d, Configuration.Service.Url()), err
+	return http.StatusOK, models.CommandResponseFromDevice(d, d.Profile.CoreCommands, Configuration.Service.Url()), err
 }


### PR DESCRIPTION
…Device function.

This is first step toward facilitating the decoupling of the DeviceProfile
and its associated Commands from the Device.

Resolves/Fixes: https://github.com/edgexfoundry/edgex-go/issues/1254

Related with Issue in go-mod-core-contracts : https://github.com/edgexfoundry/go-mod-core-contracts/issues/68
It is preferable both PRs to be mearged at once.

Signed-off-by: difince <dianaa@vmware.com>