### PR TITLE
Query Notification before marking PROCESSED

### DIFF
--- a/internal/support/notifications/rest_notification.go
+++ b/internal/support/notifications/rest_notification.go
@@ -53,6 +53,13 @@ func notificationHandler(w http.ResponseWriter, r *http.Request) {
 
 		if n.Severity == models.NotificationsSeverity(models.Critical) {
 			LoggingClient.Info("Critical severity scheduler is triggered for: " + n.Slug)
+			n, err = dbClient.GetNotificationById(n.ID)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				LoggingClient.Error(err.Error())
+				return
+			}
+
 			err := distributeAndMark(n)
 			if err != nil {
 				return


### PR DESCRIPTION
Created field of critical Notification is always 0,
because the field is updated to 0 when marking its status to PROCESSED
fix #1279 

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>