### PR TITLE
Build consul 1.3.1 in the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -397,8 +397,12 @@ parts:
     after: [go]
     plugin: make
     source: https://github.com/hashicorp/consul.git
-    source-tag: v1.1.0
+    source-tag: v1.3.1
     source-depth: 1
+    stage: 
+      # duplicated file with the deps of vault, so just drop this one and use
+      # the file from the vault part instead
+      - -usr/share/doc/github.com/patrickmn/go-cache/LICENSE
     override-build: |
       . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
       gopartbootstrap github.com/hashicorp/consul


### PR DESCRIPTION
Fixes #836 for the Fuji version of the snap.

This will need a back-port to Edinburgh branch after #1389 is merged.