### PR TITLE
snapcraft.yaml: update sec-secret-store binary locations

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -926,12 +926,12 @@ parts:
       cd $SNAPCRAFT_PART_SRC
       make build
 
-      install -DT pkisetup/pkisetup "$SNAPCRAFT_PART_INSTALL/bin/pkisetup"
-      install -DT core/edgex-vault-worker "$SNAPCRAFT_PART_INSTALL/bin/vault-worker"
+      install -DT cmd/pkisetup/pkisetup "$SNAPCRAFT_PART_INSTALL/bin/pkisetup"
+      install -DT cmd/vaultworker/edgex-vault-worker "$SNAPCRAFT_PART_INSTALL/bin/vault-worker"
 
       # modify the configuration file for the vault-worker
       install -d "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/"
-      cat "core/res/configuration.toml" | \
+      cat "cmd/vaultworker/res/configuration.toml" | \
         sed -e "s@tokenpath = \"res\\\\\\\\resp-init.json\"@tokenpath = \"res/resp-init.json\"@" \
             -e "s@\"/vault/config/pki/@\"\$SNAP_DATA/vault/pki/@g" \
             -e "s@EdgeXFoundryCA/edgex-vault.pem@EdgeXFoundryCA/localhost.pem@" \
@@ -940,12 +940,12 @@ parts:
         > "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/configuration.toml"
 
       # install the hcl files too for vault accesses
-      install -DT "core/res/vault-policy-admin.hcl" "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/vault-policy-admin.hcl"
-      install -DT "core/res/vault-policy-kong.hcl" "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/vault-policy-kong.hcl"
+      install -DT "cmd/vaultworker/res/vault-policy-admin.hcl" "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/vault-policy-admin.hcl"
+      install -DT "cmd/vaultworker/res/vault-policy-kong.hcl" "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/res/vault-policy-kong.hcl"
 
       # also install the pki config files
-      install -DT pkisetup/pkisetup-kong.json "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/pkisetup-kong.json"
-      install -DT pkisetup/pkisetup-vault.json "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/pkisetup-vault.json"
+      install -DT configs/pkisetup-kong.json "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/pkisetup-kong.json"
+      install -DT configs/pkisetup-vault.json "$SNAPCRAFT_PART_INSTALL/config/security-secret-store/pkisetup-vault.json"
     prime:
       - bin/*
       - config/*


### PR DESCRIPTION
Should fix builds such as https://jenkins.edgexfoundry.org/view/Snap/job/edgex-go-snap-master-stage-snap/415/, see:

```
10:44:21 Building security-secret-store 
10:44:21 cd cmd/pkisetup && CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -a -ldflags="-s -w" -o pkisetup .
10:44:28 cd cmd/vaultworker && CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -a -o edgex-vault-worker .
10:44:48 install: cannot stat 'pkisetup/pkisetup': No such file or directory
...
10:44:48 Failed to run 'override-build': Exit code was 1.
10:45:17 Build step 'Execute shell' marked build as failure
```