### PR TITLE
Fixed HTTP Response Codes

### DIFF
--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -123,7 +123,7 @@ func decodeState(r *http.Request) (mode string, state string, err error) {
 	}
 
 	// In this case, the request we were given in completely invalid
-	return "","", fmt.Errorf("unknown request type")
+	return "", "", fmt.Errorf("unknown request type")
 }
 
 func restPutDeviceStateByDeviceId(w http.ResponseWriter, r *http.Request) {
@@ -133,7 +133,7 @@ func restPutDeviceStateByDeviceId(w http.ResponseWriter, r *http.Request) {
 	updateMode, state, err := decodeState(r)
 	if err != nil {
 		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -150,7 +150,7 @@ func restPutDeviceStateByDeviceId(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), status)
 		return
 	}
 
@@ -165,7 +165,7 @@ func restPutDeviceStateByDeviceName(w http.ResponseWriter, r *http.Request) {
 	updateMode, state, err := decodeState(r)
 	if err != nil {
 		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	var status int
@@ -180,13 +180,12 @@ func restPutDeviceStateByDeviceName(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), status)
 		return
 	}
 
 	w.WriteHeader(status)
 }
-
 
 func restGetCommandsByDeviceID(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)


### PR DESCRIPTION
This commit resolves issue 1285

Updated `restPutDeviceStateByDeviceId` and
`restPutDeviceStateByDeviceName` functions to propegate the underlying
HTTP response code to the caller. Also, updated the HTTP response from
"Internal Server Error(500)" to "Bad Request(400)" when unable to decode
the request body.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>