### PR TITLE
Add First Steps in Implementing Core-Command Persistent Layer

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -31,3 +31,13 @@ File = './logs/edgex-core-command.log'
   Protocol = 'http'
   Host = 'localhost'
   Port = 48061
+
+[Databases]
+  [Databases.Primary]
+  Host = 'localhost'
+  Name = 'metadata'
+  Password = ''
+  Port = 27017
+  Username = ''
+  Timeout = 5000
+  Type = 'mongodb'

--- a/cmd/core-command/res/docker/configuration.toml
+++ b/cmd/core-command/res/docker/configuration.toml
@@ -31,3 +31,13 @@ File = '/edgex/logs/edgex-core-command.log'
   Protocol = 'http'
   Host = 'edgex-support-logging'
   Port = 48061
+
+[Databases]
+  [Databases.Primary]
+  Host = 'edgex-mongo'
+  Name = 'metadata'
+  Password = 'password'
+  Port = 27017
+  Username = 'meta'
+  Timeout = 5000
+  Type = 'mongodb'

--- a/internal/core/command/interfaces/db.go
+++ b/internal/core/command/interfaces/db.go
@@ -1,0 +1,13 @@
+package interfaces
+
+import (
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type DBClient interface {
+	GetAllCommands() ([]contract.Command, error)
+	GetCommandById(id string) (contract.Command, error)
+	GetCommandsByName(id string) ([]contract.Command, error)
+	GetCommandsByDeviceId(id string) ([]contract.Command, error)
+	GetCommandByNameAndDeviceId(cname string, did string) (contract.Command, error)
+}

--- a/internal/core/metadata/interfaces/db.go
+++ b/internal/core/metadata/interfaces/db.go
@@ -89,8 +89,9 @@ type DBClient interface {
 	// Command
 	GetAllCommands() ([]contract.Command, error)
 	GetCommandById(id string) (contract.Command, error)
-	GetCommandByName(id string) ([]contract.Command, error)
+	GetCommandsByName(id string) ([]contract.Command, error)
 	GetCommandsByDeviceId(id string) ([]contract.Command, error)
+	GetCommandByNameAndDeviceId(cname string, did string) (contract.Command, error)
 
 	// Scrub all metadata (only used in test)
 	ScrubMetadata() error

--- a/internal/core/metadata/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/interfaces/mocks/DBClient.go
@@ -541,8 +541,29 @@ func (_m *DBClient) GetCommandById(id string) (models.Command, error) {
 	return r0, r1
 }
 
-// GetCommandByName provides a mock function with given fields: id
-func (_m *DBClient) GetCommandByName(id string) ([]models.Command, error) {
+// GetCommandByNameAndDeviceId provides a mock function with given fields: cname, did
+func (_m *DBClient) GetCommandByNameAndDeviceId(cname string, did string) (models.Command, error) {
+	ret := _m.Called(cname, did)
+
+	var r0 models.Command
+	if rf, ok := ret.Get(0).(func(string, string) models.Command); ok {
+		r0 = rf(cname, did)
+	} else {
+		r0 = ret.Get(0).(models.Command)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(cname, did)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetCommandsByDeviceId provides a mock function with given fields: id
+func (_m *DBClient) GetCommandsByDeviceId(id string) ([]models.Command, error) {
 	ret := _m.Called(id)
 
 	var r0 []models.Command
@@ -564,8 +585,8 @@ func (_m *DBClient) GetCommandByName(id string) ([]models.Command, error) {
 	return r0, r1
 }
 
-// GetCommandsByDeviceId provides a mock function with given fields: id
-func (_m *DBClient) GetCommandsByDeviceId(id string) ([]models.Command, error) {
+// GetCommandsByName provides a mock function with given fields: id
+func (_m *DBClient) GetCommandsByName(id string) ([]models.Command, error) {
 	ret := _m.Called(id)
 
 	var r0 []models.Command

--- a/internal/core/metadata/rest_command.go
+++ b/internal/core/metadata/rest_command.go
@@ -56,7 +56,7 @@ func restGetCommandById(w http.ResponseWriter, r *http.Request) {
 	pkg.Encode(res, w, LoggingClient)
 }
 
-func restGetCommandByName(w http.ResponseWriter, r *http.Request) {
+func restGetCommandsByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
@@ -64,7 +64,7 @@ func restGetCommandByName(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	results, err := dbClient.GetCommandByName(n)
+	results, err := dbClient.GetCommandsByName(n)
 	if err != nil {
 		if err == db.ErrNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -206,7 +206,7 @@ func loadCommandRoutes(b *mux.Router) {
 
 	c := b.PathPrefix("/" + COMMAND).Subrouter()
 	c.HandleFunc("/{"+ID+"}", restGetCommandById).Methods(http.MethodGet)
-	c.HandleFunc("/"+NAME+"/{"+NAME+"}", restGetCommandByName).Methods(http.MethodGet)
+	c.HandleFunc("/"+NAME+"/{"+NAME+"}", restGetCommandsByName).Methods(http.MethodGet)
 
 	d := c.PathPrefix("/" + DEVICE).Subrouter()
 	d.HandleFunc("/{"+ID+"}", restGetCommandsByDeviceId).Methods(http.MethodGet)

--- a/internal/pkg/db/redis/metadata.go
+++ b/internal/pkg/db/redis/metadata.go
@@ -1159,7 +1159,29 @@ func (c *Client) GetCommandById(id string) (contract.Command, error) {
 	return d, err
 }
 
-func (c *Client) GetCommandByName(n string) ([]contract.Command, error) {
+func (c *Client) GetCommandByNameAndDeviceId(cname string, did string) (contract.Command, error) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, err := getObjectsByValues(conn, db.Command+":name:"+cname,
+		db.Command+":device:"+did)
+	if err != nil {
+		return contract.Command{}, err
+	}
+	if len(objects) != 1 {
+		return contract.Command{}, db.ErrNotFound
+	}
+
+	var cmd contract.Command
+	err = unmarshalObject(objects[0], &cmd)
+	if err != nil {
+		return contract.Command{}, err
+	}
+
+	return cmd, nil
+}
+
+func (c *Client) GetCommandsByName(n string) ([]contract.Command, error) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 

--- a/internal/pkg/db/test/db_metadata.go
+++ b/internal/pkg/db/test/db_metadata.go
@@ -504,7 +504,7 @@ func testDBCommand(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Command should not be found")
 	}
 
-	commands, err = db.GetCommandByName("name1")
+	commands, err = db.GetCommandsByName("name1")
 	if err != nil {
 		t.Fatalf("Error getting commands by name %v", err)
 	}
@@ -512,7 +512,7 @@ func testDBCommand(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("There should be 1 commands instead of %d", len(commands))
 	}
 
-	commands, err = db.GetCommandByName("INVALID")
+	commands, err = db.GetCommandsByName("INVALID")
 	if err != nil {
 		t.Fatalf("Error getting commands by name %v", err)
 	}
@@ -526,6 +526,15 @@ func testDBCommand(t *testing.T, db interfaces.DBClient) {
 	}
 	if len(commands) != 1 {
 		t.Fatalf("There should be 1 commands instead of %d", len(commands))
+	}
+
+	cn := commands[0].Name
+	command, err := db.GetCommandByNameAndDeviceId(cn, did)
+	if err != nil {
+		t.Fatalf("Error getting commands by name and device id: %v", err)
+	}
+	if command.Name != commands[0].Name {
+		t.Fatalf("Name does not match %s - %s", command.Name, cn)
 	}
 
 	commands, err = db.GetCommandsByDeviceId(uuid.New().String())


### PR DESCRIPTION
- Added direct connection from core-command service to "metadata" database
(should be change in future, core-command is supposed to have its own database)
- Added DBClient interface
- Add new GetCommandByNameAndDeviceId function in the BDClient
- Rewrite all functions that called metadata endpoints for quering commands to use
newly edded DBClient interface
- rename GetCommandByName function to GetCommandsByName (plural)

Fix: https://github.com/edgexfoundry/edgex-go/issues/1274

Signed-off-by: difince <dianaa@vmware.com>