### PR TITLE
Unit test -- Core-Metadata Get Device Service By Name/ Addressable Name

### DIFF
--- a/internal/core/metadata/operators/addressable/delete.go
+++ b/internal/core/metadata/operators/addressable/delete.go
@@ -73,13 +73,18 @@ func (op addressDelete) Execute() error {
 	return nil
 }
 
-// This factory method returns an executor used to delete an addressable.
-// Addressables will first be searched by ID.
-// If the provided ID is the empty string, it will be looked up by name.
-func NewDeleteExecutor(db AddressDeleter, id string, name string) DeleteExecutor {
+// This factory method returns an executor used to delete an addressable by ID.
+func NewDeleteByIdExecutor(db AddressDeleter, id string) DeleteExecutor {
 	return addressDelete{
 		database: db,
 		id:       id,
+	}
+}
+
+// This factory method returns an executor used to delete an addressable by name.
+func NewDeleteByNameExecutor(db AddressDeleter, name string) DeleteExecutor {
+	return addressDelete{
+		database: db,
 		name:     name,
 	}
 }

--- a/internal/core/metadata/operators/addressable/delete.go
+++ b/internal/core/metadata/operators/addressable/delete.go
@@ -37,22 +37,19 @@ func (op addressDelete) Execute() error {
 	var err error
 
 	// deleteById and deleteByName all use the deleteById database function, so abstract away the front end difference
-	if op.id == "" {
-		if op.name == "" {
-			// short circuit a bad request
-			return errors.NewErrAddressableNotFound(op.id, op.name)
-		}
-
-		addressable, err = op.database.GetAddressableByName(op.name)
-	} else {
+	if op.id != "" {
 		addressable, err = op.database.GetAddressableById(op.id)
+		if err == db.ErrNotFound {
+			err = errors.NewErrAddressableNotFound(op.id, "")
+		}
+	} else {
+		addressable, err = op.database.GetAddressableByName(op.name)
+		if err == db.ErrNotFound {
+			err = errors.NewErrAddressableNotFound("", op.name)
+		}
 	}
 
 	if err != nil {
-		if err == db.ErrNotFound {
-			return errors.NewErrAddressableNotFound(op.id, op.name)
-		}
-
 		return err
 	}
 

--- a/internal/core/metadata/operators/addressable/delete_test.go
+++ b/internal/core/metadata/operators/addressable/delete_test.go
@@ -40,7 +40,8 @@ func TestDeleteByIdExecutor(t *testing.T) {
 			mockDeleter: createMockDeleter([]mockOutline{
 				{"GetAddressableById", success.Id, success, nil},
 				{"GetDeviceServicesByAddressableId", mock.Anything, []contract.DeviceService{}, nil},
-				{"DeleteAddressableById", mock.Anything, nil, nil}}),
+				{"DeleteAddressableById", mock.Anything, nil, nil},
+			}),
 			id:               success.Id,
 			expectedError:    false,
 			expectedErrorVal: nil,
@@ -48,14 +49,17 @@ func TestDeleteByIdExecutor(t *testing.T) {
 		{
 			testName: "Addressable not found",
 			mockDeleter: createMockDeleter([]mockOutline{
-				{"GetAddressableById", success.Id, contract.Addressable{}, db.ErrNotFound}}),
+				{"GetAddressableById", success.Id, contract.Addressable{}, db.ErrNotFound},
+			}),
 			id:               success.Id,
 			expectedError:    true,
 			expectedErrorVal: errors.NewErrAddressableNotFound(success.Id, ""),
 		},
 		{
-			testName:         "No identifiers provided",
-			mockDeleter:      nil,
+			testName: "No ID provided",
+			mockDeleter: createMockDeleter([]mockOutline{
+				{"GetAddressableByName", "", contract.Addressable{}, db.ErrNotFound},
+			}),
 			id:               "",
 			expectedError:    true,
 			expectedErrorVal: errors.NewErrAddressableNotFound("", ""),
@@ -63,7 +67,8 @@ func TestDeleteByIdExecutor(t *testing.T) {
 		{
 			testName: "Unsuccessful database call retrieving addressable",
 			mockDeleter: createMockDeleter([]mockOutline{
-				{"GetAddressableById", mock.Anything, contract.Addressable{}, Error}}),
+				{"GetAddressableById", mock.Anything, contract.Addressable{}, Error},
+			}),
 			id:               success.Id,
 			expectedError:    true,
 			expectedErrorVal: Error,
@@ -82,7 +87,8 @@ func TestDeleteByIdExecutor(t *testing.T) {
 			testName: "Unsuccessful database call retrieving device services",
 			mockDeleter: createMockDeleter([]mockOutline{
 				{"GetAddressableById", success.Id, success, nil},
-				{"GetDeviceServicesByAddressableId", mock.Anything, []contract.DeviceService{}, Error}}),
+				{"GetDeviceServicesByAddressableId", mock.Anything, []contract.DeviceService{}, Error},
+			}),
 			id:               success.Id,
 			expectedError:    true,
 			expectedErrorVal: Error,
@@ -92,7 +98,8 @@ func TestDeleteByIdExecutor(t *testing.T) {
 			mockDeleter: createMockDeleter([]mockOutline{
 				{"GetAddressableById", success.Id, success, nil},
 				{"GetDeviceServicesByAddressableId", mock.Anything, []contract.DeviceService{}, nil},
-				{"DeleteAddressableById", mock.Anything, Error, nil}}),
+				{"DeleteAddressableById", mock.Anything, Error, nil},
+			}),
 			id:               success.Id,
 			expectedError:    true,
 			expectedErrorVal: Error,
@@ -137,7 +144,8 @@ func TestDeleteByNameExecutor(t *testing.T) {
 			mockDeleter: createMockDeleter([]mockOutline{
 				{"GetAddressableByName", success.Name, success, nil},
 				{"GetDeviceServicesByAddressableId", mock.Anything, []contract.DeviceService{}, nil},
-				{"DeleteAddressableById", mock.Anything, nil, nil}}),
+				{"DeleteAddressableById", mock.Anything, nil, nil},
+			}),
 			name:             success.Name,
 			expectedError:    false,
 			expectedErrorVal: nil,
@@ -145,14 +153,17 @@ func TestDeleteByNameExecutor(t *testing.T) {
 		{
 			testName: "Addressable not found",
 			mockDeleter: createMockDeleter([]mockOutline{
-				{"GetAddressableByName", success.Name, contract.Addressable{}, db.ErrNotFound}}),
+				{"GetAddressableByName", success.Name, contract.Addressable{}, db.ErrNotFound},
+			}),
 			name:             success.Name,
 			expectedError:    true,
 			expectedErrorVal: errors.NewErrAddressableNotFound("", success.Name),
 		},
 		{
-			testName:         "No identifiers provided",
-			mockDeleter:      nil,
+			testName: "No name provided",
+			mockDeleter: createMockDeleter([]mockOutline{
+				{"GetAddressableByName", "", contract.Addressable{}, db.ErrNotFound},
+			}),
 			name:             "",
 			expectedError:    true,
 			expectedErrorVal: errors.NewErrAddressableNotFound("", ""),
@@ -160,7 +171,8 @@ func TestDeleteByNameExecutor(t *testing.T) {
 		{
 			testName: "Unsuccessful database call retrieving addressable",
 			mockDeleter: createMockDeleter([]mockOutline{
-				{"GetAddressableByName", mock.Anything, contract.Addressable{}, Error}}),
+				{"GetAddressableByName", mock.Anything, contract.Addressable{}, Error},
+			}),
 			name:             success.Name,
 			expectedError:    true,
 			expectedErrorVal: Error,
@@ -170,7 +182,8 @@ func TestDeleteByNameExecutor(t *testing.T) {
 			mockDeleter: createMockDeleter([]mockOutline{
 				{"GetAddressableByName", mock.Anything, success, nil},
 				{"GetDeviceServicesByAddressableId", mock.Anything, []contract.DeviceService{{}}, nil},
-				{"DeleteAddressableById", mock.Anything, nil, nil}}),
+				{"DeleteAddressableById", mock.Anything, nil, nil},
+			}),
 			name:             success.Name,
 			expectedError:    true,
 			expectedErrorVal: errors.NewErrAddressableInUse(success.Name),
@@ -179,7 +192,8 @@ func TestDeleteByNameExecutor(t *testing.T) {
 			testName: "Unsuccessful database call retrieving device services",
 			mockDeleter: createMockDeleter([]mockOutline{
 				{"GetAddressableByName", mock.Anything, contract.Addressable{}, Error},
-				{"GetDeviceServicesByAddressableId", mock.Anything, []contract.DeviceService{}, Error}}),
+				{"GetDeviceServicesByAddressableId", mock.Anything, []contract.DeviceService{}, Error},
+			}),
 			name:             success.Name,
 			expectedError:    true,
 			expectedErrorVal: Error,
@@ -189,7 +203,8 @@ func TestDeleteByNameExecutor(t *testing.T) {
 			mockDeleter: createMockDeleter([]mockOutline{
 				{"GetAddressableByName", mock.Anything, contract.Addressable{}, Error},
 				{"GetDeviceServicesByAddressableId", mock.Anything, []contract.DeviceService{}, nil},
-				{"DeleteAddressableById", mock.Anything, Error, nil}}),
+				{"DeleteAddressableById", mock.Anything, Error, nil},
+			}),
 			name:             success.Name,
 			expectedError:    true,
 			expectedErrorVal: Error,

--- a/internal/core/metadata/operators/device_service/db.go
+++ b/internal/core/metadata/operators/device_service/db.go
@@ -25,6 +25,7 @@ type DeviceServiceLoader interface {
 	GetDeviceServicesByAddressableId(id string) ([]contract.DeviceService, error)
 
 	GetAddressableById(id string) (contract.Addressable, error)
+	GetAddressableByName(id string) (contract.Addressable, error)
 }
 
 type DeviceServiceUpdater interface {

--- a/internal/core/metadata/operators/device_service/db.go
+++ b/internal/core/metadata/operators/device_service/db.go
@@ -25,7 +25,7 @@ type DeviceServiceLoader interface {
 	GetDeviceServicesByAddressableId(id string) ([]contract.DeviceService, error)
 
 	GetAddressableById(id string) (contract.Addressable, error)
-	GetAddressableByName(id string) (contract.Addressable, error)
+	GetAddressableByName(name string) (contract.Addressable, error)
 }
 
 type DeviceServiceUpdater interface {

--- a/internal/core/metadata/operators/device_service/get.go
+++ b/internal/core/metadata/operators/device_service/get.go
@@ -115,7 +115,7 @@ type deviceServiceLoadById struct {
 	db DeviceServiceLoader
 }
 
-// NewDeviceServiceLoadById creates a new Executor that retrieves all DeviceService associated with a given ID.
+// NewDeviceServiceLoadById creates a new Executor that retrieves the DeviceService associated with a given ID.
 func NewDeviceServiceLoadById(id string, db DeviceServiceLoader) DeviceServiceGetExecutor {
 	return deviceServiceLoadById{id: id, db: db}
 }
@@ -126,6 +126,30 @@ func (op deviceServiceLoadById) Execute() (contract.DeviceService, error) {
 	if err != nil {
 		if err == db.ErrNotFound {
 			return contract.DeviceService{}, errors.NewErrItemNotFound(op.id)
+		} else {
+			return contract.DeviceService{}, err
+		}
+	}
+
+	return ds, nil
+}
+
+type deviceServiceLoadByName struct {
+	name string
+	db   DeviceServiceLoader
+}
+
+// NewDeviceServiceLoadByName creates a new Executor that retrieves the DeviceService associated with a given name.
+func NewDeviceServiceLoadByName(name string, db DeviceServiceLoader) DeviceServiceGetExecutor {
+	return deviceServiceLoadByName{name: name, db: db}
+}
+
+// Execute performs an operation that retrieves the DeviceService associated with a given name.
+func (op deviceServiceLoadByName) Execute() (contract.DeviceService, error) {
+	ds, err := op.db.GetDeviceServiceByName(op.name)
+	if err != nil {
+		if err == db.ErrNotFound {
+			return contract.DeviceService{}, errors.NewErrItemNotFound(op.name)
 		} else {
 			return contract.DeviceService{}, err
 		}

--- a/internal/core/metadata/operators/device_service/get.go
+++ b/internal/core/metadata/operators/device_service/get.go
@@ -59,13 +59,13 @@ type deviceServiceLoadByAddressable struct {
 	db   DeviceServiceLoader
 }
 
-// NewDeviceServiceLoadByAddressableByName creates a new Executor that retrieves all DeviceService associated with a given Addressable name.
-func NewDeviceServiceLoadByAddressableByName(name string, db DeviceServiceLoader) DeviceServiceGetAllExecutor {
+// NewDeviceServiceLoadByAddressableName creates a new Executor that retrieves all DeviceService associated with a given Addressable name.
+func NewDeviceServiceLoadByAddressableName(name string, db DeviceServiceLoader) DeviceServiceGetAllExecutor {
 	return deviceServiceLoadByAddressable{name: name, db: db}
 }
 
-// NewDeviceServiceLoadByAddressableByID creates a new Executor that retrieves all DeviceService associated with a given Addressable ID.
-func NewDeviceServiceLoadByAddressableByID(id string, db DeviceServiceLoader) DeviceServiceGetAllExecutor {
+// NewDeviceServiceLoadByAddressableID creates a new Executor that retrieves all DeviceService associated with a given Addressable ID.
+func NewDeviceServiceLoadByAddressableID(id string, db DeviceServiceLoader) DeviceServiceGetAllExecutor {
 	return deviceServiceLoadByAddressable{id: id, db: db}
 }
 

--- a/internal/core/metadata/operators/device_service/get_test.go
+++ b/internal/core/metadata/operators/device_service/get_test.go
@@ -229,8 +229,10 @@ func TestGetDeviceServiceByAddressableId(t *testing.T) {
 			expectedErrorVal: nil,
 		},
 		{
-			name:             "No ID provided",
-			mockLoader:       nil,
+			name: "No ID provided",
+			mockLoader: createMockLoader([]mockOutline{
+				{"GetAddressableByName", "", contract.Addressable{}, db.ErrNotFound},
+			}),
 			value:            "",
 			expectedVal:      nil,
 			expectedError:    true,
@@ -318,8 +320,10 @@ func TestGetDeviceServiceByAddressableName(t *testing.T) {
 			expectedErrorVal: nil,
 		},
 		{
-			name:             "No name provided",
-			mockLoader:       nil,
+			name: "No name provided",
+			mockLoader: createMockLoader([]mockOutline{
+				{"GetAddressableByName", "", contract.Addressable{}, db.ErrNotFound},
+			}),
 			value:            "",
 			expectedVal:      nil,
 			expectedError:    true,

--- a/internal/core/metadata/operators/device_service/get_test.go
+++ b/internal/core/metadata/operators/device_service/get_test.go
@@ -271,7 +271,7 @@ func TestGetDeviceServiceByAddressableId(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			op := NewDeviceServiceLoadByAddressableByID(test.value, test.mockLoader)
+			op := NewDeviceServiceLoadByAddressableID(test.value, test.mockLoader)
 			actualVal, err := op.Execute()
 			if !reflect.DeepEqual(test.expectedVal, actualVal) {
 				t.Errorf("Observed value doesn't match expected.\nExpected: %v\nActual: %v\n", test.expectedVal, actualVal)
@@ -360,7 +360,7 @@ func TestGetDeviceServiceByAddressableName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			op := NewDeviceServiceLoadByAddressableByName(test.value, test.mockLoader)
+			op := NewDeviceServiceLoadByAddressableName(test.value, test.mockLoader)
 			actualVal, err := op.Execute()
 			if !reflect.DeepEqual(test.expectedVal, actualVal) {
 				t.Errorf("Observed value doesn't match expected.\nExpected: %v\nActual: %v\n", test.expectedVal, actualVal)

--- a/internal/core/metadata/operators/device_service/get_test.go
+++ b/internal/core/metadata/operators/device_service/get_test.go
@@ -78,6 +78,71 @@ func TestGetAllDeviceServices(t *testing.T) {
 	}
 }
 
+func TestGetDeviceServiceByName(t *testing.T) {
+	tests := []struct {
+		name             string
+		mockLoader       DeviceServiceLoader
+		expectedVal      contract.DeviceService
+		expectedError    bool
+		expectedErrorVal error
+	}{
+		{
+			name: "Successful database call",
+			mockLoader: createMockLoader([]mockOutline{
+				{"GetDeviceServiceByName", testDeviceServiceName, testDeviceService, nil},
+			}),
+			expectedVal:      testDeviceService,
+			expectedError:    false,
+			expectedErrorVal: nil,
+		},
+		{
+			name: "Device service not found",
+			mockLoader: createMockLoader([]mockOutline{
+				{"GetDeviceServiceByName", testDeviceServiceName, contract.DeviceService{}, db.ErrNotFound},
+			}),
+			expectedVal:      contract.DeviceService{},
+			expectedError:    true,
+			expectedErrorVal: errors.NewErrItemNotFound(testDeviceServiceName),
+		},
+		{
+			name: "Device services lookup error",
+			mockLoader: createMockLoader([]mockOutline{
+				{"GetDeviceServiceByName", testDeviceServiceName, contract.DeviceService{}, testError},
+			}),
+			expectedVal:      contract.DeviceService{},
+			expectedError:    true,
+			expectedErrorVal: testError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			op := NewDeviceServiceLoadByName(testDeviceServiceName, test.mockLoader)
+			actualVal, err := op.Execute()
+			if !reflect.DeepEqual(test.expectedVal, actualVal) {
+				t.Errorf("Observed value doesn't match expected.\nExpected: %v\nActual: %v\n", test.expectedVal, actualVal)
+				return
+			}
+
+			if test.expectedError && err == nil {
+				t.Error("Expected an error")
+				return
+			}
+
+			if !test.expectedError && err != nil {
+				t.Errorf("Unexpectedly encountered error: %s", err.Error())
+				return
+			}
+
+			if test.expectedErrorVal != nil && err != nil {
+				if test.expectedErrorVal.Error() != err.Error() {
+					t.Errorf("Observed error doesn't match expected.\nExpected: %v\nActual: %v\n", test.expectedErrorVal.Error(), err.Error())
+				}
+			}
+		})
+	}
+}
+
 func TestGetDeviceServiceById(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/core/metadata/operators/device_service/mocks/DeviceServiceLoader.go
+++ b/internal/core/metadata/operators/device_service/mocks/DeviceServiceLoader.go
@@ -31,6 +31,27 @@ func (_m *DeviceServiceLoader) GetAddressableById(id string) (models.Addressable
 	return r0, r1
 }
 
+// GetAddressableByName provides a mock function with given fields: id
+func (_m *DeviceServiceLoader) GetAddressableByName(id string) (models.Addressable, error) {
+	ret := _m.Called(id)
+
+	var r0 models.Addressable
+	if rf, ok := ret.Get(0).(func(string) models.Addressable); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(models.Addressable)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAllDeviceServices provides a mock function with given fields:
 func (_m *DeviceServiceLoader) GetAllDeviceServices() ([]models.DeviceService, error) {
 	ret := _m.Called()

--- a/internal/core/metadata/operators/device_service/mocks/DeviceServiceUpdater.go
+++ b/internal/core/metadata/operators/device_service/mocks/DeviceServiceUpdater.go
@@ -31,6 +31,27 @@ func (_m *DeviceServiceUpdater) GetAddressableById(id string) (models.Addressabl
 	return r0, r1
 }
 
+// GetAddressableByName provides a mock function with given fields: id
+func (_m *DeviceServiceUpdater) GetAddressableByName(id string) (models.Addressable, error) {
+	ret := _m.Called(id)
+
+	var r0 models.Addressable
+	if rf, ok := ret.Get(0).(func(string) models.Addressable); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(models.Addressable)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAllDeviceServices provides a mock function with given fields:
 func (_m *DeviceServiceUpdater) GetAllDeviceServices() ([]models.DeviceService, error) {
 	ret := _m.Called()

--- a/internal/core/metadata/rest_addressable.go
+++ b/internal/core/metadata/rest_addressable.go
@@ -137,7 +137,7 @@ func restDeleteAddressableById(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	var id string = vars[ID]
 
-	op := addressable.NewDeleteExecutor(dbClient, id, "")
+	op := addressable.NewDeleteByIdExecutor(dbClient, id)
 	err := op.Execute()
 	if err != nil {
 		switch err.(type) {
@@ -166,7 +166,7 @@ func restDeleteAddressableByName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	op := addressable.NewDeleteExecutor(dbClient, "", name)
+	op := addressable.NewDeleteByNameExecutor(dbClient, name)
 	err = op.Execute()
 	if err != nil {
 		switch err.(type) {

--- a/internal/core/metadata/rest_deviceservice.go
+++ b/internal/core/metadata/rest_deviceservice.go
@@ -224,7 +224,7 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 

--- a/internal/core/metadata/rest_deviceservice.go
+++ b/internal/core/metadata/rest_deviceservice.go
@@ -278,18 +278,20 @@ func restGetServiceByName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := dbClient.GetDeviceServiceByName(dn)
+	op := device_service.NewDeviceServiceLoadByName(dn, dbClient)
+	res, err := op.Execute()
 	if err != nil {
-		if err == db.ErrNotFound {
+		switch err.(type) {
+		case *types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
+		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		LoggingClient.Error(err.Error())
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 

--- a/internal/core/metadata/rest_deviceservice.go
+++ b/internal/core/metadata/rest_deviceservice.go
@@ -211,7 +211,7 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	op := device_service.NewDeviceServiceLoadByAddressableByName(an, dbClient)
+	op := device_service.NewDeviceServiceLoadByAddressableName(an, dbClient)
 	res, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
@@ -232,7 +232,7 @@ func restGetServiceByAddressableId(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	var sid = vars[ADDRESSABLEID]
 
-	op := device_service.NewDeviceServiceLoadByAddressableByID(sid, dbClient)
+	op := device_service.NewDeviceServiceLoadByAddressableID(sid, dbClient)
 	res, err := op.Execute()
 	if err != nil {
 		switch err.(type) {

--- a/internal/core/metadata/rest_deviceservice_test.go
+++ b/internal/core/metadata/rest_deviceservice_test.go
@@ -205,7 +205,9 @@ func TestGetServiceByAddressableName(t *testing.T) {
 		},
 		{
 			"No name provided",
-			nil,
+			createMockWithOutlines([]mockOutline{
+				{"GetAddressableByName", "", contract.Addressable{}, db.ErrNotFound},
+			}),
 			"",
 			http.StatusNotFound,
 		},
@@ -268,7 +270,9 @@ func TestGetServiceByAddressableId(t *testing.T) {
 		},
 		{
 			"No ID provided",
-			nil,
+			createMockWithOutlines([]mockOutline{
+				{"GetAddressableByName", "", contract.Addressable{}, db.ErrNotFound},
+			}),
 			"",
 			http.StatusNotFound,
 		},


### PR DESCRIPTION
Fix #1696

While I was working, I also refactored Addressable's delete code to take advantage of the pattern I used in this PR with the GetByAddressable Executor. Instead of having one factory method that takes both an ID and a name, I have two factory methods to reduce the chance that a consumer does the wrong thing. Technically out of scope, but I wanted to catch it while it was on my mind.