### PR TITLE
Transmission resend entries created with 0 CreateDate

### DIFF
--- a/internal/pkg/db/mongo/notifications.go
+++ b/internal/pkg/db/mongo/notifications.go
@@ -369,6 +369,14 @@ func (mc MongoClient) DeleteTransmission(age int64, status contract.Transmission
 	return mc.deleteAll(bson.M{"modified": bson.M{"$lt": end}, "status": status}, TRANSMISSION_COLLECTION)
 }
 
+func (mc MongoClient) GetTransmissionById(id string) (contract.Transmission, error) {
+	query, err := idToBsonM(id)
+	if err != nil {
+		return contract.Transmission{}, err
+	}
+	return mc.getTransmission(query)
+}
+
 func (mc MongoClient) GetTransmissionsByNotificationSlug(slug string, resendLimit int) ([]contract.Transmission, error) {
 	return mc.getTransmissionsLimit(bson.M{"resendcount": bson.M{"$lt": resendLimit}, "notification.slug": slug})
 }

--- a/internal/pkg/db/redis/notifications.go
+++ b/internal/pkg/db/redis/notifications.go
@@ -15,7 +15,6 @@ package redis
 
 import (
 	"fmt"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gomodule/redigo/redis"
@@ -532,6 +531,17 @@ func (c Client) GetTransmissionsByStart(start int64, resendLimit int) (transmiss
 	}
 
 	return transmissions, nil
+}
+
+func (c Client) GetTransmissionById(id string) (transmission contract.Transmission, err error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	err = getObjectById(conn, id, unmarshalObject, &transmission)
+	if err != nil {
+		return transmission, err
+	}
+	return transmission, nil
 }
 
 func (c Client) GetTransmissionsByEnd(end int64, resendLimit int) (transmissions []contract.Transmission, err error) {

--- a/internal/support/notifications/interfaces/db.go
+++ b/internal/support/notifications/interfaces/db.go
@@ -59,6 +59,7 @@ type DBClient interface {
 	DeleteSubscriptionBySlug(id string) error
 
 	// Transmissions
+	GetTransmissionById(id string) (contract.Transmission, error)
 	GetTransmissionsByNotificationSlug(slug string, resendLimit int) ([]contract.Transmission, error)
 	GetTransmissionsByStartEnd(start int64, end int64, resendLimit int) ([]contract.Transmission, error)
 	GetTransmissionsByStart(start int64, resendLimit int) ([]contract.Transmission, error)

--- a/internal/support/notifications/sending_service.go
+++ b/internal/support/notifications/sending_service.go
@@ -73,7 +73,13 @@ func persistTransmission(tr models.TransmissionRecord, n models.Notification, c 
 		LoggingClient.Error("Transmission cannot be persisted: " + trx.String())
 		return trx, err
 	}
-	trx.ID = id
+
+	//We need to fetch this transmission for later use in retries, otherwise timestamp information will be lost.
+	trx, err = dbClient.GetTransmissionById(id)
+	if err != nil {
+		LoggingClient.Error("error fetching newly saved transmission: " + id)
+		return models.Transmission{}, err
+	}
 	return trx, nil
 }
 


### PR DESCRIPTION
Fix #1315

If a notification comes in and transmittal to a subscriber fails, a
retry can occur. In this case, the retry transmission record was being
created with a 0 CreateDate value. This was because dates are managed
at the database provider level and the return value on an ADD operation
is simply the ID of the newly inserted record.  In order to fix this,
I had to add a new function to the DBClient and supporting providers
that would fetch the newly inserted Transmission record so that the
date values could be retained for further opertations.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>