### PR TITLE
Update restAddProfileByYaml response code

### DIFF
--- a/internal/core/metadata/rest_deviceprofile_test.go
+++ b/internal/core/metadata/rest_deviceprofile_test.go
@@ -950,7 +950,7 @@ func TestAddProfileByYaml(t *testing.T) {
 			"Duplicate command name",
 			createDeviceProfileRequestWithFile(dupeBody),
 			nil,
-			http.StatusBadRequest,
+			http.StatusConflict,
 		},
 		{
 			"Duplicate profile name",


### PR DESCRIPTION
Fix #1670

Update the restAddProfileByYaml REST handler to return a '409(Conflict)'
when unable to unmarshal the request body. The reason for this change is
backwards compatibility with EdgeX 1.x. Disregarding backwards
compatibility, the correct response code is '400(Bad Request)'.

Updated unit tests to adhere to the new expectations of the API.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>