### PR TITLE
Fix security-secrets-setup vulnerability issue of sensitive TLS assets on docker image

### DIFF
--- a/cmd/security-secrets-setup/Dockerfile
+++ b/cmd/security-secrets-setup/Dockerfile
@@ -1,6 +1,7 @@
 #  ----------------------------------------------------------------------------------
 #  Copyright 2018 ForgeRock AS.
 #  Copyright 2019 Dell Technologies, Inc.
+#  Copyright 2019 Intel Corp.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,11 +15,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-#  @author: Alain Pulluelo, ForgeRock (created: June 14, 2018)
-#  @version: 1.0.0
+#  @author: Alain Pulluelo, ForgeRock (created: Jun 14, 2018)
 #
 #  @author: Trevor Conn, Dell Technologies, Inc. (created: July 2, 2019)
-#  @version: 1.0.1
+#
+#  @author: Jim Wang, Intel Corp. (modified: August 8, 2019)
 #
 #  SPDX-License-Identifier: Apache-2.0'
 #  ----------------------------------------------------------------------------------
@@ -50,11 +51,17 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
 
 USER root
 
+# install necessary tools
+RUN apk update && apk add ca-certificates dumb-init jq \
+    && rm -rf /var/cache/apk/* 
+
+ENV BASE_DIR=/vault
+
 # Vault Config File
-WORKDIR /vault/config
+WORKDIR $BASE_DIR/config
 COPY --from=build-env /edgex-go/cmd/security-secrets-setup/res/local-tls.hcl ./local.hcl
 
-WORKDIR /vault
+WORKDIR $BASE_DIR
 RUN mkdir res
 
 # Vault PKI/TLS setup/config binary
@@ -66,15 +73,20 @@ COPY --from=build-env /edgex-go/cmd/security-secrets-setup/res/pkisetup-vault.js
 # Kong PKI/TLS materials
 COPY --from=build-env /edgex-go/cmd/security-secrets-setup/res/pkisetup-kong.json ./res
 
+# setup the entry point script
+# it uses `dumb-init` as the top-level process to reap any
+# zombie processes created by sub-processes
+COPY --from=build-env /edgex-go/cmd/security-secrets-setup/entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && ln -s /usr/local/bin/entrypoint.sh /
+
 # Create assets folder (needed for unseal key/s, root token and tmp)
 # Run CA/Vault and Kong PKI/TLS setups and peform housekeeping tasks
-RUN mkdir /vault/config/assets && \
-    chown -R vault:vault /vault && \
-    chmod 644 /vault/config/local.hcl && \
-    chmod 744 security-secrets-setup && \
-    /vault/security-secrets-setup --config /vault/res/pkisetup-vault.json && \
-    echo "" && \
-    /vault/security-secrets-setup --config /vault/res/pkisetup-kong.json && \
-    chown -R vault:vault /vault/config/pki
+RUN mkdir $BASE_DIR/config/assets && \
+    chown -R vault:vault $BASE_DIR && \
+    chmod 644 $BASE_DIR/config/local.hcl && \
+    chmod 744 security-secrets-setup
 
-VOLUME /vault/config
+VOLUME $BASE_DIR/config
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/cmd/security-secrets-setup/README.md
+++ b/cmd/security-secrets-setup/README.md
@@ -1,0 +1,27 @@
+# Testing Instruction for security-secrets-setup
+
+## Build
+
+Use Makefile in the base directory of this repository to build the docker image of security-secretes-setup:
+
+```sh
+make docker_security_secrets_setup
+```
+
+It should create a docker image with the name `edgexfoundry/docker-edgex-vault:<version>-dev` if sucessfully built.
+
+# Run
+
+To see what the TLS materials are generated inside the docker container, 
+one can run the built docker image above (assuming the version number is `1.1.0`) as:
+
+```sh
+docker run --rm -it edgexfoundry/docker-edgex-vault:1.1.0-dev /bin/sh
+```
+
+once that is run, one should see the execution console outputs and gives the interactive console prompt in the base directory `/vault`.  Based on the current JSON configuration, TLS materials should be able to found in the directory of `./config/pki/EdgeXFoundryCA/` showed as follows:
+
+```sh
+/vault # ls ./config/pki/EdgeXFoundryCA/
+EdgeXFoundryCA.pem    edgex-kong.pem        edgex-kong.priv.key   edgex-vault.pem       edgex-vault.priv.key
+```

--- a/cmd/security-secrets-setup/entrypoint.sh
+++ b/cmd/security-secrets-setup/entrypoint.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/dumb-init /bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2019 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+set -e
+
+# Use dumb-init as PID 1 in order to reap zombie processes and forward system signals to 
+# all processes in its session. This can alleviate the chance of leaking zombies, 
+# thus more graceful termination of all sub-processes if any.
+
+# runtime directory is set per user:
+export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(echo $(id -u))}
+
+PKI_INIT_RUNTIME_DIR=${XDG_RUNTIME_DIR}/${PKI_INIT_DIR}
+
+# debug output:
+echo XDG_RUNTIME_DIR $XDG_RUNTIME_DIR
+echo PKI_INIT_RUNTIME_DIR $PKI_INIT_RUNTIME_DIR
+
+# configuration for TLS materials:
+PKI_CONFIG_JSON_DIR="res"
+PKI_SETUP_VAULT_FILE=${PKI_CONFIG_JSON_DIR}"/pkisetup-vault.json"
+PKI_SETUP_KONG_FILE=${PKI_CONFIG_JSON_DIR}"/pkisetup-kong.json"
+
+# check if files exists
+if [ ! -f "${PKI_SETUP_VAULT_FILE}" ]; then
+    echo "Error: certificate config file for Vault is missing"
+    exit 1
+fi
+
+if [ ! -f "${PKI_SETUP_KONG_FILE}" ]; then
+    echo "Error: certificate config file for Kong is missing"
+    exit 1
+fi
+
+# the working dir should be in vault dir based upon the current Docker image
+BASE_DIR="${BASE_DIR:-/vault}"
+cd $BASE_DIR
+CERT_DIR=$(jq -r '.working_dir' ${PKI_SETUP_VAULT_FILE})
+CERT_SUBDIR=$(jq -r '.pki_setup_dir' ${PKI_SETUP_VAULT_FILE})
+ROOT_NAME=$(jq -r '.x509_root_ca_parameters | .ca_name' ${PKI_SETUP_VAULT_FILE})
+CERT_EXEC="${CERT_EXEC:-./security-secrets-setup}"
+# check to see if the root certificate generate with security-secrets-setup already exists
+# if so then do not generate a new set of them
+if [ ! -f "$CERT_DIR/$CERT_SUBDIR/$ROOT_NAME/$ROOT_NAME.pem" ]; then
+    ${CERT_EXEC} --config ${PKI_SETUP_VAULT_FILE}
+    [ $? -eq 0 ] || (echo "failed to generate TLS assets for Vault" && exit 1)
+
+    ${CERT_EXEC} --config ${PKI_SETUP_KONG_FILE}
+    [ $? -eq 0 ] || (echo "failed to generate TLS assets for Kong" && exit 1)
+
+    # delete CA private key
+    rm "$PWD/$CERT_DIR/$CERT_SUBDIR/$ROOT_NAME/$ROOT_NAME.priv.key"
+    [ $? -eq 0 ] || (echo "failed to delete sensitive CA private key" && exit 1)
+
+    # take ownership
+    chown -R vault:vault $PWD/$CERT_DIR/$CERT_SUBDIR || true
+fi 
+
+# run the Vault's docker-entry script 
+source /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION

- Remove the execution of security-secrets-setup inside Dockerfile to avoid generating TLS assets on the build time so that docker image does not contain sensitive information 

- Add docker entrypoint shell script to generate TLS assets of Vault/Kong on run-time if not exists yet

With above two it circumvents the issue CWE-318 of CA root private key although the whole process still running on the persistent storage (which should be addressed once features of Pki-Init Go-code are integrated into security-secrets-setup as one: using tmpfs running on the memory, not on the disk).  Nevertheless, with this step 0, it serves the purpose to pave the path to code-refactor security-secrets-setup with Pki-Init (which is much bigger effort) in terms of docker-image aspects.  It also unblocks the road to Fuji release due to vulnerability point-of-view.

Ref: issue #1635 

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>