### PR TITLE
Add Config-Seed Override to Populate Redis Config

### DIFF
--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -30,6 +30,7 @@ func main() {
 	var useProfile string
 	var dirCmd string
 	var dirProperties string
+	var useDatabase string
 	var overwriteConfig bool
 
 	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
@@ -38,6 +39,8 @@ func main() {
 	flag.StringVar(&dirProperties, "r", "./res/properties", "Specify alternate properties location as absolute path")
 	flag.StringVar(&dirCmd, "cmd", "../cmd", "Specify alternate cmd location as absolute path")
 	flag.StringVar(&dirCmd, "c", "../cmd", "Specify alternate cmd location as absolute path")
+	flag.StringVar(&useDatabase, "database", "mongo", "Specify either mongo or redis database")
+	flag.StringVar(&useDatabase, "d", "mongo", "Specify either mongo or redis database")
 	flag.BoolVar(&overwriteConfig, "overwrite", false, "Overwrite configuration in Registry")
 	flag.BoolVar(&overwriteConfig, "o", false, "Overwrite configuration in Registry")
 
@@ -57,7 +60,7 @@ func main() {
 		config.LoggingClient.Error(err.Error())
 	}
 
-	err = config.ImportConfiguration(dirCmd, useProfile, overwriteConfig)
+	err = config.ImportConfiguration(dirCmd, useProfile, overwriteConfig, useDatabase)
 	if err != nil {
 		config.LoggingClient.Error(err.Error())
 	}

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -23,7 +23,7 @@ Usage: %s [options]
 Server Options:
     -r, --registry                  Indicates service should use Registry
     -p, --profile <name>            Indicate configuration profile other than default
-    -confdir                        Specify local configuration directory
+    --confdir                        Specify local configuration directory
 Common Options:
     -h, --help                      Show this message
 `
@@ -31,9 +31,14 @@ Common Options:
 var configSeedUsageStr = `
 Usage: %s [options]
 Server Options:
+	-c, --cmd <dir>                 Provide absolute path to "cmd" directory containing EdgeX services
+    -d, --database <name>			Indicate which database to use -- mongo or redis. Mongo is default.
+	-o, --overwrite					Indicates service should overwrite any entries already present in the configuration
     -p, --profile <name>            Indicate configuration profile other than default
     -r, --props <dir>               Provide alternate location for legacy application.properties files
-    -c, --cmd <dir>                 Provide absolute path to "cmd" directory containing EdgeX services
+	--confdir                       Specify local configuration directory
+    
+
 Common Options:
     -h, --help                      Show this message
 `

--- a/internal/seed/config/populate.go
+++ b/internal/seed/config/populate.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 	"github.com/magiconair/properties"
@@ -75,7 +76,7 @@ func ImportProperties(root string) error {
 
 // Import configuration files using the specified path to the cmd directory where service configuration files reside.
 // Also, profile indicates the preferred deployment target (such as "docker")
-func ImportConfiguration(root string, profile string, overwrite bool) error {
+func ImportConfiguration(root string, profile string, overwrite bool, useDatabase string) error {
 	dirs := listDirectories()
 	absRoot, err := determineAbsRoot(root)
 	if err != nil {
@@ -110,6 +111,13 @@ func ImportConfiguration(root string, profile string, overwrite bool) error {
 		if err != nil {
 			LoggingClient.Warn(err.Error())
 			return nil
+		}
+
+		if useDatabase == "redis" {
+			if configuration.GetPath([]string{"Databases", "Primary", "Type"}) != nil {
+				configuration.SetPath([]string{"Databases", "Primary", "Type"}, db.RedisDB)
+				configuration.SetPath([]string{"Databases", "Primary", "Port"}, "6379")
+			}
 		}
 
 		registryConfig := types.Config{


### PR DESCRIPTION
Fix #1347
Fix #1302

If the new --database flag is provided to the config-seed on startup
and if the value is "redis" then the database configurations will be
overridden prior to Consul population with the Redis type and port.

Also cleaned up help message from command line usage.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>