### PR TITLE
Upgrade to Go 1.12

### DIFF
--- a/cmd/config-seed/Dockerfile
+++ b/cmd/config-seed/Dockerfile
@@ -16,7 +16,7 @@
 ###############################################################################
 
 # Docker image for building EdgeX Foundry Config Seed
-FROM golang:1.11-alpine AS build-env
+FROM golang:1.12-alpine AS build-env
 
 # environment variables
 ENV GO111MODULE=on

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # Docker image for Golang Core Data micro service 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/export-client/Dockerfile
+++ b/cmd/export-client/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/export-distro/Dockerfile
+++ b/cmd/export-distro/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/support-logging/Dockerfile
+++ b/cmd/support-logging/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/sys-mgmt-agent/Dockerfile
+++ b/cmd/sys-mgmt-agent/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -373,20 +373,20 @@ parts:
       # note - we specifically don't use arch
       case "$(dpkg --print-architecture)" in
         amd64)
-          FILE_NAME=go1.11.9.linux-amd64.tar.gz
-          FILE_HASH=e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608
+          FILE_NAME=go1.12.5.linux-amd64.tar.gz
+          FILE_HASH=aea86e3c73495f205929cfebba0d63f1382c8ac59be081b6351681415f4063cf
           ;;
         arm64)
-          FILE_NAME=go1.11.9.linux-arm64.tar.gz
-          FILE_HASH=892ab6c2510c4caa5905b3b1b6a1d4c6f04e384841fec50881ca2be7e8accf05
+          FILE_NAME=go1.12.5.linux-arm64.tar.gz
+          FILE_HASH=ff09f34935cd189a4912f3f308ec83e4683c309304144eae9cf60ebc552e7cd8
           ;;
         armhf)
-          FILE_NAME=go1.11.9.linux-armv6l.tar.gz
-          FILE_HASH=f0d7b039cae61efdc346669f3459460e3dc03b6c6de528ca107fc53970cba0d1
+          FILE_NAME=go1.12.5.linux-armv6l.tar.gz
+          FILE_HASH=311f5e76c7cec1ec752474a61d837e474b8e750b8e3eed267911ab57c0e5da9a
           ;;
         i386)
-          FILE_NAME=go1.11.9.linux-386.tar.gz
-          FILE_HASH=0fa4001fcf1ef0644e261bf6dde02fc9f10ae4df6d74fda61fc4d3c3cbef1d79
+          FILE_NAME=go1.12.5.linux-386.tar.gz
+          FILE_HASH=146605e13bf337ff3aacd941a816c5d97a8fef8b5817e07fcec4540632085980
           ;;
       esac
       # download the archive, failing on ssl cert problems


### PR DESCRIPTION
Fix #1401

Upgrade Docker images to use Go 1.12 as a base image

Upgrade snap configuration to Go 1.12.5

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>