### PR TITLE
Use string instead of interface{} in Attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/BurntSushi/toml v0.3.1
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190429073535-f8b9cd669563
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190501042311-65beb1e99b02
 	github.com/edgexfoundry/go-mod-messaging v0.0.0-20190327144236-4222ae1edb0b
 	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8

--- a/internal/pkg/db/mongo/models/deviceprofile.go
+++ b/internal/pkg/db/mongo/models/deviceprofile.go
@@ -56,11 +56,11 @@ type ProfileProperty struct {
 }
 
 type DeviceResource struct {
-	Description string                 `bson:"description"`
-	Name        string                 `bson:"name"`
-	Tag         string                 `bson:"tag"`
-	Properties  ProfileProperty        `bson:"properties"`
-	Attributes  map[string]interface{} `bson:"attributes"`
+	Description string            `bson:"description"`
+	Name        string            `bson:"name"`
+	Tag         string            `bson:"tag"`
+	Properties  ProfileProperty   `bson:"properties"`
+	Attributes  map[string]string `bson:"attributes"`
 }
 
 type ResourceOperation struct {


### PR DESCRIPTION
Replace Attributes data type with map[string]string in DeviceResource
fix #1289

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>