### PR TITLE
Fix security-api-gateway config file

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -974,7 +974,7 @@ parts:
       mkdir -p $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res
       cp core/res/configuration.toml $SNAPCRAFT_PART_INSTALL/config/security-api-gateway/res/configuration.toml
       sed -i \
-        -e "s@tokenpath = \"res\\\\\\\\admin-token.json\"@tokenpath = \"\$SNAP_DATA/config/security-api-gateway/res/kong-token.json\"@" \
+        -e "s@tokenpath = \"res\\\\\\\\resp-init.json\"@tokenpath = \"\$SNAP_DATA/config/security-api-gateway/res/kong-token.json\"@" \
         -e "s:snis = \"edgex.com\":snis = \"localhost\":" \
         -e "s:host = \"edgex-core-data\":host = \"localhost\":" \
         -e "s:host = \"edgex-core-metadata\":host = \"localhost\":" \


### PR DESCRIPTION
The upstream configuration.toml default value changed such that this sed expression changing the tokenpath to the correct one for the snap no longer applied, leading to edgexproxy being unable to use the token to load the certificates from vault into Kong for Kong to use when serving HTTPS endpoints.

Fixes: #1458 for Edinburgh, will need a forward port to master as well