### PR TITLE
Add redis config files into config-seed container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 docs
+*.snap

--- a/cmd/config-seed/Dockerfile
+++ b/cmd/config-seed/Dockerfile
@@ -63,51 +63,46 @@ RUN configFile=./cmd-redis/support-logging/res/docker/configuration.toml && \
     json2toml --preserve-key-order > "$configFile.tmp" && \
     mv "$configFile.tmp" "$configFile"
 
+# cleanup build only utils
 RUN python3 -m pip uninstall -y remarshal && apk del python3 jq
 
 # build
 RUN make cmd/config-seed/config-seed
 
-# Consul Docker image for EdgeX Foundry
-FROM golang:1.11-alpine
+FROM scratch
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
     copyright='Copyright (c) 2017: Samsung'
 
-RUN apk add --no-cache bash
-
-# environment variables
-ENV APP_DIR=/edgex/cmd/config-seed
-
 # set the working directory
-WORKDIR $APP_DIR
+WORKDIR /edgex/cmd/config-seed
 
 # copy files
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/Attribution.txt  .
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/config-seed  .
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/res ./res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/Attribution.txt  .
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/config-seed  .
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/res ./res
 
 # copy all the default (i.e. mongodb) configuration.toml files into /edgex/cmd
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/core-command/res /edgex/cmd/core-command/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/core-data/res /edgex/cmd/core-data/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/core-metadata/res /edgex/cmd/core-metadata/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/export-client/res /edgex/cmd/export-client/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/export-distro/res /edgex/cmd/export-distro/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-logging/res /edgex/cmd/support-logging/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-notifications/res /edgex/cmd/support-notifications/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-scheduler/res /edgex/cmd/support-scheduler/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/sys-mgmt-agent/res /edgex/cmd/sys-mgmt-agent/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/core-command/res /edgex/cmd/core-command/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/core-data/res /edgex/cmd/core-data/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/core-metadata/res /edgex/cmd/core-metadata/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/export-client/res /edgex/cmd/export-client/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/export-distro/res /edgex/cmd/export-distro/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/support-logging/res /edgex/cmd/support-logging/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/support-notifications/res /edgex/cmd/support-notifications/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/support-scheduler/res /edgex/cmd/support-scheduler/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd/sys-mgmt-agent/res /edgex/cmd/sys-mgmt-agent/res
 
 # copy all the redis configuration.toml into /edgex/cmd-redis
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/core-command/res /edgex/cmd-redis/core-command/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/core-data/res /edgex/cmd-redis/core-data/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/core-metadata/res /edgex/cmd-redis/core-metadata/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/export-client/res /edgex/cmd-redis/export-client/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/export-distro/res /edgex/cmd-redis/export-distro/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/support-logging/res /edgex/cmd-redis/support-logging/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/support-notifications/res /edgex/cmd-redis/support-notifications/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/support-scheduler/res /edgex/cmd-redis/support-scheduler/res
-COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/sys-mgmt-agent/res /edgex/cmd-redis/sys-mgmt-agent/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd-redis/core-command/res /edgex/cmd-redis/core-command/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd-redis/core-data/res /edgex/cmd-redis/core-data/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd-redis/core-metadata/res /edgex/cmd-redis/core-metadata/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd-redis/export-client/res /edgex/cmd-redis/export-client/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd-redis/export-distro/res /edgex/cmd-redis/export-distro/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd-redis/support-logging/res /edgex/cmd-redis/support-logging/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd-redis/support-notifications/res /edgex/cmd-redis/support-notifications/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd-redis/support-scheduler/res /edgex/cmd-redis/support-scheduler/res
+COPY --from=build-env /go/src/github.com/edgexfoundry/edgex-go/cmd-redis/sys-mgmt-agent/res /edgex/cmd-redis/sys-mgmt-agent/res
 
 ENTRYPOINT ["/edgex/cmd/config-seed/config-seed"]
 CMD ["--profile=docker", "--cmd=/edgex/cmd"]

--- a/cmd/config-seed/Dockerfile
+++ b/cmd/config-seed/Dockerfile
@@ -43,7 +43,7 @@ RUN make cmd/config-seed/config-seed
 FROM golang:1.11-alpine
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-      copyright='Copyright (c) 2017: Samsung'
+    copyright='Copyright (c) 2017: Samsung'
 
 RUN apk add --no-cache bash
 
@@ -67,4 +67,5 @@ COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-n
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-scheduler/res /edgex/cmd/support-scheduler/res
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/sys-mgmt-agent/res /edgex/cmd/sys-mgmt-agent/res
 
-ENTRYPOINT /edgex/cmd/config-seed/config-seed --profile=docker --cmd=/edgex/cmd
+ENTRYPOINT ["/edgex/cmd/config-seed/config-seed"]
+CMD ["--profile=docker", "--cmd=/edgex/cmd"]

--- a/cmd/config-seed/Dockerfile
+++ b/cmd/config-seed/Dockerfile
@@ -26,7 +26,12 @@ ENV PATH=$GOPATH/bin:$PATH
 # set the working directory
 WORKDIR $GOPATH/src/github.com/edgexfoundry/edgex-go
 
-RUN apk update && apk add make git
+RUN apk update && apk add make git python3 jq
+
+# install remarshal for processing config files in proper way, i.e. turn toml
+# into json, use jq to set the correct keys, then turn back into toml in the 
+# files
+RUN python3 -m pip install remarshal
 
 # copy go source files
 COPY go.mod .
@@ -35,6 +40,30 @@ COPY go.mod .
 RUN go mod download
 
 COPY . .
+
+# create an identical dir structure under /cmd-redis for using redis
+# instead of mongodb
+COPY ./cmd ./cmd-redis
+
+# for svcs supporting redis directly, change the following keys before copying
+# Databases.Primary.Type = redisdb 
+# Databases.Primary.Port = 6379
+# Databases.Primary.Host = edgex-redis
+RUN for svc in core-data core-metadata export-client support-notifications support-scheduler; do \
+    configFile=./cmd-redis/$svc/res/docker/configuration.toml && \
+    toml2json --preserve-key-order "$configFile" | \
+    jq -r '.Databases.Primary.Type = "redisdb" | .Databases.Primary.Port = 6379 | .Databases.Primary.Host = "edgex-redis"' | \
+    json2toml --preserve-key-order > "$configFile.tmp" && \
+    mv "$configFile.tmp" "$configFile"; done
+
+# support-logging needs the Writable.Persistence key set to file to be usable with Redis
+RUN configFile=./cmd-redis/support-logging/res/docker/configuration.toml && \
+    toml2json --preserve-key-order "$configFile" | \
+    jq -r '.Writable.Persistence = "file"' | \
+    json2toml --preserve-key-order > "$configFile.tmp" && \
+    mv "$configFile.tmp" "$configFile"
+
+RUN python3 -m pip uninstall -y remarshal && apk del python3 jq
 
 # build
 RUN make cmd/config-seed/config-seed
@@ -57,6 +86,8 @@ WORKDIR $APP_DIR
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/Attribution.txt  .
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/config-seed  .
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/config-seed/res ./res
+
+# copy all the default (i.e. mongodb) configuration.toml files into /edgex/cmd
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/core-command/res /edgex/cmd/core-command/res
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/core-data/res /edgex/cmd/core-data/res
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/core-metadata/res /edgex/cmd/core-metadata/res
@@ -66,6 +97,17 @@ COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-l
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-notifications/res /edgex/cmd/support-notifications/res
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/support-scheduler/res /edgex/cmd/support-scheduler/res
 COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd/sys-mgmt-agent/res /edgex/cmd/sys-mgmt-agent/res
+
+# copy all the redis configuration.toml into /edgex/cmd-redis
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/core-command/res /edgex/cmd-redis/core-command/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/core-data/res /edgex/cmd-redis/core-data/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/core-metadata/res /edgex/cmd-redis/core-metadata/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/export-client/res /edgex/cmd-redis/export-client/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/export-distro/res /edgex/cmd-redis/export-distro/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/support-logging/res /edgex/cmd-redis/support-logging/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/support-notifications/res /edgex/cmd-redis/support-notifications/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/support-scheduler/res /edgex/cmd-redis/support-scheduler/res
+COPY --from=build-env $GOPATH/src/github.com/edgexfoundry/edgex-go/cmd-redis/sys-mgmt-agent/res /edgex/cmd-redis/sys-mgmt-agent/res
 
 ENTRYPOINT ["/edgex/cmd/config-seed/config-seed"]
 CMD ["--profile=docker", "--cmd=/edgex/cmd"]


### PR DESCRIPTION
This is my proposal to solve #1347 (in contrast with #1348).

Specifically this PR is different in that in order for the config-seed container to support Redis, we just make copies of all the config files that are currently under `/edgex/cmd` at `/edgex/cmd-redis`, then use some simple shell tools (`toml2json`, `jq` and `json2toml`) to modify some of the configuration.toml files in the `cmd-redis` directory with Redis configuration. 

I originally had thought that the increased total file size would be 9 KB, but I measured it as actually 16 KB, which I still think is very minimal. You can measure this by building the config-seed container and getting the size with:
```
$ echo "$(docker image inspect redis-config-seed --format='{{.Size}}') - $(docker image inspect mongo-config-seed --format='{{.Size}}')" | bc
16968
```
(where `mongo-config-seed` is a local image built from of current master config-seed Dockerfile and `redis-config-seed` is a local image built from this branch's config-seed Dockerfile).

## Justification

I think this PR is better than #1348 for a few reasons:
* A slight increase in complexity of the docker build process offsets a slight increase in complexity of the go code because it has smaller scope
* Less maintenance burden for the config-seed options handling - less options means config-seed is simpler to use and simpler to maintain
* Lets us handle the larger problem for overwriting config keys from the command line using config-seed in a more general way for Fuji or Geneva

## Testing

To test this, I first modified the redis docker-compose file for delhi to delete the device-virtual and portainer containers, and then reference the local `1.0.0-dev` tags of the containers with this patch to the developer-scripts repo:

<details>

```patch
diff --git a/compose-files/docker-compose-redis-delhi-0.7.1.yml b/compose-files/docker-compose-redis-delhi-0.7.1.yml
index e75f299..1013ad9 100644
--- a/compose-files/docker-compose-redis-delhi-0.7.1.yml
+++ b/compose-files/docker-compose-redis-delhi-0.7.1.yml
@@ -57,7 +57,7 @@ services:
       - volume  
 
   config-seed:
-    image: edgexfoundry/docker-core-config-seed-go:0.7.1
+    image: edgexfoundry/docker-core-config-seed-go:1.0.0-dev
     container_name: edgex-config-seed
     hostname: edgex-core-config-seed
     networks:
@@ -103,7 +103,7 @@ services:
       - volume
 
   logging:
-    image: edgexfoundry/docker-support-logging-go:0.7.1
+    image: edgexfoundry/docker-support-logging-go:1.0.0-dev
     ports:
       - "48061:48061"
     container_name: edgex-support-logging
@@ -121,7 +121,7 @@ services:
       - volume
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go:0.7.1
+    image: edgexfoundry/docker-support-notifications-go:1.0.0-dev
     ports:
       - "48060:48060"
     container_name: edgex-support-notifications
@@ -137,7 +137,7 @@ services:
       - logging
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go:0.7.1
+    image: edgexfoundry/docker-core-metadata-go:1.0.0-dev
     ports:
       - "48081:48081"
     container_name: edgex-core-metadata
@@ -153,7 +153,7 @@ services:
       - logging
 
   data:
-    image: edgexfoundry/docker-core-data-go:0.7.1
+    image: edgexfoundry/docker-core-data-go:1.0.0-dev
     ports:
       - "48080:48080"
       - "5563:5563"
@@ -170,7 +170,7 @@ services:
       - logging
 
   command:
-    image: edgexfoundry/docker-core-command-go:0.7.1
+    image: edgexfoundry/docker-core-command-go:1.0.0-dev
     ports:
       - "48082:48082"
     container_name: edgex-core-command
@@ -186,7 +186,7 @@ services:
       - metadata
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go:0.7.1
+    image: edgexfoundry/docker-support-scheduler-go:1.0.0-dev
     ports:
       - "48085:48085"
     container_name: edgex-support-scheduler
@@ -202,7 +202,7 @@ services:
       - metadata
 
   export-client:
-    image: edgexfoundry/docker-export-client-go:0.7.1
+    image: edgexfoundry/docker-export-client-go:1.0.0-dev
     ports:
       - "48071:48071"
     container_name: edgex-export-client
@@ -222,7 +222,7 @@ services:
       - EXPORT_CLIENT_CONSUL_HOST=edgex-config-seed
 
   export-distro:
-    image: edgexfoundry/docker-export-distro-go:0.7.1
+    image: edgexfoundry/docker-export-distro-go:1.0.0-dev
     ports:
       - "48070:48070"
       - "5566:5566"
@@ -262,23 +262,6 @@ services:
 # Device Services
 #################################################################
 
-  device-virtual:
-    image: edgexfoundry/docker-device-virtual:0.6.0
-    ports:
-      - "49990:49990"
-    container_name: edgex-device-virtual
-    hostname: edgex-device-virtual
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-    depends_on:
-      - data
-      - command
-
 #  device-random:
 #    image: edgexfoundry/docker-device-random-go:0.7.1
 #    ports:
@@ -428,17 +411,6 @@ services:
 # Tooling
 #################################################################
 
-  portainer:
-    image:  portainer/portainer
-    ports:
-      - "9000:9000"
-    command: -H unix:///var/run/docker.sock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - portainer_data:/data
-    depends_on:
-      - volume  
-
 networks:
   edgex-network:
     driver: "bridge"
```
</details>

Then I started that running with:
```
docker-compose -f compose-files/docker-compose-redis-delhi-0.7.1.yml up -d
```
And then checked in consul that all the keys were set for mongodb under `edgex/core/1.0/core-command/databases/primary` for all of the services that use the database layer.
That confirms that the container works for mongodb.

After, I applied a slightly different patch to the docker-compose file to overwrite the `command` for the config-seed container to use `--profile=docker --cmd=/edgex/cmd-redis` instead of the default in order to use redis. The patch is here:

<details>

```patch
diff --git a/compose-files/docker-compose-redis-delhi-0.7.1.yml b/compose-files/docker-compose-redis-delhi-0.7.1.yml
index e75f299..7cfd3aa 100644
--- a/compose-files/docker-compose-redis-delhi-0.7.1.yml
+++ b/compose-files/docker-compose-redis-delhi-0.7.1.yml
@@ -57,7 +57,8 @@ services:
       - volume  
 
   config-seed:
-    image: edgexfoundry/docker-core-config-seed-go:0.7.1
+    image: edgexfoundry/docker-core-config-seed-go:1.0.0-dev
+    command: ["--profile=docker","--cmd=/edgex/cmd-redis"]
     container_name: edgex-config-seed
     hostname: edgex-core-config-seed
     networks:
@@ -103,7 +104,7 @@ services:
       - volume
 
   logging:
-    image: edgexfoundry/docker-support-logging-go:0.7.1
+    image: edgexfoundry/docker-support-logging-go:1.0.0-dev
     ports:
       - "48061:48061"
     container_name: edgex-support-logging
@@ -121,7 +122,7 @@ services:
       - volume
 
   notifications:
-    image: edgexfoundry/docker-support-notifications-go:0.7.1
+    image: edgexfoundry/docker-support-notifications-go:1.0.0-dev
     ports:
       - "48060:48060"
     container_name: edgex-support-notifications
@@ -137,7 +138,7 @@ services:
       - logging
 
   metadata:
-    image: edgexfoundry/docker-core-metadata-go:0.7.1
+    image: edgexfoundry/docker-core-metadata-go:1.0.0-dev
     ports:
       - "48081:48081"
     container_name: edgex-core-metadata
@@ -153,7 +154,7 @@ services:
       - logging
 
   data:
-    image: edgexfoundry/docker-core-data-go:0.7.1
+    image: edgexfoundry/docker-core-data-go:1.0.0-dev
     ports:
       - "48080:48080"
       - "5563:5563"
@@ -170,7 +171,7 @@ services:
       - logging
 
   command:
-    image: edgexfoundry/docker-core-command-go:0.7.1
+    image: edgexfoundry/docker-core-command-go:1.0.0-dev
     ports:
       - "48082:48082"
     container_name: edgex-core-command
@@ -186,7 +187,7 @@ services:
       - metadata
 
   scheduler:
-    image: edgexfoundry/docker-support-scheduler-go:0.7.1
+    image: edgexfoundry/docker-support-scheduler-go:1.0.0-dev
     ports:
       - "48085:48085"
     container_name: edgex-support-scheduler
@@ -202,7 +203,7 @@ services:
       - metadata
 
   export-client:
-    image: edgexfoundry/docker-export-client-go:0.7.1
+    image: edgexfoundry/docker-export-client-go:1.0.0-dev
     ports:
       - "48071:48071"
     container_name: edgex-export-client
@@ -222,7 +223,7 @@ services:
       - EXPORT_CLIENT_CONSUL_HOST=edgex-config-seed
 
   export-distro:
-    image: edgexfoundry/docker-export-distro-go:0.7.1
+    image: edgexfoundry/docker-export-distro-go:1.0.0-dev
     ports:
       - "48070:48070"
       - "5566:5566"
@@ -262,23 +263,6 @@ services:
 # Device Services
 #################################################################
 
-  device-virtual:
-    image: edgexfoundry/docker-device-virtual:0.6.0
-    ports:
-      - "49990:49990"
-    container_name: edgex-device-virtual
-    hostname: edgex-device-virtual
-    networks:
-      - edgex-network
-    volumes:
-      - db-data:/data/db
-      - log-data:/edgex/logs
-      - consul-config:/consul/config
-      - consul-data:/consul/data
-    depends_on:
-      - data
-      - command
-
 #  device-random:
 #    image: edgexfoundry/docker-device-random-go:0.7.1
 #    ports:
@@ -428,17 +412,6 @@ services:
 # Tooling
 #################################################################
 
-  portainer:
-    image:  portainer/portainer
-    ports:
-      - "9000:9000"
-    command: -H unix:///var/run/docker.sock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - portainer_data:/data
-    depends_on:
-      - volume  
-
 networks:
   edgex-network:
     driver: "bridge"
```

</details>

Then I started that running with:
```
docker-compose -f compose-files/docker-compose-redis-delhi-0.7.1.yml up -d
```
And then checked in consul that all the keys were set for redisdb under `edgex/core/1.0/core-command/databases/primary` for all of the services that use the database layer.
That confirms that the container works for redisdb.