### PR TITLE
Update support-notifications transmission endpoints

### DIFF
--- a/internal/pkg/db/mongo/notifications.go
+++ b/internal/pkg/db/mongo/notifications.go
@@ -377,24 +377,24 @@ func (mc MongoClient) GetTransmissionById(id string) (contract.Transmission, err
 	return mc.getTransmission(query)
 }
 
-func (mc MongoClient) GetTransmissionsByNotificationSlug(slug string, resendLimit int) ([]contract.Transmission, error) {
-	return mc.getTransmissionsLimit(bson.M{"resendcount": bson.M{"$lt": resendLimit}, "notification.slug": slug})
+func (mc MongoClient) GetTransmissionsByNotificationSlug(slug string, limit int) ([]contract.Transmission, error) {
+	return mc.getTransmissionsLimit(bson.M{"notification.slug": slug}, limit)
 }
 
-func (mc MongoClient) GetTransmissionsByStartEnd(start int64, end int64, resendLimit int) ([]contract.Transmission, error) {
-	return mc.getTransmissionsLimit(bson.M{"resendcount": bson.M{"$lt": resendLimit}, "created": bson.M{"$gt": start, "$lt": end}})
+func (mc MongoClient) GetTransmissionsByStartEnd(start int64, end int64, limit int) ([]contract.Transmission, error) {
+	return mc.getTransmissionsLimit(bson.M{"created": bson.M{"$gt": start, "$lt": end}}, limit)
 }
 
-func (mc MongoClient) GetTransmissionsByStart(start int64, resendLimit int) ([]contract.Transmission, error) {
-	return mc.getTransmissionsLimit(bson.M{"resendcount": bson.M{"$lt": resendLimit}, "created": bson.M{"$gt": start}})
+func (mc MongoClient) GetTransmissionsByStart(start int64, limit int) ([]contract.Transmission, error) {
+	return mc.getTransmissionsLimit(bson.M{"created": bson.M{"$gt": start}}, limit)
 }
 
-func (mc MongoClient) GetTransmissionsByEnd(end int64, resendLimit int) ([]contract.Transmission, error) {
-	return mc.getTransmissionsLimit(bson.M{"resendcount": bson.M{"$lt": resendLimit}, "created": bson.M{"$lt": end}})
+func (mc MongoClient) GetTransmissionsByEnd(end int64, limit int) ([]contract.Transmission, error) {
+	return mc.getTransmissionsLimit(bson.M{"created": bson.M{"$lt": end}}, limit)
 }
 
-func (mc MongoClient) GetTransmissionsByStatus(resendLimit int, status contract.TransmissionStatus) ([]contract.Transmission, error) {
-	return mc.getTransmissionsLimit(bson.M{"resendcount": bson.M{"$lt": resendLimit}, "status": status})
+func (mc MongoClient) GetTransmissionsByStatus(limit int, status contract.TransmissionStatus) ([]contract.Transmission, error) {
+	return mc.getTransmissionsLimit(bson.M{"status": status}, limit)
 }
 
 func (mc MongoClient) getTransmission(q bson.M) (c contract.Transmission, err error) {
@@ -409,12 +409,16 @@ func (mc MongoClient) getTransmission(q bson.M) (c contract.Transmission, err er
 	return
 }
 
-func (mc MongoClient) getTransmissionsLimit(q bson.M) (c []contract.Transmission, err error) {
+func (mc MongoClient) getTransmissionsLimit(q bson.M, limit int) (c []contract.Transmission, err error) {
 	s := mc.getSessionCopy()
 	defer s.Close()
 
+	if limit == 0 {
+		return []contract.Transmission{}, nil
+	}
+
 	var transmissions []models.Transmission
-	if err = errorMap(s.DB(mc.database.Name).C(TRANSMISSION_COLLECTION).Find(q).All(&transmissions)); err != nil {
+	if err = errorMap(s.DB(mc.database.Name).C(TRANSMISSION_COLLECTION).Find(q).Limit(limit).All(&transmissions)); err != nil {
 		return
 	}
 

--- a/internal/support/notifications/interfaces/db.go
+++ b/internal/support/notifications/interfaces/db.go
@@ -60,11 +60,11 @@ type DBClient interface {
 
 	// Transmissions
 	GetTransmissionById(id string) (contract.Transmission, error)
-	GetTransmissionsByNotificationSlug(slug string, resendLimit int) ([]contract.Transmission, error)
-	GetTransmissionsByStartEnd(start int64, end int64, resendLimit int) ([]contract.Transmission, error)
-	GetTransmissionsByStart(start int64, resendLimit int) ([]contract.Transmission, error)
-	GetTransmissionsByEnd(end int64, resendLimit int) ([]contract.Transmission, error)
-	GetTransmissionsByStatus(resendLimit int, status contract.TransmissionStatus) ([]contract.Transmission, error)
+	GetTransmissionsByNotificationSlug(slug string, limit int) ([]contract.Transmission, error)
+	GetTransmissionsByStartEnd(start int64, end int64, limit int) ([]contract.Transmission, error)
+	GetTransmissionsByStart(start int64, limit int) ([]contract.Transmission, error)
+	GetTransmissionsByEnd(end int64, limit int) ([]contract.Transmission, error)
+	GetTransmissionsByStatus(limit int, status contract.TransmissionStatus) ([]contract.Transmission, error)
 	AddTransmission(t contract.Transmission) (string, error)
 	UpdateTransmission(t contract.Transmission) error
 	DeleteTransmission(age int64, status contract.TransmissionStatus) error

--- a/internal/support/notifications/rest_transmission.go
+++ b/internal/support/notifications/rest_transmission.go
@@ -65,7 +65,7 @@ func transmissionBySlugHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	vars := mux.Vars(r)
-	resendLimit, err := strconv.Atoi(vars["limit"])
+	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error("Error converting limit to integer: " + err.Error())
@@ -75,7 +75,7 @@ func transmissionBySlugHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 
-		t, err := dbClient.GetTransmissionsByNotificationSlug(vars["slug"], resendLimit)
+		t, err := dbClient.GetTransmissionsByNotificationSlug(vars["slug"], limitNum)
 		if err != nil {
 			if err == db.ErrNotFound {
 				http.Error(w, "Transmission not found", http.StatusNotFound)
@@ -110,7 +110,7 @@ func transmissionByStartEndHandler(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error("Error converting the end to an integer")
 		return
 	}
-	resendLimit, err := strconv.Atoi(vars["limit"])
+	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error("Error converting limit to integer: " + err.Error())
@@ -120,7 +120,7 @@ func transmissionByStartEndHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 
-		t, err := dbClient.GetTransmissionsByStartEnd(start, end, resendLimit)
+		t, err := dbClient.GetTransmissionsByStartEnd(start, end, limitNum)
 		if err != nil {
 			if err == db.ErrNotFound {
 				http.Error(w, "Transmission not found", http.StatusNotFound)
@@ -147,7 +147,7 @@ func transmissionByStartHandler(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error("Error converting the start to an integer")
 		return
 	}
-	resendLimit, err := strconv.Atoi(vars["limit"])
+	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error("Error converting limit to integer: " + err.Error())
@@ -156,7 +156,7 @@ func transmissionByStartHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 
-		t, err := dbClient.GetTransmissionsByStart(start, resendLimit)
+		t, err := dbClient.GetTransmissionsByStart(start, limitNum)
 		if err != nil {
 			if err == db.ErrNotFound {
 				http.Error(w, "Transmission not found", http.StatusNotFound)
@@ -185,7 +185,7 @@ func transmissionByEndHandler(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error("Error converting the end to an integer")
 		return
 	}
-	resendLimit, err := strconv.Atoi(vars["limit"])
+	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error("Error converting limit to integer: " + err.Error())
@@ -195,7 +195,7 @@ func transmissionByEndHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 
-		t, err := dbClient.GetTransmissionsByEnd(end, resendLimit)
+		t, err := dbClient.GetTransmissionsByEnd(end, limitNum)
 		if err != nil {
 			if err == db.ErrNotFound {
 				http.Error(w, "Transmission not found", http.StatusNotFound)
@@ -225,7 +225,7 @@ func transmissionByStatusHandler(w http.ResponseWriter, r *http.Request, status 
 	}
 
 	vars := mux.Vars(r)
-	resendLimit, err := strconv.Atoi(vars["limit"])
+	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		LoggingClient.Error("Error converting limit to integer: " + err.Error())
@@ -235,7 +235,7 @@ func transmissionByStatusHandler(w http.ResponseWriter, r *http.Request, status 
 	switch r.Method {
 	case http.MethodGet:
 
-		t, err := dbClient.GetTransmissionsByStatus(resendLimit, status)
+		t, err := dbClient.GetTransmissionsByStatus(limitNum, status)
 		if err != nil {
 			if err == db.ErrNotFound {
 				http.Error(w, "Transmission not found", http.StatusNotFound)


### PR DESCRIPTION
Fix #1338 

Change support-notifications transmission endpoints to handle
the limit parameter like every other route in the system.

Signed-off-by: Daniel Harms <jdharms@gmail.com>