### PR TITLE
Use subscription (s), instead of subscription (s2), to properly update subscription per PUT operation.

### DIFF
--- a/internal/support/notifications/rest_subscription.go
+++ b/internal/support/notifications/rest_subscription.go
@@ -71,7 +71,7 @@ func subscriptionHandler(w http.ResponseWriter, r *http.Request) {
 
 		LoggingClient.Info("Updating subscription by slug: " + slug)
 
-		if err = dbClient.UpdateSubscription(s2); err != nil {
+		if err = dbClient.UpdateSubscription(s); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			LoggingClient.Error(err.Error())
 			return


### PR DESCRIPTION
Fix [#1313](https://github.com/edgexfoundry/edgex-go/issues/1313)

- Need to use subscription (s), instead of subscription (s2), to properly update subscription per PUT operation.