### PR TITLE
Unit Test -- Refactored add addressable using operator pattern and added tests.

### DIFF
--- a/internal/core/metadata/addressable.go
+++ b/internal/core/metadata/addressable.go
@@ -14,29 +14,10 @@
 package metadata
 
 import (
-	"fmt"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
-
-func addAddressable(addressable contract.Addressable) (string, error) {
-	if len(addressable.Name) == 0 {
-		err := errors.NewErrEmptyAddressableName()
-		LoggingClient.Error(err.Error())
-		return "", err
-	}
-	id, err := dbClient.AddAddressable(addressable)
-	if err != nil {
-		if err == db.ErrNotUnique {
-			err = errors.NewErrDuplicateName(fmt.Sprintf("duplicate name for addressable: %s", addressable.Name))
-		}
-		LoggingClient.Error(err.Error())
-		return "", err
-	}
-
-	return id, nil // Coupling to mongo?
-}
 
 func updateAddressable(addressable contract.Addressable) error {
 	var dest contract.Addressable

--- a/internal/core/metadata/addressable_test.go
+++ b/internal/core/metadata/addressable_test.go
@@ -18,77 +18,13 @@ import (
 	"os"
 	"testing"
 
-	metadataErrors "github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	dbMock "github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces/mocks"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 )
-
-func TestAddAddressable(t *testing.T) {
-	reset()
-	dbClient = newMockDb()
-
-	objectId := uuid.New().String()
-	newAddr := models.Addressable{
-		Id:   objectId,
-		Name: "new addressable",
-	}
-
-	id, err := addAddressable(newAddr)
-
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-	if id != objectId {
-		t.Errorf("Id returned by addAddressable() doesn't match expectation")
-	}
-}
-
-func TestAddAddressableEmptyName(t *testing.T) {
-	reset()
-	dbClient = newMockDb()
-
-	objectId := uuid.New().String()
-	newAddr := models.Addressable{
-		Id: objectId,
-	}
-
-	_, expectedErr := addAddressable(newAddr)
-
-	if expectedErr == nil {
-		t.Errorf("addAddressable() with empty addressable name should cause error")
-		return
-	}
-
-	if _, ok := expectedErr.(*metadataErrors.ErrEmptyAddressableName); !ok {
-		t.Errorf("expected an ErrEmptyAddressableName, found: %s", expectedErr.Error())
-	}
-}
-
-func TestAddDuplicateAddressableName(t *testing.T) {
-	reset()
-	dbClient = newMockDb(db.ErrNotUnique)
-
-	objectId := uuid.New().String()
-	newAddr := models.Addressable{
-		Id:   objectId,
-		Name: "new addressable",
-	}
-
-	_, expectedErr := addAddressable(newAddr)
-
-	if expectedErr == nil {
-		t.Errorf("addAddressable() with duplicate addressable name should cause error")
-	}
-
-	if _, ok := expectedErr.(*metadataErrors.ErrDuplicateName); !ok {
-		t.Errorf("expected an ErrDuplicateAddressableName, found: %s", expectedErr.Error())
-	}
-}
 
 func TestMain(m *testing.M) {
 	LoggingClient = logger.NewMockClient()

--- a/internal/core/metadata/operators/addressable/add.go
+++ b/internal/core/metadata/operators/addressable/add.go
@@ -1,0 +1,44 @@
+package addressable
+
+import (
+	"fmt"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type AddExecutor interface {
+	Execute() (string, error)
+}
+
+type addressAdd struct {
+	database    AddressWriter
+	addressable contract.Addressable
+}
+
+// This method adds the provided Addressable to the database.
+func (op addressAdd) Execute() (id string, err error) {
+	if len(op.addressable.Name) == 0 {
+		err := errors.NewErrEmptyAddressableName()
+		return "", err
+	}
+	id, err = op.database.AddAddressable(op.addressable)
+	if err != nil {
+		if err == db.ErrNotUnique {
+			err = errors.NewErrDuplicateName(fmt.Sprintf("duplicate name for addressable: %s", op.addressable.Name))
+		}
+		return "", err
+	}
+
+	return id, nil
+}
+
+// This factory method returns an executor used to add an addressable.
+func NewAddExecutor(db AddressWriter, addressable contract.Addressable) AddExecutor {
+	return addressAdd{
+		database:    db,
+		addressable: addressable,
+	}
+}

--- a/internal/core/metadata/operators/addressable/add_test.go
+++ b/internal/core/metadata/operators/addressable/add_test.go
@@ -1,0 +1,109 @@
+package addressable
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/operators/addressable/mocks"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/stretchr/testify/mock"
+)
+
+var missingName = contract.Addressable{
+	User:       "User1",
+	Protocol:   "http",
+	Id:         "address #1",
+	HTTPMethod: "POST",
+}
+
+var duplicate = contract.Addressable{
+	User:       "faker",
+	Name:       "Not Good",
+	Protocol:   "http",
+	Id:         "duplicated",
+	HTTPMethod: "POST",
+}
+
+func TestExecutor(t *testing.T) {
+	success := SuccessfulDatabaseResult[0]
+
+	tests := []struct {
+		name             string
+		mockDb           AddressWriter
+		addr             contract.Addressable
+		expectedResult   string
+		expectedError    bool
+		expectedErrorVal error
+	}{
+		{
+			name:             "Successful database call",
+			mockDb:           createAddMockAddressWriter(nil, success.Id),
+			addr:             success,
+			expectedResult:   success.Id,
+			expectedError:    false,
+			expectedErrorVal: nil,
+		},
+		{
+			name:             "Unsuccessful database call",
+			mockDb:           createAddMockAddressWriter(Error, ""),
+			addr:             success,
+			expectedResult:   "",
+			expectedError:    true,
+			expectedErrorVal: Error,
+		},
+		{
+			name:             "Missing name field on new addressable",
+			mockDb:           createAddMockAddressWriter(nil, missingName.Id),
+			addr:             missingName,
+			expectedResult:   "",
+			expectedError:    true,
+			expectedErrorVal: errors.NewErrEmptyAddressableName(),
+		},
+		{
+			name:             "Duplicated addressable",
+			mockDb:           createAddMockAddressWriter(Error, duplicate.Id),
+			addr:             duplicate,
+			expectedResult:   "",
+			expectedError:    true,
+			expectedErrorVal: errors.NewErrDuplicateName(fmt.Sprintf("duplicate name for addressable: %s", duplicate.Name)),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			op := NewAddExecutor(test.mockDb, test.addr)
+			actual, err := op.Execute()
+			if test.expectedError && err == nil {
+				t.Error("Expected an error")
+				return
+			}
+
+			if !test.expectedError && err != nil {
+				t.Errorf("Unexpectedly encountered error: %s", err.Error())
+				return
+			}
+
+			if !reflect.DeepEqual(test.expectedResult, actual) {
+				t.Errorf("Expected result does not match the observed.\nExpected: %v\nObserved: %v\n", test.expectedResult, actual)
+				return
+			}
+
+			if test.expectedErrorVal != nil && err != nil {
+				if test.expectedErrorVal.Error() != err.Error() {
+					t.Errorf("Observed error doesn't match expected.\nExpected: %v\nActual: %v\n", test.expectedErrorVal.Error(), err.Error())
+				}
+			}
+		})
+	}
+}
+
+func createAddMockAddressWriter(err error, id string) AddressWriter {
+	dbMock := mocks.AddressLoader{}
+	dbMock.On("AddAddressable", duplicate).Return(id, db.ErrNotUnique)
+	dbMock.On("AddAddressable", mock.Anything).Return(id, err)
+	return &dbMock
+}

--- a/internal/core/metadata/operators/addressable/db.go
+++ b/internal/core/metadata/operators/addressable/db.go
@@ -13,3 +13,8 @@ type AddressLoader interface {
 	GetAddressableByName(n string) (contract.Addressable, error)
 	GetAddressableById(id string) (contract.Addressable, error)
 }
+
+// AddressWriter provides functionality for adding and updating Addressables.
+type AddressWriter interface {
+	AddAddressable(addressable contract.Addressable) (string, error)
+}

--- a/internal/core/metadata/operators/addressable/get_test.go
+++ b/internal/core/metadata/operators/addressable/get_test.go
@@ -23,12 +23,14 @@ var Port = 8080
 var SuccessfulDatabaseResult = []contract.Addressable{
 	{
 		User:       "User1",
+		Name:       "Ein",
 		Protocol:   "http",
 		Id:         "address #1",
 		HTTPMethod: "POST",
 	},
 	{
 		User:       "User2",
+		Name:       "Zwei",
 		Protocol:   "http",
 		Id:         "address #2",
 		HTTPMethod: "GET",
@@ -125,7 +127,7 @@ func TestAllAddressablesExecutor(t *testing.T) {
 			if !reflect.DeepEqual(actual, test.expectedResult) {
 				t.Errorf("Observed result doesn't match expected.\nExpected: %v\nActual: %v\n", test.expectedResult, actual)
 			}
-			if test.expectedErrorVal != nil {
+			if test.expectedErrorVal != nil && err != nil {
 				if test.expectedErrorVal.Error() != err.Error() {
 					t.Errorf("Observed error doesn't match expected.\nExpected: %v\nActual: %v\n", test.expectedErrorVal.Error(), err.Error())
 				}

--- a/internal/core/metadata/operators/addressable/mocks/AddressLoader.go
+++ b/internal/core/metadata/operators/addressable/mocks/AddressLoader.go
@@ -10,6 +10,27 @@ type AddressLoader struct {
 	mock.Mock
 }
 
+// AddAddressable provides a mock function with given fields: _a0
+func (_m *AddressLoader) AddAddressable(_a0 models.Addressable) (string, error) {
+	ret := _m.Called(_a0)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(models.Addressable) string); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(models.Addressable) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAddressableById provides a mock function with given fields: id
 func (_m *AddressLoader) GetAddressableById(id string) (models.Addressable, error) {
 	ret := _m.Called(id)

--- a/internal/core/metadata/rest_addressable.go
+++ b/internal/core/metadata/rest_addressable.go
@@ -60,7 +60,8 @@ func restAddAddressable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id, err := addAddressable(a)
+	op := addressable.NewAddExecutor(dbClient, a)
+	id, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
 		case *types.ErrDuplicateName:


### PR DESCRIPTION
Fix #1517 

Refactors the AddAddressable logic and adds unit test for that operator and executor.

Signed-off-by: Brandon Forster <brandonforster@gmail.com>