### PR TITLE
snapcraft.yaml: update registry arg for dev svcs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -281,7 +281,9 @@ apps:
       - core-data
       - core-metadata
       - support-logging
-    command: bin/device-random -confdir $SNAP_DATA/config/device-random -profile res --registry
+    command: bin/device-random -confdir $SNAP_DATA/config/device-random -profile res --registry $CONSUL_ADDR
+    environment:
+      CONSUL_ADDR: "consul://localhost:8500"
     daemon: simple
     plugs: [network, network-bind]
   device-virtual:
@@ -293,7 +295,9 @@ apps:
       - core-data
       - core-metadata
       - support-logging
-    command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual -profile res --registry
+    command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual -profile res --registry $CONSUL_ADDR
+    environment:
+      CONSUL_ADDR: "consul://localhost:8500"
     daemon: simple
     plugs: [network, network-bind]
 


### PR DESCRIPTION
The registry arg is now a --key=val style option, where the value is
a custom URL spec with the scheme as the registry type. Since the snap
only works with consul for now, the scheme is just "consul".

Note we have to specify the value as an environment variable because
snapd doesn't allow the ":" character in a app's command spec. See
https://bugs.launchpad.net/snapd/+bug/1827392 for the upstream
bug/feature request to snapd.