### PR TITLE
Export-Distro Send Correct HTTP Content-Type for CBOR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0
-	github.com/edgexfoundry/go-mod-messaging v0.0.0-20190516182930-407d7a2e54f0
-	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.1
+	github.com/edgexfoundry/go-mod-messaging v0.0.0
+	github.com/edgexfoundry/go-mod-registry v0.0.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0
 	github.com/go-stack/stack v1.8.0 // indirect

--- a/internal/export/distro/httpsender_test.go
+++ b/internal/export/distro/httpsender_test.go
@@ -104,6 +104,7 @@ func TestHttpSender(t *testing.T) {
 			sender := newHTTPSender(addressableTest)
 
 			ctx := context.WithValue(context.Background(), clients.CorrelationHeader, uuid.New().String())
+			ctx = context.WithValue(ctx, clients.ContentType, clients.ContentTypeJSON)
 			sender.Send(msg, ctx)
 		})
 	}


### PR DESCRIPTION
Fix #1366

- For HTTP export, Content-Type header was always JSON even when sending
  CBOR content.
- Streamlined context handling to eliminate unneccesary duplication
- Found that for CBOR events, CBOR Content-Type was being sent back to
  core-data during MarkPushed operations.
- In HTTP export, added WARN log output for status codes returned other
  than 200.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>