### PR TITLE
Remove duplicate "internal" constants for service keys 

### DIFF
--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/seed/config"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
@@ -47,7 +48,7 @@ func main() {
 	bootstrap(useProfile)
 	ok := config.Init()
 	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.ConfigSeedServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.ConfigSeedServiceKey))
 		os.Exit(1)
 	}
 	config.LoggingClient.Info("Service dependencies resolved...")
@@ -87,6 +88,6 @@ func bootstrap(profile string) {
 }
 
 func logBeforeInit(err error) {
-	l := logger.NewClient(internal.ConfigSeedServiceKey, false, "", models.InfoLog)
+	l := logger.NewClient(clients.ConfigSeedServiceKey, false, "", models.InfoLog)
 	l.Error(err.Error())
 }

--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/context"
@@ -50,12 +51,12 @@ func main() {
 
 	ok := command.Init(useRegistry)
 	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.CoreCommandServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.CoreCommandServiceKey))
 		os.Exit(1)
 	}
 
 	command.LoggingClient.Info("Service dependencies resolved...")
-	command.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.CoreCommandServiceKey, edgex.Version))
+	command.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.CoreCommandServiceKey, edgex.Version))
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(command.Configuration.Service.Timeout), "Request timed out")
 	command.LoggingClient.Info(command.Configuration.Service.StartupMsg)
@@ -75,7 +76,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	command.LoggingClient = logger.NewClient(internal.CoreCommandServiceKey, false, "", models.InfoLog)
+	command.LoggingClient = logger.NewClient(clients.CoreCommandServiceKey, false, "", models.InfoLog)
 	command.LoggingClient.Error(err.Error())
 }
 

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/context"
@@ -51,12 +52,12 @@ func main() {
 
 	ok := data.Init(useRegistry)
 	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.CoreDataServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.CoreDataServiceKey))
 		os.Exit(1)
 	}
 
 	data.LoggingClient.Info("Service dependencies resolved...")
-	data.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.CoreDataServiceKey, edgex.Version))
+	data.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.CoreDataServiceKey, edgex.Version))
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(data.Configuration.Service.Timeout), "Request timed out")
 	data.LoggingClient.Info(data.Configuration.Service.StartupMsg)
@@ -76,7 +77,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	l := logger.NewClient(internal.CoreDataServiceKey, false, "", models.InfoLog)
+	l := logger.NewClient(clients.CoreDataServiceKey, false, "", models.InfoLog)
 	l.Error(err.Error())
 }
 

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/context"
@@ -50,12 +51,12 @@ func main() {
 
 	ok := metadata.Init(useRegistry)
 	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.CoreMetaDataServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.CoreMetaDataServiceKey))
 		os.Exit(1)
 	}
 
 	metadata.LoggingClient.Info("Service dependencies resolved...")
-	metadata.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.CoreMetaDataServiceKey, edgex.Version))
+	metadata.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.CoreMetaDataServiceKey, edgex.Version))
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(metadata.Configuration.Service.Timeout), "Request timed out")
 	metadata.LoggingClient.Info(metadata.Configuration.Service.StartupMsg)
@@ -75,7 +76,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	l := logger.NewClient(internal.CoreMetaDataServiceKey, false, "", models.InfoLog)
+	l := logger.NewClient(clients.CoreMetaDataServiceKey, false, "", models.InfoLog)
 	l.Error(err.Error())
 }
 

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
@@ -46,12 +47,12 @@ func main() {
 
 	ok := client.Init(useRegistry)
 	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed", internal.ExportClientServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed", clients.ExportClientServiceKey))
 		os.Exit(1)
 	}
 
 	client.LoggingClient.Info("Service dependencies resolved...")
-	client.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.ExportClientServiceKey, edgex.Version))
+	client.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.ExportClientServiceKey, edgex.Version))
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(client.Configuration.Service.Timeout), "Request timed out")
 	client.LoggingClient.Info(client.Configuration.Service.StartupMsg)
@@ -71,7 +72,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	l := logger.NewClient(internal.ExportClientServiceKey, false, "", models.InfoLog)
+	l := logger.NewClient(clients.ExportClientServiceKey, false, "", models.InfoLog)
 	l.Error(err.Error())
 }
 

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 
@@ -45,12 +46,12 @@ func main() {
 	startup.Bootstrap(params, distro.Retry, logBeforeInit)
 
 	if ok := distro.Init(useRegistry); !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed", internal.ExportDistroServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed", clients.ExportDistroServiceKey))
 		os.Exit(1)
 	}
 
 	distro.LoggingClient.Info("Service dependencies resolved...")
-	distro.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.ExportDistroServiceKey, edgex.Version))
+	distro.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.ExportDistroServiceKey, edgex.Version))
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(distro.Configuration.Service.Timeout), "Request timed out")
 	distro.LoggingClient.Info(distro.Configuration.Service.StartupMsg)
@@ -73,7 +74,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	l := logger.NewClient(internal.ExportDistroServiceKey, false, "", models.InfoLog)
+	l := logger.NewClient(clients.ExportDistroServiceKey, false, "", models.InfoLog)
 	l.Error(err.Error())
 }
 

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/logging"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
@@ -45,11 +46,11 @@ func main() {
 	ok := logging.Init(useRegistry)
 	if !ok {
 		time.Sleep(time.Millisecond * time.Duration(15))
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.SupportLoggingServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.SupportLoggingServiceKey))
 		os.Exit(1)
 	}
 	logging.LoggingClient.Info("Service dependencies resolved...")
-	logging.LoggingClient.Info(fmt.Sprintf("Starting %s %s", internal.SupportLoggingServiceKey, edgex.Version))
+	logging.LoggingClient.Info(fmt.Sprintf("Starting %s %s", clients.SupportLoggingServiceKey, edgex.Version))
 
 	errs := make(chan error, 2)
 	listenForInterrupt(errs)
@@ -67,7 +68,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	l := logger.NewClient(internal.SupportLoggingServiceKey, false, "", models.InfoLog)
+	l := logger.NewClient(clients.SupportLoggingServiceKey, false, "", models.InfoLog)
 	l.Error(err.Error())
 }
 

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
@@ -54,12 +55,12 @@ func main() {
 
 	ok := notifications.Init(useRegistry)
 	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.SupportNotificationsServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.SupportNotificationsServiceKey))
 		os.Exit(1)
 	}
 
 	notifications.LoggingClient.Info("Service dependencies resolved...")
-	notifications.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.SupportNotificationsServiceKey, edgex.Version))
+	notifications.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.SupportNotificationsServiceKey, edgex.Version))
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(notifications.Configuration.Service.Timeout), "Request timed out")
 	notifications.LoggingClient.Info(notifications.Configuration.Service.StartupMsg)
@@ -79,7 +80,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	l := logger.NewClient(internal.SupportNotificationsServiceKey, false, "", models.InfoLog)
+	l := logger.NewClient(clients.SupportNotificationsServiceKey, false, "", models.InfoLog)
 	l.Error(err.Error())
 }
 

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/context"
@@ -38,12 +39,12 @@ func main() {
 
 	ok := scheduler.Init(useRegistry)
 	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", internal.SupportSchedulerServiceKey))
+		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.SupportSchedulerServiceKey))
 		os.Exit(1)
 	}
 
-	scheduler.LoggingClient.Info(fmt.Sprintf("Service dependencies resolved...%s %s ", internal.SupportSchedulerServiceKey, edgex.Version))
-	scheduler.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.SupportSchedulerServiceKey, edgex.Version))
+	scheduler.LoggingClient.Info(fmt.Sprintf("Service dependencies resolved...%s %s ", clients.SupportSchedulerServiceKey, edgex.Version))
+	scheduler.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.SupportSchedulerServiceKey, edgex.Version))
 
 	// Bootstrap schedulers
 	err := scheduler.LoadScheduler()
@@ -72,7 +73,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	scheduler.LoggingClient = logger.NewClient(internal.SupportSchedulerServiceKey, false, "", models.InfoLog)
+	scheduler.LoggingClient = logger.NewClient(clients.SupportSchedulerServiceKey, false, "", models.InfoLog)
 	scheduler.LoggingClient.Error(err.Error())
 }
 

--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -16,12 +16,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/gorilla/context"
 	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
 	"time"
+
+	"github.com/gorilla/context"
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
@@ -29,6 +30,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
@@ -50,12 +52,12 @@ func main() {
 
 	ok := agent.Init(useRegistry)
 	if !ok {
-		logBeforeInit(fmt.Errorf("%s: service bootstrap failed", internal.SystemManagementAgentServiceKey))
+		logBeforeInit(fmt.Errorf("%s: service bootstrap failed", clients.SystemManagementAgentServiceKey))
 		os.Exit(1)
 	}
 
 	agent.LoggingClient.Info("Service dependencies resolved...")
-	agent.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", internal.SystemManagementAgentServiceKey, edgex.Version))
+	agent.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.SystemManagementAgentServiceKey, edgex.Version))
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(agent.Configuration.Service.Timeout), "Request timed out")
 	agent.LoggingClient.Info(agent.Configuration.Service.StartupMsg)
@@ -75,7 +77,7 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	l := logger.NewClient(internal.SystemManagementAgentServiceKey, false, "", models.InfoLog)
+	l := logger.NewClient(clients.SystemManagementAgentServiceKey, false, "", models.InfoLog)
 	l.Error(err.Error())
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190515170337-eeea036f04bd
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0
 	github.com/edgexfoundry/go-mod-messaging v0.0.0-20190516182930-407d7a2e54f0
 	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
@@ -25,7 +25,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
 	github.com/stretchr/testify v1.3.0
-	github.com/ugorji/go/codec v0.0.0-20190316192920-e2bddce071ad
+	github.com/ugorji/go v1.1.4
 	github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5 // indirect
 	gopkg.in/eapache/queue.v1 v1.1.0
 	gopkg.in/yaml.v2 v2.2.2

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -22,16 +22,5 @@ const (
 )
 
 const (
-	ServiceKeyPrefix                = "edgex-"
-	ConfigSeedServiceKey            = "edgex-config-seed"
-	CoreCommandServiceKey           = "edgex-core-command"
-	CoreDataServiceKey              = "edgex-core-data"
-	CoreMetaDataServiceKey          = "edgex-core-metadata"
-	ExportClientServiceKey          = "edgex-export-client"
-	ExportDistroServiceKey          = "edgex-export-distro"
-	SupportLoggingServiceKey        = "edgex-support-logging"
-	SupportNotificationsServiceKey  = "edgex-support-notifications"
-	SystemManagementAgentServiceKey = "edgex-sys-mgmt-agent"
-	SupportSchedulerServiceKey      = "edgex-support-scheduler"
-	WritableKey                     = "/Writable"
+	WritableKey = "/Writable"
 )

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -67,7 +67,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				}
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.CoreCommandServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+				LoggingClient = logger.NewClient(clients.CoreCommandServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				//Initialize service clients
 				initializeClients(useRegistry)
@@ -152,7 +152,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		Host:            conf.Registry.Host,
 		Port:            conf.Registry.Port,
 		Type:            conf.Registry.Type,
-		ServiceKey:      internal.CoreCommandServiceKey,
+		ServiceKey:      clients.CoreCommandServiceKey,
 		ServiceHost:     conf.Service.Host,
 		ServicePort:     conf.Service.Port,
 		ServiceProtocol: conf.Service.Protocol,
@@ -217,7 +217,7 @@ func listenForConfigChanges() {
 func initializeClients(useRegistry bool) {
 	// Create metadata clients
 	params := types.EndpointParams{
-		ServiceKey:  internal.CoreMetaDataServiceKey,
+		ServiceKey:  clients.CoreMetaDataServiceKey,
 		Path:        clients.ApiDeviceRoute,
 		UseRegistry: useRegistry,
 		Url:         Configuration.Clients["Metadata"].Url() + clients.ApiDeviceRoute,

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -75,7 +75,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 			} else {
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.CoreDataServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+				LoggingClient = logger.NewClient(clients.CoreDataServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				// Initialize service clients
 				initializeClients(useRegistry)
@@ -213,7 +213,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		Host:            conf.Registry.Host,
 		Port:            conf.Registry.Port,
 		Type:            conf.Registry.Type,
-		ServiceKey:      internal.CoreDataServiceKey,
+		ServiceKey:      clients.CoreDataServiceKey,
 		ServiceHost:     conf.Service.Host,
 		ServicePort:     conf.Service.Port,
 		ServiceProtocol: conf.Service.Protocol,
@@ -284,7 +284,7 @@ func listenForConfigChanges() {
 func initializeClients(useRegistry bool) {
 	// Create metadata clients
 	params := types.EndpointParams{
-		ServiceKey:  internal.CoreMetaDataServiceKey,
+		ServiceKey:  clients.CoreMetaDataServiceKey,
 		Path:        clients.ApiDeviceRoute,
 		UseRegistry: useRegistry,
 		Url:         Configuration.Clients["Metadata"].Url() + clients.ApiDeviceRoute,

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -69,7 +69,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				initializeClients(useRegistry)
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.CoreMetaDataServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+				LoggingClient = logger.NewClient(clients.CoreMetaDataServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 			}
 		}
 
@@ -152,7 +152,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		Host:            conf.Registry.Host,
 		Port:            conf.Registry.Port,
 		Type:            conf.Registry.Type,
-		ServiceKey:      internal.CoreMetaDataServiceKey,
+		ServiceKey:      clients.CoreMetaDataServiceKey,
 		ServiceHost:     conf.Service.Host,
 		ServicePort:     conf.Service.Port,
 		ServiceProtocol: conf.Service.Protocol,
@@ -256,7 +256,7 @@ func newDBClient(dbType string) (interfaces.DBClient, error) {
 func initializeClients(useRegistry bool) {
 	// Create notification client
 	params := types.EndpointParams{
-		ServiceKey:  internal.SupportNotificationsServiceKey,
+		ServiceKey:  clients.SupportNotificationsServiceKey,
 		Path:        clients.ApiNotificationRoute,
 		UseRegistry: useRegistry,
 		Url:         Configuration.Clients["Notifications"].Url() + clients.ApiNotificationRoute,

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -60,7 +60,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 			} else {
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.ExportClientServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+				LoggingClient = logger.NewClient(clients.ExportClientServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				//Initialize service clients
 				initializeClients(useRegistry)
@@ -188,7 +188,7 @@ func initializeConfiguration(useRegistry bool, useProfile string) (*Configuratio
 func initializeClients(useRegistry bool) {
 	// Create export-distro client
 	params := types.EndpointParams{
-		ServiceKey:  internal.ExportDistroServiceKey,
+		ServiceKey:  clients.ExportDistroServiceKey,
 		UseRegistry: useRegistry,
 		Url:         Configuration.Clients["Distro"].Url(),
 		Interval:    Configuration.Service.ClientMonitor,
@@ -203,7 +203,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		Host:            conf.Registry.Host,
 		Port:            conf.Registry.Port,
 		Type:            conf.Registry.Type,
-		ServiceKey:      internal.ExportClientServiceKey,
+		ServiceKey:      clients.ExportClientServiceKey,
 		ServiceHost:     conf.Service.Host,
 		ServicePort:     conf.Service.Port,
 		ServiceProtocol: conf.Service.Protocol,

--- a/internal/export/client/server_test.go
+++ b/internal/export/client/server_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -44,7 +43,7 @@ func (d *distroMockClient) NotifyRegistrations(models.NotifyUpdate, context.Cont
 }
 
 func prepareTest(t *testing.T) *httptest.Server {
-	LoggingClient = logger.NewClient(internal.ExportClientServiceKey, false, "./logs/edgex-export-client-test.log", models.InfoLog)
+	LoggingClient = logger.NewClient(clients.ExportClientServiceKey, false, "./logs/edgex-export-client-test.log", models.InfoLog)
 
 	dbClient = &MemDB{}
 	dc = &distroMockClient{}

--- a/internal/export/distro/init.go
+++ b/internal/export/distro/init.go
@@ -60,7 +60,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 			} else {
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.ExportDistroServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+				LoggingClient = logger.NewClient(clients.ExportDistroServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				//Initialize service clients
 				initializeClients(useRegistry)
@@ -131,7 +131,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		Host:            conf.Registry.Host,
 		Port:            conf.Registry.Port,
 		Type:            conf.Registry.Type,
-		ServiceKey:      internal.ExportDistroServiceKey,
+		ServiceKey:      clients.ExportDistroServiceKey,
 		ServiceHost:     conf.Service.Host,
 		ServicePort:     conf.Service.Port,
 		ServiceProtocol: conf.Service.Protocol,
@@ -160,7 +160,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 
 func initializeClients(useRegistry bool) {
 	params := types.EndpointParams{
-		ServiceKey:  internal.CoreDataServiceKey,
+		ServiceKey:  clients.CoreDataServiceKey,
 		Path:        clients.ApiEventRoute,
 		UseRegistry: useRegistry,
 		Url:         Configuration.Clients["CoreData"].Url() + clients.ApiEventRoute,

--- a/internal/seed/config/init.go
+++ b/internal/seed/config/init.go
@@ -21,11 +21,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
 
@@ -49,7 +49,7 @@ func Retry(useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) 
 			} else {
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.ConfigSeedServiceKey, Configuration.EnableRemoteLogging, logTarget, Configuration.LoggingLevel)
+				LoggingClient = logger.NewClient(clients.ConfigSeedServiceKey, Configuration.EnableRemoteLogging, logTarget, Configuration.LoggingLevel)
 			}
 		}
 		//Check to verify Registry connectivity

--- a/internal/seed/config/populate.go
+++ b/internal/seed/config/populate.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 	"github.com/magiconair/properties"
@@ -117,7 +118,7 @@ func ImportConfiguration(root string, profile string, overwrite bool) error {
 			Port:       Configuration.Registry.Port,
 			Type:       Configuration.Registry.Type,
 			Stem:       internal.ConfigRegistryStem,
-			ServiceKey: internal.ServiceKeyPrefix + serviceName,
+			ServiceKey: clients.ServiceKeyPrefix + serviceName,
 		}
 		Registry, err = registry.NewRegistryClient(registryConfig)
 		if err != nil {
@@ -132,12 +133,12 @@ func ImportConfiguration(root string, profile string, overwrite bool) error {
 
 // As services are converted to utilize V2 types, add them to this list and remove from the one above.
 func listDirectories() [9]string {
-	var names = [9]string{internal.CoreMetaDataServiceKey, internal.CoreCommandServiceKey, internal.CoreDataServiceKey,
-		internal.ExportDistroServiceKey, internal.ExportClientServiceKey, internal.SupportLoggingServiceKey,
-		internal.SupportSchedulerServiceKey, internal.SupportNotificationsServiceKey, internal.SystemManagementAgentServiceKey}
+	var names = [9]string{clients.CoreMetaDataServiceKey, clients.CoreCommandServiceKey, clients.CoreDataServiceKey,
+		clients.ExportDistroServiceKey, clients.ExportClientServiceKey, clients.SupportLoggingServiceKey,
+		clients.SupportSchedulerServiceKey, clients.SupportNotificationsServiceKey, clients.SystemManagementAgentServiceKey}
 
 	for i, name := range names {
-		names[i] = strings.Replace(name, internal.ServiceKeyPrefix, "", 1)
+		names[i] = strings.Replace(name, clients.ServiceKeyPrefix, "", 1)
 	}
 
 	return names

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -139,7 +139,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		Host:            conf.Registry.Host,
 		Port:            conf.Registry.Port,
 		Type:            conf.Registry.Type,
-		ServiceKey:      internal.SupportLoggingServiceKey,
+		ServiceKey:      clients.SupportLoggingServiceKey,
 		ServiceHost:     conf.Service.Host,
 		ServicePort:     conf.Service.Port,
 		ServiceProtocol: conf.Service.Protocol,

--- a/internal/support/logging/types.go
+++ b/internal/support/logging/types.go
@@ -9,8 +9,8 @@ package logging
 import (
 	"os"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -49,7 +49,7 @@ func newPrivateLogger() privLogger {
 
 	pl.rootLogger = log.NewLogfmtLogger(os.Stdout)
 	pl.rootLogger = log.WithPrefix(pl.rootLogger, "ts", log.DefaultTimestampUTC,
-		"app", internal.SupportLoggingServiceKey, "source", log.Caller(5))
+		"app", clients.SupportLoggingServiceKey, "source", log.Caller(5))
 
 	return pl
 }
@@ -74,7 +74,7 @@ func (l privLogger) log(logLevel string, msg string, args ...interface{}) {
 		logEntry := models.LogEntry{
 			Level:         logLevel,
 			Args:          args,
-			OriginService: internal.SupportLoggingServiceKey,
+			OriginService: clients.SupportLoggingServiceKey,
 			Message:       msg,
 			Created:       db.MakeTimestamp(),
 		}

--- a/internal/support/notifications/init.go
+++ b/internal/support/notifications/init.go
@@ -65,7 +65,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 			} else {
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.SupportNotificationsServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+				LoggingClient = logger.NewClient(clients.SupportNotificationsServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 			}
 		}
 
@@ -190,7 +190,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		Host:            conf.Registry.Host,
 		Port:            conf.Registry.Port,
 		Type:            conf.Registry.Type,
-		ServiceKey:      internal.SupportNotificationsServiceKey,
+		ServiceKey:      clients.SupportNotificationsServiceKey,
 		ServiceHost:     conf.Service.Host,
 		ServicePort:     conf.Service.Port,
 		ServiceProtocol: conf.Service.Protocol,

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -17,7 +17,6 @@ package scheduler
 import (
 	"errors"
 	"fmt"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"os"
 	"os/signal"
 	"sync"
@@ -33,6 +32,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/interfaces"
 )
@@ -70,7 +70,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				}
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.SupportSchedulerServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+				LoggingClient = logger.NewClient(clients.SupportSchedulerServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				// Initialize the ticker time
 				ticker = time.NewTicker(time.Duration(Configuration.Writable.ScheduleIntervalTime) * time.Millisecond)
@@ -176,7 +176,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		Host:            conf.Registry.Host,
 		Port:            conf.Registry.Port,
 		Type:            conf.Registry.Type,
-		ServiceKey:      internal.SupportSchedulerServiceKey,
+		ServiceKey:      clients.SupportSchedulerServiceKey,
 		ServiceHost:     conf.Service.Host,
 		ServicePort:     conf.Service.Port,
 		ServiceProtocol: conf.Service.Protocol,

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -46,14 +46,14 @@ var chUpdates chan interface{} //A channel for "config updates" sourced from Reg
 var executorClient interface{}
 
 var services = map[string]string{
-	internal.SupportNotificationsServiceKey: "Notifications",
-	internal.CoreCommandServiceKey:          "Command",
-	internal.CoreDataServiceKey:             "CoreData",
-	internal.CoreMetaDataServiceKey:         "Metadata",
-	internal.ExportClientServiceKey:         "Export",
-	internal.ExportDistroServiceKey:         "Distro",
-	internal.SupportLoggingServiceKey:       "Logging",
-	internal.SupportSchedulerServiceKey:     "Scheduler",
+	clients.SupportNotificationsServiceKey: "Notifications",
+	clients.CoreCommandServiceKey:          "Command",
+	clients.CoreDataServiceKey:             "CoreData",
+	clients.CoreMetaDataServiceKey:         "Metadata",
+	clients.ExportClientServiceKey:         "Export",
+	clients.ExportDistroServiceKey:         "Distro",
+	clients.SupportLoggingServiceKey:       "Logging",
+	clients.SupportSchedulerServiceKey:     "Scheduler",
 }
 
 func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
@@ -77,7 +77,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 			} else {
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.SystemManagementAgentServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+				LoggingClient = logger.NewClient(clients.SystemManagementAgentServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				//Initialize service clients
 				initializeClients(useRegistry)
@@ -163,7 +163,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		Host:            conf.Registry.Host,
 		Port:            conf.Registry.Port,
 		Type:            conf.Registry.Type,
-		ServiceKey:      internal.SystemManagementAgentServiceKey,
+		ServiceKey:      clients.SystemManagementAgentServiceKey,
 		ServiceHost:     conf.Service.Host,
 		ServicePort:     conf.Service.Port,
 		ServiceProtocol: conf.Service.Protocol,

--- a/internal/system/agent/services.go
+++ b/internal/system/agent/services.go
@@ -18,6 +18,7 @@ package agent
 import (
 	"context"
 	"fmt"
+
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
@@ -278,15 +279,15 @@ func getHealth(services []string) (map[string]interface{}, error) {
 func IsKnownServiceKey(serviceKey string) bool {
 	// create a map because this is the easiest/cleanest way to determine whether something exists in a set
 	var services = map[string]struct{}{
-		internal.SupportNotificationsServiceKey: {},
-		internal.CoreCommandServiceKey:          {},
-		internal.CoreDataServiceKey:             {},
-		internal.CoreMetaDataServiceKey:         {},
-		internal.ExportClientServiceKey:         {},
-		internal.ExportDistroServiceKey:         {},
-		internal.SupportLoggingServiceKey:       {},
-		internal.SupportSchedulerServiceKey:     {},
-		internal.ConfigSeedServiceKey:           {},
+		clients.SupportNotificationsServiceKey: {},
+		clients.CoreCommandServiceKey:          {},
+		clients.CoreDataServiceKey:             {},
+		clients.CoreMetaDataServiceKey:         {},
+		clients.ExportClientServiceKey:         {},
+		clients.ExportDistroServiceKey:         {},
+		clients.SupportLoggingServiceKey:       {},
+		clients.SupportSchedulerServiceKey:     {},
+		clients.ConfigSeedServiceKey:           {},
 	}
 
 	_, exists := services[serviceKey]


### PR DESCRIPTION
Fix #1345 

In go-mod-core-contracts we have available the following constants (https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/clients/constants.go): 
```
const (
	ServiceKeyPrefix                = "edgex-"
	ConfigSeedServiceKey            = "edgex-config-seed"
	CoreCommandServiceKey           = "edgex-core-command"
	CoreDataServiceKey              = "edgex-core-data"
	CoreMetaDataServiceKey          = "edgex-core-metadata"
	ExportClientServiceKey          = "edgex-export-client"
	ExportDistroServiceKey          = "edgex-export-distro"
	SupportLoggingServiceKey        = "edgex-support-logging"
	SupportNotificationsServiceKey  = "edgex-support-notifications"
	SystemManagementAgentServiceKey = "edgex-sys-mgmt-agent"
	SupportSchedulerServiceKey      = "edgex-support-scheduler"
)
```
which happen to also be in located in https://github.com/edgexfoundry/edgex-go/blob/master/internal/constants.go. The exception is the `WriteableKey` which for now I have left in internal as it is not in go-mod-core-contracts, but potentially could be moved over as it seems relevant and could be used for other services as well.

With the intention of removing duplicate code, this pull request removes the duplicate "internal" constants for service keys and leverage go-mod-core-contracts throughout edgex-go. This pull request does not depend on any others and is purely a code clean up thing. Noticed it as I was adding the client info sections to the app-functions-sdk.

Signed-off-by: Mike Johanson <michael.johanson@intel.com>