### PR TITLE
Refactor restGetAddressableByPort to use operators

### DIFF
--- a/internal/core/metadata/operators/addressable/db.go
+++ b/internal/core/metadata/operators/addressable/db.go
@@ -7,4 +7,5 @@ import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 type AddressLoader interface {
 	GetAddressablesByAddress(address string) ([]contract.Addressable, error)
 	GetAddressablesByPublisher(p string) ([]contract.Addressable, error)
+	GetAddressablesByPort(p int) ([]contract.Addressable, error)
 }

--- a/internal/core/metadata/operators/addressable/get.go
+++ b/internal/core/metadata/operators/addressable/get.go
@@ -31,7 +31,7 @@ type PublisherExecutor interface {
 	Execute() ([]contract.Addressable, error)
 }
 
-// PublisherExecutor loads address by way of the operator pattern.
+// addressLoadByPublisher loads address by way of the operator pattern.
 type addressLoadByPublisher struct {
 	database  AddressLoader
 	publisher string
@@ -42,10 +42,33 @@ func (p addressLoadByPublisher) Execute() ([]contract.Addressable, error) {
 	return p.database.GetAddressablesByPublisher(p.publisher)
 }
 
-// NewAddressExecutor creates a PublisherExecutor.
+// NewPublisherExecutor creates a PublisherExecutor.
 func NewPublisherExecutor(db AddressLoader, publisher string) PublisherExecutor {
 	return addressLoadByPublisher{
 		database:  db,
 		publisher: publisher,
 	}
+}
+
+// PortExecutor provides functionality for retrieving addresses from an underlying data-store.
+type PortExecutor interface {
+	Execute() ([]contract.Addressable, error)
+}
+
+// addressByPortLoader loads address by way of the operator pattern.
+type addressByPortLoader struct {
+	database AddressLoader
+	port     int
+}
+
+// Execute retrieves the addressables from the underlying data-store.
+func (n addressByPortLoader) Execute() ([]contract.Addressable, error) {
+	return n.database.GetAddressablesByPort(n.port)
+}
+
+// NewPortExecutor creates a PortExecutor.
+func NewPortExecutor(db AddressLoader, port int) PortExecutor {
+	return addressByPortLoader{
+		database: db,
+		port:     port}
 }

--- a/internal/core/metadata/operators/addressable/get_test.go
+++ b/internal/core/metadata/operators/addressable/get_test.go
@@ -14,6 +14,7 @@ import (
 var AddressName = "TestAddress"
 var PublisherName = "TestPublisher"
 var Error = errors.New("test error")
+var Port = 8080
 var SuccessfulDatabaseResult = []contract.Addressable{
 	{
 		User:       "User1",
@@ -38,13 +39,13 @@ func TestAddressExecutor(t *testing.T) {
 	}{
 		{
 			name:           "Successful database call",
-			mockDb:         createMockAddressLoader("GetAddressablesByAddress", nil, SuccessfulDatabaseResult, AddressName),
+			mockDb:         createMockAddressLoaderName("GetAddressablesByAddress", nil, SuccessfulDatabaseResult, AddressName),
 			expectedResult: SuccessfulDatabaseResult,
 			expectedError:  false,
 		},
 		{
 			name:           "Error database result",
-			mockDb:         createMockAddressLoader("GetAddressablesByAddress", Error, nil, AddressName),
+			mockDb:         createMockAddressLoaderName("GetAddressablesByAddress", Error, nil, AddressName),
 			expectedResult: nil,
 			expectedError:  true,
 		},
@@ -80,13 +81,13 @@ func TestPublisherExecutor(t *testing.T) {
 	}{
 		{
 			name:           "Successful database call",
-			mockDb:         createMockAddressLoader("GetAddressablesByPublisher", nil, SuccessfulDatabaseResult, PublisherName),
+			mockDb:         createMockAddressLoaderName("GetAddressablesByPublisher", nil, SuccessfulDatabaseResult, PublisherName),
 			expectedResult: SuccessfulDatabaseResult,
 			expectedError:  false,
 		},
 		{
 			name:           "Error database result",
-			mockDb:         createMockAddressLoader("GetAddressablesByPublisher", Error, nil, PublisherName),
+			mockDb:         createMockAddressLoaderName("GetAddressablesByPublisher", Error, nil, PublisherName),
 			expectedResult: nil,
 			expectedError:  true,
 		},
@@ -113,7 +114,55 @@ func TestPublisherExecutor(t *testing.T) {
 	}
 }
 
-func createMockAddressLoader(methodName string, err error, ret interface{}, arg string) AddressLoader {
+func TestPortExecutor(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockDb         AddressLoader
+		expectedResult []contract.Addressable
+		expectedError  bool
+	}{
+		{
+			name:           "Successful database call",
+			mockDb:         createMockAddressLoaderPort("GetAddressablesByPort", nil, SuccessfulDatabaseResult, Port),
+			expectedResult: SuccessfulDatabaseResult,
+			expectedError:  false,
+		},
+		{
+			name:           "Error database result",
+			mockDb:         createMockAddressLoaderPort("GetAddressablesByPort", Error, nil, Port),
+			expectedResult: nil,
+			expectedError:  true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			op := NewPortExecutor(test.mockDb, Port)
+			actual, err := op.Execute()
+			if test.expectedError && err == nil {
+				t.Error("Expected an error")
+				return
+			}
+
+			if !test.expectedError && err != nil {
+				t.Errorf("Unexpectedly encountered error: %s", err.Error())
+				return
+			}
+
+			if !reflect.DeepEqual(test.expectedResult, actual) {
+				t.Errorf("Expected result does not match the observed. \nExpected : %v \n Observed: %v", test.expectedResult, actual)
+				return
+			}
+		})
+	}
+}
+
+func createMockAddressLoaderName(methodName string, err error, ret interface{}, arg string) AddressLoader {
+	dbMock := &mocks.AddressLoader{}
+	dbMock.On(methodName, arg).Return(ret, err)
+	return dbMock
+}
+
+func createMockAddressLoaderPort(methodName string, err error, ret interface{}, arg int) AddressLoader {
 	dbMock := &mocks.AddressLoader{}
 	dbMock.On(methodName, arg).Return(ret, err)
 	return dbMock

--- a/internal/core/metadata/operators/addressable/mocks/AddressLoader.go
+++ b/internal/core/metadata/operators/addressable/mocks/AddressLoader.go
@@ -33,6 +33,29 @@ func (_m *AddressLoader) GetAddressablesByAddress(address string) ([]models.Addr
 	return r0, r1
 }
 
+// GetAddressablesByPort provides a mock function with given fields: p
+func (_m *AddressLoader) GetAddressablesByPort(p int) ([]models.Addressable, error) {
+	ret := _m.Called(p)
+
+	var r0 []models.Addressable
+	if rf, ok := ret.Get(0).(func(int) []models.Addressable); ok {
+		r0 = rf(p)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Addressable)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int) error); ok {
+		r1 = rf(p)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAddressablesByPublisher provides a mock function with given fields: p
 func (_m *AddressLoader) GetAddressablesByPublisher(p string) ([]models.Addressable, error) {
 	ret := _m.Called(p)

--- a/internal/core/metadata/rest_addressable.go
+++ b/internal/core/metadata/rest_addressable.go
@@ -272,7 +272,8 @@ func restGetAddressableByPort(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := dbClient.GetAddressablesByPort(p)
+	op := addressable.NewPortExecutor(dbClient, p)
+	res, err := op.Execute()
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Fix #1489

Refactor the `restGetAddressableByPort` REST function handler to use the
operator pattern in efforts to increase unit test coverage.

Update the `restGetAddressableByPort` to use the PortExecutor operator
rather than directly using the DBClient. This will allow for easy
mocking during testing.

Add tests for the newly added PortExecutor operator and all of the
necessary layers needed by the operator.

Add tests for the REST handler `restGetAddressableByPort` to cover the
different situations the function is expected to handle.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>