### PR TITLE
Add [generate] subcommand from merging pki-init option generate into security-secrets-setup

### DIFF
--- a/cmd/security-secrets-setup/entrypoint.sh
+++ b/cmd/security-secrets-setup/entrypoint.sh
@@ -58,10 +58,10 @@ CERT_EXEC="${CERT_EXEC:-./security-secrets-setup}"
 # check to see if the root certificate generate with security-secrets-setup already exists
 # if so then do not generate a new set of them
 if [ ! -f "$CERT_DIR/$CERT_SUBDIR/$ROOT_NAME/$ROOT_NAME.pem" ]; then
-    ${CERT_EXEC} --config ${PKI_SETUP_VAULT_FILE}
+    ${CERT_EXEC} legacy --config ${PKI_SETUP_VAULT_FILE}
     [ $? -eq 0 ] || (echo "failed to generate TLS assets for Vault" && exit 1)
 
-    ${CERT_EXEC} --config ${PKI_SETUP_KONG_FILE}
+    ${CERT_EXEC} legacy --config ${PKI_SETUP_KONG_FILE}
     [ $? -eq 0 ] || (echo "failed to generate TLS assets for Kong" && exit 1)
 
     # delete CA private key

--- a/cmd/security-secrets-setup/main.go
+++ b/cmd/security-secrets-setup/main.go
@@ -128,9 +128,7 @@ func setupPkiInitOption(subcommand string) (executor option.OptionsExecutor, sta
 	case "generate":
 		generateOpt = true
 	default:
-		flag.Usage()
-		exitInstance.exit(0)
-		return
+		return nil, 1, fmt.Errorf("unsupported subcommand %s", subcommand)
 	}
 
 	opts := option.PkiInitOption{

--- a/cmd/security-secrets-setup/main.go
+++ b/cmd/security-secrets-setup/main.go
@@ -42,11 +42,13 @@ type pkiInitOptionDispatcher struct{}
 var exitInstance = newExit()
 var dispatcherInstance = newOptionDispatcher()
 var configFile string
+var generateOpt bool
 
 func init() {
 	// define and register command line flags:
 	flag.StringVar(&configFile, "config", "", "specify JSON configuration file: /path/to/file.json")
 	flag.StringVar(&configFile, "c", "", "specify JSON configuration file: /path/to/file.json")
+	flag.BoolVar(&generateOpt, "generate", false, "to generate a new PKI from scratch")
 	flag.Usage = usage.HelpCallbackSecuritySetup
 }
 
@@ -102,7 +104,9 @@ func newOptionDispatcher() optionDispatcher {
 }
 
 func (dispatcher *pkiInitOptionDispatcher) run() (statusCode int, err error) {
-	opts := option.PkiInitOption{}
+	opts := option.PkiInitOption{
+		GenerateOpt: generateOpt,
+	}
 	optsExecutor, statusCode, err := option.NewPkiInitOption(opts)
 	if err != nil {
 		return statusCode, err

--- a/cmd/security-secrets-setup/main_test.go
+++ b/cmd/security-secrets-setup/main_test.go
@@ -55,7 +55,7 @@ func TestMainWithConfigFileOption(t *testing.T) {
 	defer tearDown(t, origArgs)
 	assert := assert.New(t)
 
-	os.Args = []string{"cmd", "-config", "./res/pkisetup-vault.json"}
+	os.Args = []string{"cmd", "legacy", "-config", "./res/pkisetup-vault.json"}
 	printCommandLineStrings(os.Args)
 	main()
 
@@ -75,7 +75,7 @@ func TestConfigFileOptionError(t *testing.T) {
 	defer tearDown(t, origArgs)
 	assert := assert.New(t)
 
-	os.Args = []string{"cmd", "-config", "./non-exist/cert.json"}
+	os.Args = []string{"cmd", "legacy", "-config", "./non-exist/cert.json"}
 	printCommandLineStrings(os.Args)
 	main()
 

--- a/cmd/security-secrets-setup/main_test.go
+++ b/cmd/security-secrets-setup/main_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/internal/security/setup"
 	"github.com/edgexfoundry/edgex-go/internal/security/setup/option"
 	"github.com/stretchr/testify/assert"
 )
@@ -91,7 +90,6 @@ func TestMainWithGenerateOption(t *testing.T) {
 
 	runWithGenerateOption(false)
 	assert.Equal(0, (exitInstance.(*testExitCode)).getStatusCode())
-	assert.True(generateOpt)
 	optionExec := (dispatcherInstance.(*testPkiInitOptionDispatcher)).testOptsExecutor
 	assert.True((optionExec.(*option.PkiInitOption)).GenerateOpt)
 }
@@ -104,11 +102,10 @@ func TestGenerateOptionWithRunError(t *testing.T) {
 
 	runWithGenerateOption(true)
 	assert.Equal(2, (exitInstance.(*testExitCode)).getStatusCode())
-	assert.Equal(true, generateOpt)
 }
 
 func runWithGenerateOption(hasError bool) {
-	os.Args = []string{"cmd", "-generate"}
+	os.Args = []string{"cmd", "generate"}
 	printCommandLineStrings(os.Args)
 	hasDispatchError = hasError
 	main()
@@ -124,7 +121,6 @@ func setupTest(t *testing.T) func(t *testing.T, args []string) {
 	return func(t *testing.T, args []string) {
 		// reset after each test
 		configFile = ""
-		generateOpt = false
 		os.Args = args
 		// cleanup the generated files
 		os.RemoveAll("./config")
@@ -158,11 +154,11 @@ func newTestDispatcher() optionDispatcher {
 }
 
 func (testDispatcher *testPkiInitOptionDispatcher) run() (statusCode int, err error) {
-	setup.LoggingClient.Debug(fmt.Sprintf("In test flag value: generateOpt = %v, configFile = %v", generateOpt, configFile))
+	optsExecutor, _, _ := setupPkiInitOption(os.Args[1])
 
-	optsExecutor, _, _ := option.NewPkiInitOption(option.PkiInitOption{
-		GenerateOpt: generateOpt,
-	})
+	genOpt := (optsExecutor.(*option.PkiInitOption)).GenerateOpt
+	fmt.Printf("In test flag value: generateOpt = %v, configFile = %v", genOpt, configFile)
+
 	testDispatcher.testOptsExecutor = optsExecutor
 
 	if hasDispatchError {

--- a/cmd/security-secrets-setup/main_test.go
+++ b/cmd/security-secrets-setup/main_test.go
@@ -115,7 +115,7 @@ func TestMainUnsupportedArgument(t *testing.T) {
 	hasDispatchError = false
 	main()
 
-	assert.Equal(0, (exitInstance.(*testExitCode)).getStatusCode())
+	assert.Equal(1, (exitInstance.(*testExitCode)).getStatusCode())
 }
 
 func runWithGenerateOption(hasError bool) {
@@ -168,7 +168,7 @@ func newTestDispatcher() optionDispatcher {
 }
 
 func (testDispatcher *testPkiInitOptionDispatcher) run(command string) (statusCode int, err error) {
-	optsExecutor, _, _ := setupPkiInitOption(command)
+	optsExecutor, statusCode, err := setupPkiInitOption(command)
 
 	genOpt := false
 	if pkiInit, ok := optsExecutor.(*option.PkiInitOption); ok {

--- a/cmd/security-secrets-setup/main_test.go
+++ b/cmd/security-secrets-setup/main_test.go
@@ -104,6 +104,20 @@ func TestGenerateOptionWithRunError(t *testing.T) {
 	assert.Equal(2, (exitInstance.(*testExitCode)).getStatusCode())
 }
 
+func TestMainUnsupportedArgument(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	os.Args = []string{"cmd", "unsupported"}
+	printCommandLineStrings(os.Args)
+	hasDispatchError = false
+	main()
+
+	assert.Equal(0, (exitInstance.(*testExitCode)).getStatusCode())
+}
+
 func runWithGenerateOption(hasError bool) {
 	os.Args = []string{"cmd", "generate"}
 	printCommandLineStrings(os.Args)
@@ -153,10 +167,14 @@ func newTestDispatcher() optionDispatcher {
 	return &testPkiInitOptionDispatcher{}
 }
 
-func (testDispatcher *testPkiInitOptionDispatcher) run() (statusCode int, err error) {
-	optsExecutor, _, _ := setupPkiInitOption(os.Args[1])
+func (testDispatcher *testPkiInitOptionDispatcher) run(command string) (statusCode int, err error) {
+	optsExecutor, _, _ := setupPkiInitOption(command)
 
-	genOpt := (optsExecutor.(*option.PkiInitOption)).GenerateOpt
+	genOpt := false
+	if pkiInit, ok := optsExecutor.(*option.PkiInitOption); ok {
+		genOpt = pkiInit.GenerateOpt
+	}
+
 	fmt.Printf("In test flag value: generateOpt = %v, configFile = %v", genOpt, configFile)
 
 	testDispatcher.testOptsExecutor = optsExecutor

--- a/cmd/security-secrets-setup/main_test.go
+++ b/cmd/security-secrets-setup/main_test.go
@@ -118,6 +118,34 @@ func TestMainUnsupportedArgument(t *testing.T) {
 	assert.Equal(1, (exitInstance.(*testExitCode)).getStatusCode())
 }
 
+func TestMainVerifyMultipleSubcommands(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	os.Args = []string{"cmd", "generate", "legacy"}
+	printCommandLineStrings(os.Args)
+	hasDispatchError = false
+	main()
+
+	assert.Equal(2, (exitInstance.(*testExitCode)).getStatusCode())
+}
+
+func TestMainLegacySubcommandWithExtraArgs(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	os.Args = []string{"cmd", "legacy", "-c", "./res/pkisetup-vault.json", "extra"}
+	printCommandLineStrings(os.Args)
+	hasDispatchError = false
+	main()
+
+	assert.Equal(2, (exitInstance.(*testExitCode)).getStatusCode())
+}
+
 func runWithGenerateOption(hasError bool) {
 	os.Args = []string{"cmd", "generate"}
 	printCommandLineStrings(os.Args)

--- a/internal/pkg/config/x509.go
+++ b/internal/pkg/config/x509.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
+ * Copyright 2019 Intel Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,6 +21,11 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+)
+
+const (
+	skFileExt   = ".priv.key"
+	certFileExt = ".pem"
 )
 
 // NewX509Config will populate a struct representing configuration for X.509 key generation
@@ -54,6 +60,7 @@ type X509Config struct {
 	TLSServer       TLSServer `json:"x509_tls_server_parameters"`
 }
 
+// PkiCADir returns the pkisetup root CA dir
 func (cfg X509Config) PkiCADir() (string, error) {
 	dir, err := filepath.Abs(cfg.WorkingDir)
 	if err != nil {
@@ -62,6 +69,26 @@ func (cfg X509Config) PkiCADir() (string, error) {
 	}
 	// pkiCaDir: Concatenate working dir absolute path with PKI setup dir, using separator "/"
 	return strings.Join([]string{dir, cfg.PKISetupDir, cfg.RootCA.CAName}, "/"), nil
+}
+
+// GetCAPemFileName returns the file name of CA certificate
+func (cfg X509Config) GetCAPemFileName() string {
+	return cfg.RootCA.CAName + certFileExt
+}
+
+// GetCAPrivateKeyFileName returns the file name of CA private key
+func (cfg X509Config) GetCAPrivateKeyFileName() string {
+	return cfg.RootCA.CAName + skFileExt
+}
+
+// GetTLSPemFileName returns the file name of TLS certificate
+func (cfg X509Config) GetTLSPemFileName() string {
+	return cfg.TLSServer.TLSHost + certFileExt
+}
+
+// GetTLSPrivateKeyFileName returns the file name of TLS private key
+func (cfg X509Config) GetTLSPrivateKeyFileName() string {
+	return cfg.TLSServer.TLSHost + skFileExt
 }
 
 // KeyScheme parameters (RSA vs EC)

--- a/internal/pkg/config/x509.go
+++ b/internal/pkg/config/x509.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	skFileExt   = ".priv.key"
-	certFileExt = ".pem"
+	skFileExt   = "priv.key"
+	certFileExt = "pem"
 )
 
 // NewX509Config will populate a struct representing configuration for X.509 key generation
@@ -73,22 +73,22 @@ func (cfg X509Config) PkiCADir() (string, error) {
 
 // GetCAPemFileName returns the file name of CA certificate
 func (cfg X509Config) GetCAPemFileName() string {
-	return cfg.RootCA.CAName + certFileExt
+	return cfg.RootCA.CAName + "." + certFileExt
 }
 
 // GetCAPrivateKeyFileName returns the file name of CA private key
 func (cfg X509Config) GetCAPrivateKeyFileName() string {
-	return cfg.RootCA.CAName + skFileExt
+	return cfg.RootCA.CAName + "." + skFileExt
 }
 
 // GetTLSPemFileName returns the file name of TLS certificate
 func (cfg X509Config) GetTLSPemFileName() string {
-	return cfg.TLSServer.TLSHost + certFileExt
+	return cfg.TLSServer.TLSHost + "." + certFileExt
 }
 
 // GetTLSPrivateKeyFileName returns the file name of TLS private key
 func (cfg X509Config) GetTLSPrivateKeyFileName() string {
-	return cfg.TLSServer.TLSHost + skFileExt
+	return cfg.TLSServer.TLSHost + "." + skFileExt
 }
 
 // KeyScheme parameters (RSA vs EC)

--- a/internal/pkg/config/x509_test.go
+++ b/internal/pkg/config/x509_test.go
@@ -69,26 +69,26 @@ func TestGetCAPemFileName(t *testing.T) {
 	// ignore the file reading error since it will be caught by other test already
 	x509Config, _ := NewX509Config(testJSONFileName)
 	pemFileName := x509Config.GetCAPemFileName()
-	assert.Equal(t, x509Config.RootCA.CAName+"."+certFileExt, pemFileName)
+	assert.Equal(t, "EdgeXFoundryCA."+certFileExt, pemFileName)
 }
 
 func TestGetCAPrivateKeyFileName(t *testing.T) {
 	// ignore the file reading error since it will be caught by other test already
 	x509Config, _ := NewX509Config(testJSONFileName)
 	prvKeyFileName := x509Config.GetCAPrivateKeyFileName()
-	assert.Equal(t, x509Config.RootCA.CAName+"."+skFileExt, prvKeyFileName)
+	assert.Equal(t, "EdgeXFoundryCA."+skFileExt, prvKeyFileName)
 }
 
 func TestGetTLSPemFileName(t *testing.T) {
 	// ignore the file reading error since it will be caught by other test already
 	x509Config, _ := NewX509Config(testJSONFileName)
 	pemFileName := x509Config.GetTLSPemFileName()
-	assert.Equal(t, x509Config.TLSServer.TLSHost+"."+certFileExt, pemFileName)
+	assert.Equal(t, "edgex-kong."+certFileExt, pemFileName)
 }
 
 func TestGetTLSPrivateKeyFileName(t *testing.T) {
 	// ignore the file reading error since it will be caught by other test already
 	x509Config, _ := NewX509Config(testJSONFileName)
 	prvKeyFileName := x509Config.GetTLSPrivateKeyFileName()
-	assert.Equal(t, x509Config.TLSServer.TLSHost+"."+skFileExt, prvKeyFileName)
+	assert.Equal(t, "edgex-kong."+skFileExt, prvKeyFileName)
 }

--- a/internal/pkg/config/x509_test.go
+++ b/internal/pkg/config/x509_test.go
@@ -64,3 +64,31 @@ func TestPkiCAOutDir(t *testing.T) {
 	assert.True(strings.Contains(pkiDir,
 		filepath.Join(filepath.Base(x509Config.WorkingDir), x509Config.PKISetupDir, x509Config.RootCA.CAName)))
 }
+
+func TestGetCAPemFileName(t *testing.T) {
+	// ignore the file reading error since it will be caught by other test already
+	x509Config, _ := NewX509Config(testJSONFileName)
+	pemFileName := x509Config.GetCAPemFileName()
+	assert.Equal(t, x509Config.RootCA.CAName+certFileExt, pemFileName)
+}
+
+func TestGetCAPrivateKeyFileName(t *testing.T) {
+	// ignore the file reading error since it will be caught by other test already
+	x509Config, _ := NewX509Config(testJSONFileName)
+	prvKeyFileName := x509Config.GetCAPrivateKeyFileName()
+	assert.Equal(t, x509Config.RootCA.CAName+skFileExt, prvKeyFileName)
+}
+
+func TestGetTLSPemFileName(t *testing.T) {
+	// ignore the file reading error since it will be caught by other test already
+	x509Config, _ := NewX509Config(testJSONFileName)
+	pemFileName := x509Config.GetTLSPemFileName()
+	assert.Equal(t, x509Config.TLSServer.TLSHost+certFileExt, pemFileName)
+}
+
+func TestGetTLSPrivateKeyFileName(t *testing.T) {
+	// ignore the file reading error since it will be caught by other test already
+	x509Config, _ := NewX509Config(testJSONFileName)
+	prvKeyFileName := x509Config.GetTLSPrivateKeyFileName()
+	assert.Equal(t, x509Config.TLSServer.TLSHost+skFileExt, prvKeyFileName)
+}

--- a/internal/pkg/config/x509_test.go
+++ b/internal/pkg/config/x509_test.go
@@ -69,26 +69,26 @@ func TestGetCAPemFileName(t *testing.T) {
 	// ignore the file reading error since it will be caught by other test already
 	x509Config, _ := NewX509Config(testJSONFileName)
 	pemFileName := x509Config.GetCAPemFileName()
-	assert.Equal(t, x509Config.RootCA.CAName+certFileExt, pemFileName)
+	assert.Equal(t, x509Config.RootCA.CAName+"."+certFileExt, pemFileName)
 }
 
 func TestGetCAPrivateKeyFileName(t *testing.T) {
 	// ignore the file reading error since it will be caught by other test already
 	x509Config, _ := NewX509Config(testJSONFileName)
 	prvKeyFileName := x509Config.GetCAPrivateKeyFileName()
-	assert.Equal(t, x509Config.RootCA.CAName+skFileExt, prvKeyFileName)
+	assert.Equal(t, x509Config.RootCA.CAName+"."+skFileExt, prvKeyFileName)
 }
 
 func TestGetTLSPemFileName(t *testing.T) {
 	// ignore the file reading error since it will be caught by other test already
 	x509Config, _ := NewX509Config(testJSONFileName)
 	pemFileName := x509Config.GetTLSPemFileName()
-	assert.Equal(t, x509Config.TLSServer.TLSHost+certFileExt, pemFileName)
+	assert.Equal(t, x509Config.TLSServer.TLSHost+"."+certFileExt, pemFileName)
 }
 
 func TestGetTLSPrivateKeyFileName(t *testing.T) {
 	// ignore the file reading error since it will be caught by other test already
 	x509Config, _ := NewX509Config(testJSONFileName)
 	prvKeyFileName := x509Config.GetTLSPrivateKeyFileName()
-	assert.Equal(t, x509Config.TLSServer.TLSHost+skFileExt, prvKeyFileName)
+	assert.Equal(t, x509Config.TLSServer.TLSHost+"."+skFileExt, prvKeyFileName)
 }

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -44,7 +44,10 @@ Common Options:
 var securitySetupUsageStr = `
 Usage: %s [options]
 Server Options:
-	-c, --config <name>             Provide absolute path to JSON configuration file
+    -c, --config <name>             Provide absolute path to JSON configuration file
+
+Server Subcommand:	
+    generate                        Generate PKI afresh every time and deployed. Typically, this will be whenever the framework is started.
 
 Common Options:
     -h, --help                      Show this message

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -42,12 +42,14 @@ Common Options:
 `
 
 var securitySetupUsageStr = `
-Usage: %s [options]
+Usage: %s <subcommands> [options]
 Server Options:
-    -c, --config <name>             Provide absolute path to JSON configuration file
+    --confdir                       Specify local configuration directory
 
 Server Subcommand:	
-    generate                        Generate PKI afresh every time and deployed. Typically, this will be whenever the framework is started.
+	generate                        Generate PKI afresh every time and deployed. Typically, this will be whenever the framework is started.
+	legacy                          [Will be deprecated] Legacy mode to generate PKI
+	  -c, --config <name>           Provide absolute path to JSON configuration file
 
 Common Options:
     -h, --help                      Show this message

--- a/internal/security/setup/option/constant.go
+++ b/internal/security/setup/option/constant.go
@@ -43,6 +43,8 @@ const (
 	kongServiceName  = "edgex-kong"
 )
 
-var pkiInitScratchDir = filepath.Join(pkiInitBaseDir, "scratch")
-var pkiInitGeneratedDir = filepath.Join(pkiInitBaseDir, "generated")
-var pkiInitDeployDir = filepath.Join(tmpfsRunDir, "edgex", "secrets")
+var (
+	pkiInitScratchDir   = filepath.Join(pkiInitBaseDir, "scratch")
+	pkiInitGeneratedDir = filepath.Join(pkiInitBaseDir, "generated")
+	pkiInitDeployDir    = filepath.Join(tmpfsRunDir, "edgex", "secrets")
+)

--- a/internal/security/setup/option/constant.go
+++ b/internal/security/setup/option/constant.go
@@ -16,7 +16,33 @@
 
 package option
 
+import (
+	"path/filepath"
+)
+
 const (
 	// SecuritySecretsSetup is the name of this module
 	SecuritySecretsSetup = "security-secrets-setup"
+
+	pkiSetupVaultJSON             = "pkisetup-vault.json"
+	pkiSetupKongJSON              = "pkisetup-kong.json"
+	resourceDirName               = "res"
+	configTomlFile                = "configuration.toml"
+	envXdgRuntimeDir              = "XDG_RUNTIME_DIR"
+	defaultXdgRuntimeDir          = "/tmp"
+	pkiInitBaseDir                = "/edgex/security-secrets-setup"
+	tmpfsRunDir                   = "/run"
+	tlsSecretFileName             = "server.key"
+	tlsCertFileName               = "server.crt"
+	caCertFileName                = "ca.pem"
+	pkiInitFilePerServiceComplete = ".security-secrets-setup.complete"
+
+	// service name section:
+	caServiceName    = "ca"
+	vaultServiceName = "edgex-vault"
+	kongServiceName  = "edgex-kong"
 )
+
+var pkiInitScratchDir = filepath.Join(pkiInitBaseDir, "scratch")
+var pkiInitGeneratedDir = filepath.Join(pkiInitBaseDir, "generated")
+var pkiInitDeployDir = filepath.Join(tmpfsRunDir, "edgex", "secrets")

--- a/internal/security/setup/option/generate.go
+++ b/internal/security/setup/option/generate.go
@@ -1,0 +1,188 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package option
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	config "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/setup"
+)
+
+// Generate option....
+func Generate() func(*PkiInitOption) (exitCode, error) {
+	return func(pkiInitOption *PkiInitOption) (exitCode, error) {
+
+		if isGenerateNoOp(pkiInitOption) {
+			return normal, nil
+		}
+
+		if statusCode, err := generatePkis(); err != nil {
+			return statusCode, err
+		}
+		generatedDirPath := filepath.Join(getXdgRuntimeDir(), pkiInitGeneratedDir)
+		// Shred the CA private key before deploy
+		caPrivateKeyFile := filepath.Join(generatedDirPath, caServiceName, tlsSecretFileName)
+		if err := secureEraseFile(caPrivateKeyFile); err != nil {
+			return exitWithError, err
+		}
+
+		if err := deploy(generatedDirPath, pkiInitDeployDir); err != nil {
+			return exitWithError, err
+		}
+
+		return normal, nil
+	}
+}
+
+func isGenerateNoOp(pkiInitOption *PkiInitOption) bool {
+	// nop: if the flag is missing or not on
+	return pkiInitOption == nil || !pkiInitOption.GenerateOpt
+}
+
+func generatePkis() (exitCode, error) {
+	baseWorkingDir, err := os.Getwd()
+	if err != nil {
+		return exitWithError, err
+	}
+
+	resourceDirPath := filepath.Join(baseWorkingDir, resourceDirName)
+	pkiSetupVaultJSONPath := filepath.Join(resourceDirPath, pkiSetupVaultJSON)
+	pkiSetupKongJSONPath := filepath.Join(resourceDirPath, pkiSetupKongJSON)
+
+	scratchPath := filepath.Join(getXdgRuntimeDir(), pkiInitScratchDir)
+
+	setup.LoggingClient.Debug(fmt.Sprint("pkiSetupVaultJSONPath: ", pkiSetupVaultJSONPath,
+		"  pkiSetupKongJSONPath: ", pkiSetupKongJSONPath,
+		"  scratchPath: ", scratchPath,
+		"  resourceDirPath: ", resourceDirPath))
+
+	if !checkIfFileExists(pkiSetupVaultJSONPath) {
+		setup.LoggingClient.Error(fmt.Sprint("Vault JSON file for security-secrets-setup not exists in ", pkiSetupVaultJSONPath))
+		return exitWithError, err
+	}
+
+	if !checkIfFileExists(pkiSetupKongJSONPath) {
+		setup.LoggingClient.Error(fmt.Sprint("Kong JSON file for security-secrets-setup not exists in ", pkiSetupKongJSONPath))
+		return exitWithError, err
+	}
+
+	// create scratch dir if not exists yet:
+	if err := createDirectoryIfNotExists(scratchPath); err != nil {
+		return exitWithError, err
+	}
+
+	// after done, need to change it back to the original working dir to avoid os.Getwd() error
+	// and delete the scratch dir
+	defer cleanup(baseWorkingDir, scratchPath)
+
+	// generate TLS certs on the env. of $XDG_RUNTIME_DIR/edgex/pki-init/scratch
+	if err := os.Chdir(scratchPath); err != nil {
+		return exitWithError, err
+	}
+
+	if err := GenTLSAssets(pkiSetupVaultJSONPath); err != nil {
+		return exitWithError, err
+	}
+
+	if err := GenTLSAssets(pkiSetupKongJSONPath); err != nil {
+		return exitWithError, err
+	}
+
+	return rearrangePkiByServices(pkiSetupVaultJSONPath, pkiSetupKongJSONPath)
+}
+
+func rearrangePkiByServices(pkiSetupVaultJSONPath, pkiSetupKongJSONPath string) (exitCode, error) {
+	vaultConfig, readErr := config.NewX509Config(pkiSetupVaultJSONPath)
+	if readErr != nil {
+		return exitWithError, readErr
+	}
+
+	kongConfig, readErr := config.NewX509Config(pkiSetupKongJSONPath)
+	if readErr != nil {
+		return exitWithError, readErr
+	}
+
+	generatedDirPath := filepath.Join(getXdgRuntimeDir(), pkiInitGeneratedDir)
+
+	setup.LoggingClient.Debug(fmt.Sprint("pki-init generate output base dir: ", generatedDirPath))
+
+	// create generated dir if not exists yet:
+	if err := createDirectoryIfNotExists(generatedDirPath); err != nil {
+		return exitWithError, err
+	}
+
+	// CA:
+	caDirPath := filepath.Join(generatedDirPath, caServiceName)
+	if err := copyGeneratedForService(caDirPath, vaultConfig); err != nil {
+		return exitWithError, err
+	}
+
+	// Vault:
+	vaultServicePath := filepath.Join(generatedDirPath, vaultServiceName)
+	if err := copyGeneratedForService(vaultServicePath, vaultConfig); err != nil {
+		return exitWithError, err
+	}
+
+	// Kong:
+	kongServicePath := filepath.Join(generatedDirPath, kongServiceName)
+	if err := copyGeneratedForService(kongServicePath, kongConfig); err != nil {
+		return exitWithError, err
+	}
+
+	return normal, nil
+}
+
+func copyGeneratedForService(servicePath string, config config.X509Config) error {
+	if err := createDirectoryIfNotExists(servicePath); err != nil {
+		return err
+	}
+
+	pkiOutputDir, err := config.PkiCADir()
+	if err != nil {
+		return err
+	}
+
+	if _, err := copyFile(filepath.Join(pkiOutputDir, config.GetCAPemFileName()), filepath.Join(servicePath, caCertFileName)); err != nil {
+		return err
+	}
+
+	privKeyFileName := filepath.Join(servicePath, tlsSecretFileName)
+	if filepath.Base(servicePath) == caServiceName {
+		if _, err := copyFile(filepath.Join(pkiOutputDir, config.GetCAPrivateKeyFileName()), privKeyFileName); err != nil {
+			return err
+		}
+	} else {
+		if _, err := copyFile(filepath.Join(pkiOutputDir, config.GetTLSPrivateKeyFileName()), privKeyFileName); err != nil {
+			return err
+		}
+		// if not CA, then also copy the TLS cert as well
+		if _, err := copyFile(filepath.Join(pkiOutputDir, config.GetTLSPemFileName()), filepath.Join(servicePath, tlsCertFileName)); err != nil {
+			return err
+		}
+	}
+
+	// read-only to the owner
+	return os.Chmod(privKeyFileName, 0400)
+}
+
+func cleanup(baseWorkingDir, scratchPath string) {
+	_ = os.Chdir(baseWorkingDir)
+	os.RemoveAll(scratchPath)
+	setup.LoggingClient.Info("pki-init generation completes")
+}

--- a/internal/security/setup/option/generate_test.go
+++ b/internal/security/setup/option/generate_test.go
@@ -1,0 +1,216 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package option
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/setup"
+	"github.com/stretchr/testify/assert"
+)
+
+var testExecutor *mockOptionsExecutor
+var vaultJSONPkiSetupExist bool
+var kongJSONPkiSetupExist bool
+
+func TestGenerate(t *testing.T) {
+	vaultJSONPkiSetupExist = true
+	kongJSONPkiSetupExist = true
+	tearDown := setupGenerateTest(t)
+	defer tearDown(t)
+
+	options := PkiInitOption{
+		GenerateOpt: true,
+	}
+	generateOn, _, _ := NewPkiInitOption(options)
+	generateOn.(*PkiInitOption).executor = testExecutor
+
+	f := Generate()
+	exitCode, err := f(generateOn.(*PkiInitOption))
+
+	assert := assert.New(t)
+	assert.Equal(normal, exitCode)
+	assert.Nil(err)
+	generatedDirPath := filepath.Join(getXdgRuntimeDir(), pkiInitGeneratedDir)
+	caPrivateKeyFile := filepath.Join(generatedDirPath, caServiceName, tlsSecretFileName)
+	fileExists := checkIfFileExists(caPrivateKeyFile)
+	assert.False(fileExists, "CA private key are not removed!")
+
+	deployEmpty, emptyErr := isDirEmpty(pkiInitDeployDir)
+	assert.Nil(emptyErr)
+	assert.False(deployEmpty)
+
+	// check sentinel file is present when deploy is done
+	sentinel := filepath.Join(pkiInitDeployDir, caServiceName, pkiInitFilePerServiceComplete)
+	fileExists = checkIfFileExists(sentinel)
+	assert.True(fileExists, "sentinel file does not exist for CA service!")
+
+	sentinel = filepath.Join(pkiInitDeployDir, vaultServiceName, pkiInitFilePerServiceComplete)
+	fileExists = checkIfFileExists(sentinel)
+	assert.True(fileExists, "sentinel file does not exist for vault service!")
+}
+
+func TestGenerateWithVaultJSONPkiSetupMissing(t *testing.T) {
+	vaultJSONPkiSetupExist = false // this will lead to missing json
+	kongJSONPkiSetupExist = true
+	tearDown := setupGenerateTest(t)
+	defer tearDown(t)
+
+	options := PkiInitOption{
+		GenerateOpt: true,
+	}
+	generateOn, _, _ := NewPkiInitOption(options)
+	generateOn.(*PkiInitOption).executor = testExecutor
+
+	f := Generate()
+	exitCode, err := f(generateOn.(*PkiInitOption))
+
+	assert := assert.New(t)
+	assert.Equal(exitWithError, exitCode)
+	assert.NotNil(err)
+}
+
+func TestGenerateWithKongJSONPkiSetupMissing(t *testing.T) {
+	kongJSONPkiSetupExist = false // this will lead to missing json
+	vaultJSONPkiSetupExist = true
+	tearDown := setupGenerateTest(t)
+	defer tearDown(t)
+
+	options := PkiInitOption{
+		GenerateOpt: true,
+	}
+	generateOn, _, _ := NewPkiInitOption(options)
+	generateOn.(*PkiInitOption).executor = testExecutor
+
+	f := Generate()
+	exitCode, err := f(generateOn.(*PkiInitOption))
+
+	assert := assert.New(t)
+	assert.Equal(exitWithError, exitCode)
+	assert.NotNil(err)
+}
+
+func TestGenerateOff(t *testing.T) {
+	vaultJSONPkiSetupExist = true
+	kongJSONPkiSetupExist = true
+	tearDown := setupGenerateTest(t)
+	defer tearDown(t)
+
+	options := PkiInitOption{
+		GenerateOpt: false,
+	}
+	generateOff, _, _ := NewPkiInitOption(options)
+	generateOff.(*PkiInitOption).executor = testExecutor
+	exitCode, err := generateOff.executeOptions(Generate())
+
+	assert := assert.New(t)
+	assert.Equal(normal, exitCode)
+	assert.Nil(err)
+}
+
+func TestGetXdgRuntimeDir(t *testing.T) {
+	origEnvVal := os.Getenv(envXdgRuntimeDir)
+	os.Unsetenv(envXdgRuntimeDir)
+	runTimeDir := getXdgRuntimeDir()
+	assert.Equal(t, defaultXdgRuntimeDir, runTimeDir)
+
+	os.Setenv(envXdgRuntimeDir, origEnvVal)
+	runTimeDir = getXdgRuntimeDir()
+	assert.Equal(t, origEnvVal, runTimeDir)
+}
+
+func setupGenerateTest(t *testing.T) func(t *testing.T) {
+	testExecutor = &mockOptionsExecutor{}
+
+	curDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot get the working dir %s: %v", curDir, err)
+	}
+
+	testResourceDir := filepath.Join(curDir, resourceDirName)
+	if err := createDirectoryIfNotExists(testResourceDir); err != nil {
+		t.Fatalf("cannot create resource dir %s for the test: %v", testResourceDir, err)
+	}
+
+	resDir := filepath.Join(curDir, "..", "..", "..", "..", "cmd", SecuritySecretsSetup, resourceDirName)
+	jsonVaultFile := filepath.Join(curDir, resourceDirName, pkiSetupVaultJSON)
+	if vaultJSONPkiSetupExist {
+		if _, err := copyFile(filepath.Join(resDir, pkiSetupVaultJSON), jsonVaultFile); err != nil {
+			t.Fatalf("cannot copy %s for the test: %v", pkiSetupVaultJSON, err)
+		}
+	}
+
+	jsonKongFile := filepath.Join(curDir, resourceDirName, pkiSetupKongJSON)
+	if kongJSONPkiSetupExist {
+		if _, err := copyFile(filepath.Join(resDir, pkiSetupKongJSON), jsonKongFile); err != nil {
+			t.Fatalf("cannot copy %s for the test: %v", pkiSetupKongJSON, err)
+		}
+	}
+
+	testResTomlFile := filepath.Join(testResourceDir, configTomlFile)
+	if _, err := copyFile(filepath.Join(resDir, configTomlFile), testResTomlFile); err != nil {
+		t.Fatalf("cannot copy %s for the test: %v", configTomlFile, err)
+	}
+
+	setup.Init()
+
+	origEnvXdgRuntimeDir := getXdgRuntimeDir()
+	fmt.Println("Env XDG_RUNTIME_DIR: ", origEnvXdgRuntimeDir)
+
+	// change it to the current working directory
+	os.Setenv(envXdgRuntimeDir, curDir)
+
+	origScratchDir := pkiInitScratchDir
+	testScratchDir, tempDirErr := ioutil.TempDir(curDir, "scratch")
+	if tempDirErr != nil {
+		t.Fatalf("cannot create temporary scratch directory for the test: %v", tempDirErr)
+	}
+	pkiInitScratchDir = filepath.Base(testScratchDir)
+
+	origGeneratedDir := pkiInitGeneratedDir
+	testGeneratedDir, tempDirErr := ioutil.TempDir(curDir, "generated")
+	if tempDirErr != nil {
+		t.Fatalf("cannot create temporary generated directory for the test: %v", tempDirErr)
+	}
+	pkiInitGeneratedDir = filepath.Base(testGeneratedDir)
+
+	origDeployDir := pkiInitDeployDir
+	tempDir, tempDirErr := ioutil.TempDir(curDir, "deploytest")
+	if tempDirErr != nil {
+		t.Fatalf("cannot create temporary scratch directory for the test: %v", tempDirErr)
+	}
+	pkiInitDeployDir = tempDir
+
+	return func(t *testing.T) {
+		// cleanup
+		os.Remove(jsonVaultFile)
+		os.Remove(jsonKongFile)
+		os.Setenv(envXdgRuntimeDir, origEnvXdgRuntimeDir)
+		os.RemoveAll(testScratchDir)
+		os.RemoveAll(testGeneratedDir)
+		os.RemoveAll(pkiInitDeployDir)
+		os.RemoveAll(testResourceDir)
+		pkiInitScratchDir = origScratchDir
+		pkiInitGeneratedDir = origGeneratedDir
+		pkiInitDeployDir = origDeployDir
+		vaultJSONPkiSetupExist = true
+		kongJSONPkiSetupExist = true
+	}
+}

--- a/internal/security/setup/option/generate_test.go
+++ b/internal/security/setup/option/generate_test.go
@@ -149,7 +149,7 @@ func setupGenerateTest(t *testing.T) func(t *testing.T) {
 		t.Fatalf("cannot create resource dir %s for the test: %v", testResourceDir, err)
 	}
 
-	resDir := filepath.Join(curDir, "..", "..", "..", "..", "cmd", SecuritySecretsSetup, resourceDirName)
+	resDir := filepath.Join(curDir, "testdata", resourceDirName)
 	jsonVaultFile := filepath.Join(curDir, resourceDirName, pkiSetupVaultJSON)
 	if vaultJSONPkiSetupExist {
 		if _, err := copyFile(filepath.Join(resDir, pkiSetupVaultJSON), jsonVaultFile); err != nil {

--- a/internal/security/setup/option/optionHelpers.go
+++ b/internal/security/setup/option/optionHelpers.go
@@ -19,10 +19,210 @@ package option
 import (
 	"errors"
 
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"time"
+
 	config "github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/setup"
 	"github.com/edgexfoundry/edgex-go/internal/security/setup/certificates"
 )
+
+func copyFile(fileSrc, fileDest string) (int64, error) {
+	var zeroByte int64
+	sourceFileSt, err := os.Stat(fileSrc)
+	if err != nil {
+		return zeroByte, err
+	}
+
+	// only regular file allows to be copied
+	if !sourceFileSt.Mode().IsRegular() {
+		return zeroByte, fmt.Errorf("[%s] is not a regular file to be copied", fileSrc)
+	}
+
+	// now open the source file
+	source, openErr := os.Open(fileSrc)
+	if openErr != nil {
+		return zeroByte, openErr
+	}
+	defer source.Close()
+
+	if _, err := os.Stat(fileDest); err == nil {
+		// if fileDest alrady exists, remove it first before create a new one
+		os.Remove(fileDest)
+	}
+
+	// now create a new file
+	dest, createErr := os.Create(fileDest)
+	if createErr != nil {
+		return zeroByte, createErr
+	}
+	defer dest.Close()
+
+	bytesWritten, copyErr := io.Copy(dest, source)
+	if copyErr != nil {
+		return zeroByte, copyErr
+	}
+	// make dest has the same file mode as the source
+	_ = os.Chmod(fileDest, sourceFileSt.Mode())
+	return bytesWritten, nil
+}
+
+func createDirectoryIfNotExists(dirName string) (err error) {
+	if _, err := os.Stat(dirName); os.IsNotExist(err) {
+		err = os.MkdirAll(dirName, os.ModePerm)
+	}
+	return err
+}
+
+func isDirEmpty(dir string) (empty bool, err error) {
+	handle, err := os.Open(dir)
+	if err != nil {
+		return empty, err
+	}
+	defer handle.Close()
+
+	_, err = handle.Readdir(1)
+	if err == io.EOF {
+		// EOF error means the dir is empty
+		empty = true
+		err = nil
+	}
+
+	return empty, err
+}
+
+func copyDir(srcDir, destDir string) error {
+	srcFileInfo, statErr := os.Stat(srcDir)
+	if statErr != nil {
+		return statErr
+	}
+	if makeDirErr := os.MkdirAll(destDir, srcFileInfo.Mode()); makeDirErr != nil {
+		return makeDirErr
+	}
+
+	fileDescs, readErr := ioutil.ReadDir(srcDir)
+	if readErr != nil {
+		return readErr
+	}
+
+	for _, fileDesc := range fileDescs {
+		srcFilePath := filepath.Join(srcDir, fileDesc.Name())
+		destFilePath := filepath.Join(destDir, fileDesc.Name())
+
+		if fileDesc.IsDir() {
+			if err := copyDir(srcFilePath, destFilePath); err != nil {
+				return err
+			}
+		} else {
+			log.Printf("copying srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath)
+			if _, copyErr := copyFile(srcFilePath, destFilePath); copyErr != nil {
+				return copyErr
+			}
+
+		}
+	}
+
+	return nil
+}
+
+func deploy(srcDir, destDir string) error {
+	if err := copyDir(srcDir, destDir); err != nil {
+		return err
+	}
+	return markComplete(destDir)
+}
+
+func secureEraseFile(fileToErase string) error {
+	if err := zeroOutFile(fileToErase); err != nil {
+		return err
+	}
+	return os.Remove(fileToErase)
+}
+
+func zeroOutFile(fileToErase string) error {
+	// grant the file read-write permission first
+	_ = os.Chmod(fileToErase, 0600)
+	fileHdl, err := os.OpenFile(fileToErase, os.O_RDWR, 0600)
+	defer func() {
+		_ = fileHdl.Close()
+	}()
+	if err != nil {
+		return err
+	}
+	fileInfo, err := fileHdl.Stat()
+	if err != nil {
+		return err
+	}
+
+	fileSize := fileInfo.Size()
+	zeroBytes := make([]byte, fileSize)
+	copy(zeroBytes[:], "0")
+
+	// fill the file with zero bytes
+	if _, err := fileHdl.Write(zeroBytes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkIfFileExists(fileName string) bool {
+	fileInfo, statErr := os.Stat(fileName)
+	if os.IsNotExist(statErr) {
+		return false
+	}
+	return !fileInfo.IsDir()
+}
+
+func writeSentinel(sentinelFilename string) error {
+	timestamp := []byte(strconv.FormatInt(time.Now().Unix(), 10))
+	return ioutil.WriteFile(sentinelFilename, timestamp, 0400)
+}
+
+// markComplete creates sentinel files of all services to signal pki-init deploy is done
+func markComplete(dirPath string) error {
+	// recursively walk through all sub-directories until reach the leaf node
+	// to write the sentinel files
+	fileDescs, readErr := ioutil.ReadDir(dirPath)
+	if readErr != nil {
+		return readErr
+	}
+
+	for _, fileDesc := range fileDescs {
+		aFilePath := filepath.Join(dirPath, fileDesc.Name())
+
+		if fileDesc.IsDir() {
+			if err := markComplete(aFilePath); err != nil {
+				return err
+			}
+		} else {
+			// now we are at the leaf node, write sentinel file if not yet
+			deployPathDir := path.Dir(aFilePath)
+			sentinel := filepath.Join(deployPathDir, pkiInitFilePerServiceComplete)
+			if !checkIfFileExists(sentinel) {
+				if err := writeSentinel(sentinel); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func getXdgRuntimeDir() string {
+	if xdgRuntimeDir, ok := os.LookupEnv(envXdgRuntimeDir); ok {
+		return xdgRuntimeDir
+	}
+	// if $XDG_RUNTIME_DIR is undefined, default to /tmp
+	return defaultXdgRuntimeDir
+}
 
 // GenTLSAssets generates the TLS assets based on the JSON configuration file
 func GenTLSAssets(jsonConfig string) error {
@@ -56,7 +256,7 @@ func GenTLSAssets(jsonConfig string) error {
 		return err
 	}
 
-	tlsCert.Generate()
+	err = tlsCert.Generate()
 	if err != nil {
 		return err
 	}

--- a/internal/security/setup/option/pkiOption.go
+++ b/internal/security/setup/option/pkiOption.go
@@ -24,7 +24,8 @@ type OptionsExecutor interface {
 
 // PkiInitOption contains command line options for pki-init
 type PkiInitOption struct {
-	executor OptionsExecutor
+	GenerateOpt bool
+	executor    OptionsExecutor
 }
 
 // NewPkiInitOption constructor to get options built for pki-init
@@ -36,7 +37,9 @@ func NewPkiInitOption(opts PkiInitOption) (ex OptionsExecutor, statusCode int, e
 
 // ProcessOptions processes all the input options from the caller
 func (pkiInitOpt *PkiInitOption) ProcessOptions() (int, error) {
-	statusCode, err := pkiInitOpt.executor.executeOptions()
+	statusCode, err := pkiInitOpt.executor.executeOptions(
+		Generate(),
+	)
 
 	return statusCode.intValue(), err
 }

--- a/internal/security/setup/option/testdata/res/configuration.toml
+++ b/internal/security/setup/option/testdata/res/configuration.toml
@@ -1,0 +1,6 @@
+[Writable]
+LogLevel = 'DEBUG'
+
+[Logging]
+EnableRemote = false
+File = './logs/security-secrets-setup.log'

--- a/internal/security/setup/option/testdata/res/pkisetup-kong.json
+++ b/internal/security/setup/option/testdata/res/pkisetup-kong.json
@@ -1,0 +1,28 @@
+{
+    "create_new_rootca": "false",
+    "working_dir": "./config",
+    "pki_setup_dir": "pki",
+    "dump_config": "true",
+    "key_scheme": {
+        "dump_keys": "false",
+        "rsa": "false",
+        "rsa_key_size": "4096",
+        "ec": "true",
+        "ec_curve": "384"
+    },
+    "x509_root_ca_parameters": {
+        "ca_name": "EdgeXFoundryCA",
+        "ca_c": "US",
+        "ca_st": "CA",
+        "ca_l": "San Francisco",
+        "ca_o": "EdgeXFoundry"
+    },
+    "x509_tls_server_parameters": {
+        "tls_host": "edgex-kong",
+        "tls_domain": "local",
+        "tls_c": "US",
+        "tls_st": "CA",
+        "tls_l": "San Francisco",
+        "tls_o": "Kong"
+    }
+}

--- a/internal/security/setup/option/testdata/res/pkisetup-vault.json
+++ b/internal/security/setup/option/testdata/res/pkisetup-vault.json
@@ -1,0 +1,28 @@
+{
+    "create_new_rootca": "true",
+    "working_dir": "./config",
+    "pki_setup_dir": "pki",
+    "dump_config": "true",
+    "key_scheme": {
+        "dump_keys": "false",
+        "rsa": "false",
+        "rsa_key_size": "4096",
+        "ec": "true",
+        "ec_curve": "384"
+    },
+    "x509_root_ca_parameters": {
+        "ca_name": "EdgeXFoundryCA",
+        "ca_c": "US",
+        "ca_st": "CA",
+        "ca_l": "San Francisco",
+        "ca_o": "EdgeXFoundry"
+    },
+    "x509_tls_server_parameters": {
+        "tls_host": "edgex-vault",
+        "tls_domain": "local",
+        "tls_c": "US",
+        "tls_st": "CA",
+        "tls_l": "San Francisco",
+        "tls_o": "Vault"
+    }
+}


### PR DESCRIPTION
To add generate subcommand into security-secrets-setup:

 - TLS assets are generated from "scratch" ("working") dir and currently
   default to `/edgex/security-secretes-setup/scratch` which is under the path
   given by `XDG_RUNTIME_DIR` environment variable

 - TLS assets are arranged into several directories based on service names

 - TLS assets are deployed into "deployed" dir and is currently default to `/run/edgex/secrets` tmpfs directory

 - TLS assets include `CA`, `Vault`, and `Kong` (reverse proxy)

 - Sentinel files are generated upon completion of deploy for services

Note: 
  The legacy option `-config <configuration_file_dir>` or `-c <configuration_file_dir>` is still available under subcommand `legacy` until phase out in the next phase or release.    Example of usage.:  `./security-secrets-setup legacy -config ./res/pkisetup-vault.json`


Related to: 
- Issue #1635
- Issue #1558 


Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>