### PR TITLE
JSON Event ID Lost When Published to Bus

### DIFF
--- a/internal/core/data/event.go
+++ b/internal/core/data/event.go
@@ -16,8 +16,10 @@ package data
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/pkg/types"
 
@@ -236,6 +238,15 @@ func updateEventPushDate(id string, ctx context.Context) error {
 func putEventOnQueue(evt models.Event, ctx context.Context) {
 	LoggingClient.Info("Putting event on message queue")
 
+	//Re-marshal JSON content into bytes.
+	if clients.FromContext(clients.ContentType, ctx) == clients.ContentTypeJSON {
+		data, err := json.Marshal(evt)
+		if err != nil {
+			LoggingClient.Error(fmt.Sprintf("error marshaling event: %s", evt.String()))
+			return
+		}
+		evt.Bytes = data
+	}
 	evt.CorrelationId = correlation.FromContext(ctx)
 
 	msgEnvelope := msgTypes.NewMessageEnvelope(evt.Bytes, ctx)

--- a/internal/core/data/io.go
+++ b/internal/core/data/io.go
@@ -44,15 +44,11 @@ func (jsonReader) Read(reader io.Reader, ctx *context.Context) (models.Event, er
 	*ctx = c
 
 	event := models.Event{}
-	bytes, err := ioutil.ReadAll(reader)
+	err := json.NewDecoder(reader).Decode(&event)
 	if err != nil {
 		return event, err
 	}
-	err = json.Unmarshal(bytes, &event)
-	if err != nil {
-		return event, err
-	}
-	event.Bytes = bytes
+
 	return event, nil
 }
 


### PR DESCRIPTION
Fix #1339

It's not feasible to set the bytes for a JSON event when the event is
read into core-data. This is because those bytes won't contain the new
event ID obtained during persistence. Marshal the event at the time of
publication if the Content-Type is application/json.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>