### PR TITLE
Attribution.txt cleanup for all services

### DIFF
--- a/cmd/config-seed/Attribution.txt
+++ b/cmd/config-seed/Attribution.txt
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/config-seed/Attribution.txt
+++ b/cmd/config-seed/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/core-data/Attribution.txt
+++ b/cmd/core-data/Attribution.txt
@@ -105,3 +105,38 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
 
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/core-data/Attribution.txt
+++ b/cmd/core-data/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -99,37 +102,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
-
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/export-client/Attribution.txt
+++ b/cmd/export-client/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/export-distro/Attribution.txt
+++ b/cmd/export-distro/Attribution.txt
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/export-distro/Attribution.txt
+++ b/cmd/export-distro/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/security-proxy-setup/Attribution.txt
+++ b/cmd/security-proxy-setup/Attribution.txt
@@ -51,9 +51,6 @@ https://github.com/mitchellh/consulstructure/blob/master/LICENSE
 mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
 https://github.com/mitchellh/mapstructure/blob/master/LICENSE
 
-mitchellh/copystructure (MIT) https://github.com/mitchellh/copystructure
-https://github.com/mitchellh/copystructure/blob/master/LICENSE
-
 mitchellh/reflectwalk (MIT) https://github.com/mitchellh/reflectwalk
 https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 
@@ -74,6 +71,9 @@ https://github.com/mitchellh/go-homedir/blob/master/LICENSE
 
 mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
 https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+mitchellh/copystructure (MIT) https://github.com/mitchellh/copystructure
+https://github.com/mitchellh/copystructure/blob/master/LICENSE
 
 hashicorp/serf (Mozilla Public License 2.0) https://github.com/hashicorp/serf
 https://github.com/hashicorp/serf/blob/master/LICENSE
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/security-proxy-setup/Attribution.txt
+++ b/cmd/security-proxy-setup/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/security-secrets-setup/Attribution.txt
+++ b/cmd/security-secrets-setup/Attribution.txt
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/security-secrets-setup/Attribution.txt
+++ b/cmd/security-secrets-setup/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 
@@ -98,38 +101,6 @@ https://github.com/magiconair/properties/blob/master/LICENSE
 
 gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
 https://github.com/eapache/queue/blob/v1.1.0/LICENSE
-
-All of the following are due to sys-mgmt-agent's docker import...
-
-docker/docker/api/types (Apache 2.0) https://github.com/moby/moby/tree/master/api/types
-https://github.com/moby/moby/blob/master/LICENSE
-
-docker/go-connections (Apache 2.0) https://github.com/docker/go-connections
-https://github.com/docker/go-connections/blob/master/LICENSE
-
-gogo/protobuf/proto (unspecified) https://github.com/gogo/protobuf/proto
-https://github.com/gogo/protobuf/blob/master/LICENSE
-
-opencontainers/image-spec/specs-go/v1 (Apache 2.0) https://github.com/opencontainers/image-spec
-https://github.com/opencontainers/image-spec/blob/master/LICENSE
-
-opencontainers/go-digest (Apache 2.0) https://github.com/opencontainers/go-digest
-https://github.com/opencontainers/go-digest/blob/master/LICENSE
-
-Azure/go-ansiterm (MIT) https://github.com/Azure/go-ansiterm
-https://github.com/Azure/go-ansiterm/blob/master/LICENSE
-
-sirupsen/logrus (MIT) https://github.com/sirupsen/logrus
-https://github.com/sirupsen/logrus/blob/master/LICENSE
-
-Nvveen/Gotty (unspecified) https://github.com/Nvveen/Gotty
-https://github.com/Nvveen/Gotty/blob/master/LICENSE
-
-docker/go-units (Apache 2.0) https://github.com/docker/go-units
-https://github.com/docker/go-units/blob/master/LICENSE
-
-docker/distribution (Apache 2.0) https://github.com/docker/distribution/
-https://github.com/docker/distribution/blob/master/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -51,9 +51,6 @@ https://github.com/mitchellh/consulstructure/blob/master/LICENSE
 mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
 https://github.com/mitchellh/mapstructure/blob/master/LICENSE
 
-mitchellh/copystructure (MIT) https://github.com/mitchellh/copystructure
-https://github.com/mitchellh/copystructure/blob/master/LICENSE
-
 mitchellh/reflectwalk (MIT) https://github.com/mitchellh/reflectwalk
 https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 
@@ -74,6 +71,9 @@ https://github.com/mitchellh/go-homedir/blob/master/LICENSE
 
 mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
 https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+mitchellh/copystructure (MIT) https://github.com/mitchellh/copystructure
+https://github.com/mitchellh/copystructure/blob/master/LICENSE
 
 hashicorp/serf (Mozilla Public License 2.0) https://github.com/hashicorp/serf
 https://github.com/hashicorp/serf/blob/master/LICENSE
@@ -104,3 +104,39 @@ https://github.com/eapache/queue/blob/v1.1.0/LICENSE
 
 bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
 https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -21,6 +21,9 @@ https://github.com/go-logfmt/logfmt/blob/master/LICENSE
 robfig/cron (MIT) https://github.com/robfig/cron
 https://github.com/robfig/cron/blob/master/LICENSE
 
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 

--- a/cmd/sys-mgmt-executor/Attribution.txt
+++ b/cmd/sys-mgmt-executor/Attribution.txt
@@ -1,4 +1,4 @@
-The following open source projects are referenced by Export Client Go:
+The following open source projects are referenced by System Mgmt Executor
 
 pkg/errors (BSD-2) https://github.com/pkg/errors
 https://github.com/pkg/errors/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/imdario/mergo v0.3.6
 	github.com/magiconair/properties v1.8.0
 	github.com/mattn/go-xmpp v0.0.0-20190124093244-6093f50721ed
-	github.com/mitchellh/copystructure v1.0.0
 	github.com/pebbe/zmq4 v1.0.0
 	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
Fix #1655

- Added entry for github.com/dgrijalva/jwt-go to all
- Removed entries necessitated by previous import of docker by SMA
  bitbucket.org/bertimus9/systemstat is still in use

Signed-off-by: Trevor Conn <trevor_conn@dell.com>