### PR TITLE
Standardize error usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.14
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.19
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.9
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8

--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -28,7 +28,7 @@ func commandByDeviceID(deviceID string, commandID string, body string, queryPara
 	if err != nil {
 		LoggingClient.Error(err.Error())
 
-		chk, ok := err.(*types.ErrServiceClient)
+		chk, ok := err.(types.ErrServiceClient)
 		if ok {
 			return err.Error(), chk.StatusCode
 		} else {
@@ -73,7 +73,7 @@ func commandByNames(dn string, cn string, body string, queryParams string, isPut
 	d, err := mdc.DeviceForName(dn, ctx)
 	if err != nil {
 		LoggingClient.Error(err.Error())
-		chk, ok := err.(*types.ErrServiceClient)
+		chk, ok := err.(types.ErrServiceClient)
 		if ok {
 			return err.Error(), chk.StatusCode
 		} else {
@@ -119,7 +119,7 @@ func commandByDevice(device contract.Device, command contract.Command, body stri
 func getCommands(ctx context.Context) (int, []contract.CommandResponse, error) {
 	devices, err := mdc.Devices(ctx)
 	if err != nil {
-		chk, ok := err.(*types.ErrServiceClient)
+		chk, ok := err.(types.ErrServiceClient)
 		if ok {
 			return chk.StatusCode, nil, chk
 		} else {
@@ -146,7 +146,7 @@ func getCommands(ctx context.Context) (int, []contract.CommandResponse, error) {
 func getCommandsByDeviceID(did string, ctx context.Context) (int, contract.CommandResponse, error) {
 	d, err := mdc.Device(did, ctx)
 	if err != nil {
-		chk, ok := err.(*types.ErrServiceClient)
+		chk, ok := err.(types.ErrServiceClient)
 		if ok {
 			return chk.StatusCode, contract.CommandResponse{}, chk
 		} else {
@@ -170,7 +170,7 @@ func getCommandsByDeviceID(did string, ctx context.Context) (int, contract.Comma
 func getCommandsByDeviceName(dn string, ctx context.Context) (int, contract.CommandResponse, error) {
 	d, err := mdc.DeviceForName(dn, ctx)
 	if err != nil {
-		chk, ok := err.(*types.ErrServiceClient)
+		chk, ok := err.(types.ErrServiceClient)
 		if ok {
 			return chk.StatusCode, contract.CommandResponse{}, err
 		} else {

--- a/internal/core/data/errors/types.go
+++ b/internal/core/data/errors/types.go
@@ -29,7 +29,7 @@ func (e ErrEventNotFound) Error() string {
 }
 
 func NewErrEventNotFound(id string) error {
-	return &ErrEventNotFound{id: id}
+	return ErrEventNotFound{id: id}
 }
 
 type ErrValueDescriptorInvalid struct {
@@ -42,7 +42,7 @@ func (b ErrValueDescriptorInvalid) Error() string {
 }
 
 func NewErrValueDescriptorInvalid(name string, err error) error {
-	return &ErrValueDescriptorInvalid{name: name, err: err}
+	return ErrValueDescriptorInvalid{name: name, err: err}
 }
 
 type ErrValueDescriptorNotFound struct {
@@ -54,7 +54,7 @@ func (e ErrValueDescriptorNotFound) Error() string {
 }
 
 func NewErrValueDescriptorNotFound(id string) error {
-	return &ErrValueDescriptorNotFound{id: id}
+	return ErrValueDescriptorNotFound{id: id}
 }
 
 type ErrUnsupportedDatabase struct {
@@ -66,7 +66,7 @@ func (e ErrUnsupportedDatabase) Error() string {
 }
 
 func NewErrUnsupportedDatabase(dbType string) error {
-	return &ErrUnsupportedDatabase{dbType: dbType}
+	return ErrUnsupportedDatabase{dbType: dbType}
 }
 
 type ErrUnsupportedPublisher struct {
@@ -78,7 +78,7 @@ func (e ErrUnsupportedPublisher) Error() string {
 }
 
 func NewErrUnsupportedPublisher(pubType string) error {
-	return &ErrUnsupportedPublisher{pubType: pubType}
+	return ErrUnsupportedPublisher{pubType: pubType}
 }
 
 type ErrValueDescriptorInUse struct {
@@ -90,7 +90,7 @@ func (e ErrValueDescriptorInUse) Error() string {
 }
 
 func NewErrValueDescriptorInUse(name string) error {
-	return &ErrValueDescriptorInUse{name: name}
+	return ErrValueDescriptorInUse{name: name}
 }
 
 type ErrValueDescriptorsInUse struct {
@@ -102,7 +102,7 @@ func (e ErrValueDescriptorsInUse) Error() string {
 }
 
 func NewErrValueDescriptorsInUse(names []string) error {
-	return &ErrValueDescriptorsInUse{names: names}
+	return ErrValueDescriptorsInUse{names: names}
 }
 
 type ErrDuplicateValueDescriptorName struct {
@@ -114,7 +114,7 @@ func (e ErrDuplicateValueDescriptorName) Error() string {
 }
 
 func NewErrDuplicateValueDescriptorName(name string) error {
-	return &ErrDuplicateValueDescriptorName{name: name}
+	return ErrDuplicateValueDescriptorName{name: name}
 }
 
 type ErrLimitExceeded struct {
@@ -126,7 +126,7 @@ func (e ErrLimitExceeded) Error() string {
 }
 
 func NewErrLimitExceeded(limit int) error {
-	return &ErrLimitExceeded{limit: limit}
+	return ErrLimitExceeded{limit: limit}
 }
 
 type ErrJsonDecoding struct {
@@ -138,7 +138,7 @@ func (e ErrJsonDecoding) Error() string {
 }
 
 func NewErrJsonDecoding(name string) error {
-	return &ErrJsonDecoding{name: name}
+	return ErrJsonDecoding{name: name}
 }
 
 type ErrDbNotFound struct {
@@ -149,7 +149,7 @@ func (e ErrDbNotFound) Error() string {
 }
 
 func NewErrDbNotFound() error {
-	return &ErrDbNotFound{}
+	return ErrDbNotFound{}
 }
 
 type ErrInvalidId struct {
@@ -161,5 +161,5 @@ func (e ErrInvalidId) Error() string {
 }
 
 func NewErrInvalidId(id string) error {
-	return &ErrInvalidId{id: id}
+	return ErrInvalidId{id: id}
 }

--- a/internal/core/data/event_test.go
+++ b/internal/core/data/event_test.go
@@ -274,7 +274,7 @@ func TestUpdateEventNotFound(t *testing.T) {
 	evt := models.Event{ID: bson.NewObjectId().Hex(), Device: "Not Found", Origin: testOrigin}
 	err := updateEvent(correlation.Event{Event: evt}, context.Background())
 	if err != nil {
-		if x, ok := err.(*errors.ErrEventNotFound); !ok {
+		if x, ok := err.(errors.ErrEventNotFound); !ok {
 			t.Errorf("unexpected error type: %s", x.Error())
 		}
 	} else {
@@ -350,7 +350,7 @@ func TestGetEventByIdNotFound(t *testing.T) {
 
 	_, err := getEventById("abcxyz")
 	if err != nil {
-		if x, ok := err.(*errors.ErrEventNotFound); !ok {
+		if x, ok := err.(errors.ErrEventNotFound); !ok {
 			t.Errorf(x.Error())
 		}
 	}
@@ -420,7 +420,7 @@ func TestDeleteEvent(t *testing.T) {
 
 	_, err = getEventById(testEvent.ID)
 	if err != nil {
-		if x, ok := err.(*errors.ErrEventNotFound); !ok {
+		if x, ok := err.(errors.ErrEventNotFound); !ok {
 			t.Errorf(x.Error())
 		}
 	}

--- a/internal/core/data/operators/reading/get_test.go
+++ b/internal/core/data/operators/reading/get_test.go
@@ -17,14 +17,14 @@
 package reading
 
 import (
-	"errors"
+	goErrors "errors"
 	"reflect"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
-	errors2 "github.com/edgexfoundry/edgex-go/internal/core/data/errors"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/operators/reading/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -36,7 +36,7 @@ var TestErrorReadingName = "TestReadingError"
 var TestLoaderLimit = 5
 
 // TestError error used to simulate non EdgeX type errors.
-var TestError = errors.New("testing error")
+var TestError = goErrors.New("testing error")
 
 var TestReading = contract.Reading{
 	Name:        "TestReadingName",
@@ -120,7 +120,7 @@ func TestGetReadingsExecutor(t *testing.T) {
 			config.ServiceInfo{MaxResultCount: 1},
 			nil,
 			true,
-			&errors2.ErrLimitExceeded{},
+			errors.ErrLimitExceeded{},
 		},
 	}
 	for _, test := range tests {

--- a/internal/core/data/operators/value_descriptor/get_test.go
+++ b/internal/core/data/operators/value_descriptor/get_test.go
@@ -17,20 +17,20 @@
 package value_descriptor
 
 import (
+	goErrors "errors"
 	"reflect"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-	"github.com/pkg/errors"
 
-	errors2 "github.com/edgexfoundry/edgex-go/internal/core/data/errors"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/operators/value_descriptor/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
 
 var TestSuccessfulConfig = config.ServiceInfo{MaxResultCount: 5}
-var TestError = errors.New("test error")
+var TestError = goErrors.New("test error")
 
 var TestVDDescription = "test description"
 var TestVDName = "Temperature"
@@ -95,7 +95,7 @@ func TestGetValueDescriptorsByNames(t *testing.T) {
 			config.ServiceInfo{MaxResultCount: 1},
 			nil,
 			true,
-			&errors2.ErrLimitExceeded{},
+			errors.ErrLimitExceeded{},
 		},
 	}
 	for _, test := range tests {
@@ -167,7 +167,7 @@ func TestGetAllValueDescriptors(t *testing.T) {
 			config.ServiceInfo{MaxResultCount: 1},
 			nil,
 			true,
-			&errors2.ErrLimitExceeded{},
+			errors.ErrLimitExceeded{},
 		},
 	}
 	for _, test := range tests {

--- a/internal/core/data/reading_test.go
+++ b/internal/core/data/reading_test.go
@@ -47,7 +47,7 @@ func TestGetAllReadingsOverLimit(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrLimitExceeded:
+		case errors.ErrLimitExceeded:
 			return
 		default:
 			t.Errorf("Unexpected error getting all readings")
@@ -132,7 +132,7 @@ func TestGetReadingByIdNotFound(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrDbNotFound:
+		case errors.ErrDbNotFound:
 			return
 		default:
 			t.Errorf("Unexpected error getting reading by ID missing in DB")

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -148,7 +148,7 @@ func eventCountByDeviceIdHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("error checking device %s %v", id, err))
 		switch err := err.(type) {
-		case *types.ErrServiceClient:
+		case types.ErrServiceClient:
 			http.Error(w, err.Error(), err.StatusCode)
 			return
 		default: // return an error on everything else.
@@ -272,7 +272,7 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 		err = updateEvent(from, ctx)
 		if err != nil {
 			switch t := err.(type) {
-			case *errors.ErrEventNotFound:
+			case errors.ErrEventNotFound:
 				http.Error(w, t.Error(), http.StatusNotFound)
 			default:
 				http.Error(w, t.Error(), http.StatusInternalServerError)
@@ -321,7 +321,7 @@ func getEventByIdHandler(w http.ResponseWriter, r *http.Request) {
 	e, err := getEventById(id)
 	if err != nil {
 		switch x := err.(type) {
-		case *errors.ErrEventNotFound:
+		case errors.ErrEventNotFound:
 			http.Error(w, x.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, x.Error(), http.StatusInternalServerError)
@@ -366,7 +366,7 @@ func getEventByDeviceHandler(w http.ResponseWriter, r *http.Request) {
 	if err := checkDevice(deviceId, ctx); err != nil {
 		LoggingClient.Error(fmt.Sprintf("error checking device %s %v", deviceId, err))
 		switch err := err.(type) {
-		case *types.ErrServiceClient:
+		case types.ErrServiceClient:
 			http.Error(w, err.Error(), err.StatusCode)
 			return
 		default: // return an error on everything else.
@@ -424,7 +424,7 @@ func eventIdHandler(w http.ResponseWriter, r *http.Request) {
 		err := updateEventPushDate(id, ctx)
 		if err != nil {
 			switch x := err.(type) {
-			case *errors.ErrEventNotFound:
+			case errors.ErrEventNotFound:
 				http.Error(w, x.Error(), http.StatusNotFound)
 			default:
 				http.Error(w, x.Error(), http.StatusInternalServerError)
@@ -444,7 +444,7 @@ func eventIdHandler(w http.ResponseWriter, r *http.Request) {
 		err := deleteEventById(id)
 		if err != nil {
 			switch x := err.(type) {
-			case *errors.ErrEventNotFound:
+			case errors.ErrEventNotFound:
 				http.Error(w, x.Error(), http.StatusNotFound)
 			default:
 				http.Error(w, x.Error(), http.StatusInternalServerError)
@@ -516,7 +516,7 @@ func deleteByDeviceIdHandler(w http.ResponseWriter, r *http.Request) {
 	if err := checkDevice(deviceId, ctx); err != nil {
 		LoggingClient.Error(fmt.Sprintf("error checking device %s %v", deviceId, err))
 		switch err := err.(type) {
-		case *types.ErrServiceClient:
+		case types.ErrServiceClient:
 			http.Error(w, err.Error(), err.StatusCode)
 			return
 		default: // return an error on everything else.
@@ -635,7 +635,7 @@ func readingHandler(w http.ResponseWriter, r *http.Request) {
 
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrLimitExceeded:
+			case errors.ErrLimitExceeded:
 				http.Error(w, maxExceededString, http.StatusRequestEntityTooLarge)
 				return
 			default:
@@ -651,13 +651,13 @@ func readingHandler(w http.ResponseWriter, r *http.Request) {
 		// Problem decoding
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrJsonDecoding:
+			case errors.ErrJsonDecoding:
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
 				return
-			case *errors.ErrValueDescriptorInvalid:
+			case errors.ErrValueDescriptorInvalid:
 				http.Error(w, err.Error(), http.StatusConflict)
 				return
 			default:
@@ -671,7 +671,7 @@ func readingHandler(w http.ResponseWriter, r *http.Request) {
 			if err := checkDevice(reading.Device, ctx); err != nil {
 				LoggingClient.Error(fmt.Sprintf("error checking device %s %v", reading.Device, err))
 				switch err := err.(type) {
-				case *types.ErrServiceClient:
+				case types.ErrServiceClient:
 					http.Error(w, err.Error(), err.StatusCode)
 					return
 				default: // return an error on everything else.
@@ -699,13 +699,13 @@ func readingHandler(w http.ResponseWriter, r *http.Request) {
 		// Problem decoding
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrJsonDecoding:
+			case errors.ErrJsonDecoding:
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
 				return
-			case *errors.ErrValueDescriptorInvalid:
+			case errors.ErrValueDescriptorInvalid:
 				http.Error(w, err.Error(), http.StatusConflict)
 				return
 			default:
@@ -717,10 +717,10 @@ func readingHandler(w http.ResponseWriter, r *http.Request) {
 		err = updateReading(from)
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, "Value descriptor not found for reading", http.StatusNotFound)
 				return
-			case *errors.ErrValueDescriptorInvalid:
+			case errors.ErrValueDescriptorInvalid:
 				http.Error(w, err.Error(), http.StatusConflict)
 				return
 			default:
@@ -749,7 +749,7 @@ func getReadingByIdHandler(w http.ResponseWriter, r *http.Request) {
 		reading, err := getReadingById(id)
 		if err != nil {
 			switch err := err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			default: // return an error on everything else.
@@ -796,7 +796,7 @@ func deleteReadingByIdHandler(w http.ResponseWriter, r *http.Request) {
 		err := deleteReadingById(id)
 		if err != nil {
 			switch err := err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			default: // return an error on everything else.
@@ -847,7 +847,7 @@ func readingByDeviceHandler(w http.ResponseWriter, r *http.Request) {
 		readings, err := getReadingsByDevice(deviceId, limit, ctx)
 		if err != nil {
 			switch err := err.(type) {
-			case *types.ErrServiceClient:
+			case types.ErrServiceClient:
 				http.Error(w, err.Error(), err.StatusCode)
 				return
 			default:
@@ -1126,7 +1126,7 @@ func readingByValueDescriptorAndDeviceHandler(w http.ResponseWriter, r *http.Req
 	if err := checkDevice(device, ctx); err != nil {
 		LoggingClient.Error(fmt.Sprintf("error checking device %s %v", device, err))
 		switch err := err.(type) {
-		case *types.ErrServiceClient:
+		case types.ErrServiceClient:
 			http.Error(w, err.Error(), err.StatusCode)
 			return
 		default: // return an error on everything else.
@@ -1140,7 +1140,7 @@ func readingByValueDescriptorAndDeviceHandler(w http.ResponseWriter, r *http.Req
 		_, err = getValueDescriptorByName(name)
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, "Value descriptor not found for reading", http.StatusConflict)
 				return
 			default:
@@ -1186,10 +1186,10 @@ func valueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
 		v, err := decodeValueDescriptor(r.Body)
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrJsonDecoding:
+			case errors.ErrJsonDecoding:
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
-			case *errors.ErrValueDescriptorInvalid:
+			case errors.ErrValueDescriptorInvalid:
 				http.Error(w, err.Error(), http.StatusConflict)
 				return
 			default:
@@ -1201,10 +1201,10 @@ func valueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
 		id, err := addValueDescriptor(v)
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrValueDescriptorInUse:
+			case errors.ErrValueDescriptorInUse:
 				http.Error(w, err.Error(), http.StatusConflict)
 				return
-			case *errors.ErrDuplicateValueDescriptorName:
+			case errors.ErrDuplicateValueDescriptorName:
 				http.Error(w, err.Error(), http.StatusConflict)
 				return
 			default:
@@ -1219,10 +1219,10 @@ func valueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
 		vd, err := decodeValueDescriptor(r.Body)
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrJsonDecoding:
+			case errors.ErrJsonDecoding:
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
-			case *errors.ErrValueDescriptorInvalid:
+			case errors.ErrValueDescriptorInvalid:
 				http.Error(w, err.Error(), http.StatusConflict)
 				return
 			default:
@@ -1234,13 +1234,13 @@ func valueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
 		err = updateValueDescriptor(vd)
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
-			case *errors.ErrValueDescriptorInvalid:
+			case errors.ErrValueDescriptorInvalid:
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
-			case *errors.ErrValueDescriptorInUse:
+			case errors.ErrValueDescriptorInUse:
 				http.Error(w, "Data integrity issue. Value Descriptor still in use by readings", http.StatusConflict)
 				return
 			default:
@@ -1268,16 +1268,16 @@ func deleteValueDescriptorByIdHandler(w http.ResponseWriter, r *http.Request) {
 	err := deleteValueDescriptorById(id)
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrDbNotFound:
+		case errors.ErrDbNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
-		case *errors.ErrValueDescriptorInvalid:
+		case errors.ErrValueDescriptorInvalid:
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
-		case *errors.ErrValueDescriptorInUse:
+		case errors.ErrValueDescriptorInUse:
 			http.Error(w, "Data integrity issue. Value Descriptor still in use by readings", http.StatusConflict)
 			return
-		case *errors.ErrInvalidId:
+		case errors.ErrInvalidId:
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		default:
@@ -1311,7 +1311,7 @@ func valueDescriptorByNameHandler(w http.ResponseWriter, r *http.Request) {
 		v, err := dbClient.ValueDescriptorByName(name)
 		if err != nil {
 			switch err := err.(type) {
-			case *types.ErrServiceClient:
+			case types.ErrServiceClient:
 				http.Error(w, err.Error(), err.StatusCode)
 			default:
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1323,13 +1323,13 @@ func valueDescriptorByNameHandler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		if err = deleteValueDescriptorByName(name); err != nil {
 			switch err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
-			case *errors.ErrValueDescriptorInvalid:
+			case errors.ErrValueDescriptorInvalid:
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
-			case *errors.ErrValueDescriptorInUse:
+			case errors.ErrValueDescriptorInUse:
 				http.Error(w, "Data integrity issue. Value Descriptor still in use by readings", http.StatusConflict)
 				return
 			default:
@@ -1358,7 +1358,7 @@ func valueDescriptorByIdHandler(w http.ResponseWriter, r *http.Request) {
 		vd, err := getValueDescriptorById(id)
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			default:
@@ -1391,7 +1391,7 @@ func valueDescriptorByUomLabelHandler(w http.ResponseWriter, r *http.Request) {
 		vdList, err := getValueDescriptorsByUomLabel(uomLabel)
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			default:
@@ -1424,7 +1424,7 @@ func valueDescriptorByLabelHandler(w http.ResponseWriter, r *http.Request) {
 		v, err := getValueDescriptorsByLabel(label)
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			default:
@@ -1457,10 +1457,10 @@ func valueDescriptorByDeviceHandler(w http.ResponseWriter, r *http.Request) {
 	vdList, err := getValueDescriptorsByDeviceName(device, ctx)
 	if err != nil {
 		switch err := err.(type) {
-		case *errors.ErrDbNotFound:
+		case errors.ErrDbNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
-		case *types.ErrServiceClient:
+		case types.ErrServiceClient:
 			http.Error(w, err.Error(), err.StatusCode)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1491,9 +1491,9 @@ func valueDescriptorByDeviceIdHandler(w http.ResponseWriter, r *http.Request) {
 	vdList, err := getValueDescriptorsByDeviceId(deviceId, ctx)
 	if err != nil {
 		switch err := err.(type) {
-		case *types.ErrServiceClient:
+		case types.ErrServiceClient:
 			http.Error(w, err.Error(), err.StatusCode)
-		case *errors.ErrDbNotFound:
+		case errors.ErrDbNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		default:
@@ -1532,7 +1532,7 @@ func restValueDescriptorsUsageHandler(w http.ResponseWriter, r *http.Request) {
 	vds, err = op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrLimitExceeded:
+		case errors.ErrLimitExceeded:
 			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -142,7 +142,7 @@ func getValueDescriptorsByDevice(device contract.Device) (vdList []contract.Valu
 		// Not an error if not found
 		if err != nil {
 			switch err.(type) {
-			case *errors.ErrDbNotFound:
+			case errors.ErrDbNotFound:
 				continue
 			default:
 				return []contract.ValueDescriptor{}, err

--- a/internal/core/data/valuedescriptor_test.go
+++ b/internal/core/data/valuedescriptor_test.go
@@ -71,7 +71,7 @@ func TestGetValueDescriptorByNameNotFound(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrDbNotFound:
+		case errors.ErrDbNotFound:
 			return
 		default:
 			t.Errorf("Unexpected error getting value descriptor by name missing in DB")
@@ -129,7 +129,7 @@ func TestGetValueDescriptorByIdNotFound(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrDbNotFound:
+		case errors.ErrDbNotFound:
 			return
 		default:
 			t.Errorf("Unexpected error getting value descriptor by ID missing in DB")
@@ -183,7 +183,7 @@ func TestGetValueDescriptorsByUomLabelNotFound(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrDbNotFound:
+		case errors.ErrDbNotFound:
 			return
 		default:
 			t.Errorf("Unexpected error getting value descriptor by UOM label missing in DB")
@@ -243,7 +243,7 @@ func TestGetValueDescriptorsByLabelNotFound(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrDbNotFound:
+		case errors.ErrDbNotFound:
 			return
 		default:
 			t.Errorf("Unexpected error getting value descriptor by label missing in DB")
@@ -297,7 +297,7 @@ func TestGetValueDescriptorsByTypeNotFound(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrDbNotFound:
+		case errors.ErrDbNotFound:
 			return
 		default:
 			t.Errorf("Unexpected error getting value descriptor by type missing in DB")
@@ -343,7 +343,7 @@ func TestGetValueDescriptorsByDeviceNameNotFound(t *testing.T) {
 
 	if err != nil {
 		switch err := err.(type) {
-		case *types.ErrServiceClient:
+		case types.ErrServiceClient:
 			if err.StatusCode != http.StatusNotFound {
 				t.Errorf("Expected a 404 error")
 			}
@@ -388,7 +388,7 @@ func TestGetValueDescriptorsByDeviceIdNotFound(t *testing.T) {
 
 	if err != nil {
 		switch err := err.(type) {
-		case *types.ErrServiceClient:
+		case types.ErrServiceClient:
 			if err.StatusCode != http.StatusNotFound {
 				t.Errorf("Expected a 404 error")
 			}
@@ -475,7 +475,7 @@ func TestAddDuplicateValueDescriptor(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrDuplicateValueDescriptorName:
+		case errors.ErrDuplicateValueDescriptorName:
 			return
 		default:
 			t.Errorf("Unexpected error adding value descriptor that already exists")
@@ -530,7 +530,7 @@ func TestDeleteValueDescriptorInUse(t *testing.T) {
 
 	if err != nil {
 		switch err.(type) {
-		case *errors.ErrValueDescriptorInUse:
+		case errors.ErrValueDescriptorInUse:
 			return
 		default:
 			t.Errorf("Unexpected error deleting value descriptor in use")

--- a/internal/core/metadata/errors/types.go
+++ b/internal/core/metadata/errors/types.go
@@ -27,7 +27,7 @@ func (e ErrLimitExceeded) Error() string {
 }
 
 func NewErrLimitExceeded(limit int) error {
-	return &ErrLimitExceeded{limit: limit}
+	return ErrLimitExceeded{limit: limit}
 }
 
 type ErrDuplicateName struct {
@@ -39,7 +39,7 @@ func (e ErrDuplicateName) Error() string {
 }
 
 func NewErrDuplicateName(message string) error {
-	return &ErrDuplicateName{msg: message}
+	return ErrDuplicateName{msg: message}
 }
 
 type ErrEmptyAddressableName struct {
@@ -50,7 +50,7 @@ func (e ErrEmptyAddressableName) Error() string {
 }
 
 func NewErrEmptyAddressableName() error {
-	return &ErrEmptyAddressableName{}
+	return ErrEmptyAddressableName{}
 }
 
 type ErrAddressableNotFound struct {
@@ -68,7 +68,7 @@ func (e ErrAddressableNotFound) Error() string {
 }
 
 func NewErrAddressableNotFound(id string, name string) error {
-	return &ErrAddressableNotFound{id: id}
+	return ErrAddressableNotFound{id: id}
 }
 
 type ErrAddressableInUse struct {
@@ -80,7 +80,7 @@ func (e ErrAddressableInUse) Error() string {
 }
 
 func NewErrAddressableInUse(name string) error {
-	return &ErrAddressableInUse{name: name}
+	return ErrAddressableInUse{name: name}
 }
 
 type ErrBadRequest struct {
@@ -92,7 +92,7 @@ func (e ErrBadRequest) Error() string {
 }
 
 func NewErrBadRequest(invalid string) error {
-	return &ErrBadRequest{value: invalid}
+	return ErrBadRequest{value: invalid}
 }
 
 type ErrItemNotFound struct {
@@ -104,7 +104,7 @@ func (e ErrItemNotFound) Error() string {
 }
 
 func NewErrItemNotFound(key string) error {
-	return &ErrItemNotFound{key: key}
+	return ErrItemNotFound{key: key}
 }
 
 type ErrDeviceProfileNotFound struct {

--- a/internal/core/metadata/operators/device_profile/value_descriptor.go
+++ b/internal/core/metadata/operators/device_profile/value_descriptor.go
@@ -8,8 +8,8 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
-	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
-	errors2 "github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
+	dataErrors "github.com/edgexfoundry/edgex-go/internal/core/data/errors"
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 )
 
 // ValueDescriptorAdder provides the necessary functionality for creating a ValueDescriptor.
@@ -99,7 +99,7 @@ func (u updateValueDescriptor) Execute() error {
 			associatedDeviceNames = append(associatedDeviceNames, d.Name)
 		}
 
-		return errors2.NewErrDeviceProfileInvalidState(
+		return errors.NewErrDeviceProfileInvalidState(
 			persistedDeviceProfile.Id,
 			persistedDeviceProfile.Name,
 			fmt.Sprintf("The DeviceProfile is in use by Device(s):[%s]", strings.Join(associatedDeviceNames, ",")))
@@ -126,7 +126,7 @@ func (u updateValueDescriptor) Execute() error {
 	}
 
 	if len(inUseValueDescriptors) > 0 {
-		return errors.NewErrValueDescriptorsInUse(inUseValueDescriptors)
+		return dataErrors.NewErrValueDescriptorsInUse(inUseValueDescriptors)
 	}
 
 	// Based on the DeviceProfile as it is before the update, determine which operation needs to be applied to each

--- a/internal/core/metadata/operators/device_profile/value_descriptor_test.go
+++ b/internal/core/metadata/operators/device_profile/value_descriptor_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
-	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
-	errors2 "github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
+	dataErrors "github.com/edgexfoundry/edgex-go/internal/core/data/errors"
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	mocks2 "github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/operators/device_profile/mocks"
@@ -190,7 +190,7 @@ func TestUpdateValueDescriptors(t *testing.T) {
 			createMockDBClientDeviceProfileInUse(),
 			createMockValueDescriptorUpdater(),
 			true,
-			errors2.ErrDeviceProfileInvalidState{},
+			errors.ErrDeviceProfileInvalidState{},
 		},
 		{
 			"ValueDescriptor in use",
@@ -199,7 +199,7 @@ func TestUpdateValueDescriptors(t *testing.T) {
 			createMockDBClient(),
 			createMockValueDescriptorUpdaterInUseError(),
 			true,
-			&errors.ErrValueDescriptorsInUse{},
+			dataErrors.ErrValueDescriptorsInUse{},
 		},
 		{
 			"ValueDescriptorUsage error",

--- a/internal/core/metadata/rest_addressable.go
+++ b/internal/core/metadata/rest_addressable.go
@@ -32,7 +32,7 @@ func restGetAllAddressables(w http.ResponseWriter, _ *http.Request) {
 	addressables, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrLimitExceeded:
+		case types.ErrLimitExceeded:
 			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -63,9 +63,9 @@ func restAddAddressable(w http.ResponseWriter, r *http.Request) {
 	id, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrDuplicateName:
+		case types.ErrDuplicateName:
 			http.Error(w, err.Error(), http.StatusConflict)
-		case *types.ErrEmptyAddressableName:
+		case types.ErrEmptyAddressableName:
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -95,9 +95,9 @@ func restUpdateAddressable(w http.ResponseWriter, r *http.Request) {
 	err = op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrAddressableNotFound:
+		case types.ErrAddressableNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
-		case *types.ErrAddressableInUse:
+		case types.ErrAddressableInUse:
 			http.Error(w, err.Error(), http.StatusConflict)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -141,9 +141,9 @@ func restDeleteAddressableById(w http.ResponseWriter, r *http.Request) {
 	err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrAddressableNotFound:
+		case types.ErrAddressableNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
-		case *types.ErrAddressableInUse:
+		case types.ErrAddressableInUse:
 			http.Error(w, err.Error(), http.StatusConflict)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -170,9 +170,9 @@ func restDeleteAddressableByName(w http.ResponseWriter, r *http.Request) {
 	err = op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrAddressableNotFound:
+		case types.ErrAddressableNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
-		case *types.ErrAddressableInUse:
+		case types.ErrAddressableInUse:
 			http.Error(w, err.Error(), http.StatusConflict)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/core/metadata/rest_command.go
+++ b/internal/core/metadata/rest_command.go
@@ -28,7 +28,7 @@ func restGetAllCommands(w http.ResponseWriter, _ *http.Request) {
 	cmds, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrLimitExceeded:
+		case types.ErrLimitExceeded:
 			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -52,7 +52,7 @@ func restGetCommandById(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -94,7 +94,7 @@ func restGetCommandsByDeviceId(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/core/metadata/rest_device.go
+++ b/internal/core/metadata/rest_device.go
@@ -39,7 +39,7 @@ func restGetAllDevices(w http.ResponseWriter, _ *http.Request) {
 	devices, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrLimitExceeded:
+		case types.ErrLimitExceeded:
 			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -90,9 +90,9 @@ func restAddNewDevice(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		switch err.(type) {
-		case *types.ErrDuplicateName:
+		case types.ErrDuplicateName:
 			http.Error(w, err.Error(), http.StatusConflict)
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -137,9 +137,9 @@ func restUpdateDevice(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		switch err.(type) {
-		case *types.ErrDuplicateName:
+		case types.ErrDuplicateName:
 			http.Error(w, err.Error(), http.StatusConflict)
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gorilla/mux"
 	"gopkg.in/yaml.v2"
 
-	errors2 "github.com/edgexfoundry/edgex-go/internal/core/data/errors"
+	dataErrors "github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/operators/device"
@@ -110,7 +110,7 @@ func restUpdateDeviceProfile(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), err.(types.ErrServiceClient).StatusCode)
 			case errors.ErrDeviceProfileNotFound:
 				http.Error(w, err.Error(), http.StatusNotFound)
-			case *errors2.ErrValueDescriptorsInUse:
+			case dataErrors.ErrValueDescriptorsInUse:
 				http.Error(w, err.Error(), http.StatusConflict)
 			case errors.ErrDeviceProfileInvalidState:
 				http.Error(w, err.Error(), http.StatusConflict)
@@ -277,7 +277,7 @@ func restAddProfileByYaml(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		case models.ErrContractInvalid:
 			http.Error(w, err.Error(), http.StatusConflict)
-		case *errors.ErrDuplicateName:
+		case errors.ErrDuplicateName:
 			http.Error(w, err.Error(), http.StatusConflict)
 		case errors.ErrEmptyDeviceProfileName:
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -326,7 +326,7 @@ func addDeviceProfile(dp models.DeviceProfile, dbClient interfaces.DBClient, w h
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		case errors.ErrDeviceProfileInvalidState:
 			http.Error(w, err.Error(), http.StatusBadRequest)
-		case *errors.ErrDuplicateName:
+		case errors.ErrDuplicateName:
 			http.Error(w, err.Error(), http.StatusConflict)
 		case errors.ErrEmptyDeviceProfileName:
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/core/metadata/rest_deviceprofile_test.go
+++ b/internal/core/metadata/rest_deviceprofile_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
+	goErrors "errors"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"gopkg.in/yaml.v2"
 
-	errors2 "github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces/mocks"
@@ -39,7 +39,7 @@ var TestDeviceProfiles = []contract.DeviceProfile{
 	createTestDeviceProfileWithCommands("TestErrorID", "TestErrorName", []string{TestLabelError1, TestLabelError2}, "TestErrorManufacturer", "TestErrorModel", TestCommand),
 }
 var TestDeviceProfileValidated = createValidatedTestDeviceProfile()
-var TestError = errors.New("test error")
+var TestError = goErrors.New("test error")
 var TestContext = context.WithValue(context.Background(), "TestKey", "TestValue")
 var TestDeviceProfileID = "TestProfileID"
 var TestDeviceProfileName = "TestProfileName"
@@ -1144,10 +1144,10 @@ func createDBClientDeviceProfileErrorNotFound() interfaces.DBClient {
 
 func createMockErrDeviceProfileNotFound() interfaces.DBClient {
 	d := &mocks.DBClient{}
-	d.On("GetDeviceProfileByName", TestDeviceProfileName).Return(contract.DeviceProfile{}, errors2.ErrDeviceProfileNotFound{})
-	d.On("GetDeviceProfileById", TestDeviceProfileName).Return(contract.DeviceProfile{}, errors2.ErrDeviceProfileNotFound{})
-	d.On("GetDeviceProfileByName", TestDeviceProfileID).Return(contract.DeviceProfile{}, errors2.ErrDeviceProfileNotFound{})
-	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(contract.DeviceProfile{}, errors2.ErrDeviceProfileNotFound{})
+	d.On("GetDeviceProfileByName", TestDeviceProfileName).Return(contract.DeviceProfile{}, errors.ErrDeviceProfileNotFound{})
+	d.On("GetDeviceProfileById", TestDeviceProfileName).Return(contract.DeviceProfile{}, errors.ErrDeviceProfileNotFound{})
+	d.On("GetDeviceProfileByName", TestDeviceProfileID).Return(contract.DeviceProfile{}, errors.ErrDeviceProfileNotFound{})
+	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(contract.DeviceProfile{}, errors.ErrDeviceProfileNotFound{})
 
 	return d
 }
@@ -1223,14 +1223,14 @@ func createDBClientGetDeviceProfileError() interfaces.DBClient {
 
 func createDBClientGetDeviceProfileMaxLimitError() interfaces.DBClient {
 	d := &mocks.DBClient{}
-	d.On("GetAllDeviceProfiles").Return(nil, errors2.ErrLimitExceeded{})
-	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(contract.DeviceProfile{}, errors2.ErrLimitExceeded{})
-	d.On("GetDeviceProfileByName", TestDeviceProfileName).Return(contract.DeviceProfile{}, errors2.ErrLimitExceeded{})
-	d.On("GetDeviceProfilesByModel", TestDeviceProfile.Model).Return(nil, errors2.ErrLimitExceeded{})
-	d.On("GetDeviceProfilesWithLabel", TestDeviceProfileLabel1).Return(nil, errors2.ErrLimitExceeded{})
-	d.On("GetDeviceProfilesWithLabel", TestDeviceProfileLabel2).Return(nil, errors2.ErrLimitExceeded{})
-	d.On("GetDeviceProfilesByManufacturer", TestDeviceProfile.Manufacturer).Return(nil, errors2.ErrLimitExceeded{})
-	d.On("GetDeviceProfilesByManufacturerModel", TestDeviceProfile.Manufacturer, TestDeviceProfile.Model).Return(nil, errors2.ErrLimitExceeded{})
+	d.On("GetAllDeviceProfiles").Return(nil, errors.ErrLimitExceeded{})
+	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(contract.DeviceProfile{}, errors.ErrLimitExceeded{})
+	d.On("GetDeviceProfileByName", TestDeviceProfileName).Return(contract.DeviceProfile{}, errors.ErrLimitExceeded{})
+	d.On("GetDeviceProfilesByModel", TestDeviceProfile.Model).Return(nil, errors.ErrLimitExceeded{})
+	d.On("GetDeviceProfilesWithLabel", TestDeviceProfileLabel1).Return(nil, errors.ErrLimitExceeded{})
+	d.On("GetDeviceProfilesWithLabel", TestDeviceProfileLabel2).Return(nil, errors.ErrLimitExceeded{})
+	d.On("GetDeviceProfilesByManufacturer", TestDeviceProfile.Manufacturer).Return(nil, errors.ErrLimitExceeded{})
+	d.On("GetDeviceProfilesByManufacturerModel", TestDeviceProfile.Manufacturer, TestDeviceProfile.Model).Return(nil, errors.ErrLimitExceeded{})
 
 	return d
 }

--- a/internal/core/metadata/rest_deviceservice.go
+++ b/internal/core/metadata/rest_deviceservice.go
@@ -38,7 +38,7 @@ func restGetAllDeviceServices(w http.ResponseWriter, _ *http.Request) {
 	services, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrLimitExceeded:
+		case types.ErrLimitExceeded:
 			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -215,7 +215,7 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 	res, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -236,7 +236,7 @@ func restGetServiceByAddressableId(w http.ResponseWriter, r *http.Request) {
 	res, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -282,7 +282,7 @@ func restGetServiceByName(w http.ResponseWriter, r *http.Request) {
 	res, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -479,7 +479,7 @@ func restGetServiceById(w http.ResponseWriter, r *http.Request) {
 	res, err := op.Execute()
 	if err != nil {
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -509,7 +509,7 @@ func restUpdateServiceOpStateById(w http.ResponseWriter, r *http.Request) {
 	op := device_service.NewUpdateOpStateByIdExecutor(id, newOs, dbClient)
 	if err := op.Execute(); err != nil {
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -544,7 +544,7 @@ func restUpdateServiceOpStateByName(w http.ResponseWriter, r *http.Request) {
 	op := device_service.NewUpdateOpStateByNameExecutor(n, newOs, dbClient)
 	if err := op.Execute(); err != nil {
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -574,7 +574,7 @@ func restUpdateServiceAdminStateById(w http.ResponseWriter, r *http.Request) {
 	op := device_service.NewUpdateAdminStateByIdExecutor(id, newAs, dbClient)
 	if err := op.Execute(); err != nil {
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -609,7 +609,7 @@ func restUpdateServiceAdminStateByName(w http.ResponseWriter, r *http.Request) {
 	op := device_service.NewUpdateAdminStateByNameExecutor(n, newAs, dbClient)
 	if err := op.Execute(); err != nil {
 		switch err.(type) {
-		case *types.ErrItemNotFound:
+		case types.ErrItemNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/support/scheduler/errors/types.go
+++ b/internal/support/scheduler/errors/types.go
@@ -40,7 +40,7 @@ func (e ErrIntervalNameInUse) Error() string {
 }
 
 func NewErrIntervalNameInUse(name string) error {
-	return &ErrIntervalNameInUse{name: name}
+	return ErrIntervalNameInUse{name: name}
 }
 
 type ErrIntervalStillUsedByIntervalActions struct {
@@ -65,7 +65,7 @@ func (e ErrIntervalActionNotFound) Error() string {
 }
 
 func NewErrIntervalActionNotFound(id string) error {
-	return &ErrIntervalActionNotFound{id: id}
+	return ErrIntervalActionNotFound{id: id}
 }
 
 type ErrIntervalActionTargetNameRequired struct {
@@ -77,7 +77,7 @@ func (e ErrIntervalActionTargetNameRequired) Error() string {
 }
 
 func NewErrIntervalActionTargetNameRequired(id string) error {
-	return &ErrIntervalActionTargetNameRequired{id: id}
+	return ErrIntervalActionTargetNameRequired{id: id}
 }
 
 type ErrIntervalActionNameInUse struct {
@@ -89,7 +89,7 @@ func (e ErrIntervalActionNameInUse) Error() string {
 }
 
 func NewErrIntervalActionNameInUse(name string) error {
-	return &ErrIntervalActionNameInUse{name: name}
+	return ErrIntervalActionNameInUse{name: name}
 }
 
 type ErrInvalidTimeFormat struct {
@@ -101,7 +101,7 @@ func (e ErrInvalidTimeFormat) Error() string {
 }
 
 func NewErrInvalidTimeFormat(value string) error {
-	return &ErrInvalidTimeFormat{value: value}
+	return ErrInvalidTimeFormat{value: value}
 }
 
 type ErrInvalidFrequencyFormat struct {
@@ -113,7 +113,7 @@ func (e ErrInvalidFrequencyFormat) Error() string {
 }
 
 func NewErrInvalidFrequencyFormat(frequency string) error {
-	return &ErrInvalidFrequencyFormat{frequency: frequency}
+	return ErrInvalidFrequencyFormat{frequency: frequency}
 }
 
 type ErrInvalidCronFormat struct {
@@ -136,5 +136,5 @@ func (e ErrDbNotFound) Error() string {
 }
 
 func NewErrDbNotFound() error {
-	return &ErrDbNotFound{}
+	return ErrDbNotFound{}
 }

--- a/internal/support/scheduler/interval_test.go
+++ b/internal/support/scheduler/interval_test.go
@@ -139,7 +139,7 @@ func TestAddIntervalFailOnExistingName(t *testing.T) {
 	_, err := addNewInterval(nInterval)
 	if err != nil {
 		switch err.(type) {
-		case *errorsSched.ErrIntervalNameInUse:
+		case errorsSched.ErrIntervalNameInUse:
 		// expected
 		default:
 			t.Errorf("Expected errors.ErrIntervalNameInUse")
@@ -175,7 +175,7 @@ func TestAddIntervalFailOnInvalidTimeFormat(t *testing.T) {
 	_, err := addNewInterval(nInterval)
 	if err != nil {
 		switch err.(type) {
-		case *errorsSched.ErrInvalidTimeFormat:
+		case errorsSched.ErrInvalidTimeFormat:
 		// expected
 		default:
 			t.Errorf("Expected errors.ErrInvalidTimeFormat")

--- a/internal/support/scheduler/rest_interval.go
+++ b/internal/support/scheduler/rest_interval.go
@@ -70,7 +70,7 @@ func restUpdateInterval(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, t.Error(), http.StatusBadRequest)
 		case errors.ErrIntervalStillUsedByIntervalActions:
 			http.Error(w, t.Error(), http.StatusBadRequest)
-		case *errors.ErrIntervalNameInUse:
+		case errors.ErrIntervalNameInUse:
 			http.Error(w, t.Error(), http.StatusBadRequest)
 		default: //return an error on everything else.
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -103,7 +103,7 @@ func restAddInterval(w http.ResponseWriter, r *http.Request) {
 	newId, err := op.Execute()
 	if err != nil {
 		switch t := err.(type) {
-		case *errors.ErrIntervalNameInUse:
+		case errors.ErrIntervalNameInUse:
 			http.Error(w, t.Error(), http.StatusBadRequest)
 		default:
 			http.Error(w, t.Error(), http.StatusInternalServerError)
@@ -197,7 +197,7 @@ func restGetIntervalByName(w http.ResponseWriter, r *http.Request) {
 		switch err := err.(type) {
 		case errors.ErrIntervalNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
-		case *types.ErrServiceClient:
+		case types.ErrServiceClient:
 			http.Error(w, err.Error(), err.StatusCode)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/support/scheduler/router.go
+++ b/internal/support/scheduler/router.go
@@ -134,11 +134,11 @@ func intervalActionHandler(w http.ResponseWriter, r *http.Request) {
 		newId, err := addNewIntervalAction(intervalAction)
 		if err != nil {
 			switch t := err.(type) {
-			case *errors.ErrIntervalActionNameInUse:
+			case errors.ErrIntervalActionNameInUse:
 				http.Error(w, t.Error(), http.StatusBadRequest)
-			case *errors.ErrInvalidTimeFormat:
+			case errors.ErrInvalidTimeFormat:
 				http.Error(w, t.Error(), http.StatusBadRequest)
-			case *errors.ErrInvalidFrequencyFormat:
+			case errors.ErrInvalidFrequencyFormat:
 				http.Error(w, t.Error(), http.StatusBadRequest)
 			default:
 				http.Error(w, t.Error(), http.StatusInternalServerError)
@@ -166,17 +166,17 @@ func intervalActionHandler(w http.ResponseWriter, r *http.Request) {
 		err = updateIntervalAction(from)
 		if err != nil {
 			switch t := err.(type) {
-			case *errors.ErrIntervalNotFound:
+			case errors.ErrIntervalNotFound:
 				http.Error(w, t.Error(), http.StatusNotFound)
-			case *errors.ErrInvalidCronFormat:
+			case errors.ErrInvalidCronFormat:
 				http.Error(w, t.Error(), http.StatusBadRequest)
-			case *errors.ErrInvalidFrequencyFormat:
+			case errors.ErrInvalidFrequencyFormat:
 				http.Error(w, t.Error(), http.StatusBadRequest)
-			case *errors.ErrInvalidTimeFormat:
+			case errors.ErrInvalidTimeFormat:
 				http.Error(w, t.Error(), http.StatusBadRequest)
-			case *errors.ErrIntervalStillUsedByIntervalActions:
+			case errors.ErrIntervalStillUsedByIntervalActions:
 				http.Error(w, t.Error(), http.StatusBadRequest)
-			case *errors.ErrIntervalNameInUse:
+			case errors.ErrIntervalNameInUse:
 				http.Error(w, t.Error(), http.StatusBadRequest)
 			default: //return an error on everything else.
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -216,7 +216,7 @@ func intervalActionByIdHandler(w http.ResponseWriter, r *http.Request) {
 		intervalAction, err := getIntervalActionById(id)
 		if err != nil {
 			switch x := err.(type) {
-			case *errors.ErrIntervalActionNotFound:
+			case errors.ErrIntervalActionNotFound:
 				http.Error(w, x.Error(), http.StatusNotFound)
 			default:
 				http.Error(w, x.Error(), http.StatusInternalServerError)
@@ -229,7 +229,7 @@ func intervalActionByIdHandler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		if err = deleteIntervalActionById(id); err != nil {
 			switch err.(type) {
-			case *errors.ErrIntervalActionNotFound:
+			case errors.ErrIntervalActionNotFound:
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			default:
@@ -268,7 +268,7 @@ func intervalActionByNameHandler(w http.ResponseWriter, r *http.Request) {
 		intervalAction, err := getIntervalActionByName(name)
 		if err != nil {
 			switch x := err.(type) {
-			case *errors.ErrIntervalActionNotFound:
+			case errors.ErrIntervalActionNotFound:
 				http.Error(w, x.Error(), http.StatusNotFound)
 			default:
 				http.Error(w, x.Error(), http.StatusInternalServerError)
@@ -281,7 +281,7 @@ func intervalActionByNameHandler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		if err = deleteIntervalActionByName(name); err != nil {
 			switch err.(type) {
-			case *errors.ErrIntervalActionNotFound:
+			case errors.ErrIntervalActionNotFound:
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			default:


### PR DESCRIPTION
Fix #1671

Update constructors, error type checks, and tests to use values rather
than references(pointers) for errors.

Update tests to conform to the changes in the production code.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>