### PR TITLE
EF-1642 Added three environment variables which, when provided, overr…

### DIFF
--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"os"
 	"sync"
 
@@ -70,7 +71,7 @@ func bootstrap(profile string) {
 	deps := make(chan error, 2)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	var params = config2.BootParams{UseProfile: profile, Retry: config2.GetRetryInfo()}
+	var params = startup.BootParams{UseProfile: profile, Retry: config2.NewRetryInfo()}
 	go config.Retry(params, &wg, deps)
 	go func(ch chan error) {
 		for {

--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/edgexfoundry/edgex-go/internal"
+	config2 "github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/seed/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
@@ -70,7 +70,8 @@ func bootstrap(profile string) {
 	deps := make(chan error, 2)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	go config.Retry(profile, internal.BootTimeoutDefault, &wg, deps)
+	var params = config2.BootParams{UseProfile: profile, Retry: config2.GetRetryInfo()}
+	go config.Retry(params, &wg, deps)
 	go func(ch chan error) {
 		for {
 			select {

--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -46,7 +46,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, command.Retry, logBeforeInit)
 
 	ok := command.Init(useRegistry)

--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/command"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
@@ -46,7 +46,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, command.Retry, logBeforeInit)
 
 	ok := command.Init(useRegistry)

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -47,7 +47,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, data.Retry, logBeforeInit)
 
 	ok := data.Init(useRegistry)

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/data"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
@@ -47,7 +47,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, data.Retry, logBeforeInit)
 
 	ok := data.Init(useRegistry)

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -46,7 +46,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, metadata.Retry, logBeforeInit)
 
 	ok := metadata.Init(useRegistry)

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
@@ -46,7 +46,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, metadata.Retry, logBeforeInit)
 
 	ok := metadata.Init(useRegistry)

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -42,7 +42,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, client.Retry, logBeforeInit)
 
 	ok := client.Init(useRegistry)

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/export/client"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
@@ -42,7 +42,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, client.Retry, logBeforeInit)
 
 	ok := client.Init(useRegistry)

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -42,7 +42,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, distro.Retry, logBeforeInit)
 
 	if ok := distro.Init(useRegistry); !ok {

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -23,8 +23,8 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/export/distro"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
@@ -42,7 +42,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, distro.Retry, logBeforeInit)
 
 	if ok := distro.Init(useRegistry); !ok {

--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -56,7 +56,7 @@ func main() {
 	flag.Usage = usage.HelpCallbackSecurityProxy
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, proxy.Retry, logBeforeInit)
 
 	req := proxy.NewRequestor(ensureSkipVerify, proxy.Configuration.Writable.RequestTimeout)

--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy"
@@ -56,7 +56,7 @@ func main() {
 	flag.Usage = usage.HelpCallbackSecurityProxy
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, proxy.Retry, logBeforeInit)
 
 	req := proxy.NewRequestor(ensureSkipVerify, proxy.Configuration.Writable.RequestTimeout)

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -40,7 +40,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, logging.Retry, logBeforeInit)
 
 	ok := logging.Init(useRegistry)

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
@@ -40,7 +40,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, logging.Retry, logBeforeInit)
 
 	ok := logging.Init(useRegistry)

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
@@ -50,7 +50,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, notifications.Retry, logBeforeInit)
 
 	ok := notifications.Init(useRegistry)

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -50,7 +50,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, notifications.Retry, logBeforeInit)
 
 	ok := notifications.Init(useRegistry)

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
@@ -34,7 +34,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, scheduler.Retry, logBeforeInit)
 
 	ok := scheduler.Init(useRegistry)

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -34,7 +34,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, scheduler.Retry, logBeforeInit)
 
 	ok := scheduler.Init(useRegistry)

--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -47,7 +47,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
+	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.NewRetryInfo()}
 	startup.Bootstrap(params, agent.Retry, logBeforeInit)
 
 	ok := agent.Init(useRegistry)

--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gorilla/context"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
@@ -47,7 +47,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := config.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, Retry: config.GetRetryInfo()}
 	startup.Bootstrap(params, agent.Retry, logBeforeInit)
 
 	ok := agent.Init(useRegistry)

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -17,15 +17,15 @@ import "math"
 
 const (
 	BootRetryCountDefault        = math.MaxInt64
+	BootRetryCountKey            = "edgex_registry_retry_count"
 	BootRetryTimeoutDefault      = 30000
+	BootRetryTimeKey             = "edgex_registry_retry_timeout"
 	BootRetryWaitDefault         = 1
+	BootRetryWaitKey             = "edgex_registry_retry_wait"
 	ClientMonitorDefault         = 15000
 	ConfigFileName               = "configuration.toml"
 	ConfigRegistryStem           = "edgex/core/1.0/"
 	LogDurationKey               = "duration"
 	SecurityProxySetupServiceKey = "edgex-security-proxy-setup"
-)
-
-const (
-	WritableKey = "/Writable"
+	WritableKey                  = "/Writable"
 )

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -13,8 +13,12 @@
  *******************************************************************************/
 package internal
 
+import "math"
+
 const (
-	BootTimeoutDefault           = 30000
+	BootRetryCountDefault        = math.MaxInt64
+	BootRetryTimeoutDefault      = 30000
+	BootRetryWaitDefault         = 1
 	ClientMonitorDefault         = 15000
 	ConfigFileName               = "configuration.toml"
 	ConfigRegistryStem           = "edgex/core/1.0/"

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -49,17 +49,18 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
 	now := time.Now()
-	until := now.Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
+	until := now.Add(time.Millisecond * time.Duration(params.Retry.Timeout))
+	attempts := 0
+	for time.Now().Before(until) && attempts < params.Retry.Count {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(params.UseRegistry, params.UseProfile)
 			if err != nil {
 				ch <- err
-				if !useRegistry {
+				if !params.UseRegistry {
 					//Error occurred when attempting to read from local filesystem. Fail fast.
 					close(ch)
 					wait.Done()
@@ -67,7 +68,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				}
 			} else {
 				//Check against boot timeout default
-				if Configuration.Service.BootTimeout != timeout {
+				if Configuration.Service.BootTimeout != params.Retry.Timeout {
 					until = now.Add(time.Millisecond * time.Duration(Configuration.Service.BootTimeout))
 				}
 				// Setup Logging
@@ -75,7 +76,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				LoggingClient = logger.NewClient(clients.CoreCommandServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				//Initialize service clients
-				initializeClients(useRegistry)
+				initializeClients(params.UseRegistry)
 			}
 		}
 
@@ -88,7 +89,8 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				break
 			}
 		}
-		time.Sleep(time.Second * time.Duration(1))
+		time.Sleep(time.Second * time.Duration(params.Retry.Wait))
+		attempts++
 	}
 	close(ch)
 	wait.Done()

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -49,7 +49,7 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	now := time.Now()
 	until := now.Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -57,16 +57,17 @@ var msgClient messaging.MessageClient
 var mdc metadata.DeviceClient
 var msc metadata.DeviceServiceClient
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
+func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
+	attempts := 0
+	for time.Now().Before(until) && attempts < params.Retry.Count {
 		var err error
 		// When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(params.UseRegistry, params.UseProfile)
 			if err != nil {
 				ch <- err
-				if !useRegistry {
+				if !params.UseRegistry {
 					// Error occurred when attempting to read from local filesystem. Fail fast.
 					close(ch)
 					wait.Done()
@@ -78,7 +79,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				LoggingClient = logger.NewClient(clients.CoreDataServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				// Initialize service clients
-				initializeClients(useRegistry)
+				initializeClients(params.UseRegistry)
 			}
 		}
 
@@ -91,7 +92,8 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				break
 			}
 		}
-		time.Sleep(time.Second * time.Duration(1))
+		time.Sleep(time.Second * time.Duration(params.Retry.Wait))
+		attempts++
 	}
 	close(ch)
 	wait.Done()

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -57,7 +57,7 @@ var msgClient messaging.MessageClient
 var mdc metadata.DeviceClient
 var msc metadata.DeviceServiceClient
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0
 	for time.Now().Before(until) && attempts < params.Retry.Count {

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -51,16 +51,17 @@ var vdc coredata.ValueDescriptorClient
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry.
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
+func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
+	attempts := 0
+	for time.Now().Before(until) && attempts < params.Retry.Count {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(params.UseRegistry, params.UseProfile)
 			if err != nil {
 				ch <- err
-				if !useRegistry {
+				if !params.UseRegistry {
 					//Error occurred when attempting to read from local filesystem. Fail fast.
 					close(ch)
 					wait.Done()
@@ -68,7 +69,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				}
 			} else {
 				// Initialize notificationsClient based on configuration
-				initializeClients(useRegistry)
+				initializeClients(params.UseRegistry)
 				// Setup Logging
 				logTarget := setLoggingTarget()
 				LoggingClient = logger.NewClient(clients.CoreMetaDataServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
@@ -84,7 +85,8 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				break
 			}
 		}
-		time.Sleep(time.Second * time.Duration(1))
+		time.Sleep(time.Second * time.Duration(params.Retry.Wait))
+		attempts++
 	}
 	close(ch)
 	wait.Done()

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -51,7 +51,7 @@ var vdc coredata.ValueDescriptorClient
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry.
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0
 	for time.Now().Before(until) && attempts < params.Retry.Count {

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -42,7 +42,7 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0
 	for time.Now().Before(until) && attempts < params.Retry.Count {

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -42,16 +42,17 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
+func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
+	attempts := 0
+	for time.Now().Before(until) && attempts < params.Retry.Count{
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(params.UseRegistry, params.UseProfile)
 			if err != nil {
 				ch <- err
-				if !useRegistry {
+				if !params.UseRegistry {
 					//Error occurred when attempting to read from local filesystem. Fail fast.
 					close(ch)
 					wait.Done()
@@ -63,7 +64,7 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				LoggingClient = logger.NewClient(clients.ExportClientServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				//Initialize service clients
-				initializeClients(useRegistry)
+				initializeClients(params.UseRegistry)
 			}
 		}
 
@@ -76,7 +77,8 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				break
 			}
 		}
-		time.Sleep(time.Second * time.Duration(1))
+		time.Sleep(time.Second * time.Duration(params.Retry.Wait))
+		attempts++
 	}
 	close(ch)
 	wait.Done()

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -45,7 +45,7 @@ var registryUpdates chan interface{} //A channel for "config updates" sourced fr
 func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0
-	for time.Now().Before(until) && attempts < params.Retry.Count{
+	for time.Now().Before(until) && attempts < params.Retry.Count {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {

--- a/internal/export/distro/init.go
+++ b/internal/export/distro/init.go
@@ -42,16 +42,17 @@ var messageErrors chan error
 var messageEnvelopes chan msgTypes.MessageEnvelope
 var processStop chan bool
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
+func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
+	attempts := 0
+	for time.Now().Before(until) && attempts < params.Retry.Count {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(params.UseRegistry, params.UseProfile)
 			if err != nil {
 				ch <- err
-				if !useRegistry {
+				if !params.UseRegistry {
 					//Error occurred when attempting to read from local filesystem. Fail fast.
 					close(ch)
 					wait.Done()
@@ -63,14 +64,15 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				LoggingClient = logger.NewClient(clients.ExportDistroServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 
 				//Initialize service clients
-				initializeClients(useRegistry)
+				initializeClients(params.UseRegistry)
 			}
 		} else {
 			// once config is initialized, stop looping
 			break
 		}
 
-		time.Sleep(time.Second * time.Duration(1))
+		time.Sleep(time.Second * time.Duration(params.Retry.Wait))
+		attempts++
 	}
 	close(ch)
 	wait.Done()

--- a/internal/export/distro/init.go
+++ b/internal/export/distro/init.go
@@ -42,7 +42,7 @@ var messageErrors chan error
 var messageEnvelopes chan msgTypes.MessageEnvelope
 var processStop chan bool
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0
 	for time.Now().Before(until) && attempts < params.Retry.Count {

--- a/internal/pkg/config/environment.go
+++ b/internal/pkg/config/environment.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	envKeyUrl  = "edgex_registry"
+	envKeyUrl = "edgex_registry"
 )
 
 func OverrideFromEnvironment(registry RegistryInfo) RegistryInfo {

--- a/internal/pkg/config/environment.go
+++ b/internal/pkg/config/environment.go
@@ -20,13 +20,11 @@ import (
 	"strconv"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 )
 
 const (
-	envKeyUrl          = "edgex_registry"
-	envKeyRetryCount   = "edgex_registry_retry_count"
-	envKeyRetryTimeout = "edgex_registry_retry_timeout"
-	envKeyRetryWait    = "edgex_registry_retry_wait"
+	envKeyUrl  = "edgex_registry"
 )
 
 func OverrideFromEnvironment(registry RegistryInfo) RegistryInfo {
@@ -42,11 +40,11 @@ func OverrideFromEnvironment(registry RegistryInfo) RegistryInfo {
 	return registry
 }
 
-func GetRetryInfo() RetryInfo {
-	return RetryInfo{
-		Count:   GetFromEnvironmentUint(envKeyRetryCount, internal.BootRetryCountDefault),
-		Timeout: GetFromEnvironmentUint(envKeyRetryTimeout, internal.BootRetryTimeoutDefault),
-		Wait:    GetFromEnvironmentUint(envKeyRetryWait, internal.BootRetryWaitDefault),
+func NewRetryInfo() startup.RetryInfo {
+	return startup.RetryInfo{
+		Count:   GetFromEnvironmentUint(internal.BootRetryCountKey, internal.BootRetryCountDefault),
+		Timeout: GetFromEnvironmentUint(internal.BootRetryTimeKey, internal.BootRetryTimeoutDefault),
+		Wait:    GetFromEnvironmentUint(internal.BootRetryWaitKey, internal.BootRetryWaitDefault),
 	}
 }
 

--- a/internal/pkg/config/environment.go
+++ b/internal/pkg/config/environment.go
@@ -18,10 +18,15 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+
+	"github.com/edgexfoundry/edgex-go/internal"
 )
 
 const (
-	envKeyUrl = "edgex_registry"
+	envKeyUrl          = "edgex_registry"
+	envKeyRetryCount   = "edgex_registry_retry_count"
+	envKeyRetryTimeout = "edgex_registry_retry_timeout"
+	envKeyRetryWait    = "edgex_registry_retry_wait"
 )
 
 func OverrideFromEnvironment(registry RegistryInfo) RegistryInfo {
@@ -35,4 +40,21 @@ func OverrideFromEnvironment(registry RegistryInfo) RegistryInfo {
 		}
 	}
 	return registry
+}
+
+func GetRetryInfo () RetryInfo {
+	return RetryInfo {
+		Count:   GetFromEnvironmentUint(envKeyRetryCount, internal.BootRetryCountDefault),
+		Timeout: GetFromEnvironmentUint(envKeyRetryTimeout, internal.BootRetryTimeoutDefault),
+		Wait:    GetFromEnvironmentUint(envKeyRetryWait, internal.BootRetryWaitDefault),
+	}
+}
+
+func GetFromEnvironmentUint(key string, defval int) int {
+	if env := os.Getenv(key); env != "" {
+		if i, err := strconv.ParseInt(env, 10, 0); err == nil && i > 0 {
+			return int(i)
+		}
+	}
+	return defval
 }

--- a/internal/pkg/config/environment.go
+++ b/internal/pkg/config/environment.go
@@ -42,8 +42,8 @@ func OverrideFromEnvironment(registry RegistryInfo) RegistryInfo {
 	return registry
 }
 
-func GetRetryInfo () RetryInfo {
-	return RetryInfo {
+func GetRetryInfo() RetryInfo {
+	return RetryInfo{
 		Count:   GetFromEnvironmentUint(envKeyRetryCount, internal.BootRetryCountDefault),
 		Timeout: GetFromEnvironmentUint(envKeyRetryTimeout, internal.BootRetryTimeoutDefault),
 		Wait:    GetFromEnvironmentUint(envKeyRetryWait, internal.BootRetryWaitDefault),

--- a/internal/pkg/config/types.go
+++ b/internal/pkg/config/types.go
@@ -79,20 +79,6 @@ type RegistryInfo struct {
 	Type string
 }
 
-//	Various values for use when running the Retry function
-type RetryInfo struct {
-	Count   int
-	Timeout int
-	Wait    int
-}
-
-// Aggregation of properties used when booting a service
-type BootParams struct {
-	UseRegistry bool
-	UseProfile  string
-	Retry       RetryInfo
-}
-
 // LoggingInfo provides basic parameters related to where logs should be written.
 type LoggingInfo struct {
 	EnableRemote bool

--- a/internal/pkg/config/types.go
+++ b/internal/pkg/config/types.go
@@ -81,9 +81,9 @@ type RegistryInfo struct {
 
 //	Various values for use when running the Retry function
 type RetryInfo struct {
-	Count int
+	Count   int
 	Timeout int
-	Wait int
+	Wait    int
 }
 
 // Aggregation of properties used when booting a service
@@ -92,6 +92,7 @@ type BootParams struct {
 	UseProfile  string
 	Retry       RetryInfo
 }
+
 // LoggingInfo provides basic parameters related to where logs should be written.
 type LoggingInfo struct {
 	EnableRemote bool

--- a/internal/pkg/config/types.go
+++ b/internal/pkg/config/types.go
@@ -79,6 +79,19 @@ type RegistryInfo struct {
 	Type string
 }
 
+//	Various values for use when running the Retry function
+type RetryInfo struct {
+	Count int
+	Timeout int
+	Wait int
+}
+
+// Aggregation of properties used when booting a service
+type BootParams struct {
+	UseRegistry bool
+	UseProfile  string
+	Retry       RetryInfo
+}
 // LoggingInfo provides basic parameters related to where logs should be written.
 type LoggingInfo struct {
 	EnableRemote bool

--- a/internal/pkg/startup/bootstrap.go
+++ b/internal/pkg/startup/bootstrap.go
@@ -15,15 +15,13 @@ package startup
 
 import (
 	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
 
-type RetryFunc func(params config.BootParams, wait *sync.WaitGroup, ch chan error)
+type RetryFunc func(params BootParams, wait *sync.WaitGroup, ch chan error)
 
 type LogFunc func(err error)
 
-func Bootstrap(params config.BootParams, retry RetryFunc, log LogFunc) {
+func Bootstrap(params BootParams, retry RetryFunc, log LogFunc) {
 	deps := make(chan error, 2)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -43,3 +41,18 @@ func Bootstrap(params config.BootParams, retry RetryFunc, log LogFunc) {
 
 	wg.Wait()
 }
+
+// Aggregation of properties used when booting a service
+type BootParams struct {
+	UseRegistry bool
+	UseProfile  string
+	Retry       RetryInfo
+}
+
+//	Various values for use when running the Retry function
+type RetryInfo struct {
+	Count   int
+	Timeout int
+	Wait    int
+}
+

--- a/internal/pkg/startup/bootstrap.go
+++ b/internal/pkg/startup/bootstrap.go
@@ -13,23 +13,21 @@
  *******************************************************************************/
 package startup
 
-import "sync"
+import (
+	"sync"
 
-type RetryFunc func(UseRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error)
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+)
+
+type RetryFunc func(params config.BootParams, wait *sync.WaitGroup, ch chan error)
 
 type LogFunc func(err error)
 
-type BootParams struct {
-	UseRegistry bool
-	UseProfile  string
-	BootTimeout int
-}
-
-func Bootstrap(params BootParams, retry RetryFunc, log LogFunc) {
+func Bootstrap(params config.BootParams, retry RetryFunc, log LogFunc) {
 	deps := make(chan error, 2)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	go retry(params.UseRegistry, params.UseProfile, params.BootTimeout, &wg, deps)
+	go retry(params, &wg, deps)
 	go func(ch chan error) {
 		for {
 			select {

--- a/internal/pkg/startup/bootstrap.go
+++ b/internal/pkg/startup/bootstrap.go
@@ -55,4 +55,3 @@ type RetryInfo struct {
 	Timeout int
 	Wait    int
 }
-

--- a/internal/pkg/startup/bootstrap_test.go
+++ b/internal/pkg/startup/bootstrap_test.go
@@ -41,7 +41,7 @@ func clearVars() {
 func testPass(t *testing.T) {
 	clearVars()
 
-	p := config.BootParams{true, "", config.RetryInfo{Timeout: timeoutPass}}
+	p := config.BootParams{UseRegistry: true, UseProfile: "", Retry: config.RetryInfo{Timeout: timeoutPass}}
 	Bootstrap(p, mockRetry, mockLog)
 	if !checkInit {
 		t.Error("checkInit should be true.")
@@ -53,7 +53,7 @@ func testPass(t *testing.T) {
 
 func testFail(t *testing.T) {
 	clearVars()
-	p := config.BootParams{true, "", config.RetryInfo{Timeout: timeoutFail}}
+	p := config.BootParams{UseRegistry: true, UseProfile: "", Retry: config.RetryInfo{Timeout: timeoutFail}}
 	Bootstrap(p, mockRetry, mockLog)
 	time.Sleep(time.Millisecond * time.Duration(25)) //goroutine timing
 	if checkInit {

--- a/internal/pkg/startup/bootstrap_test.go
+++ b/internal/pkg/startup/bootstrap_test.go
@@ -14,7 +14,6 @@
 package startup
 
 import (
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"sync"
 	"testing"
 
@@ -41,7 +40,7 @@ func clearVars() {
 func testPass(t *testing.T) {
 	clearVars()
 
-	p := config.BootParams{UseRegistry: true, UseProfile: "", Retry: config.RetryInfo{Timeout: timeoutPass}}
+	p := BootParams{UseRegistry: true, UseProfile: "", Retry: RetryInfo{Timeout: timeoutPass}}
 	Bootstrap(p, mockRetry, mockLog)
 	if !checkInit {
 		t.Error("checkInit should be true.")
@@ -53,7 +52,7 @@ func testPass(t *testing.T) {
 
 func testFail(t *testing.T) {
 	clearVars()
-	p := config.BootParams{UseRegistry: true, UseProfile: "", Retry: config.RetryInfo{Timeout: timeoutFail}}
+	p := BootParams{UseRegistry: true, UseProfile: "", Retry: RetryInfo{Timeout: timeoutFail}}
 	Bootstrap(p, mockRetry, mockLog)
 	time.Sleep(time.Millisecond * time.Duration(25)) //goroutine timing
 	if checkInit {
@@ -68,7 +67,7 @@ func testFail(t *testing.T) {
 //Different test cases are toggled according to the timeout value
 //SUCCESS = short duration 100ms
 //FAIL = long duration 1000ms
-func mockRetry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func mockRetry(params BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	for time.Now().Before(until) {
 		if params.Retry.Timeout == timeoutFail {

--- a/internal/pkg/startup/bootstrap_test.go
+++ b/internal/pkg/startup/bootstrap_test.go
@@ -41,7 +41,7 @@ func clearVars() {
 func testPass(t *testing.T) {
 	clearVars()
 
-	p := config.BootParams{true, "", config.RetryInfo{9999999, timeoutPass, 1}}
+	p := config.BootParams{true, "", config.RetryInfo{Timeout: timeoutPass}}
 	Bootstrap(p, mockRetry, mockLog)
 	if !checkInit {
 		t.Error("checkInit should be true.")
@@ -53,7 +53,7 @@ func testPass(t *testing.T) {
 
 func testFail(t *testing.T) {
 	clearVars()
-	p := config.BootParams{true, "", config.RetryInfo{9999999, timeoutFail, 1}}
+	p := config.BootParams{true, "", config.RetryInfo{Timeout: timeoutFail}}
 	Bootstrap(p, mockRetry, mockLog)
 	time.Sleep(time.Millisecond * time.Duration(25)) //goroutine timing
 	if checkInit {

--- a/internal/pkg/startup/bootstrap_test.go
+++ b/internal/pkg/startup/bootstrap_test.go
@@ -14,6 +14,7 @@
 package startup
 
 import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"sync"
 	"testing"
 
@@ -39,7 +40,8 @@ func clearVars() {
 
 func testPass(t *testing.T) {
 	clearVars()
-	p := BootParams{true, "", timeoutPass}
+
+	p := config.BootParams{true, "", config.RetryInfo{9999999, timeoutPass, 1}}
 	Bootstrap(p, mockRetry, mockLog)
 	if !checkInit {
 		t.Error("checkInit should be true.")
@@ -51,7 +53,7 @@ func testPass(t *testing.T) {
 
 func testFail(t *testing.T) {
 	clearVars()
-	p := BootParams{true, "", timeoutFail}
+	p := config.BootParams{true, "", config.RetryInfo{9999999, timeoutPass, 1}}
 	Bootstrap(p, mockRetry, mockLog)
 	time.Sleep(time.Millisecond * time.Duration(25)) //goroutine timing
 	if checkInit {
@@ -66,10 +68,10 @@ func testFail(t *testing.T) {
 //Different test cases are toggled according to the timeout value
 //SUCCESS = short duration 100ms
 //FAIL = long duration 1000ms
-func mockRetry(UseRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
+func mockRetry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	for time.Now().Before(until) {
-		if timeout == timeoutFail {
+		if params.Retry.Timeout == timeoutFail {
 			err := fmt.Errorf("Timeout Fail caught")
 			ch <- err
 			close(ch)

--- a/internal/pkg/startup/bootstrap_test.go
+++ b/internal/pkg/startup/bootstrap_test.go
@@ -53,7 +53,7 @@ func testPass(t *testing.T) {
 
 func testFail(t *testing.T) {
 	clearVars()
-	p := config.BootParams{true, "", config.RetryInfo{9999999, timeoutPass, 1}}
+	p := config.BootParams{true, "", config.RetryInfo{9999999, timeoutFail, 1}}
 	Bootstrap(p, mockRetry, mockLog)
 	time.Sleep(time.Millisecond * time.Duration(25)) //goroutine timing
 	if checkInit {

--- a/internal/security/proxy/init.go
+++ b/internal/security/proxy/init.go
@@ -29,16 +29,17 @@ import (
 var Configuration *ConfigurationStruct
 var LoggingClient logger.LoggingClient
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
+func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
+	attempts := 0
+	for time.Now().Before(until) && attempts < params.Retry.Count {
 		var err error
 		// When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(params.UseRegistry, params.UseProfile)
 			if err != nil {
 				ch <- err
-				if !useRegistry {
+				if !params.UseRegistry {
 					// Error occurred when attempting to read from local filesystem. Fail fast.
 					close(ch)
 					wait.Done()
@@ -55,7 +56,8 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 		if Configuration != nil {
 			break
 		}
-		time.Sleep(time.Second * time.Duration(1))
+		time.Sleep(time.Second * time.Duration(params.Retry.Wait))
+		attempts++
 	}
 	close(ch)
 	wait.Done()

--- a/internal/security/proxy/init.go
+++ b/internal/security/proxy/init.go
@@ -16,6 +16,7 @@
 package proxy
 
 import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"sync"
 	"time"
 
@@ -29,7 +30,7 @@ import (
 var Configuration *ConfigurationStruct
 var LoggingClient logger.LoggingClient
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0
 	for time.Now().Before(until) && attempts < params.Retry.Count {

--- a/internal/seed/config/init.go
+++ b/internal/seed/config/init.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"io/ioutil"
 	"net/http"
 	"sync"
@@ -37,7 +38,7 @@ var Registry registry.Client
 // The purpose of Retry is different here than in other services. In this case, we use a retry in order
 // to initialize the RegistryClient that will be used to write configuration information. Other services
 // use Retry to read their information. Config-seed writes information.
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0
 	for time.Now().Before(until) && attempts < params.Retry.Count {

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -33,17 +33,18 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
 	LoggingClient = newPrivateLogger()
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
+	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
+	attempts := 0
+	for time.Now().Before(until) && attempts < params.Retry.Count {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(params.UseRegistry, params.UseProfile)
 			if err != nil {
 				ch <- err
-				if !useRegistry {
+				if !params.UseRegistry {
 					//Error occurred when attempting to read from local filesystem. Fail fast.
 					close(ch)
 					wait.Done()
@@ -61,7 +62,8 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 				break
 			}
 		}
-		time.Sleep(time.Second * time.Duration(1))
+		time.Sleep(time.Second * time.Duration(params.Retry.Wait))
+		attempts++
 	}
 	close(ch)
 	wait.Done()

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -10,6 +10,7 @@ package logging
 import (
 	"errors"
 	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"os"
 	"os/signal"
 	"sync"
@@ -33,7 +34,7 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	LoggingClient = newPrivateLogger()
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0

--- a/internal/support/notifications/init.go
+++ b/internal/support/notifications/init.go
@@ -20,6 +20,7 @@ package notifications
 import (
 	"errors"
 	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"os"
 	"os/signal"
 	"sync"
@@ -47,7 +48,7 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registerUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0
 	for time.Now().Before(until) && attempts < params.Retry.Count {

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -17,6 +17,7 @@ package scheduler
 import (
 	"errors"
 	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
 	"os"
 	"os/signal"
 	"sync"
@@ -47,7 +48,7 @@ var registryUpdates chan interface{} //A channel for "config updates" sourced fr
 
 var ticker *time.Ticker
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	now := time.Now()
 	until := now.Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -45,7 +45,7 @@ var chUpdates chan interface{} //A channel for "config updates" sourced from Reg
 // to whatever operation we need it to do at runtime.
 var executorClient interface{}
 
-func Retry(params config.BootParams, wait *sync.WaitGroup, ch chan error) {
+func Retry(params startup.BootParams, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(params.Retry.Timeout))
 	attempts := 0
 	for time.Now().Before(until) && attempts < params.Retry.Count {


### PR DESCRIPTION
…ide the default retry timeout/wait, and refactored all existing main.go/init.go usages.

There are three retry values: timeout, wait, count.  Logically, timeout = wait * count (or should), so really might not need a separate timeout value; however, by keeping three the existing usage/paradigm is kept intact, but if preferred someone can specify the n attempts instead.  Just a matter of preference and not forcing people to do unnecessary math.

Refactored func retry() to accept a structure containining the necessary values used rather than continuing to add more individual parameters (previous 3, today 5, tomorrow?).  To support this, a new RetryType was created for holding the three retry values, and BootParam was moved from startup to config so that everything tied together cleanly (or so I believe).

Signed-off-by: Scott C Sosna <me@scottsosna.dev>