### PR TITLE
Pass QueryParams on through EdgeX to Device Services

### DIFF
--- a/internal/core/command/get.go
+++ b/internal/core/command/get.go
@@ -15,16 +15,17 @@ package command
 
 import (
 	"context"
+	"net/http"
+	"strings"
+
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-	"net/http"
-	"strings"
 )
 
 // NewGetCommand creates and Executor which can be used to execute the GET related command.
-func NewGetCommand(device contract.Device, command contract.Command, context context.Context, httpCaller internal.HttpCaller) (Executor, error) {
-	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
+func NewGetCommand(device contract.Device, command contract.Command, queryParams string, context context.Context, httpCaller internal.HttpCaller) (Executor, error) {
+	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1) + "?" + queryParams
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return serviceCommand{}, err

--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -42,7 +42,7 @@ func issueDeviceCommand(w http.ResponseWriter, r *http.Request, isPutCommand boo
 	}
 
 	ctx := r.Context()
-	body, status := commandByDeviceID(did, cid, string(b), isPutCommand, ctx)
+	body, status := commandByDeviceID(did, cid, string(b), r.URL.RawQuery, isPutCommand, ctx)
 	if status != http.StatusOK {
 		http.Error(w, body, status)
 	} else {
@@ -75,7 +75,7 @@ func issueDeviceCommandByNames(w http.ResponseWriter, r *http.Request, isPutComm
 		LoggingClient.Error(err.Error())
 		return
 	}
-	body, status := commandByNames(dn, cn, string(b), isPutCommand, ctx)
+	body, status := commandByNames(dn, cn, string(b), r.URL.RawQuery, isPutCommand, ctx)
 
 	if status != http.StatusOK {
 		http.Error(w, body, status)


### PR DESCRIPTION
This pull request is an example/POC that @lenny-intel and I put together of how #1564 could be accomplished. This is only 1/2 of the equation as the device-sdk would need to be updated to handle the query parameters. The good thing with this is that it wouldn't be a breaking change as the device-sdk would simply ignore the query parameters that are sent on.


Signed-off-by: Mike Johanson <michael.johanson@intel.com>