### PR TITLE
Set snap release metadata to fuji

### DIFF
--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -3,4 +3,4 @@
 # save this revision for when we run again in the post-refresh
 snapctl set lastrev="$SNAP_REVISION"
 
-snapctl set release="edinburgh"
+snapctl set release="fuji"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ description: |
 icon: snap/local/assets/edgex-snap-icon.png
 
 # delhi is epoch 0, edinburgh epoch 1, etc.
-epoch: 1
+epoch: 2
 
 # TODO: add armhf here when that's supported
 architectures:


### PR DESCRIPTION
This was missed in PR #1319 since the PR was merged after edinburgh was
branched, but for master now we want fuji as the release.

Also set epoch to 2 for fuji to prevent automatic edinburgh -> fuji
upgrades until we have a migration strategy ready that will use an epoch
of 2* (to read epoch 1 and write epoch 2).