### PR TITLE
Add Issue Templates for more structure of Github Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,47 @@
+---
+name: "\U0001F41EBug report"
+about: Report a bug in the EdgeX Framework
+labels: bug
+---
+<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅
+
+Hello there! 😄
+
+To expedite issue processing please search open and closed issues before submitting a new one.
+Existing issues often contain information about workarounds, resolution, or progress updates.
+
+🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->
+
+
+# 🐞 Bug Report
+
+### Affected Services
+<!-- Can you pin-point one or more EdgeX services (Data, Metadata, Command, etc...) as the source of the bug? -->
+<!-- ✍️edit: --> The issue is located in: 
+
+
+### Is this a regression?
+
+<!-- Did this behavior work correctly in the previous version? -->
+<!-- ✍️--> Yes, the previous version in which this bug was not present was: ....
+
+
+### Description and Minimal Reproduction
+
+
+## 🔥 Exception or Error
+<pre><code>
+<!-- If the issue is accompanied by an exception or an error, please share it below: -->
+<!-- ✍️-->
+
+</code></pre>
+
+
+## 🌍  Your Environment
+**Deployment Environment:**
+
+**EdgeX Version:**
+
+
+**Anything else relevant?**
+

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,32 @@
+---
+name: "\U0001F680Feature request"
+about: Suggest a feature for EdgeX Framework
+labels: enhancement
+---
+<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅
+
+Oh hi there! 😄 
+
+To expedite issue processing please search open and closed issues before submitting a new one.
+Existing issues often contain information about workarounds, resolution, or progress updates.
+
+🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->
+
+
+# 🚀 Feature Request
+
+### Relevant Package
+<!-- Can you pin-point one or more EdgeX services the are relevant for this feature request? -->
+<!-- ✍️edit: --> This feature request is for...
+
+
+### Description
+<!-- ✍️--> A clear and concise description of the problem or missing capability...
+
+
+### Describe the solution you'd like
+<!-- ✍️--> If you have a solution in mind, please describe it.
+
+
+### Describe alternatives you've considered
+<!-- ✍️--> Have you considered any alternative solutions or workarounds?

--- a/.github/ISSUE_TEMPLATE/3-docs-bug.md
+++ b/.github/ISSUE_TEMPLATE/3-docs-bug.md
@@ -1,0 +1,48 @@
+---
+name: "📚 Docs or Wiki issue report"
+about: Report an issue in EdgeX's documentation or wiki
+labels: bug, documentation
+---
+<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅
+
+Oh hi there! 😄
+
+To expedite issue processing please search open and closed issues before submitting a new one.
+Existing issues often contain information about workarounds, resolution, or progress updates.
+
+🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->
+
+# 📚 Docs or Wiki Bug Report
+
+### Description
+
+<!-- ✍️edit:--> A clear and concise description of the problem...
+
+
+## 🔬 Minimal Reproduction
+
+### What's the affected URL?**
+<!-- ✍️edit:--> https://docs.edgexfoundry.org/...
+
+
+### Expected vs Actual Behavior**
+<!-- If applicable please describe the difference between the expected and actual behavior after following the steps to reproduce. -->
+<!-- ✍️edit:-->
+
+
+## 📷Screenshot 
+<!-- Often a screenshot can help to capture the issue better than a long description. -->
+<!-- ✍️upload a screenshot:-->
+
+
+## 🔥 Exception or Error
+<pre><code>
+<!-- If the issue is accompanied by an exception or an error, please share it below: -->
+<!-- ✍️-->
+
+</code></pre>
+
+
+## 🌍  Your Environment
+<!-- How are you viewing the docs? What browser? What version? : -->
+<!-- ✍️-->

--- a/.github/ISSUE_TEMPLATE/4-security-issue-disclosure.md
+++ b/.github/ISSUE_TEMPLATE/4-security-issue-disclosure.md
@@ -1,8 +1,12 @@
 ---
 name: ⚠️ Security issue disclosure
-about: Report a security issue in EdgeX Framework
+about: Report a security issue in the EdgeX Framework
 labels: security
 ---
 
 
-# Security Issue
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑
+
+Please read https://bit.ly/2VqlLd4 on how to disclose security related issues.
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑

--- a/.github/ISSUE_TEMPLATE/4-security-issue-disclosure.md
+++ b/.github/ISSUE_TEMPLATE/4-security-issue-disclosure.md
@@ -7,6 +7,13 @@ labels: security
 
 🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑
 
-Please read https://bit.ly/2VqlLd4 on how to disclose security related issues.
+The EdgeX Foundry project practices responsible disclosure. Since GitHub issues are public, 
+instead of reporting the issue through GitHub, please email our security issues team at 
+edgex-tsc-security@lists.edgexfoundry.org with details on your environment, expected behavior, 
+how this is a security issue and any applicable exploits or associated CVE's if this issue is 
+related to any previously reported CVE.
+
+For full details please read the "Security Issue Reporting Process" located at 
+https://wiki.edgexfoundry.org/display/FA/Security+Working+Group on how to disclose security related issues.
 
 🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑

--- a/.github/ISSUE_TEMPLATE/4-security-issue-disclosure.md
+++ b/.github/ISSUE_TEMPLATE/4-security-issue-disclosure.md
@@ -1,0 +1,8 @@
+---
+name: ⚠️ Security issue disclosure
+about: Report a security issue in EdgeX Framework
+labels: security
+---
+
+
+# Security Issue

--- a/.github/ISSUE_TEMPLATE/5-support-request.md
+++ b/.github/ISSUE_TEMPLATE/5-support-request.md
@@ -1,0 +1,15 @@
+---
+name: "❓Support request"
+about: Questions and requests for support
+labels: question
+---
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑
+
+Please do not file questions or support requests on the GitHub issues tracker.
+
+You can get your questions answered using other communication channels such as Slack (edgexfoundry.slack.com)
+
+Thank you!
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑


### PR DESCRIPTION
This is a first stab attempt at creating issue templates for assisting a more structured issue list.  When you click "New Issue" you would then be presented with the following:

![image](https://user-images.githubusercontent.com/22204562/57057048-620d7000-6ce1-11e9-8985-2dab94cfb05a.png)


Each template automatically adds labels as appropriate per issue type. I.e. if you create a "Feature Request" issue, the `enhancement` label will automatically be added. 

![image](https://user-images.githubusercontent.com/22204562/57057214-1c04dc00-6ce2-11e9-8c4c-96499482e578.png)

Here's an example of each issue type:
Security: https://github.com/rsdmike/edgex-go/issues/64
Docs Bug: https://github.com/rsdmike/edgex-go/issues/63
Feature Request: https://github.com/rsdmike/edgex-go/issues/62
Bug Report: https://github.com/rsdmike/edgex-go/issues/61
Question/Support Request: https://github.com/rsdmike/edgex-go/issues/65


I've started with a pretty strong structure in each category type (adapted from Angular Issue Templates), which we lighten up a bit if need be. But, I do strongly believe that as the EdgeX Community continues to grow...having a structure that prompts developers to think through a few steps will greatly assist the community in being able to help others. 


In the bottom of the screenshot, there is an option to create an issue without a template if the issue doesn't follow any of the suggested categories.

Can't assign reviewers :( @mhall119 @tsconn23 

Signed-off-by: Mike Johanson <michael.johanson@intel.com>