### PR TITLE
Handle Content-Type header value as case-insensitive

### DIFF
--- a/internal/core/data/io.go
+++ b/internal/core/data/io.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/OneOfOne/xxhash"
 
@@ -87,7 +88,7 @@ func (cborReader) Read(reader io.Reader, ctx *context.Context) (models.Event, er
 func NewRequestReader(request *http.Request) EventReader {
 	contentType := request.Header.Get(clients.ContentType)
 
-	switch contentType {
+	switch strings.ToLower(contentType) {
 	case clients.ContentTypeCBOR:
 		return cborReader{}
 	default:


### PR DESCRIPTION
Fix #1379

When determining whether to treat a message as CBOR or JSON it was
requested that we treat the value of the Content-Type header in a
case insensitive manner.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>