### PR TITLE
Fixed logging issue when bootstrapping

### DIFF
--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -73,7 +73,10 @@ func main() {
 }
 
 func logBeforeInit(err error) {
-	scheduler.LoggingClient = logger.NewClient(clients.SupportSchedulerServiceKey, false, "", models.InfoLog)
+	if scheduler.LoggingClient == nil {
+		scheduler.LoggingClient = logger.NewClient(clients.SupportSchedulerServiceKey, false, "", models.InfoLog)
+	}
+
 	scheduler.LoggingClient.Error(err.Error())
 }
 


### PR DESCRIPTION
Fix #1138

Added a guard around the logic which handles logging before an
application has completely bootstrapped. Previous to this commit the
Logging client was being initialized twice and during the second
initialization there would be an error which then lead to nothing being
logged before the application exited with a non-zero status

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>