### PR TITLE
snap/README.md: update LXD section

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -176,18 +176,34 @@ $ snapcraft
 
 ### Building with LXD containers
 
-Alternatively, you can instruct snapcraft to use LXD containers instead of multipass VM's. This requires installing LXD as documented (here)[https://docs.snapcraft.io/build-on-lxd].
+Alternatively, you can instruct snapcraft to use LXD containers instead of multipass VM's. This requires installing LXD as documented [here](https://docs.snapcraft.io/build-on-lxd).
 
 ```bash
-$ export SNAPCRAFT_BUILD_ENVIRONMENT=lxd
-$ snapcraft
+$ snapcraft --use-lxd
 ```
+
+Note that if you are building on non-amd64 hardware, snapcraft won't be able to use it's default LXD container image, so you can follow the next section to create an LXD container to run snapcraft in destructive-mode natively in the container.
 
 ### Building inside external container/VM using native snapcraft
 
 Finally, snapcraft can be run inside a VM, container or other similar build environment to build the snap without having snapcraft manage the environment (such as in a docker container where snaps are not available, or inside a VM launched from a build-farm without using nested VM's). 
 
 This requires creating an Ubuntu 18.04 environment and running snapcraft (from the snap) inside the environment with `--destructive-mode`. 
+
+#### LXD
+
+Snaps run inside LXD containers just like they do outside the container, so all you need to do is launch an Ubuntu 18.04 container, install snapcraft and run snapcraft like follows:
+
+```bash
+$ lxc launch ubuntu:18.04 edgex
+Creating edgex
+Starting edgex
+$ lxc exec edgex /bin/bash
+root@edgex:~# sudo apt update && sudo apt install snapd squashfuse git -y
+root@edgex:~# sudo snap install snapcraft --classic
+root@edgex:~# git clone https://github.com/edgexfoundry/edgex-go
+root@edgex:~# cd edgex-go && snapcraft --destructive-mode
+```
 
 #### Docker
 


### PR DESCRIPTION
* Fix markdown link for building on lxd
* Show new --use-lxd option for building with LXD in recent snapcraft
  versions
* Add section about setting LXD container environment to build the snap
  natively with --destructive-mode in
* Add note about needing to create LXD container manually if building on
  non-amd64 machine with snapcraft.