### PR TITLE
Adding CBOR support to export-distro

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190509203106-0e8d8505b6d1
-	github.com/edgexfoundry/go-mod-messaging v0.0.0-20190507192740-04f9582c7a08
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190515170337-eeea036f04bd
+	github.com/edgexfoundry/go-mod-messaging v0.0.0-20190516182930-407d7a2e54f0
 	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0

--- a/internal/core/data/event.go
+++ b/internal/core/data/event.go
@@ -238,6 +238,7 @@ func updateEventPushDate(id string, ctx context.Context) error {
 func putEventOnQueue(evt models.Event, ctx context.Context) {
 	LoggingClient.Info("Putting event on message queue")
 
+	evt.CorrelationId = correlation.FromContext(ctx)
 	//Re-marshal JSON content into bytes.
 	if clients.FromContext(clients.ContentType, ctx) == clients.ContentTypeJSON {
 		data, err := json.Marshal(evt)
@@ -247,7 +248,6 @@ func putEventOnQueue(evt models.Event, ctx context.Context) {
 		}
 		evt.Bytes = data
 	}
-	evt.CorrelationId = correlation.FromContext(ctx)
 
 	msgEnvelope := msgTypes.NewMessageEnvelope(evt.Bytes, ctx)
 	err := msgClient.Publish(msgEnvelope, Configuration.MessageQueue.Topic)

--- a/internal/export/distro/httpsender_test.go
+++ b/internal/export/distro/httpsender_test.go
@@ -8,6 +8,7 @@ package distro
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -16,8 +17,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/google/uuid"
 )
 
 func TestHttpSender(t *testing.T) {
@@ -101,8 +103,8 @@ func TestHttpSender(t *testing.T) {
 			}
 			sender := newHTTPSender(addressableTest)
 
-			e := models.Event{CorrelationId: "test"}
-			sender.Send(msg, &e)
+			ctx := context.WithValue(context.Background(), clients.CorrelationHeader, uuid.New().String())
+			sender.Send(msg, ctx)
 		})
 	}
 }

--- a/internal/export/distro/init.go
+++ b/internal/export/distro/init.go
@@ -39,7 +39,7 @@ var registryErrors chan error        //A channel for "config wait errors" source
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 var messageClient messaging.MessageClient
 var messageErrors chan error
-var messageEnvelopes chan *msgTypes.MessageEnvelope
+var messageEnvelopes chan msgTypes.MessageEnvelope
 var processStop chan bool
 
 func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {

--- a/internal/export/distro/messaging.go
+++ b/internal/export/distro/messaging.go
@@ -23,13 +23,13 @@ import (
 	"github.com/edgexfoundry/go-mod-messaging/pkg/types"
 )
 
-func initMessaging(client messaging.MessageClient) (chan error, chan *types.MessageEnvelope, error) {
+func initMessaging(client messaging.MessageClient) (chan error, chan types.MessageEnvelope, error) {
 	if err := client.Connect(); err != nil {
 		return nil, nil, fmt.Errorf("failed to connect to message bus: %s ", err.Error())
 	}
 
 	errs := make(chan error, 2)
-	messages := make(chan *types.MessageEnvelope, 10)
+	messages := make(chan types.MessageEnvelope, 10)
 
 	topics := []types.TopicChannel{
 		{

--- a/internal/export/distro/mqtt.go
+++ b/internal/export/distro/mqtt.go
@@ -10,13 +10,13 @@
 package distro
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"strconv"
 	"strings"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -63,7 +63,7 @@ func newMqttSender(addr contract.Addressable, cert string, key string) sender {
 	return sender
 }
 
-func (sender *mqttSender) Send(data []byte, event *models.Event) bool {
+func (sender *mqttSender) Send(data []byte, ctx context.Context) bool {
 	if !sender.client.IsConnected() {
 		LoggingClient.Info("Connecting to mqtt server")
 		if token := sender.client.Connect(); token.Wait() && token.Error() != nil {

--- a/internal/export/distro/types.go
+++ b/internal/export/distro/types.go
@@ -10,13 +10,14 @@
 package distro
 
 import (
-	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	"context"
+
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 // Sender - Send interface
 type sender interface {
-	Send(data []byte, event *models.Event) bool
+	Send(data []byte, ctx context.Context) bool
 }
 
 // Formatter - Format interface

--- a/internal/export/distro/xmpp.go
+++ b/internal/export/distro/xmpp.go
@@ -9,11 +9,11 @@
 package distro
 
 import (
+	"context"
 	"crypto/tls"
 	"strings"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 	"github.com/mattn/go-xmpp"
@@ -60,7 +60,7 @@ func newXMPPSender(addr contract.Addressable) sender {
 	return sender
 }
 
-func (sender *xmppSender) Send(data []byte, event *models.Event) bool {
+func (sender *xmppSender) Send(data []byte, ctx context.Context) bool {
 	stringData := string(data)
 
 	sender.client.Send(xmpp.Chat{

--- a/internal/export/distro/zeromq.go
+++ b/internal/export/distro/zeromq.go
@@ -8,6 +8,7 @@
 package distro
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -33,7 +34,7 @@ func newZeroMQEventPublisher() sender {
 	return sender
 }
 
-func (sender *zeroMQEventPublisher) Send(data []byte, event *models.Event) bool {
+func (sender *zeroMQEventPublisher) Send(data []byte, ctx context.Context) bool {
 	sender.mux.Lock()
 	defer sender.mux.Unlock()
 	LoggingClient.Debug("Sending data to 0MQ: " + string(data[:]))


### PR DESCRIPTION
Fix #1217

- For all channels involved in handling of incoming events via bus,
  the type has been changed to MessageEnvelope to provide ease of access
  to ContentType, Checksum and so-forth
- Added handling of CBOR encoded events. JSON handling continues as
  previously defined.
- CBOR events are not processed in any way. The payload is simply sent
  out to the relevant subscriber, per decisions in Core WG
- Unit tests have been adjusted and extended to process at least one
  CBOR event.
- CBOR events will be sent to the Rules Engine whereupon the RE will
  log an error. This does not cause a crash, just a log message on the
  RE side. Pending decision from @jpwhitemn as to whether RE should be
  filtered from export-distro or possible code change to RE.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>