### PR TITLE
Fix update DeviceProfile API handling of name

### DIFF
--- a/internal/core/metadata/operators/device_profile/update.go
+++ b/internal/core/metadata/operators/device_profile/update.go
@@ -56,6 +56,12 @@ func (n updateDeviceProfile) Execute() (contract.DeviceProfile, error) {
 	}
 
 	n.dp.Id = existingDeviceProfile.Id
+
+	// For the name field only we will not process an update unless it has been explicitly provided.
+	if n.dp.Name == "" {
+		n.dp.Name = existingDeviceProfile.Name
+	}
+
 	if err := n.database.UpdateDeviceProfile(n.dp); err != nil {
 		return contract.DeviceProfile{}, err
 	}

--- a/internal/core/metadata/operators/device_profile/update_test.go
+++ b/internal/core/metadata/operators/device_profile/update_test.go
@@ -46,6 +46,24 @@ func TestUpdateDeviceProfile(t *testing.T) {
 		expectError bool
 	}{
 		{
+			"Update DeviceProfile",
+			createDBClient(TestDeviceProfile),
+			TestDeviceProfile,
+			false,
+		},
+		{
+			"Update DeviceProfile with no name",
+			createDBClient(TestDeviceProfile),
+			createTestDeviceProfileWithName(""),
+			false,
+		},
+		{
+			"Update DeviceProfile with updated name",
+			createDBClient(createTestDeviceProfileWithName("NewName")),
+			createTestDeviceProfileWithName("NewName"),
+			false,
+		},
+		{
 			"Multiple devices associated with device profile",
 			createDBClientMultipleDevicesFoundError(),
 			TestDeviceProfile,
@@ -105,13 +123,13 @@ func TestUpdateDeviceProfile(t *testing.T) {
 	}
 }
 
-func createDBClient() DeviceProfileUpdater {
+func createDBClient(expectedTestProfile contract.DeviceProfile) DeviceProfileUpdater {
 	d := &mocks.DeviceProfileUpdater{}
 	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(TestDeviceProfile, nil)
 	d.On("GetDevicesByProfileId", TestDeviceProfileID).Return(make([]contract.Device, 0), nil)
 	d.On("GetProvisionWatchersByProfileId", TestDeviceProfileID).Return(make([]contract.ProvisionWatcher, 0), nil)
 	d.On("GetAllDeviceProfiles").Return(make([]contract.DeviceProfile, 0), nil)
-	d.On("UpdateDeviceProfile", TestDeviceProfile).Return(nil)
+	d.On("UpdateDeviceProfile", expectedTestProfile).Return(nil)
 
 	return d
 }
@@ -139,34 +157,6 @@ func createDBClientMultipleProvisionWatchersFoundError() DeviceProfileUpdater {
 
 	return d
 }
-func createDBClientDuplicateDeviceProfileNameError() DeviceProfileUpdater {
-	d := &mocks.DeviceProfileUpdater{}
-	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(TestDeviceProfile, nil)
-	d.On("GetDevicesByProfileId", TestDeviceProfileID).Return(make([]contract.Device, 0), nil)
-	d.On("GetProvisionWatchersByProfileId", TestDeviceProfileID).Return(make([]contract.ProvisionWatcher, 0), nil)
-	d.On("GetAllDeviceProfiles").Return([]contract.DeviceProfile{{Name: TestDeviceProfile.Name, Id: "SomethingElse"}}, nil)
-	d.On("UpdateDeviceProfile", TestDeviceProfile).Return(nil)
-
-	return d
-}
-
-func createDBClientGetDevicesByProfileIdError() DeviceProfileUpdater {
-	d := &mocks.DeviceProfileUpdater{}
-	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(TestDeviceProfile, nil)
-	d.On("GetDevicesByProfileId", TestDeviceProfileID).Return(make([]contract.Device, 0), TestError)
-
-	return d
-}
-func createDBClientGetAllDeviceProfilesError() DeviceProfileUpdater {
-	d := &mocks.DeviceProfileUpdater{}
-	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(TestDeviceProfile, nil)
-	d.On("GetDevicesByProfileId", TestDeviceProfileID).Return(make([]contract.Device, 0), nil)
-	d.On("GetProvisionWatchersByProfileId", TestDeviceProfileID).Return(make([]contract.ProvisionWatcher, 0), nil)
-	d.On("GetAllDeviceProfiles").Return([]contract.DeviceProfile{}, TestError)
-	d.On("UpdateDeviceProfile", TestDeviceProfile).Return(nil)
-
-	return d
-}
 
 func createDBClientGetProvisionWatchersByProfileIdError() DeviceProfileUpdater {
 	d := &mocks.DeviceProfileUpdater{}
@@ -187,6 +177,13 @@ func createDBClientUpdateDeviceProfileError() DeviceProfileUpdater {
 	d.On("UpdateDeviceProfile", TestDeviceProfile).Return(TestError)
 
 	return d
+}
+
+// createTestDeviceProfileWithName creates a device profile with the specified name.
+func createTestDeviceProfileWithName(name string) contract.DeviceProfile {
+	dp := createTestDeviceProfile()
+	dp.Name = name
+	return dp
 }
 
 // createTestDeviceProfile creates a device profile to be used during testing.


### PR DESCRIPTION
Fixes #1668
Fixes #1669

Update the `updateDeviceProfile` executor to only update the
DeviceProfile name if it has been provided. Otherwise, use the
pre-existing name.

Add tests to cover situations for updating the DeviceProfile's name.

Removed unused test functions.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>