### PR TITLE
Pare down logging for the docker-compose reference implementation of sys-mgmt-executor.

### DIFF
--- a/cmd/sys-mgmt-agent/res/docker/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/docker/configuration.toml
@@ -5,6 +5,8 @@
 # In the first release of the SMA, the manifest will be static.
 # In the future, the manifest may be more dynamic or even provided by some 3rd party orchestrator.
 
+ExecutorPath = '/path/to/the/file'
+
 [Writable]
 ResendLimit = 2
 LogLevel = 'INFO'
@@ -20,7 +22,6 @@ ReadMaxLimit = 100
 StartupMsg = 'This is the System Management Agent Service'
 Timeout = 5000
 FormatSpecifier = '%(\\d+\\$)?([-#+ 0(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])'
-ExecutorPath = '/path/to/the/file'
 
 [Registry]
 Host = 'edgex-core-consul'

--- a/internal/system/agent/services.go
+++ b/internal/system/agent/services.go
@@ -39,7 +39,7 @@ func InvokeOperation(action string, services []string) error {
 	for _, service := range services {
 		LoggingClient.Info("invoking operation")
 
-		if !isKnownServiceKey(service) {
+		if !IsKnownServiceKey(service) {
 			LoggingClient.Warn(fmt.Sprintf("unknown service %s during invocation", service))
 		}
 
@@ -97,7 +97,7 @@ func getConfig(services []string, ctx context.Context) (ConfigRespMap, error) {
 	for _, service := range services {
 
 		// Check whether SMA does _not_ know of ServiceKey ("service") as being one for one of its ready-made list of clients.
-		if !isKnownServiceKey(service) {
+		if !IsKnownServiceKey(service) {
 			LoggingClient.Info(fmt.Sprintf("service %s not known to SMA as being in the ready-made list of clients", service))
 
 			// Service unknown to SMA, so ask the Registry whether `service` is available.
@@ -180,7 +180,7 @@ func getMetrics(services []string, ctx context.Context) (MetricsRespMap, error) 
 	for _, service := range services {
 
 		// Check whether SMA does _not_ know of ServiceKey ("service") as being one for one of its ready-made list of clients.
-		if !isKnownServiceKey(service) {
+		if !IsKnownServiceKey(service) {
 			LoggingClient.Info(fmt.Sprintf("service %s not known to SMA as being in the ready-made list of clients", service))
 
 			// Service unknown to SMA, so ask the Registry whether `service` is available.
@@ -259,7 +259,7 @@ func getHealth(services []string) (map[string]interface{}, error) {
 
 	for _, service := range services {
 
-		if !isKnownServiceKey(service) {
+		if !IsKnownServiceKey(service) {
 			LoggingClient.Warn(fmt.Sprintf("unknown service %s found while getting health", service))
 		}
 
@@ -275,7 +275,7 @@ func getHealth(services []string) (map[string]interface{}, error) {
 	return health, nil
 }
 
-func isKnownServiceKey(serviceKey string) bool {
+func IsKnownServiceKey(serviceKey string) bool {
 	// create a map because this is the easiest/cleanest way to determine whether something exists in a set
 	var services = map[string]struct{}{
 		internal.SupportNotificationsServiceKey: {},


### PR DESCRIPTION
- This PR is to enable the Docker-in-Docker solution to to deploy and function properly. For this, we need to pare down logging for the docker-compose reference implementation of the system management executor (aka `sys-mgmt-executor`) because, while the facilities for logging are available to edgex-go services in general, `sys-mgmt-executor` is a standalone, bare-bones executable for which it does not make sense to initialize full-blown logging; instead, we are paring down to lean (built-in golang) logging 👍 
- As part of this, we have moved the field `ExecutorPath` to the top-level in `configuration.toml` (for sys-mgmt-agent docker) so it can be picked up by the runtime.
- The relevant Issue is: [Issue-1266](https://github.com/edgexfoundry/edgex-go/issues/1266)
- Crucially, and separately, the file `docker-compose.yml` (located in the `compose-files` folder in a separate repo, the `developer-scripts` repo) will need to be updated to start services, in particular the Docker-in-Docker SMA container in order to enable REST calls to the SMA to reach the Docker-in-Docker image container, since we need to have port-forwarding enabled, by incorporating a new directive (`/var/run/docker.sock:/var/run/docker.sock`), like so:
```
  system:
    image: edgexfoundry/sys-mgmt-agent-go:1.0.0-dev
    ports:
      - "48090:48090"
    container_name: edgex-sys-mgmt-agent
    hostname: edgex-sys-mgmt-agent
    networks:
      - edgex-network
    volumes:
      - db-data:/data/db
      - log-data:/edgex/logs
      - consul-config:/consul/config
      - consul-data:/consul/data
      - /var/run/docker.sock:/var/run/docker.sock
    depends_on:
      - logging
```