### PR TITLE
Fix issue #1750: add header when sending request to post kong cert into vault; change …

### DIFF
--- a/internal/security/proxy/consumer_test.go
+++ b/internal/security/proxy/consumer_test.go
@@ -169,26 +169,3 @@ func TestCreateJWTToken(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 }
-
-/*func TestCreateOAuth2Token(t *testing.T) {
-	t.Skip()
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"token_type": "oauth2", "access_token": "test", "expires_in": 1442426001000}`))
-		if r.Method != "POST" {
-			t.Errorf("expected POST request, got %s instead", r.Method)
-		}
-
-		if r.URL.EscapedPath() != "/consumers/testuser/oauth2" {
-			t.Errorf("expected request to /consumers/testuser/oauth2, got %s instead", r.URL.EscapedPath())
-		}
-	}))
-	defer ts.Close()
-
-	co := Consumer{"testuser", &testConsumerRequestor{ts.URL}, &testConsumerConfig{ts.URL}}
-	_, err := co.createOAuth2Token()
-	if err != nil {
-		t.Errorf("failed to creat OAuth2 token for consumer")
-		t.Errorf(err.Error())
-	}
-}*/

--- a/internal/security/proxy/requestor.go
+++ b/internal/security/proxy/requestor.go
@@ -23,9 +23,9 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 )
 
-func NewRequestor(skipVerify bool, timeout int) internal.HttpCaller {
+func NewRequestor(skipVerify bool, timeoutInSecond int) internal.HttpCaller {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
 	}
-	return &http.Client{Timeout: time.Duration(timeout) * time.Second, Transport: tr}
+	return &http.Client{Timeout: time.Duration(timeoutInSecond) * time.Second, Transport: tr}
 }


### PR DESCRIPTION
…the kong services/routes names to lower cases

Signed-off-by: Tingyu Zeng <tingyu.zeng@rsa.com>

1. Header information is required inside postCert(), or the post action to KONG will be failed. 
2. When initializing services/routes for KONG, the names need to be lower case, or the initialization will be failed. 

