### PR TITLE
Fixes error handling in core-data event/ POST rte

### DIFF
--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -228,6 +228,20 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		newId, err := addNewEvent(evt, ctx)
+		if err != nil {
+			switch e := err.(type) {
+			case *errors.ErrValueDescriptorNotFound:
+				http.Error(w, err.Error(), http.StatusNotFound)
+			case *errors.ErrValueDescriptorInvalid:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			case *types.ErrServiceClient:
+				http.Error(w, e.Error(), e.StatusCode)
+			default:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			LoggingClient.Error(err.Error())
+			return
+		}
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(newId))


### PR DESCRIPTION
Fix #1731 

Error from a call to `addNewEvent()` was being ignored in the
handler, causing failures to add Events to be swallowed and
200 OKs to be returned to clients.  This change adds error
handling for the route in accordance with the RAML file at
https://github.com/edgexfoundry/edgex-go/blob/master/api/raml/core-data.raml

Signed-off-by: Daniel Harms <jdharms@gmail.com>