### PR TITLE
Changing interval frequency field to use go standard time format

### DIFF
--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -42,7 +42,7 @@ File = './logs/edgex-support-scheduler.log'
     [Intervals.Midnight]
     Name = 'midnight'
     Start = '20180101T000000'
-    Frequency = 'P1D'
+    Frequency = '24h'
 
 [IntervalActions]
     [IntervalActions.ScrubPushed]

--- a/cmd/support-scheduler/res/docker/configuration.toml
+++ b/cmd/support-scheduler/res/docker/configuration.toml
@@ -42,7 +42,7 @@ File = '/edgex/logs/edgex-support-scheduler.log'
     [Intervals.Midnight]
     Name = 'midnight'
     Start = '20180101T000000'
-    Frequency = 'P1D'
+    Frequency = '24h'
 
 [IntervalActions]
     [IntervalActions.ScrubPushed]

--- a/internal/support/scheduler/const.go
+++ b/internal/support/scheduler/const.go
@@ -16,22 +16,21 @@ package scheduler
 const (
 
 	/* -------------- Constants for Scheduler -------------------- */
-	ID                   = "id"
-	NAME                 = "name"
-	TARGETNAME           = "targetname"
-	INTERVALACTION       = "intervalaction"
-	INTERVAL             = "interval"
-	LABEL                = "label"
-	YAML                 = "yaml"
-	COMMAND              = "command"
-	KEY                  = "key"
-	VALUE                = "value"
-	UNLOCKED             = "UNLOCKED"
-	ENABLED              = "ENABLED"
-	SCHEDULER_TIMELAYOUT = "20060102T150405" /** Scheduler **/
-	TIMELAYOUT           = "20060102T150405" /** Scheduler **/
-	SCRUB                = "scrub"
-	TARGET               = "target"
+	ID             = "id"
+	NAME           = "name"
+	TARGETNAME     = "targetname"
+	INTERVALACTION = "intervalaction"
+	INTERVAL       = "interval"
+	LABEL          = "label"
+	YAML           = "yaml"
+	COMMAND        = "command"
+	KEY            = "key"
+	VALUE          = "value"
+	UNLOCKED       = "UNLOCKED"
+	ENABLED        = "ENABLED"
+	TIMELAYOUT     = "20060102T150405"
+	SCRUB          = "scrub"
+	TARGET         = "target"
 
 	/* ---------------- URL PARAM NAMES -----------------------*/
 	ContentTypeKey       = "Content-Type"

--- a/internal/support/scheduler/interval.go
+++ b/internal/support/scheduler/interval.go
@@ -63,7 +63,8 @@ func addNewInterval(interval contract.Interval) (string, error) {
 	// Validate the Frequency
 	freq := interval.Frequency
 	if freq != "" {
-		if !isFrequencyValid(interval.Frequency) {
+		_, err := parseFrequency(freq)
+		if err != nil {
 			return "", errors.NewErrInvalidFrequencyFormat(freq)
 		}
 	}
@@ -107,7 +108,8 @@ func updateInterval(from contract.Interval) error {
 		to.End = from.End
 	}
 	if from.Frequency != "" {
-		if !isFrequencyValid(from.Frequency) {
+		_, err := parseFrequency(from.Frequency)
+		if err != nil {
 			return errors.NewErrInvalidFrequencyFormat(from.Frequency)
 		}
 		to.Frequency = from.Frequency

--- a/internal/support/scheduler/utils.go
+++ b/internal/support/scheduler/utils.go
@@ -14,24 +14,9 @@
 package scheduler
 
 import (
-	"regexp"
 	"strconv"
 	"time"
 )
-
-const (
-	frequencyPattern = `^P(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+S)?)?$`
-)
-
-func isFrequencyValid(frequency string) bool {
-	matched, _ := regexp.MatchString(frequencyPattern, frequency)
-	if matched {
-		if frequency == "P" || frequency == "PT" {
-			matched = false
-		}
-	}
-	return matched
-}
 
 // Convert millisecond string to Time
 func msToTime(ms string) (time.Time, error) {
@@ -46,6 +31,26 @@ func msToTime(ms string) (time.Time, error) {
 	}
 
 	return time.Unix(0, msInt*int64(time.Millisecond)), nil
+}
+
+// Frequency indicates how often the specific resource needs to be polled.
+// It represents as a duration string.
+//
+// Nanosecond Duration = 1
+// Microsecond = 1000 * Nanosecond
+// Millisecond = 1000 * Microsecond
+// Second = 1000 * Millisecond
+// Minute = 60 * Second
+// Hour = 60 * Minute
+func parseFrequency(durationStr string) (time.Duration, error) {
+
+	// check Frequency
+	timeDuration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return 24 * time.Hour, err // default time.Duration w/error
+	}
+
+	return timeDuration, nil
 }
 
 // Scheduler Queue Client


### PR DESCRIPTION
Issue #1246  - Adjust Interval frequency so that uses Go standard time format.
Should allow miliseconds, microseconds, as well as nonoseconds.

Signed-off-by: xmlviking <ecotter@gmail.com>