### PR TITLE
Adding SonarCloud Config for AutoScan

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,4 @@
+sonar.exclusions=.git/*,/api/raml/*,/bin/*,/snap/**/*,**/mocks/**/*,**/*_test.go,**/vendor/**
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/vendor/**


### PR DESCRIPTION
Fix #1553

- Added .sonarcloud.properties file to the root directory. This will
  allow the DevOps team to configure auto-scan in SonarCloud so we can
  review the output. This may get rolled back if we aren't satisfied.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>