### PR TITLE
Refactor restGetAddressableByTopic to use operator

### DIFF
--- a/internal/core/metadata/operators/addressable/db.go
+++ b/internal/core/metadata/operators/addressable/db.go
@@ -8,4 +8,5 @@ type AddressLoader interface {
 	GetAddressablesByAddress(address string) ([]contract.Addressable, error)
 	GetAddressablesByPublisher(p string) ([]contract.Addressable, error)
 	GetAddressablesByPort(p int) ([]contract.Addressable, error)
+	GetAddressablesByTopic(t string) ([]contract.Addressable, error)
 }

--- a/internal/core/metadata/operators/addressable/get.go
+++ b/internal/core/metadata/operators/addressable/get.go
@@ -72,3 +72,26 @@ func NewPortExecutor(db AddressLoader, port int) PortExecutor {
 		database: db,
 		port:     port}
 }
+
+// TopicExecutor provides functionality for retrieving addresses from an underlying data-store.
+type TopicExecutor interface {
+	Execute() ([]contract.Addressable, error)
+}
+
+// addressByTopicLoader loads address by way of the operator pattern.
+type addressByTopicLoader struct {
+	database AddressLoader
+	topic    string
+}
+
+// Execute retrieves the addressables from the underlying data-store.
+func (n addressByTopicLoader) Execute() ([]contract.Addressable, error) {
+	return n.database.GetAddressablesByTopic(n.topic)
+}
+
+// NewTopicExecutor creates a TopicExecutor.
+func NewTopicExecutor(db AddressLoader, topic string) TopicExecutor {
+	return addressByTopicLoader{
+		database: db,
+		topic:    topic}
+}

--- a/internal/core/metadata/operators/addressable/get_test.go
+++ b/internal/core/metadata/operators/addressable/get_test.go
@@ -13,6 +13,7 @@ import (
 
 var AddressName = "TestAddress"
 var PublisherName = "TestPublisher"
+var Topic = "TestTopic"
 var Error = errors.New("test error")
 var Port = 8080
 var SuccessfulDatabaseResult = []contract.Addressable{
@@ -39,13 +40,13 @@ func TestAddressExecutor(t *testing.T) {
 	}{
 		{
 			name:           "Successful database call",
-			mockDb:         createMockAddressLoaderName("GetAddressablesByAddress", nil, SuccessfulDatabaseResult, AddressName),
+			mockDb:         createMockAddressLoaderStringArg("GetAddressablesByAddress", nil, SuccessfulDatabaseResult, AddressName),
 			expectedResult: SuccessfulDatabaseResult,
 			expectedError:  false,
 		},
 		{
 			name:           "Error database result",
-			mockDb:         createMockAddressLoaderName("GetAddressablesByAddress", Error, nil, AddressName),
+			mockDb:         createMockAddressLoaderStringArg("GetAddressablesByAddress", Error, nil, AddressName),
 			expectedResult: nil,
 			expectedError:  true,
 		},
@@ -81,13 +82,13 @@ func TestPublisherExecutor(t *testing.T) {
 	}{
 		{
 			name:           "Successful database call",
-			mockDb:         createMockAddressLoaderName("GetAddressablesByPublisher", nil, SuccessfulDatabaseResult, PublisherName),
+			mockDb:         createMockAddressLoaderStringArg("GetAddressablesByPublisher", nil, SuccessfulDatabaseResult, PublisherName),
 			expectedResult: SuccessfulDatabaseResult,
 			expectedError:  false,
 		},
 		{
 			name:           "Error database result",
-			mockDb:         createMockAddressLoaderName("GetAddressablesByPublisher", Error, nil, PublisherName),
+			mockDb:         createMockAddressLoaderStringArg("GetAddressablesByPublisher", Error, nil, PublisherName),
 			expectedResult: nil,
 			expectedError:  true,
 		},
@@ -123,13 +124,13 @@ func TestPortExecutor(t *testing.T) {
 	}{
 		{
 			name:           "Successful database call",
-			mockDb:         createMockAddressLoaderPort("GetAddressablesByPort", nil, SuccessfulDatabaseResult, Port),
+			mockDb:         createMockAddressLoaderIntArg("GetAddressablesByPort", nil, SuccessfulDatabaseResult, Port),
 			expectedResult: SuccessfulDatabaseResult,
 			expectedError:  false,
 		},
 		{
 			name:           "Error database result",
-			mockDb:         createMockAddressLoaderPort("GetAddressablesByPort", Error, nil, Port),
+			mockDb:         createMockAddressLoaderIntArg("GetAddressablesByPort", Error, nil, Port),
 			expectedResult: nil,
 			expectedError:  true,
 		},
@@ -156,13 +157,55 @@ func TestPortExecutor(t *testing.T) {
 	}
 }
 
-func createMockAddressLoaderName(methodName string, err error, ret interface{}, arg string) AddressLoader {
+func TestTopicExecutor(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockDb         AddressLoader
+		expectedResult []contract.Addressable
+		expectedError  bool
+	}{
+		{
+			name:           "Successful database call",
+			mockDb:         createMockAddressLoaderStringArg("GetAddressablesByTopic", nil, SuccessfulDatabaseResult, Topic),
+			expectedResult: SuccessfulDatabaseResult,
+			expectedError:  false,
+		},
+		{
+			name:           "Error database result",
+			mockDb:         createMockAddressLoaderStringArg("GetAddressablesByTopic", Error, nil, Topic),
+			expectedResult: nil,
+			expectedError:  true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			op := NewTopicExecutor(test.mockDb, Topic)
+			actual, err := op.Execute()
+			if test.expectedError && err == nil {
+				t.Error("Expected an error")
+				return
+			}
+
+			if !test.expectedError && err != nil {
+				t.Errorf("Unexpectedly encountered error: %s", err.Error())
+				return
+			}
+
+			if !reflect.DeepEqual(test.expectedResult, actual) {
+				t.Errorf("Expected result does not match the observed. \nExpected : %v \n Observed: %v", test.expectedResult, actual)
+				return
+			}
+		})
+	}
+}
+
+func createMockAddressLoaderStringArg(methodName string, err error, ret interface{}, arg string) AddressLoader {
 	dbMock := &mocks.AddressLoader{}
 	dbMock.On(methodName, arg).Return(ret, err)
 	return dbMock
 }
 
-func createMockAddressLoaderPort(methodName string, err error, ret interface{}, arg int) AddressLoader {
+func createMockAddressLoaderIntArg(methodName string, err error, ret interface{}, arg int) AddressLoader {
 	dbMock := &mocks.AddressLoader{}
 	dbMock.On(methodName, arg).Return(ret, err)
 	return dbMock

--- a/internal/core/metadata/operators/addressable/mocks/AddressLoader.go
+++ b/internal/core/metadata/operators/addressable/mocks/AddressLoader.go
@@ -78,3 +78,26 @@ func (_m *AddressLoader) GetAddressablesByPublisher(p string) ([]models.Addressa
 
 	return r0, r1
 }
+
+// GetAddressablesByTopic provides a mock function with given fields: t
+func (_m *AddressLoader) GetAddressablesByTopic(t string) ([]models.Addressable, error) {
+	ret := _m.Called(t)
+
+	var r0 []models.Addressable
+	if rf, ok := ret.Get(0).(func(string) []models.Addressable); ok {
+		r0 = rf(t)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Addressable)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(t)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/internal/core/metadata/rest_addressable.go
+++ b/internal/core/metadata/rest_addressable.go
@@ -252,7 +252,8 @@ func restGetAddressableByTopic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := dbClient.GetAddressablesByTopic(t)
+	op := addressable.NewTopicExecutor(dbClient, t)
+	res, err := op.Execute()
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/core/metadata/rest_addressable_test.go
+++ b/internal/core/metadata/rest_addressable_test.go
@@ -16,15 +16,17 @@ import (
 )
 
 // TestURI this is not really used since we are using the HTTP testing framework and not creating routes, but rather
-// creating a specific handler which will accept all requests. Therefore, the URI is not important
+// creating a specific handler which will accept all requests. Therefore, the URI is not important.
 var TestURI = "/addressable"
 var TestAddress = "TestAddress"
 var TestPort = 8080
+var TestPublisher = "TestPublisher"
+var TestTopic = "TestTopic"
 
 // ErrorPathParam path parameter value which will trigger the 'mux.Vars' function to throw an error due to the '%' not being followed by a valid hexadecimal number.
 var ErrorPathParam = "%zz"
 
-// ErrorPortPathParam path parameter used to trigger an error in the `restGetAddressableByPort` function where the port variable is expected to be a number
+// ErrorPortPathParam path parameter used to trigger an error in the `restGetAddressableByPort` function where the port variable is expected to be a number.
 var ErrorPortPathParam = "abc"
 
 func TestGetAddressablesByAddress(t *testing.T) {
@@ -34,11 +36,37 @@ func TestGetAddressablesByAddress(t *testing.T) {
 		dbMock         interfaces.DBClient
 		expectedStatus int
 	}{
-		{"OK", createRequest(ADDRESS, TestAddress), createMockAddressLoaderForAddressName(1, "GetAddressablesByAddress"), http.StatusOK},
-		{"OK(Multiple matches)", createRequest(ADDRESS, TestAddress), createMockAddressLoaderForAddressName(3, "GetAddressablesByAddress"), http.StatusOK},
-		{"OK(No matches)", createRequest(ADDRESS, TestAddress), createMockAddressLoaderForAddressName(0, "GetAddressablesByAddress"), http.StatusOK},
-		{"Invalid TestAddress path parameter", createRequest(ADDRESS, ErrorPathParam), createMockAddressLoaderForAddressName(1, "GetAddressablesByAddress"), http.StatusBadRequest},
-		{"Internal Server Error", createRequest(ADDRESS, TestAddress), createErrorMockAddressLoaderForAddressName("GetAddressablesByAddress"), http.StatusInternalServerError},
+		{
+			"OK",
+			createRequest(ADDRESS, TestAddress),
+			createMockAddressLoaderStringArg(1, "GetAddressablesByAddress", TestAddress),
+			http.StatusOK,
+		},
+		{
+			"OK(Multiple matches)",
+			createRequest(ADDRESS, TestAddress),
+			createMockAddressLoaderStringArg(3, "GetAddressablesByAddress", TestAddress),
+			http.StatusOK,
+		},
+		{
+
+			"OK(No matches)",
+			createRequest(ADDRESS, TestAddress),
+			createMockAddressLoaderStringArg(0, "GetAddressablesByAddress", TestAddress),
+			http.StatusOK,
+		},
+		{
+			"Invalid ADDRESS path parameter",
+			createRequest(ADDRESS, ErrorPathParam),
+			createMockAddressLoaderStringArg(1, "GetAddressablesByAddress", TestAddress),
+			http.StatusBadRequest,
+		},
+		{
+			"Internal Server Error",
+			createRequest(ADDRESS, TestAddress),
+			createErrorMockAddressLoaderStringArg("GetAddressablesByAddress", TestAddress),
+			http.StatusInternalServerError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -62,11 +90,34 @@ func TestGetAddressablesByPublisher(t *testing.T) {
 		dbMock         interfaces.DBClient
 		expectedStatus int
 	}{
-		{"OK", createRequest(PUBLISHER, TestAddress), createMockAddressLoaderForAddressName(1, "GetAddressablesByPublisher"), http.StatusOK},
-		{"OK(Multiple matches)", createRequest(PUBLISHER, TestAddress), createMockAddressLoaderForAddressName(3, "GetAddressablesByPublisher"), http.StatusOK},
-		{"OK(No matches)", createRequest(PUBLISHER, TestAddress), createMockAddressLoaderForAddressName(0, "GetAddressablesByPublisher"), http.StatusOK},
-		{"Invalid TestAddress path parameter", createRequest(PUBLISHER, ErrorPathParam), createMockAddressLoaderForAddressName(1, "GetAddressablesByPublisher"), http.StatusBadRequest},
-		{"Internal Server Error", createRequest(PUBLISHER, TestAddress), createErrorMockAddressLoaderForAddressName("GetAddressablesByPublisher"), http.StatusInternalServerError},
+		{"OK",
+			createRequest(PUBLISHER, TestPublisher),
+			createMockAddressLoaderStringArg(1, "GetAddressablesByPublisher", TestPublisher),
+			http.StatusOK,
+		},
+		{
+			"OK(Multiple matches)",
+			createRequest(PUBLISHER, TestPublisher), createMockAddressLoaderStringArg(3, "GetAddressablesByPublisher", TestPublisher),
+			http.StatusOK,
+		},
+		{
+			"OK(No matches)",
+			createRequest(PUBLISHER, TestPublisher),
+			createMockAddressLoaderStringArg(0, "GetAddressablesByPublisher", TestPublisher),
+			http.StatusOK,
+		},
+		{
+			"Invalid PUBLISHER path parameter",
+			createRequest(PUBLISHER, ErrorPathParam),
+			createMockAddressLoaderStringArg(1, "GetAddressablesByPublisher", TestPublisher),
+			http.StatusBadRequest,
+		},
+		{
+			"Internal Server Error",
+			createRequest(PUBLISHER, TestPublisher),
+			createErrorMockAddressLoaderStringArg("GetAddressablesByPublisher", TestPublisher),
+			http.StatusInternalServerError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -90,12 +141,42 @@ func TestGetAddressablesByPort(t *testing.T) {
 		dbMock         interfaces.DBClient
 		expectedStatus int
 	}{
-		{"OK", createRequest(PORT, strconv.Itoa(TestPort)), createMockAddressLoaderForPort(1, "GetAddressablesByPort"), http.StatusOK},
-		{"OK(Multiple matches)", createRequest(PORT, strconv.Itoa(TestPort)), createMockAddressLoaderForPort(3, "GetAddressablesByPort"), http.StatusOK},
-		{"OK(No matches)", createRequest(PORT, strconv.Itoa(TestPort)), createMockAddressLoaderForPort(0, "GetAddressablesByPort"), http.StatusOK},
-		{"Invalid PORT path parameter", createRequest(PORT, ErrorPathParam), createMockAddressLoaderForPort(1, "GetAddressablesByPort"), http.StatusBadRequest},
-		{"Non integer PORT path parameter", createRequest(PORT, ErrorPortPathParam), createMockAddressLoaderForPort(1, "GetAddressablesByPort"), http.StatusBadRequest},
-		{"Internal Server Error", createRequest(PORT, strconv.Itoa(TestPort)), createErrorMockAddressLoaderPortExecutor("GetAddressablesByPort"), http.StatusInternalServerError},
+		{
+			"OK",
+			createRequest(PORT, strconv.Itoa(TestPort)),
+			createMockAddressLoaderForPort(1, "GetAddressablesByPort"),
+			http.StatusOK,
+		},
+		{
+			"OK(Multiple matches)",
+			createRequest(PORT, strconv.Itoa(TestPort)),
+			createMockAddressLoaderForPort(3, "GetAddressablesByPort"),
+			http.StatusOK,
+		},
+		{
+			"OK(No matches)",
+			createRequest(PORT, strconv.Itoa(TestPort)),
+			createMockAddressLoaderForPort(0, "GetAddressablesByPort"),
+			http.StatusOK,
+		},
+		{
+			"Invalid PORT path parameter",
+			createRequest(PORT, ErrorPathParam),
+			createMockAddressLoaderForPort(1, "GetAddressablesByPort"),
+			http.StatusBadRequest,
+		},
+		{
+			"Non-integer PORT path parameter",
+			createRequest(PORT, ErrorPortPathParam),
+			createMockAddressLoaderForPort(1, "GetAddressablesByPort"),
+			http.StatusBadRequest,
+		},
+		{
+			"Internal Server Error",
+			createRequest(PORT, strconv.Itoa(TestPort)),
+			createErrorMockAddressLoaderPortExecutor("GetAddressablesByPort"),
+			http.StatusInternalServerError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -112,12 +193,65 @@ func TestGetAddressablesByPort(t *testing.T) {
 	}
 }
 
+func TestGetAddressablesByTopic(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        *http.Request
+		dbMock         interfaces.DBClient
+		expectedStatus int
+	}{
+		{
+			"OK",
+			createRequest(TOPIC, TestTopic),
+			createMockAddressLoaderStringArg(1, "GetAddressablesByTopic", TestTopic),
+			http.StatusOK,
+		},
+		{
+			"OK(Multiple matches)",
+			createRequest(TOPIC, TestTopic),
+			createMockAddressLoaderStringArg(3, "GetAddressablesByTopic", TestTopic),
+			http.StatusOK,
+		},
+		{
+			"OK(No matches)",
+			createRequest(TOPIC, TestTopic),
+			createMockAddressLoaderStringArg(0, "GetAddressablesByTopic", TestTopic),
+			http.StatusOK,
+		},
+		{
+			"Invalid TOPIC path parameter",
+			createRequest(TOPIC, ErrorPathParam),
+			createMockAddressLoaderStringArg(1, "GetAddressablesByTopic", TestTopic),
+			http.StatusBadRequest,
+		},
+		{
+			"Internal Server Error",
+			createRequest(TOPIC, TestTopic),
+			createErrorMockAddressLoaderStringArg("GetAddressablesByTopic", TestTopic),
+			http.StatusInternalServerError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbClient = tt.dbMock
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(restGetAddressableByTopic)
+			handler.ServeHTTP(rr, tt.request)
+			response := rr.Result()
+			if response.StatusCode != tt.expectedStatus {
+				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
+				return
+			}
+		})
+	}
+}
+
 func createRequest(pathParamName string, pathParamValue string) *http.Request {
 	req := httptest.NewRequest(http.MethodGet, TestURI, nil)
 	return mux.SetURLVars(req, map[string]string{pathParamName: pathParamValue})
 }
 
-func createMockAddressLoaderForAddressName(howMany int, methodName string) interfaces.DBClient {
+func createMockAddressLoaderStringArg(howMany int, methodName string, arg string) interfaces.DBClient {
 	var addressables []contract.Addressable
 	for i := 0; i < howMany; i++ {
 		addressables = append(addressables, contract.Addressable{
@@ -129,13 +263,7 @@ func createMockAddressLoaderForAddressName(howMany int, methodName string) inter
 	}
 
 	myMock := &mocks.DBClient{}
-	myMock.On(methodName, TestAddress).Return(addressables, nil)
-	return myMock
-}
-
-func createErrorMockAddressLoaderForAddressName(methodName string) interfaces.DBClient {
-	myMock := &mocks.DBClient{}
-	myMock.On(methodName, TestAddress).Return(nil, errors.New("test error"))
+	myMock.On(methodName, arg).Return(addressables, nil)
 	return myMock
 }
 
@@ -152,6 +280,12 @@ func createMockAddressLoaderForPort(howMany int, methodName string) interfaces.D
 
 	myMock := &mocks.DBClient{}
 	myMock.On(methodName, TestPort).Return(addressables, nil)
+	return myMock
+}
+
+func createErrorMockAddressLoaderStringArg(methodName string, arg string) interfaces.DBClient {
+	myMock := &mocks.DBClient{}
+	myMock.On(methodName, arg).Return(nil, errors.New("test error"))
 	return myMock
 }
 


### PR DESCRIPTION
Fix #1492

Refactor the restGetAddressableByTopic REST function handler to use the
operator pattern in efforts to increase unit test coverage.

Update the restGetAddressableByTopic to use the TopicExecutor operator
rather than directly using the DBClient. This will allow for easy
mocking during testing.

Add tests for the newly added TopicExecutor operator and all of the
necessary layers needed by the operator.

Add tests for the REST handler restGetAddressableByTopic to cover the
different situations the function is expected to handle.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>