### PR TITLE
Update reference to go-mod-messaging, fix race condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/eclipse/paho.mqtt.golang v1.1.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
-	github.com/edgexfoundry/go-mod-messaging v0.1.0
+	github.com/edgexfoundry/go-mod-messaging v0.1.5
 	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0

--- a/internal/core/data/event.go
+++ b/internal/core/data/event.go
@@ -252,7 +252,7 @@ func putEventOnQueue(evt models.Event, ctx context.Context) {
 	msgEnvelope := msgTypes.NewMessageEnvelope(evt.Bytes, ctx)
 	err := msgClient.Publish(msgEnvelope, Configuration.MessageQueue.Topic)
 	if err != nil {
-		LoggingClient.Error(fmt.Sprintf("Unable to send message for event: %s", evt.String()))
+		LoggingClient.Error(fmt.Sprintf("Unable to send message for event: %s %v", evt.String(), err))
 	} else {
 		LoggingClient.Info(fmt.Sprintf("Event Published on message queue. Topic: %s, Correlation-id: %s ", Configuration.MessageQueue.Topic, msgEnvelope.CorrelationID))
 	}


### PR DESCRIPTION
Fix #1509

- Also noticed that if an error were to occur during publishing, our
  logging was dropping that from the message. Added error contents to
  log output in this case.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>