### PR TITLE
Fix Redis' ReadingsByDevice to get latest readings

### DIFF
--- a/internal/pkg/db/redis/data.go
+++ b/internal/pkg/db/redis/data.go
@@ -702,7 +702,7 @@ func (c *Client) ReadingsByDevice(id string, limit int) (readings []contract.Rea
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	objects, err := getObjectsByRange(conn, db.ReadingsCollection+":device:"+id, 0, limit-1)
+	objects, err := getObjectsByRevRange(conn, db.ReadingsCollection+":device:"+id, 0, limit-1)
 	if err != nil {
 		if err != redis.ErrNil {
 			return readings, err


### PR DESCRIPTION
Fix #1643

Update the Redis client to return the latest readings when a limit is
applied to the query. This make the Redis client more consistent with
the desired Mongo client results.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>