### PR TITLE
Replace references to the delhi docker-compose with edinburgh

### DIFF
--- a/docs/examples/Ch-ExamplesAddingModbusDevice.rst
+++ b/docs/examples/Ch-ExamplesAddingModbusDevice.rst
@@ -2,7 +2,7 @@
 Modbus - Adding a Device to EdgeX
 #################################
 
-EdgeX - Delhi Release
+EdgeX - Edinburgh Release
 
 PowerScout 3037 Power Submeter
 
@@ -200,7 +200,7 @@ You can download and use the provided :download:`EdgeX_ExampleModbus_configurati
 Add Device Service to docker-compose File
 -----------------------------------------
 
-Because we deploy EdgeX using docker-compose, we must add the device-modbus to the docker-compose file ( https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/docker-compose-delhi-0.7.0.yml ). If you have prepared configuration files, you can mount them using volumes and change the entrypoint for device-modbus internal use.
+Because we deploy EdgeX using docker-compose, we must add the device-modbus to the docker-compose file ( https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/docker-compose-edinburgh-1.0.0.yml ). If you have prepared configuration files, you can mount them using volumes and change the entrypoint for device-modbus internal use.
 
     .. image:: config_changes.png
         :scale: 50%

--- a/docs/getting-started/Ch-GettingStartedUsers.rst
+++ b/docs/getting-started/Ch-GettingStartedUsers.rst
@@ -60,7 +60,7 @@ Getting and running EdgeX Foundry microservices can also be accomplished more ea
 
 The collection of the EdgeX Foundry Docker compose files are found here:  https://github.com/edgexfoundry/developer-scripts/tree/master/compose-files
 
-Note that most of the Docker Compose files carry a specific version identifier (like california-0.6.0) in the file name.  These Compose files help obtain the specific version of EdgeX.  The docker-compose.yml file will pull the latest tagged EdgeX microservices from Docker Hub.  The docker-compose-nexus.yml will pull the latest microservice images from the developer's Nexus registry which contains the latest built artifacts.  These are typically work-in-progress microservice artifacts and should not be used by most end users.  It is recommended that you use the lastest version of EdgeX Foundry.  As of this writing, the latest version is: Delhi (version 0.7.1)
+Note that most of the Docker Compose files carry a specific version identifier (like california-0.6.0) in the file name.  These Compose files help obtain the specific version of EdgeX.  The docker-compose.yml file will pull the latest tagged EdgeX microservices from Docker Hub.  The docker-compose-nexus.yml will pull the latest microservice images from the developer's Nexus registry which contains the latest built artifacts.  These are typically work-in-progress microservice artifacts and should not be used by most end users.  It is recommended that you use the lastest version of EdgeX Foundry.  As of this writing, the latest version is: Edinburgh (version 1.0.0)
 
 A Docker Compose file is a manifest file, which lists:
 

--- a/docs/quick-start/Ch-QuickStart.rst
+++ b/docs/quick-start/Ch-QuickStart.rst
@@ -18,7 +18,7 @@ The fastest way to start running EdgeX is by using our pre-built Docker images. 
 Running EdgeX
 =============
 
-Once you have Docker and Docker Compose installed, you need the configuration file for downloading and running the EdgeX Foundry docker containers. Download the `latest docker-compose file here <https://github.com/edgexfoundry/developer-scripts/raw/master/compose-files/docker-compose-delhi-0.7.1.yml>`_ and save this as ``docker-compose.yml`` in your local directory. This file contains everything you need to deploy EdgeX with docker.
+Once you have Docker and Docker Compose installed, you need the configuration file for downloading and running the EdgeX Foundry docker containers. Download the `latest docker-compose file here <https://github.com/edgexfoundry/developer-scripts/raw/master/compose-files/docker-compose-edinburgh-1.0.0.yml>`_ and save this as ``docker-compose.yml`` in your local directory. This file contains everything you need to deploy EdgeX with docker.
 
 First, use this command to download the EdgeX Foundry Docker images from Docker Hub::
 

--- a/docs/security/Ch-APIGateway.rst
+++ b/docs/security/Ch-APIGateway.rst
@@ -13,7 +13,7 @@ KONG (https://konghq.com/) is the product underlying the API gateway.  The EdgeX
 Start the API Gateway
 ======================
 
-Start the API gateway with Docker Compose and a Docker Compose manifest file (the Docker Compose file named docker-compose-delhi-0.7.0.yml found at https://github.com/edgexfoundry/developer-scripts/tree/master/compose-files/security)).  This Compose file starts all of EdgeX including the security services. The command to start EdgeX inclusive of API gateway related services is:
+Start the API gateway with Docker Compose and a Docker Compose manifest file (the Docker Compose file named docker-compose-edinburgh-1.0.0.yml found at `https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/docker-compose-edinburgh-1.0.0.yml <https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/docker-compose-edinburgh-1.0.0.yml>`_). Save it as ``docker-compose.yml``.  This Compose file starts all of EdgeX including the security services. The command to start EdgeX inclusive of API gateway related services is:
 ::
 
     docker-compose up -d

--- a/docs/security/Ch-SecretStore.rst
+++ b/docs/security/Ch-SecretStore.rst
@@ -28,12 +28,9 @@ The key features of Vault are:
 Start the Secret Store
 ======================
 
-Start the Secret Store with Docker Compose and a Docker Compose manifest file. The Docker Compose file named docker-compose-delhi-0.7.0.yml can be found at these two locations:
+Start the Secret Store with Docker Compose and a Docker Compose manifest file. The Docker Compose file can be found at `https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/docker-compose-edinburgh-1.0.0.yml <https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/docker-compose-edinburgh-1.0.0.yml>`_. Save it as ``docker-compose.yml``
 
-    * https://github.com/edgexfoundry/security-secret-store/blob/delhi/docker-compose-delhi-0.7.0.yml
-    * https://github.com/edgexfoundry/developer-scripts/blob/master/compose-files/security/docker-compose-delhi-0.7.0.yml
-
-This Compose file starts the entire EdgeX Foundry platform including the security services.
+This Compose file starts the entire EdgeX Foundry platform including the security services. Save it as ``docker-compose.yml``
 
 The command to start EdgeX Foundry platform including the Secret Store and API gateway related services is:
 

--- a/docs/walk-through/Ch-WalkthroughRunning.rst
+++ b/docs/walk-through/Ch-WalkthroughRunning.rst
@@ -16,7 +16,7 @@ A Docker Compose file is a manifest file, which lists:
 * The order in which the containers should be started
 * The parameters under which the containers should be run
 
-It is recommended that you use the lastest version of EdgeX Foundry. As of this writing, the latest version can be found here: https://github.com/edgexfoundry/developer-scripts/raw/master/compose-files/docker-compose-delhi-0.7.1.yml
+It is recommended that you use the lastest version of EdgeX Foundry. As of this writing, the latest version can be found here: https://github.com/edgexfoundry/developer-scripts/raw/master/compose-files/docker-compose-edinburgh-1.0.0.yml
 
 Save this file as ``docker-compose.yml`` in your working directory so that the following commands will find it.
 


### PR DESCRIPTION
Replace references to the delhi docker-compose file with references to the edinburgh docker-compose file. Fixes #1514

Signed-off-by: Michael Hall <mhall119@gmail.com>