### PR TITLE
Persist Commands containg device info

### DIFF
--- a/docs/getting-started/configuration.toml
+++ b/docs/getting-started/configuration.toml
@@ -52,25 +52,17 @@ EnableRemote = false
 File = "./device-simple.log"
 Level = "DEBUG"
 
-# Pre-define Schedule Configuration
-[[Schedules]]
-Name = "10sec-schedule"
-Frequency = "PT10S"
-
-[[ScheduleEvents]]
-Name = "readRandom"
-Schedule = "10sec-schedule"
-  [ScheduleEvents.Addressable]
-  HTTPMethod = "GET"
-  Path = "/api/v1/device/name/RandNum-Device01/Random"
-
 # Pre-define Devices
 [[DeviceList]]
   Name = "RandNum-Device01"
   Profile = "RandNum-Device"
   Description = "Random Number Generator Device"
   Labels = [ "random", "test" ]
-  [DeviceList.Addressable]
-    Address = "random"
-    Port = 300
-    Protocol = "OTHER"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.Other]
+      Address = "random"
+      Port = 300
+  [[DeviceList.AutoEvents]]
+    Resource = "Random"
+    OnChange = false
+    Frequency = "10s"

--- a/docs/getting-started/random-generator-device.yaml
+++ b/docs/getting-started/random-generator-device.yaml
@@ -14,18 +14,18 @@ deviceResources:
             { type: "random" }
         properties:
             value:
-                { type: "INT32", readWrite: "R", defaultValue: "0.00", minimum: "0.00", maximum: "100.00"  }
+                { type: "Int32", readWrite: "R", minimum: "0.00", maximum: "100.00"  }
             units:
                 { type: "String", readWrite: "R", defaultValue: "" }
 
-resources:
+deviceCommands:
     -
         name: "Random"
         get:
             -
                 { operation: "get", object: "randomnumber", property: "value", parameter: "Random" }
 
-commands:
+coreCommands:
   -
     name: "Random"
     get:

--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -22,7 +22,7 @@ import (
 )
 
 func commandByDeviceID(deviceID string, commandID string, body string, isPutCommand bool, ctx context.Context) (string, int) {
-	device, err := mdc.Device(deviceID, ctx)
+	d, err := mdc.Device(deviceID, ctx)
 	if err != nil {
 		LoggingClient.Error(err.Error())
 
@@ -34,18 +34,38 @@ func commandByDeviceID(deviceID string, commandID string, body string, isPutComm
 		}
 	}
 
-	if device.AdminState == contract.Locked {
-		LoggingClient.Error(device.Name + " is in admin locked state")
+	if d.AdminState == contract.Locked {
+		LoggingClient.Error(d.Name + " is in admin locked state")
 		return "", http.StatusLocked
 	}
 
-	for _, c := range device.Profile.CoreCommands {
-		if c.Id == commandID {
-			return commandByDevice(device, c, body, isPutCommand, ctx)
+	//once command service have its own persistence layer this call will be changed.
+	commands, err := cc.CommandsForDevice(d.Id, ctx)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		chk, ok := err.(*types.ErrServiceClient)
+		if ok {
+			return err.Error(), chk.StatusCode
+		} else {
+			return err.Error(), http.StatusInternalServerError
 		}
 	}
-	// command with given commandID does not belong to the device
-	return err.Error(), http.StatusNotFound
+
+	var c contract.Command
+	for _, one := range commands {
+		if commandID == one.Id {
+			c = one
+			break
+		}
+	}
+
+	if c.String() == (contract.Command{}).String() {
+		errMsg := fmt.Sprintf("Command with id '%v' does not belong to device with id '%v'.", commandID, deviceID)
+		LoggingClient.Error(errMsg)
+		return errMsg, http.StatusNotFound
+	}
+
+	return commandByDevice(d, c, body, isPutCommand, ctx)
 }
 
 func commandByNames(dn string, cn string, body string, isPutCommand bool, ctx context.Context) (string, int) {
@@ -59,10 +79,20 @@ func commandByNames(dn string, cn string, body string, isPutCommand bool, ctx co
 			return err.Error(), http.StatusInternalServerError
 		}
 	}
+	//once command service has its own persistence layer, we will directly read from the db getCommandByNameAndDeviceID
+	var commands []contract.Command
+	if commands, err = cc.CommandsForDevice(d.Id, ctx); err != nil {
+		LoggingClient.Error(err.Error())
+		chk, ok := err.(*types.ErrServiceClient)
+		if ok {
+			return err.Error(), chk.StatusCode
+		} else {
+			return err.Error(), http.StatusInternalServerError
+		}
+	}
 
-	//Match command name with commands associated with Device Profile.
 	var c contract.Command
-	for _, one := range d.Profile.CoreCommands {
+	for _, one := range commands {
 		if cn == one.Name {
 			c = one
 			break
@@ -111,7 +141,17 @@ func getCommands(ctx context.Context) (int, []contract.CommandResponse, error) {
 	}
 	var cr []contract.CommandResponse
 	for _, d := range devices {
-		cr = append(cr, contract.CommandResponseFromDevice(d, d.Profile.CoreCommands, Configuration.Service.Url()))
+		commands, err := cc.CommandsForDevice(d.Id, ctx)
+		if err != nil {
+			LoggingClient.Error(err.Error())
+			chk, ok := err.(*types.ErrServiceClient)
+			if ok {
+				return chk.StatusCode, nil, err
+			} else {
+				return http.StatusInternalServerError, nil, err
+			}
+		}
+		cr = append(cr, contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()))
 	}
 	return http.StatusOK, cr, err
 
@@ -127,7 +167,19 @@ func getCommandsByDeviceID(did string, ctx context.Context) (int, contract.Comma
 			return http.StatusInternalServerError, contract.CommandResponse{}, err
 		}
 	}
-	return http.StatusOK, contract.CommandResponseFromDevice(d, d.Profile.CoreCommands, Configuration.Service.Url()), err
+
+	commands, err := cc.CommandsForDevice(d.Id, ctx)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		chk, ok := err.(*types.ErrServiceClient)
+		if ok {
+			return chk.StatusCode, contract.CommandResponse{}, err
+		} else {
+			return http.StatusInternalServerError, contract.CommandResponse{}, err
+		}
+	}
+
+	return http.StatusOK, contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()), err
 }
 
 func getCommandsByDeviceName(dn string, ctx context.Context) (int, contract.CommandResponse, error) {
@@ -140,5 +192,17 @@ func getCommandsByDeviceName(dn string, ctx context.Context) (int, contract.Comm
 			return http.StatusInternalServerError, contract.CommandResponse{}, err
 		}
 	}
-	return http.StatusOK, contract.CommandResponseFromDevice(d, d.Profile.CoreCommands, Configuration.Service.Url()), err
+
+	commands, err := cc.CommandsForDevice(d.Id, ctx)
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		chk, ok := err.(*types.ErrServiceClient)
+		if ok {
+			return chk.StatusCode, contract.CommandResponse{}, err
+		} else {
+			return http.StatusInternalServerError, contract.CommandResponse{}, err
+		}
+	}
+
+	return http.StatusOK, contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()), err
 }

--- a/internal/core/metadata/interfaces/db.go
+++ b/internal/core/metadata/interfaces/db.go
@@ -38,7 +38,7 @@ type DBClient interface {
 	GetDevicesByProfileId(pid string) ([]contract.Device, error)
 	GetDevicesByServiceId(sid string) ([]contract.Device, error)
 	GetDevicesWithLabel(l string) ([]contract.Device, error)
-	AddDevice(d contract.Device) (string, error)
+	AddDevice(d contract.Device, commands []contract.Command) (string, error)
 	DeleteDeviceById(id string) error
 
 	// Device Profile
@@ -90,6 +90,7 @@ type DBClient interface {
 	GetAllCommands() ([]contract.Command, error)
 	GetCommandById(id string) (contract.Command, error)
 	GetCommandByName(id string) ([]contract.Command, error)
+	GetCommandsByDeviceId(id string) ([]contract.Command, error)
 
 	// Scrub all metadata (only used in test)
 	ScrubMetadata() error

--- a/internal/core/metadata/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/interfaces/mocks/DBClient.go
@@ -31,41 +31,20 @@ func (_m *DBClient) AddAddressable(a models.Addressable) (string, error) {
 	return r0, r1
 }
 
-// AddCommand provides a mock function with given fields: c
-func (_m *DBClient) AddCommand(c models.Command) (string, error) {
-	ret := _m.Called(c)
+// AddDevice provides a mock function with given fields: d, commands
+func (_m *DBClient) AddDevice(d models.Device, commands []models.Command) (string, error) {
+	ret := _m.Called(d, commands)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(models.Command) string); ok {
-		r0 = rf(c)
+	if rf, ok := ret.Get(0).(func(models.Device, []models.Command) string); ok {
+		r0 = rf(d, commands)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(models.Command) error); ok {
-		r1 = rf(c)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// AddDevice provides a mock function with given fields: d
-func (_m *DBClient) AddDevice(d models.Device) (string, error) {
-	ret := _m.Called(d)
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func(models.Device) string); ok {
-		r0 = rf(d)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(models.Device) error); ok {
-		r1 = rf(d)
+	if rf, ok := ret.Get(1).(func(models.Device, []models.Command) error); ok {
+		r1 = rf(d, commands)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -164,20 +143,6 @@ func (_m *DBClient) CloseSession() {
 
 // DeleteAddressableById provides a mock function with given fields: id
 func (_m *DBClient) DeleteAddressableById(id string) error {
-	ret := _m.Called(id)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DeleteCommandById provides a mock function with given fields: id
-func (_m *DBClient) DeleteCommandById(id string) error {
 	ret := _m.Called(id)
 
 	var r0 error
@@ -1152,20 +1117,6 @@ func (_m *DBClient) UpdateAddressable(a models.Addressable) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(models.Addressable) error); ok {
 		r0 = rf(a)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdateCommand provides a mock function with given fields: c
-func (_m *DBClient) UpdateCommand(c models.Command) error {
-	ret := _m.Called(c)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(models.Command) error); ok {
-		r0 = rf(c)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/core/metadata/rest_command.go
+++ b/internal/core/metadata/rest_command.go
@@ -82,3 +82,28 @@ func restGetCommandByName(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(results)
 }
+
+func restGetCommandsByDeviceId(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	did, err := url.QueryUnescape(vars[ID])
+	if err != nil {
+		LoggingClient.Error(err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	commands, err := dbClient.GetCommandsByDeviceId(did)
+	if err != nil {
+		if err == db.ErrNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+		LoggingClient.Error(err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(commands)
+
+}

--- a/internal/core/metadata/rest_device.go
+++ b/internal/core/metadata/rest_device.go
@@ -112,7 +112,7 @@ func restAddNewDevice(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Add the device
-	d.Id, err = dbClient.AddDevice(d)
+	d.Id, err = dbClient.AddDevice(d, d.Profile.CoreCommands)
 	if err != nil {
 		if err == db.ErrNotUnique {
 			http.Error(w, "Duplicate name for device", http.StatusConflict)

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -295,11 +295,7 @@ func deleteDeviceProfile(dp models.DeviceProfile, w http.ResponseWriter) error {
 	// Check if the device profile is still in use by devices
 	d, err := dbClient.GetDevicesByProfileId(dp.Id)
 
-	// XXX ErrNotFound should always be returned but this is not consistent in the implementations
-	if err == db.ErrNotFound {
-		err = nil
-		d = []models.Device{}
-	} else if err != nil {
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return err
 	}

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -207,6 +207,9 @@ func loadCommandRoutes(b *mux.Router) {
 	c := b.PathPrefix("/" + COMMAND).Subrouter()
 	c.HandleFunc("/{"+ID+"}", restGetCommandById).Methods(http.MethodGet)
 	c.HandleFunc("/"+NAME+"/{"+NAME+"}", restGetCommandByName).Methods(http.MethodGet)
+
+	d := c.PathPrefix("/" + DEVICE).Subrouter()
+	d.HandleFunc("/{"+ID+"}", restGetCommandsByDeviceId).Methods(http.MethodGet)
 }
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")

--- a/internal/pkg/db/mongo/models/deviceprofile.go
+++ b/internal/pkg/db/mongo/models/deviceprofile.go
@@ -92,7 +92,7 @@ type DeviceProfile struct {
 	Labels          []string          `bson:"labels"`
 	DeviceResources []DeviceResource  `bson:"deviceResources"`
 	DeviceCommands  []ProfileResource `bson:"resources"`
-	CoreCommands    []Command         `bson:"commands"`
+	CoreCommands    []CommandProfile  `bson:"commands"`
 }
 
 func (dp *DeviceProfile) ToContract() (c contract.DeviceProfile, err error) {
@@ -258,7 +258,7 @@ func (dp *DeviceProfile) FromContract(from contract.DeviceProfile) (contractId s
 	}
 
 	for _, command := range from.CoreCommands {
-		var commandModel Command
+		var commandModel CommandProfile
 		if _, err = commandModel.FromContract(command); err != nil {
 			return
 		}

--- a/internal/pkg/db/test/db_metadata.go
+++ b/internal/pkg/db/test/db_metadata.go
@@ -195,7 +195,7 @@ func populateDevice(db interfaces.DBClient, count int) (string, error) {
 			return id, fmt.Errorf("Error creating DeviceProfile: %v", err)
 		}
 
-		id, err = db.AddDevice(d)
+		id, err = db.AddDevice(d, d.Profile.CoreCommands)
 		if err != nil {
 			return id, err
 		}
@@ -894,7 +894,7 @@ func testDBDevice(t *testing.T, db interfaces.DBClient) {
 
 	d := models.Device{}
 	d.Name = "name1"
-	_, err = db.AddDevice(d)
+	_, err = db.AddDevice(d, d.Profile.CoreCommands)
 	if err == nil {
 		t.Fatalf("Should be an error adding an existing name")
 	}


### PR DESCRIPTION
PR https://github.com/edgexfoundry/go-mod-core-contracts/pull/110 need to merged first.

Device Profile have commands saved in denormalized way inside the Profile itself.
When Device is added, DeviceProfile commands are used as template for creating for
new commands. For easy, fast search these commands have reference to the device they belong
via deviceName and deviceId properties.
When the device is deleted, these commands are cleaned up. 
Command service does not anymore get commands from device.DeviceProfile.commands
It use a new function in metadata service: restGetCommandsByDeviceId.
It is added via PR https://github.com/edgexfoundry/go-mod-core-contracts/pull/110
Command service will be rewriten and requests optimized once it has its
own persistence layer.

Fix: https://github.com/edgexfoundry/edgex-go/issues/1268, https://github.com/edgexfoundry/edgex-go/issues/1272, https://github.com/edgexfoundry/edgex-go/issues/1273

Signed-off-by: difince <dianaa@vmware.com>