### PR TITLE
Fix Export-Distro Ignoring ^C

### DIFF
--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	listenForInterrupt(errs)
 
-	distro.Loop()
+	go distro.Loop()
 
 	// Time it took to start service
 	distro.LoggingClient.Info("Service started in: " + time.Since(start).String())


### PR DESCRIPTION
Fix #1307 

In the case where export-client was not running when export-distro was
brought up, distro would get into a loop polling for export-client
connectivity and would ignore a signal to quit from the command line.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>