### PR TITLE
Specify epoch 0 for Delhi, add post-refresh script to fix config file paths

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -21,6 +21,11 @@ esac
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$MULTI_ARCH_PATH:$SNAP/usr/lib/$MULTI_ARCH_PATH"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
+# get the values of $SNAP_DATA and $SNAP using the current symlink instead of
+# the default behavior which has the revision hard-coded, which breaks after
+# a refresh
+SNAP_DATA_CURRENT=${SNAP_DATA/%$SNAP_REVISION/current}
+
 # install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
 # into $SNAP_DATA/config
 mkdir -p ${SNAP_DATA}/config
@@ -28,8 +33,10 @@ for service in security-api-gateway security-secret-store core-command config-se
     if [ ! -f "${SNAP_DATA}/config/${service}/res/configuration.toml" ]; then
         mkdir -p "${SNAP_DATA}/config/${service}/res"
         cp ${SNAP}/config/${service}/res/configuration.toml "${SNAP_DATA}/config/${service}/res/configuration.toml"
-        # do replacement of the SNAP_DATA and SNAP_COMMON environment variables in the config files
-        sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" -e "s@\$SNAP_DATA@$SNAP_DATA@g" "${SNAP_DATA}/config/${service}/res/configuration.toml"
+        # do replacement of the $SNAP, $SNAP_DATA, $SNAP_COMMON environment variables in the config files
+        sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
+            -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
+            "${SNAP_DATA}/config/${service}/res/configuration.toml"
     fi
 done
 
@@ -45,7 +52,7 @@ for jsvc in device-virtual edgex-support-rulesengine; do
         mkdir -p "${SNAP_DATA}/config/config-seed/res/properties/$jsvc"
         cp "${SNAP}/config/config-seed/res/properties/$jsvc/application.properties" "${SNAP_DATA}/config/config-seed/res/properties/$jsvc/application.properties"
         # also replace SNAP_DATA and SNAP_COMMON in the application files
-        sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" -e "s@\$SNAP_DATA@$SNAP_DATA@g" "${SNAP_DATA}/config/config-seed/res/properties/$jsvc/application.properties"
+        sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" "${SNAP_DATA}/config/config-seed/res/properties/$jsvc/application.properties"
     fi
 done
 
@@ -73,7 +80,7 @@ if [ ! -f "${SNAP_DATA}/config/security-secret-store/pkisetup-kong.json" ]; then
     mkdir -p ${SNAP_DATA}/config/security-secret-store
     CONFIG_FILE_PATH="config/security-secret-store/pkisetup-kong.json"
     # replace the hostname with localhost using jq
-    jq --arg WORKDIR "$SNAP_DATA/vault" \
+    jq --arg WORKDIR "$SNAP_DATA_CURRENT/vault" \
         '.x509_tls_server_parameters.tls_host = "localhost" | .pki_setup_dir = "pki" | .working_dir  = $WORKDIR' \
         "${SNAP}/${CONFIG_FILE_PATH}" > "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp"
     mv "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp" "${SNAP_DATA}/${CONFIG_FILE_PATH}"
@@ -86,7 +93,7 @@ if [ ! -f "${SNAP_DATA}/config/security-secret-store/pkisetup-vault.json" ]; the
     mkdir -p ${SNAP_DATA}/config/security-secret-store
     CONFIG_FILE_PATH="config/security-secret-store/pkisetup-vault.json"
     # modify the parameters using jq
-    jq --arg WORKDIR "$SNAP_DATA/vault" \
+    jq --arg WORKDIR "$SNAP_DATA_CURRENT/vault" \
         '.x509_tls_server_parameters.tls_host = "localhost" | .pki_setup_dir = "pki" | .working_dir  = $WORKDIR' \
         "${SNAP}/${CONFIG_FILE_PATH}" > "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp"
     mv "${SNAP_DATA}/${CONFIG_FILE_PATH}.tmp" "${SNAP_DATA}/${CONFIG_FILE_PATH}"
@@ -102,7 +109,7 @@ mkdir -p "${SNAP_DATA}/vault/pki"
 # note that if anyone ever somehow has a "@" in their $SNAP_DATA this will likely break :-/
 if [ ! -f "${SNAP_DATA}/config/security-secret-store/vault-config.json" ]; then
     mkdir -p ${SNAP_DATA}/config/security-secret-store
-    sed "s@\$SNAP_DATA@$SNAP_DATA@g" ${SNAP}/config/security-secret-store/vault-config.json.in > ${SNAP_DATA}/config/security-secret-store/vault-config.json
+    sed "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" ${SNAP}/config/security-secret-store/vault-config.json.in > ${SNAP_DATA}/config/security-secret-store/vault-config.json
     chmod 644 ${SNAP_DATA}/config/security-secret-store/vault-config.json
 fi
 
@@ -115,7 +122,7 @@ if [ ! -f ${SNAP_DATA}/config/security-api-gateway/kong.conf ]; then
     cp "${SNAP}/config/security-api-gateway/kong.conf" "${SNAP_DATA}/config/security-api-gateway/kong.conf"
     # replace the default prefix setting with an absolute path using $SNAP_DATA
     # note that if anyone ever has a "@" in their $SNAP_DATA this will likely fail
-    sed -i "s@#prefix = /usr/local/kong/@prefix = ${SNAP_DATA}/kong@" ${SNAP_DATA}/config/security-api-gateway/kong.conf
+    sed -i "s@#prefix = /usr/local/kong/@prefix = ${SNAP_DATA_CURRENT}/kong@" ${SNAP_DATA}/config/security-api-gateway/kong.conf
 
     # also replace the default nginx user/group to be root
     sed -i "s@#nginx_user = nobody nobody@nginx_user = root root@" ${SNAP_DATA}/config/security-api-gateway/kong.conf

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,127 @@
+#!/bin/bash -e
+
+# LD_LIBRARY_PATH isn't properly initialized for hooks as snapcraft does for apps, so this 
+# has to be constructed manually
+# Note - the env var SNAP_LIBRARY_PATH is set by snapd for hooks, so it can be referenced here
+# This is mainly necessary so we can use jq from the snap which needs libs from inside the snap
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+# for LD_LIBRARY_PATH, we need to handle the different architecture paths
+case $(arch) in
+    x86_64)
+        MULTI_ARCH_PATH="x86_64-linux-gnu";;
+    arm*)
+        MULTI_ARCH_PATH="arm-linux-gnueabihf";;
+    aarch64)
+        MULTI_ARCH_PATH="aarch64-linux-gnu";;
+    *)
+        echo "architecture $ARCH not supported"
+        exit 1
+        ;;
+esac
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/$MULTI_ARCH_PATH:$SNAP/usr/lib/$MULTI_ARCH_PATH"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+
+# if the lastrevision has a value, it means that the previous revision
+# was new enough to use the current symlink, and as such doesn't need
+# processing
+if [ -n "$(snapctl get lastrev)" ]; then
+    exit 0
+fi
+
+# if however the previous revision wasn't set, we know that the previous 
+# revision would have used absolute paths for things like $SNAP_DATA to
+# and are now incorrect, and so we should update relevant values to use the 
+# current symlink intead
+# see https://github.com/edgexfoundry/edgex-go/issues/799#issuecomment-480318857
+# for full details
+
+# the full set of previous config items that would have been set as verbatim 
+# $SNAP_DATA with revision
+# * $SNAP_DATA/config/config-seed/res/properties/edgex-support-rulesengine/application.properties:
+#     $SNAP_DATA/support-rulesengine/rules
+#     $SNAP_DATA/support-rulesengine/templates
+# * $SNAP_DATA/config/security-secret-store/res/configuration.toml:
+#     $SNAP_DATA/vault/pki
+#     tokenfolderpath = "$SNAP_DATA/config/security-secret-store/res"
+# * $SNAP_DATA/config/security-api-gateway/res/configuration.toml:
+#     tokenpath = "$SNAP_DATA/config/security-api-gateway/res/kong-token.json"
+# * $SNAP_DATA/config/security-secret-store/vault-config.hcl
+#     tls_client_ca_file ="$SNAP_DATA/vault/pki/EdgeXFoundryCA/EdgeXFoundryTrustCA.pem"
+#     tls_cert_file ="$SNAP_DATA/vault/pki/EdgeXFoundryCA/localhost.pem"
+#     tls_key_file = "$SNAP_DATA/vault/pki/EdgeXFoundryCA/localhost.priv.key"
+# * $SNAP_DATA/config/security-api-gateway/kong.conf
+#     prefix = $SNAP_DATA/kong
+# * $SNAP_DATA/config/security-secret-store/pkisetup-kong.json
+#     working_dir: $SNAP_DATA/vault
+# * $SNAP_DATA/config/security-secret-store/pkisetup-vault.json
+#     working_dir: $SNAP_DATA/vault
+
+# snap setup dirs
+SNAP_DATA_CURRENT=${SNAP_DATA/%$SNAP_REVISION/current}
+SNAP_DATA_DIR=$(dirname "$SNAP_DATA")
+
+RULES_ENGINE_PROP_FILE="$SNAP_DATA/config/config-seed/res/properties/edgex-support-rulesengine/application.properties"
+if [ -f "$RULES_ENGINE_PROP_FILE" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/support-rulesengine/rules@$SNAP_DATA_CURRENT/support-rulesengine/rules@" \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/support-rulesengine/templates@$SNAP_DATA_CURRENT/support-rulesengine/templates@" \
+        "$RULES_ENGINE_PROP_FILE"
+fi
+
+SECRET_STORE_CONFIG="$SNAP_DATA/config/security-secret-store/res/configuration.toml"
+if [ -f "$SECRET_STORE_CONFIG" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/vault/pki@$SNAP_DATA_CURRENT/vault/pki@" \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/config/security-secret-store/res@$SNAP_DATA_CURRENT/config/security-secret-store/res@" \
+        "$SECRET_STORE_CONFIG"
+fi
+
+API_GATEWAY_CONFIG="$SNAP_DATA/config/security-api-gateway/res/configuration.toml"
+if [ -f "$API_GATEWAY_CONFIG" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/config/security-api-gateway/res/kong-token.json@$SNAP_DATA_CURRENT/config/security-api-gateway/res/kong-token.json@" \
+        "$API_GATEWAY_CONFIG"
+fi
+
+VAULT_CONFIG_FILE="$SNAP_DATA/config/security-secret-store/vault-config.json"
+if [ -f "$VAULT_CONFIG_FILE" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/vault/pki/EdgeXFoundryCA/EdgeXFoundryTrustCA.pem@$SNAP_DATA_CURRENT/vault/pki/EdgeXFoundryCA/EdgeXFoundryTrustCA.pem@" \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/vault/pki/EdgeXFoundryCA/localhost.pem@$SNAP_DATA_CURRENT/vault/pki/EdgeXFoundryCA/localhost.pem@" \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/vault/pki/EdgeXFoundryCA/localhost.priv.key@$SNAP_DATA_CURRENT/vault/pki/EdgeXFoundryCA/localhost.priv.key@" \
+        "$VAULT_CONFIG_FILE"
+fi
+
+KONG_CONF="$SNAP_DATA/config/security-api-gateway/kong.conf"
+if [ -f "$KONG_CONF" ]; then
+    sed -i \
+        -e "s@$SNAP_DATA_DIR/[0-9]*/kong@$SNAP_DATA_CURRENT/kong@" \
+        "$KONG_CONF"
+fi
+
+PKISETUP_CONFIG_DIR=$SNAP_DATA/config/security-secret-store
+PKI_VAULT_FILE="$PKISETUP_CONFIG_DIR/pkisetup-vault.json"
+if [ -f "$PKI_VAULT_FILE" ]; then
+    # with jq we can directly check if the setting for working_dir matches the
+    # regex for the previous revision $SNAP_DATA
+    # only then do we update it
+    if [ "$(jq -r --arg REGEX "$SNAP_DATA_DIR/[0-9]+/vault" '.working_dir | test($REGEX)' < "$PKI_VAULT_FILE" )"  = "true" ]; then
+        # modify the parameters using jq
+        jq --arg WORKDIR "$SNAP_DATA_CURRENT/vault" '.working_dir  = $WORKDIR' \
+            < "$PKI_VAULT_FILE" > "$PKI_VAULT_FILE.tmp"
+        mv "$PKI_VAULT_FILE.tmp" "$PKI_VAULT_FILE"
+    fi
+fi
+
+PKI_KONG_FILE="$PKISETUP_CONFIG_DIR/pkisetup-kong.json"
+if [ -f "$PKI_KONG_FILE" ]; then
+    # with jq we can directly check if the setting for working_dir matches the
+    # regex for the previous revision $SNAP_DATA
+    # only then do we update it
+    if [ "$(jq -r --arg REGEX "$SNAP_DATA_DIR/[0-9]+/vault" '.working_dir | test($REGEX)' < "$PKI_KONG_FILE" )"  = "true" ]; then
+        # update the working_dir
+        jq --arg WORKDIR "$SNAP_DATA_CURRENT/vault" '.working_dir  = $WORKDIR' \
+            < "$PKI_KONG_FILE" > "$PKI_KONG_FILE.tmp"
+        mv "$PKI_KONG_FILE.tmp" "$PKI_KONG_FILE"
+    fi
+fi

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+# save this revision for when we run again in the post-refresh
+snapctl set lastrev="$SNAP_REVISION"
+
+# save this release channel for future potential upgrade paths
+snapctl set release="delhi"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -197,6 +197,9 @@ apps:
     plugs:
       - network-bind
 
+passthrough:
+  epoch: 0
+
 parts:
   curl:
     plugin: nil


### PR DESCRIPTION
This is the first step in resolving #799 (for Delhi).
The crux of the issue is that currently we process configuration files at install time to use snap specific paths such as $SNAP, $SNAP_DATA, $SNAP_COMMON, and use the environment variables for that. However, those environment variables include the revision number of the snap explicitly such as `/var/snap/edgexfoundry/329` for $SNAP_DATA from the stable channel, which is on revision 329. This is an issue when we push an update to the snap, because the configuration files currently wouldn't be changed and so the services would be trying to use files from a previous revision (say 329) when the current revision and actual data is now in (for example) 330. 
We can remedy this by simply using the `current` symlink instead (i.e. `/var/snap/edgexfoundry/current` which is a symlink to `/var/snap/edgexfoundry/330`).
This patch implements solution by doing 3 things:
* On install, we don't use the revision number, we use `current`
* Before a refresh, we set config items that can be used to check in future revisions if the snap has already been migrated to use the `current` symlink
* After a refresh, we check if that config item is set, and if not then we migrate the config files to use the `current` symlink instead

Finally, this also sets the snap to have `epoch: 0`, so that when we release Edinburgh we can use `epoch: 1` and block automatic refreshes from Delhi to Edinburgh. Read more about epochs [here](https://docs.snapcraft.io/snap-epochs).

## Testing

To test this, I have made some useful scripts in our certification repo to use with checkbox. To run the tests, build the snap from this repo locally somewhere, then clone the repo and run the tests locally with the `run-all-tests-locally.sh`:

```bash
$ # build the snap somewhere say $GOPATH/src/github.com/edgexfoundry/edgex-go/edgexfoundry_*.snap
$ git clone ssh://$YOUR_LP_USERNAME@git.launchpad.net/checkbox-provider-edgex
$ cd checkbox-provider-edgex
$ git checkout feature/more-tests
$ # run the tests against the local snap
$ bin/run-all-tests-locally.sh $GOPATH/src/github.com/edgexfoundry/edgex-go/edgexfoundry_*.snap
```

This currently will run 5 tests:
1. Test that the snap installs without failure
2. Test that the snap services are still running/in expected states after 120 seconds
3. Test that the security services are running, that the generated cert is presented by Kong and doesn't get regenerated when the snap is restarted
4. Test that the snap config files don't contain the revision number path anywhere after installing
5. Test that the snap config files don't contain the revision number path anywhere after refreshing

There is an additional test for the snap service states after a refresh but that test is currently broken by https://bugs.launchpad.net/snapd/+bug/1818306, so that test result is set to not fail when the services are in incorrect state.