### PR TITLE
Add tests to make test for attribution.txt correctness and go.mod tidiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ test:
 	GO111MODULE=on go vet ./...
 	gofmt -l .
 	[ "`gofmt -l .`" = "" ]
+	./bin/test-go-mod-tidy.sh
 
 run:
 	cd bin && ./edgex-launch.sh

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ test:
 	gofmt -l .
 	[ "`gofmt -l .`" = "" ]
 	./bin/test-go-mod-tidy.sh
+	./bin/test-attribution-txt.sh
 
 run:
 	cd bin && ./edgex-launch.sh

--- a/bin/test-attribution-txt.sh
+++ b/bin/test-attribution-txt.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -e
+
+# get the directory of this script
+# snippet from https://stackoverflow.com/a/246128/10102404
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+GIT_ROOT=$(dirname "$SCRIPT_DIR")
+
+EXIT_CODE=0
+
+cd "$GIT_ROOT"
+
+if [ -d vendor.bk ]; then
+    echo "vendor.bk exits - remove before continuing"
+    exit 1
+fi
+
+trap cleanup 1 2 3 6
+
+cleanup()
+{
+    cd "$GIT_ROOT"
+    # restore the vendor dir
+    rm -r vendor
+    if [ -d vendor.bk ]; then
+        mv vendor.bk vendor
+    fi
+    exit $EXIT_CODE
+}
+
+# if the vendor directory exists, back it up so we can build a fresh one
+if [ -d vendor ]; then
+    mv vendor vendor.bk
+fi
+
+# create a vendor dir with the mod dependencies
+GO111MODULE=on go mod vendor
+
+# turn on nullglobbing so if there is nothing in cmd dir then we don't do
+# anything in this loop
+shopt -s nullglob
+
+for cmd in cmd/* ; do
+    cd "$cmd"
+        if [ ! -f Attribution.txt ]; then
+            echo "An Attribution.txt file for $cmd is missing, please add"
+            EXIT_CODE=1
+        else
+            # loop over every library in the modules.txt file in vendor
+            while IFS= read -r lib; do
+                if ! grep -q "$lib" Attribution.txt; then 
+                    echo "An attribution for $lib is missing from in $cmd Attribution.txt, please add"
+                    # need to do this in a bash subshell, see SC2031
+                    (( EXIT_CODE=1 ))
+                fi
+            done < <(grep '#' < "$GIT_ROOT/vendor/modules.txt" | awk '{print $2}')
+        fi
+    cd "$GIT_ROOT"
+done
+
+cleanup 

--- a/bin/test-go-mod-tidy.sh
+++ b/bin/test-go-mod-tidy.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -e
+
+# get the directory of this script
+# snippet from https://stackoverflow.com/a/246128/10102404
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+GIT_ROOT=$(dirname "$SCRIPT_DIR")
+
+EXIT_CODE=0
+
+cd "$GIT_ROOT"
+
+if [ -f go.mod.bk ]; then
+    echo "go.mod.bk exits - remove before continuing"
+    exit 1
+fi
+
+# backup go.mod
+cp go.mod go.mod.bk
+
+trap cleanup 1 2 3 6
+
+cleanup()
+{
+    cd "$GIT_ROOT"
+    # restore the go.mod file dir
+    rm go.mod
+    if [ -f go.mod.bk ]; then
+        mv go.mod.bk go.mod
+    fi
+    exit $EXIT_CODE
+}
+
+# if go.mod doesn't exist then fail
+if [ ! -f go.mod ]; then
+    echo "missing go.mod, please fix"
+    EXIT_CODE=1
+    cleanup
+fi
+
+GO111MODULE=on go mod tidy
+
+# check if go.mod and go.mod.bk are the same
+
+set +e
+changes=$(diff -u go.mod go.mod.bk)
+set -e
+
+if [ -n "$changes" ]; then
+    echo "go.mod is not tidy, please run \"go mod tidy\""
+    echo "changes from running \"go mod tidy:\""
+    echo "$changes"
+    EXIT_CODE=1
+fi
+
+cleanup


### PR DESCRIPTION
~~Note that CI verify jobs are expected to fail here since the Attribution.txt files need to be updated and go.mod needs to be tidied on master currently.~~ edit: this should now work now that #1665 has been merged and this has been rebased on top of master.

Also note that neither of these changes will change either your vendor directory or go.mod, they both will backup any files that get modified and then restore them afterwards. 