### PR TITLE
Return New Notification ID Instead of Slug

### DIFF
--- a/api/raml/support-notifications.raml
+++ b/api/raml/support-notifications.raml
@@ -863,10 +863,10 @@ traits:
           }
     responses:
       202:
-        description: If Alerts and Notifications Service is available, it always returns 202 Accepted to clients with the slug to indicate the Notification has been received.
+        description: If Alerts and Notifications Service is available, it always returns 202 Accepted to clients with the new ID to indicate the Notification has been received.
         body:
           text/plain:
-            example: notice-test-001
+            example: fd388f69-9393-49a7-9962-d70938438b47
   /slug/{slug}:
     uriParameters:
       slug:

--- a/internal/support/notifications/rest_notification.go
+++ b/internal/support/notifications/rest_notification.go
@@ -69,7 +69,7 @@ func notificationHandler(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusAccepted)
-		w.Write([]byte(n.Slug))
+		w.Write([]byte(n.ID))
 	}
 }
 


### PR DESCRIPTION
Fix #1329

When entities are created in EdgeX the normal practice is to return the
ID of the new record. Previously we were returning the "slug" value
when a notification entry was created, which is something that is provided
by the application creating the notification. Thus it wasn't very
useful. Standardized POST of new notification to return the new ID and
updated the RAML.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>