### PR TITLE
Remove duplicate debug print statement

### DIFF
--- a/internal/support/notifications/distribution_coordinator.go
+++ b/internal/support/notifications/distribution_coordinator.go
@@ -47,6 +47,5 @@ func send(n models.Notification, s models.Subscription) {
 
 func criticalSeverityResend(t models.Transmission) {
 	LoggingClient.Info("Critical severity resend scheduler is triggered.")
-	LoggingClient.Debug("Resending transmission is: " + t.ID + " for: " + t.Notification.Slug)
 	resend(t)
 }


### PR DESCRIPTION
Fix #1420.
Debug print statement in distribution_cordinator.go is a duplicate.
:It is already displayed inside the resend function.

Signed-off-by: Nikolay Stanchev <nstanchev@vmware.com>