### PR TITLE
Common Bootstrap Package

### DIFF
--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -28,13 +28,14 @@ import (
 )
 
 func main() {
-	var useProfile string
+	var configDir, profileDir string
 	var dirCmd string
 	var dirProperties string
 	var overwriteConfig bool
 
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 	flag.StringVar(&dirProperties, "props", "./res/properties", "Specify alternate properties location as absolute path")
 	flag.StringVar(&dirProperties, "r", "./res/properties", "Specify alternate properties location as absolute path")
 	flag.StringVar(&dirCmd, "cmd", "../cmd", "Specify alternate cmd location as absolute path")
@@ -45,7 +46,7 @@ func main() {
 	flag.Usage = usage.HelpCallbackConfigSeed
 	flag.Parse()
 
-	bootstrap(useProfile)
+	bootstrap(configDir, profileDir)
 	ok := config.Init()
 	if !ok {
 		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.ConfigSeedServiceKey))
@@ -58,7 +59,7 @@ func main() {
 		config.LoggingClient.Error(err.Error())
 	}
 
-	err = config.ImportConfiguration(dirCmd, useProfile, overwriteConfig)
+	err = config.ImportConfiguration(dirCmd, profileDir, overwriteConfig)
 	if err != nil {
 		config.LoggingClient.Error(err.Error())
 	}
@@ -71,11 +72,11 @@ func main() {
 	os.Exit(0)
 }
 
-func bootstrap(profile string) {
+func bootstrap(configDir, profileDir string) {
 	deps := make(chan error, 2)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	go config.Retry(profile, internal.BootTimeoutDefault, &wg, deps)
+	go config.Retry(configDir, profileDir, internal.BootTimeoutDefault, &wg, deps)
 	go func(ch chan error) {
 		for {
 			select {

--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -36,16 +36,22 @@ import (
 func main() {
 	start := time.Now()
 	var useRegistry bool
-	var useProfile string
+	var configDir, profileDir string
 
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
 	startup.Bootstrap(params, command.Retry, logBeforeInit)
 
 	ok := command.Init(useRegistry)

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -35,16 +35,22 @@ import (
 func main() {
 	start := time.Now()
 	var useRegistry bool
-	var useProfile string
+	var configDir, profileDir string
 
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
 	startup.Bootstrap(params, metadata.Retry, logBeforeInit)
 
 	ok := metadata.Init(useRegistry)

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -30,19 +30,23 @@ import (
 
 func main() {
 	start := time.Now()
-	var (
-		useRegistry bool
-		useProfile  string
-	)
+	var useRegistry bool
+	var configDir, profileDir string
 
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
 	startup.Bootstrap(params, client.Retry, logBeforeInit)
 
 	ok := client.Init(useRegistry)

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -30,18 +30,24 @@ import (
 )
 
 func main() {
-	var useRegistry bool
-	var useProfile string
 	start := time.Now()
+	var useRegistry bool
+	var configDir, profileDir string
 
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
 	startup.Bootstrap(params, distro.Retry, logBeforeInit)
 
 	if ok := distro.Init(useRegistry); !ok {

--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -36,7 +36,7 @@ func main() {
 	var initNeeded bool
 	var insecureSkipVerify bool
 	var resetNeeded bool
-	var useProfile string
+	var configDir, profileDir string
 	var userTobeCreated string
 	var userOfGroup string
 	var userToBeDeleted string
@@ -50,13 +50,19 @@ func main() {
 	flag.StringVar(&userToBeDeleted, "userdel", "", "user that needs to be deleted from the edgex services")
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 
 	flag.Usage = usage.HelpCallbackSecurityProxy
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
 	startup.Bootstrap(params, proxy.Retry, logBeforeInit)
 
 	req := proxy.NewRequestor(insecureSkipVerify, proxy.Configuration.Writable.RequestTimeout)

--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -41,7 +41,7 @@ func main() {
 	var insecureSkipVerify bool
 	var configFileLocation string
 	var waitInterval int
-	var useProfile string
+	var configDir, profileDir string
 	var useRegistry bool
 
 	flag.BoolVar(&initNeeded, "init", false, "run init procedure for security service.")
@@ -50,13 +50,19 @@ func main() {
 	flag.IntVar(&waitInterval, "wait", 30, "time to wait between checking Vault status in seconds.")
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 
 	flag.Usage = usage.HelpCallbackSecuritySecretStore
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
 	startup.Bootstrap(params, secretstore.Retry, logBeforeInit)
 
 	//step 1: boot up secretstore general steps same as other EdgeX microservice

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -30,16 +30,22 @@ import (
 func main() {
 	start := time.Now()
 	var useRegistry bool
-	var useProfile string
+	var configDir, profileDir string
 
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
 	startup.Bootstrap(params, logging.Retry, logBeforeInit)
 
 	ok := logging.Init(useRegistry)

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -40,16 +40,22 @@ import (
 func main() {
 	start := time.Now()
 	var useRegistry bool
-	var useProfile string
+	var configDir, profileDir string
 
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
 	startup.Bootstrap(params, notifications.Retry, logBeforeInit)
 
 	ok := notifications.Init(useRegistry)

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -20,19 +20,24 @@ import (
 )
 
 func main() {
-
 	start := time.Now()
 	var useRegistry bool
-	var useProfile string
+	var configDir, profileDir string
 
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
 	startup.Bootstrap(params, scheduler.Retry, logBeforeInit)
 
 	ok := scheduler.Init(useRegistry)

--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -38,21 +38,24 @@ import (
 func main() {
 	start := time.Now()
 	var useRegistry bool
-	var useProfile string
+	var configDir, profileDir string
 
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
-	flag.StringVar(&useProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&useProfile, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
 	instance := agent.NewInstance()
-
-	startup.Bootstrap(
-		startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault},
-		instance.Retry,
-		logBeforeInit)
+	params := startup.BootParams{
+		UseRegistry: useRegistry,
+		ConfigDir:   configDir,
+		ProfileDir:  profileDir,
+		BootTimeout: internal.BootTimeoutDefault,
+	}
+	startup.Bootstrap(params, instance.Retry, logBeforeInit)
 
 	ok := instance.Init(useRegistry)
 	if !ok {

--- a/internal/core/data/config.go
+++ b/internal/core/data/config.go
@@ -13,7 +13,10 @@
  *******************************************************************************/
 package data
 
-import "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+)
 
 type ConfigurationStruct struct {
 	Writable     WritableInfo
@@ -33,4 +36,58 @@ type WritableInfo struct {
 	ValidateCheck              bool
 	LogLevel                   string
 	ChecksumAlgo               string
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		// Check that information was successfully read from Registry
+		if configuration.Service.Port == 0 {
+			return false
+		}
+		c = configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Clients:  c.Clients,
+		Service:  c.Service,
+		Registry: c.Registry,
+		Logging:  c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
+	c.Registry = registryInfo
 }

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -15,141 +15,96 @@
 package data
 
 import (
-	"errors"
+	"context"
 	"fmt"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
+	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+
 	"github.com/edgexfoundry/go-mod-messaging/messaging"
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/pkg/types"
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
-	"github.com/edgexfoundry/go-mod-registry/registry"
 
-	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
-var Configuration *ConfigurationStruct
+var Configuration = &ConfigurationStruct{}
 var dbClient interfaces.DBClient
 var LoggingClient logger.LoggingClient
-var registryClient registry.Client
 
 // TODO: Refactor names in separate PR: See comments on PR #1133
-var chEvents chan interface{}  // A channel for "domain events" sourced from event operations
-var chErrors chan error        // A channel for "config wait error" sourced from Registry
-var chUpdates chan interface{} // A channel for "config updates" sourced from Registry
-
+var chEvents chan interface{} // A channel for "domain events" sourced from event operations
 var msgClient messaging.MessageClient
 var mdc metadata.DeviceClient
 var msc metadata.DeviceServiceClient
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
-		var err error
-		// When looping, only handle configuration if it hasn't already been set.
-		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
-			if err != nil {
-				ch <- err
-				if !useRegistry {
-					// Error occurred when attempting to read from local filesystem. Fail fast.
-					close(ch)
-					wait.Done()
-					return
-				}
-			} else {
-				// Setup Logging
-				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(clients.CoreDataServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
-
-				// Initialize service clients
-				initializeClients(useRegistry)
-			}
-		}
-
-		// Only attempt to connect to database if configuration has been populated
-		if Configuration != nil {
-			err := connectToDatabase()
-			if err != nil {
-				ch <- err
-			} else {
-				break
-			}
-		}
-		time.Sleep(time.Second * time.Duration(1))
-	}
-	close(ch)
-	wait.Done()
-
-	return
+type server interface {
+	IsRunning() bool
 }
 
-func Init(useRegistry bool) bool {
-	if Configuration == nil || dbClient == nil {
-		return false
-	}
-	chEvents = make(chan interface{}, 100)
-	initEventHandlers()
-
-	if useRegistry && registryClient != nil {
-		chErrors = make(chan error)
-		chUpdates = make(chan interface{})
-		go listenForConfigChanges()
-	}
-
-	go telemetry.StartCpuUsageAverage()
-
-	return true
+type ServiceInit struct {
+	server server
 }
 
-func Destruct() {
-	if dbClient != nil {
-		dbClient.CloseSession()
-		dbClient = nil
-	}
-	if chEvents != nil {
-		close(chEvents)
-	}
-
-	if chErrors != nil {
-		close(chErrors)
-	}
-
-	if chUpdates != nil {
-		close(chUpdates)
+func NewServiceInit(server server) ServiceInit {
+	return ServiceInit{
+		server: server,
 	}
 }
 
-func connectToDatabase() error {
-	// Create a database client
+func (s ServiceInit) initializeClients(useRegistry bool, registry registry.Client) {
+	// Create metadata clients
+	mdc = metadata.NewDeviceClient(
+		types.EndpointParams{
+			ServiceKey:  clients.CoreMetaDataServiceKey,
+			Path:        clients.ApiDeviceRoute,
+			UseRegistry: useRegistry,
+			Url:         Configuration.Clients["Metadata"].Url() + clients.ApiDeviceRoute,
+			Interval:    Configuration.Service.ClientMonitor,
+		},
+		endpoint.Endpoint{RegistryClient: &registry})
+
+	msc = metadata.NewDeviceServiceClient(
+		types.EndpointParams{
+			ServiceKey:  clients.CoreMetaDataServiceKey,
+			Path:        clients.ApiDeviceServiceRoute,
+			UseRegistry: useRegistry,
+			Url:         Configuration.Clients["Metadata"].Url() + clients.ApiDeviceRoute,
+			Interval:    Configuration.Service.ClientMonitor,
+		},
+		endpoint.Endpoint{RegistryClient: &registry})
+
+	// Create the messaging client
 	var err error
+	msgClient, err = messaging.NewMessageClient(
+		msgTypes.MessageBusConfig{
+			PublishHost: msgTypes.HostInfo{
+				Host:     Configuration.MessageQueue.Host,
+				Port:     Configuration.MessageQueue.Port,
+				Protocol: Configuration.MessageQueue.Protocol,
+			},
+			Type: Configuration.MessageQueue.Type,
+		})
 
-	dbClient, err = newDBClient(Configuration.Databases["Primary"].Type)
 	if err != nil {
-		dbClient = nil
-		return fmt.Errorf("couldn't create database client: %v", err.Error())
+		LoggingClient.Error(fmt.Sprintf("failed to create messaging client: %s", err.Error()))
 	}
-
-	return nil
 }
 
 // Return the dbClient interface
-func newDBClient(dbType string) (interfaces.DBClient, error) {
+func (s ServiceInit) newDBClient(dbType string) (interfaces.DBClient, error) {
 	switch dbType {
 	case db.MongoDB:
 		dbConfig := db.Configuration{
@@ -177,150 +132,55 @@ func newDBClient(dbType string) (interfaces.DBClient, error) {
 	}
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
-	// We currently have to load configuration from filesystem first in order to obtain Registry Host/Port
-	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
-	if err != nil {
-		return nil, err
-	}
-	configuration.Registry = config.OverrideFromEnvironment(configuration.Registry)
+func (s ServiceInit) BootstrapHandler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config bootstrap.Configuration,
+	logging logger.LoggingClient,
+	registry registry.Client) bool {
 
-	if useRegistry {
-		err = connectToRegistry(configuration)
-		if err != nil {
-			return nil, err
+	// update global variables.
+	LoggingClient = logging
+
+	// initialize clients required by service.
+	s.initializeClients(registry != nil, registry)
+
+	// initialize database.
+	for startupTimer.HasNotElapsed() {
+		var err error
+		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
+		if err == nil {
+			break
 		}
-
-		rawConfig, err := registryClient.GetConfiguration(configuration)
-		if err != nil {
-			return nil, fmt.Errorf("could not get configuration from Registry: %v", err.Error())
-		}
-
-		actual, ok := rawConfig.(*ConfigurationStruct)
-		if !ok {
-			return nil, fmt.Errorf("configuration from Registry failed type check")
-		}
-
-		configuration = actual
-
-		// Check that information was successfully read from Registry
-		if configuration.Service.Port == 0 {
-			return nil, errors.New("error reading configuration from Registry")
-		}
+		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
+		startupTimer.SleepForInterval()
 	}
 
-	return configuration, nil
-}
-
-func connectToRegistry(conf *ConfigurationStruct) error {
-	var err error
-	registryConfig := registryTypes.Config{
-		Host:            conf.Registry.Host,
-		Port:            conf.Registry.Port,
-		Type:            conf.Registry.Type,
-		ServiceKey:      clients.CoreDataServiceKey,
-		ServiceHost:     conf.Service.Host,
-		ServicePort:     conf.Service.Port,
-		ServiceProtocol: conf.Service.Protocol,
-		CheckInterval:   conf.Service.CheckInterval,
-		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
+	if dbClient == nil {
+		return false
 	}
 
-	registryClient, err = registry.NewRegistryClient(registryConfig)
-	if err != nil {
-		return fmt.Errorf("connection to Registry could not be made: %v", err.Error())
-	}
+	LoggingClient.Info("Database connected")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 
-	// Check if registry service is running
-	if !registryClient.IsAlive() {
-		return fmt.Errorf("registry is not available")
-	}
-
-	// Register the service with Registry
-	err = registryClient.Register()
-	if err != nil {
-		return fmt.Errorf("could not register service with Registry: %v", err.Error())
-	}
-
-	return nil
-}
-
-func listenForConfigChanges() {
-	if registryClient == nil {
-		LoggingClient.Error("listenForConfigChanges() registry client not set")
-		return
-	}
-
-	registryClient.WatchForChanges(chUpdates, chErrors, &WritableInfo{}, internal.WritableKey)
-
-	// TODO: Refactor names in separate PR: See comments on PR #1133
-	chSignals := make(chan os.Signal)
-	signal.Notify(chSignals, os.Interrupt, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-chSignals:
-			// Quietly and gracefully stop when SIGINT/SIGTERM received
-			return
-
-		case ex := <-chErrors:
-			LoggingClient.Error(ex.Error())
-
-		case raw, ok := <-chUpdates:
-			if !ok {
-				return
+		<-ctx.Done()
+		for {
+			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
+			if s.server.IsRunning() == false {
+				dbClient.CloseSession()
+				break
 			}
-
-			actual, ok := raw.(*WritableInfo)
-			if !ok {
-				LoggingClient.Error("listenForConfigChanges() type check failed")
-				return
-			}
-
-			Configuration.Writable = *actual
-
-			LoggingClient.Info("Writeable configuration has been updated from the Registry")
-			LoggingClient.SetLogLevel(Configuration.Writable.LogLevel)
+			time.Sleep(time.Second)
 		}
-	}
-}
+		LoggingClient.Info("Database disconnected")
+	}()
 
-func initializeClients(useRegistry bool) {
-	// Create metadata clients
-	params := types.EndpointParams{
-		ServiceKey:  clients.CoreMetaDataServiceKey,
-		Path:        clients.ApiDeviceRoute,
-		UseRegistry: useRegistry,
-		Url:         Configuration.Clients["Metadata"].Url() + clients.ApiDeviceRoute,
-		Interval:    Configuration.Service.ClientMonitor,
-	}
+	// initialize event handlers
+	chEvents = make(chan interface{}, 100)
+	initEventHandlers()
 
-	mdc = metadata.NewDeviceClient(params, startup.Endpoint{RegistryClient: &registryClient})
-
-	params.Path = clients.ApiDeviceServiceRoute
-	msc = metadata.NewDeviceServiceClient(params, startup.Endpoint{RegistryClient: &registryClient})
-
-	// Create the messaging client
-	var err error
-	msgClient, err = messaging.NewMessageClient(msgTypes.MessageBusConfig{
-		PublishHost: msgTypes.HostInfo{
-			Host:     Configuration.MessageQueue.Host,
-			Port:     Configuration.MessageQueue.Port,
-			Protocol: Configuration.MessageQueue.Protocol,
-		},
-		Type: Configuration.MessageQueue.Type,
-	})
-
-	if err != nil {
-		LoggingClient.Error(fmt.Sprintf("failed to create messaging client: %s", err.Error()))
-	}
-}
-
-func setLoggingTarget() string {
-	if Configuration.Logging.EnableRemote {
-		return Configuration.Clients["Logging"].Url() + clients.ApiLoggingRoute
-	}
-	return Configuration.Logging.File
+	return true
 }

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -23,22 +23,23 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
-	"github.com/edgexfoundry/go-mod-registry/registry"
-
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+
+	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
+	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
@@ -51,13 +52,13 @@ var vdc coredata.ValueDescriptorClient
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry.
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err
 				if !useRegistry {
@@ -114,10 +115,10 @@ func Destruct() {
 	}
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
 	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
 	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
+	err := config.LoadFromFile(configDir, profileDir, configuration)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +267,7 @@ func initializeClients(useRegistry bool) {
 		Interval:    Configuration.Service.ClientMonitor,
 	}
 
-	nc = notifications.NewNotificationsClient(nParams, startup.Endpoint{RegistryClient: &registryClient})
+	nc = notifications.NewNotificationsClient(nParams, endpoint.Endpoint{RegistryClient: &registryClient})
 
 	vParams := types.EndpointParams{
 		ServiceKey:  clients.CoreDataServiceKey,
@@ -275,7 +276,7 @@ func initializeClients(useRegistry bool) {
 		Url:         Configuration.Clients["CoreData"].Url() + clients.ApiValueDescriptorRoute,
 		Interval:    Configuration.Service.ClientMonitor,
 	}
-	vdc = coredata.NewValueDescriptorClient(vParams, startup.Endpoint{RegistryClient: &registryClient})
+	vdc = coredata.NewValueDescriptorClient(vParams, endpoint.Endpoint{RegistryClient: &registryClient})
 }
 
 func setLoggingTarget() string {

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -16,21 +16,22 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/export/distro"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
-	"github.com/edgexfoundry/go-mod-registry/registry"
-
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/export"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/export/distro"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+
+	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
+	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
@@ -42,13 +43,13 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err
 				if !useRegistry {
@@ -150,10 +151,10 @@ func newDBClient(dbType string) (export.DBClient, error) {
 	}
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
 	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
 	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
+	err := config.LoadFromFile(configDir, profileDir, configuration)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +196,7 @@ func initializeClients(useRegistry bool) {
 		Interval:    Configuration.Service.ClientMonitor,
 	}
 
-	dc = distro.NewDistroClient(params, startup.Endpoint{RegistryClient: &registryClient})
+	dc = distro.NewDistroClient(params, endpoint.Endpoint{RegistryClient: &registryClient})
 }
 
 func connectToRegistry(conf *ConfigurationStruct) error {

--- a/internal/export/distro/init.go
+++ b/internal/export/distro/init.go
@@ -16,19 +16,21 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+
 	"github.com/edgexfoundry/go-mod-messaging/messaging"
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/pkg/types"
+
 	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
-
-	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 )
 
 var LoggingClient logger.LoggingClient
@@ -42,13 +44,13 @@ var messageErrors chan error
 var messageEnvelopes chan msgTypes.MessageEnvelope
 var processStop chan bool
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err
 				if !useRegistry {
@@ -167,7 +169,7 @@ func initializeClients(useRegistry bool) {
 		Interval:    Configuration.Service.ClientMonitor,
 	}
 
-	ec = coredata.NewEventClient(params, startup.Endpoint{RegistryClient: &registryClient})
+	ec = coredata.NewEventClient(params, endpoint.Endpoint{RegistryClient: &registryClient})
 
 	// Create the messaging client
 	var err error
@@ -185,10 +187,10 @@ func initializeClients(useRegistry bool) {
 	}
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
 	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
 	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
+	err := config.LoadFromFile(configDir, profileDir, configuration)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/bootstrap/bootstrap.go
+++ b/internal/pkg/bootstrap/bootstrap.go
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package bootstrap
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/configuration"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/logging"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-registry/registry"
+)
+
+// fatalError logs an error and exits the application.  It's intended to be used only within the bootstrap prior to
+// any go routines being spawned.
+func fatalError(err error, loggingClient logger.LoggingClient) {
+	loggingClient.Error(err.Error())
+	os.Exit(1)
+}
+
+// translateInterruptToCancel spawns a go routine to translate the receipt of a SIGTERM signal to a call to cancel
+// the context used by the bootstrap implementation.
+func translateInterruptToCancel(wg *sync.WaitGroup, cancel context.CancelFunc) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		signalStream := make(chan os.Signal)
+		defer func() {
+			signal.Stop(signalStream)
+			close(signalStream)
+		}()
+		signal.Notify(signalStream, os.Interrupt, syscall.SIGTERM)
+		<-signalStream
+		cancel()
+	}()
+}
+
+// Run bootstraps an application.  It loads configuration and calls the provided list of handlers.  Any long-running
+// process should be spawned as a go routine in a handler.  Handlers are expected to return immediately.  Once all of
+// the handlers are called this function will wait for any go routines spawned inside the handlers to exit before
+// returning to the caller.  It is intended that the caller stop executing on the return of this function.
+func Run(
+	configDir, profileDir, configFileName string,
+	useRegistry bool,
+	serviceKey string,
+	config interfaces.Configuration,
+	startupTimer startup.Timer,
+	handlers []interfaces.BootstrapHandler) {
+
+	loggingClient := logging.FactoryToStdout(serviceKey)
+	var err error
+	var registryClient registry.Client
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	translateInterruptToCancel(&wg, cancel)
+
+	// load configuration from file.
+	if err = configuration.LoadFromFile(configDir, profileDir, configFileName, config); err != nil {
+		fatalError(err, loggingClient)
+	}
+
+	// override file-based configuration with environment variables.
+	bootstrapConfig := config.GetBootstrap()
+	config.SetRegistryInfo(configuration.OverrideFromEnvironment(bootstrapConfig.Registry))
+
+	// set up registryClient and loggingClient; update configuration from registry if we're using a registry.
+	switch useRegistry {
+	case true:
+		registryClient, err = configuration.UpdateFromRegistry(ctx, startupTimer, config, loggingClient, serviceKey)
+		if err != nil {
+			fatalError(err, loggingClient)
+		}
+		loggingClient = logging.FactoryFromConfiguration(serviceKey, config)
+		configuration.ListenForChanges(&wg, ctx, config, loggingClient, registryClient)
+	case false:
+		loggingClient = logging.FactoryFromConfiguration(serviceKey, config)
+	}
+
+	// call individual bootstrap handlers.
+	for i := range handlers {
+		if handlers[i](&wg, ctx, startupTimer, config, loggingClient, registryClient) == false {
+			cancel()
+			break
+		}
+	}
+
+	// wait for go routines to stop executing.
+	wg.Wait()
+}

--- a/internal/pkg/bootstrap/configuration/environment.go
+++ b/internal/pkg/bootstrap/configuration/environment.go
@@ -12,20 +12,22 @@
  * the License.
  *******************************************************************************/
 
-package config
+package configuration
 
 import (
 	"net/url"
 	"os"
 	"strconv"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
 
 const (
 	envKeyUrl = "edgex_registry"
 )
 
-// deprecated
-func OverrideFromEnvironment(registry RegistryInfo) RegistryInfo {
+// OverrideFromEnvironment overrides the registryInfo values from an environment variable value (if it exists).
+func OverrideFromEnvironment(registry config.RegistryInfo) config.RegistryInfo {
 	if env := os.Getenv(envKeyUrl); env != "" {
 		if u, err := url.Parse(env); err == nil {
 			if p, err := strconv.ParseInt(u.Port(), 10, 0); err == nil {

--- a/internal/pkg/bootstrap/configuration/environment_test.go
+++ b/internal/pkg/bootstrap/configuration/environment_test.go
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package configuration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	envValue = "consul://localhost:8500"
+
+	expectedTypeValue = "consul"
+	expectedHostValue = "localhost"
+	expectedPortValue = 8500
+
+	defaultHostValue = "defaultHost"
+	defaultPortValue = 987654321
+	defaultTypeValue = "defaultType"
+)
+
+func initializeTest(t *testing.T) config.RegistryInfo {
+	os.Clearenv()
+	return config.RegistryInfo{
+		Host: defaultHostValue,
+		Port: defaultPortValue,
+		Type: defaultTypeValue,
+	}
+}
+
+func TestEnvVariableUpdatesRegistryInfo(t *testing.T) {
+	registryInfo := initializeTest(t)
+
+	if err := os.Setenv(envKeyUrl, envValue); err != nil {
+		t.Fail()
+	}
+	registryInfo = OverrideFromEnvironment(registryInfo)
+
+	assert.Equal(t, registryInfo.Host, expectedHostValue)
+	assert.Equal(t, registryInfo.Port, expectedPortValue)
+	assert.Equal(t, registryInfo.Type, expectedTypeValue)
+}
+
+func TestNoEnvVariableDoesNotUpdateRegistryInfo(t *testing.T) {
+	registryInfo := initializeTest(t)
+
+	registryInfo = OverrideFromEnvironment(registryInfo)
+
+	assert.Equal(t, registryInfo.Host, defaultHostValue)
+	assert.Equal(t, registryInfo.Port, defaultPortValue)
+	assert.Equal(t, registryInfo.Type, defaultTypeValue)
+}

--- a/internal/pkg/bootstrap/configuration/file.go
+++ b/internal/pkg/bootstrap/configuration/file.go
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package configuration
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+
+	"github.com/BurntSushi/toml"
+)
+
+// LoadFromFile attempts to read and unmarshal toml-based configuration into a configuration struct.
+func LoadFromFile(configDir, profileDir, configFileName string, config interfaces.Configuration) error {
+	// ported from determinePath() in internal/pkg/config/loader.go
+	if len(configDir) == 0 {
+		configDir = os.Getenv("EDGEX_CONF_DIR")
+	}
+	if len(configDir) == 0 {
+		configDir = "./res"
+	}
+
+	// remainder is simplification of LoadFromFile() in internal/pkg/config/loader.go
+	if len(profileDir) > 0 {
+		profileDir += "/"
+	}
+
+	fileName := configDir + "/" + profileDir + configFileName
+
+	contents, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return errors.New(fmt.Sprintf("could not load configuration file (%s): %s", fileName, err.Error()))
+	}
+	if err = toml.Unmarshal(contents, config); err != nil {
+		return errors.New(fmt.Sprintf("could not load configuration file (%s): %s", fileName, err.Error()))
+	}
+	return nil
+}

--- a/internal/pkg/bootstrap/configuration/registry.go
+++ b/internal/pkg/bootstrap/configuration/registry.go
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package configuration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
+	"github.com/edgexfoundry/go-mod-registry/registry"
+)
+
+// createRegistryClient creates and returns a registry.Client instance.
+func createRegistryClient(serviceKey string, config interfaces.Configuration) (registry.Client, error) {
+	bootstrapConfig := config.GetBootstrap()
+	return registry.NewRegistryClient(
+		registryTypes.Config{
+			Host:            bootstrapConfig.Registry.Host,
+			Port:            bootstrapConfig.Registry.Port,
+			Type:            bootstrapConfig.Registry.Type,
+			ServiceKey:      serviceKey,
+			ServiceHost:     bootstrapConfig.Service.Host,
+			ServicePort:     bootstrapConfig.Service.Port,
+			ServiceProtocol: bootstrapConfig.Service.Protocol,
+			CheckInterval:   bootstrapConfig.Service.CheckInterval,
+			CheckRoute:      clients.ApiPingRoute,
+			Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
+		})
+}
+
+// UpdateFromRegistry connects to the registry, registers the service, gets configuration, and updates the service's
+// configuration struct.
+func UpdateFromRegistry(
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config interfaces.Configuration,
+	loggingClient logger.LoggingClient,
+	serviceKey string) (registry.Client, error) {
+
+	var updateFromRegistry = func(registryClient registry.Client) error {
+		if !registryClient.IsAlive() {
+			return errors.New("registry is not available")
+		}
+
+		if err := registryClient.Register(); err != nil {
+			return errors.New(fmt.Sprintf("could not register service with Registry: %v", err.Error()))
+		}
+
+		rawConfig, err := registryClient.GetConfiguration(config)
+		if err != nil {
+			return errors.New(fmt.Sprintf("could not get configuration from Registry: %v", err.Error()))
+		}
+
+		if !config.UpdateFromRaw(rawConfig) {
+			return errors.New("configuration from Registry failed type check")
+		}
+
+		return nil
+	}
+
+	registryClient, err := createRegistryClient(serviceKey, config)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("createRegistryClient failed: %v", err.Error()))
+	}
+
+	for startupTimer.HasNotElapsed() {
+		if err := updateFromRegistry(registryClient); err != nil {
+			loggingClient.Warn(err.Error())
+			select {
+			case <-ctx.Done():
+				return nil, errors.New("aborted UpdateFromRegistry()")
+			default:
+				startupTimer.SleepForInterval()
+				continue
+			}
+		}
+		return registryClient, nil
+	}
+	return nil, errors.New("unable to update configuration from registry in allotted time")
+}
+
+// ListenForChanges leverages the registry client's WatchForChanges() method to receive changes to and update the
+// service's configuration struct's writable substruct.  It's assumed the log level is universally part of the
+// writable struct and this function explicitly updates the loggingClient's log level when new configuration changes
+// are received.
+func ListenForChanges(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	config interfaces.Configuration,
+	loggingClient logger.LoggingClient,
+	registryClient registry.Client) {
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		errorStream := make(chan error)
+		defer close(errorStream)
+
+		updateStream := make(chan interface{})
+		defer close(updateStream)
+
+		registryClient.WatchForChanges(updateStream, errorStream, config.EmptyWritablePtr(), internal.WritableKey)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case ex := <-errorStream:
+				loggingClient.Error(ex.Error())
+
+			case raw, ok := <-updateStream:
+				if !ok {
+					return
+				}
+
+				if !config.UpdateWritableFromRaw(raw) {
+					loggingClient.Error("ListenForChanges() type check failed")
+					return
+				}
+
+				loggingClient.Info("Writeable configuration has been updated from the Registry")
+				loggingClient.SetLogLevel(config.GetLogLevel())
+			}
+		}
+	}()
+}

--- a/internal/pkg/bootstrap/handlers/server.go
+++ b/internal/pkg/bootstrap/handlers/server.go
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-registry/registry"
+
+	"github.com/gorilla/mux"
+)
+
+// Server contains references to dependencies required by the http server implementation.
+type Server struct {
+	router    *mux.Router
+	isRunning bool
+}
+
+// NewServerBootstrap is a factory method that returns an initialized Server receiver struct.
+func NewServerBootstrap(router *mux.Router) Server {
+	return Server{
+		router:    router,
+		isRunning: false,
+	}
+}
+
+// IsRunning returns whether or not the http server is running.  It is provided to support delayed shutdown of
+// any resources required to successfully process http requests until after all outstanding requests have been
+// processed (e.g. a database connection).
+func (h *Server) IsRunning() bool {
+	return h.isRunning
+}
+
+// Handler fulfills the BootstrapHandler contract.  It creates two go routines -- one that executes ListenAndServe()
+// and another that waits on closure of a context's done channel before calling Shutdown() to cleanly shut down the
+// http server.
+func (h *Server) Handler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config interfaces.Configuration,
+	loggingClient logger.LoggingClient,
+	registryClient registry.Client) bool {
+
+	bootstrapConfig := config.GetBootstrap()
+	addr := bootstrapConfig.Service.Host + ":" + strconv.Itoa(bootstrapConfig.Service.Port)
+	timeout := time.Millisecond * time.Duration(bootstrapConfig.Service.Timeout)
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      h.router,
+		WriteTimeout: timeout,
+		ReadTimeout:  timeout,
+	}
+
+	loggingClient.Info("Web server starting (" + addr + ")")
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		h.isRunning = true
+		server.ListenAndServe()
+		loggingClient.Info("Web server stopped")
+		h.isRunning = false
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		<-ctx.Done()
+		loggingClient.Info("Web server shutting down")
+		server.Shutdown(context.Background())
+		loggingClient.Info("Web server shut down")
+	}()
+
+	return true
+}

--- a/internal/pkg/bootstrap/handlers/start_message.go
+++ b/internal/pkg/bootstrap/handlers/start_message.go
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-registry/registry"
+)
+
+// StartMessage contains references to dependencies required by the start message handler.
+type StartMessage struct {
+	serviceKey string
+	version    string
+}
+
+// NewStartMessage is a factory method that returns an initialized StartMessage receiver struct.
+func NewStartMessage(serviceKey, version string) StartMessage {
+	return StartMessage{
+		serviceKey: serviceKey,
+		version:    version,
+	}
+}
+
+// Handler fulfills the BootstrapHandler contract.  It creates no go routines.  It logs a "standard" set of messages
+// when the service first starts up successfully.
+func (h StartMessage) Handler(
+	wg *sync.WaitGroup,
+	context context.Context,
+	startupTimer startup.Timer,
+	config interfaces.Configuration,
+	loggingClient logger.LoggingClient,
+	registryClient registry.Client) bool {
+
+	loggingClient.Info("Service dependencies resolved...")
+	loggingClient.Info(fmt.Sprintf("Starting %s %s ", h.serviceKey, h.version))
+
+	bootstrapConfig := config.GetBootstrap()
+	if len(bootstrapConfig.Service.StartupMsg) > 0 {
+		loggingClient.Info(bootstrapConfig.Service.StartupMsg)
+	}
+
+	loggingClient.Info("Service started in: " + startupTimer.SinceAsString())
+
+	return true
+}

--- a/internal/pkg/bootstrap/interfaces/configuration.go
+++ b/internal/pkg/bootstrap/interfaces/configuration.go
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package interfaces
+
+import "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+
+// BootstrapConfiguration defines the configuration elements required by the bootstrap.
+type BootstrapConfiguration struct {
+	Clients  map[string]config.ClientInfo
+	Service  config.ServiceInfo
+	Registry config.RegistryInfo
+	Logging  config.LoggingInfo
+}
+
+// Configuration interface provides an abstraction around a configuration struct.
+type Configuration interface {
+	// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+	// then used to overwrite the service's existing configuration struct.
+	UpdateFromRaw(rawConfig interface{}) bool
+
+	// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+	// provide the appropriate structure to registry.Client's WatchForChanges().
+	EmptyWritablePtr() interface{}
+
+	// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+	// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+	UpdateWritableFromRaw(rawWritable interface{}) bool
+
+	// GetBootstrap returns the configuration elements required by the bootstrap.
+	GetBootstrap() BootstrapConfiguration
+
+	// GetLogLevel returns the current ConfigurationStruct's log level.
+	GetLogLevel() string
+
+	// SetLogLevel updates the log level in the ConfigurationStruct.
+	SetRegistryInfo(registryInfo config.RegistryInfo)
+}

--- a/internal/pkg/bootstrap/interfaces/handler.go
+++ b/internal/pkg/bootstrap/interfaces/handler.go
@@ -12,32 +12,25 @@
  * the License.
  *******************************************************************************/
 
-package startup
+package interfaces
 
 import (
-	"net/http"
-	"time"
+	"context"
+	"sync"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/gorilla/mux"
+
+	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
-// deprecated
-// StartHTTPServer creates a new server designed to receive requests from the service defined by the parameters.
-func StartHTTPServer(logger logger.LoggingClient, timeout int, router *mux.Router, url string, errChan chan error) {
-	go func() {
-		correlation.LoggingClient = logger //Not thrilled about this, can't think of anything better ATM
-		timeout := time.Millisecond * time.Duration(timeout)
-
-		server := &http.Server{
-			Handler:      router,
-			Addr:         url,
-			WriteTimeout: timeout,
-			ReadTimeout:  timeout,
-		}
-
-		errChan <- server.ListenAndServe()
-	}()
-}
+// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
+// handler completed successfully, false if it did not.
+type BootstrapHandler func(
+	wg *sync.WaitGroup,
+	context context.Context,
+	startupTimer startup.Timer,
+	config Configuration,
+	loggingClient logger.LoggingClient,
+	registryClient registry.Client) (success bool)

--- a/internal/pkg/bootstrap/logging/factory.go
+++ b/internal/pkg/bootstrap/logging/factory.go
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package logging
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+// FactoryToStdout returns a logger.LoggingClient that outputs to stdout.
+func FactoryToStdout(serviceKey string) logger.LoggingClient {
+	return logger.NewClient(serviceKey, false, "", models.DebugLog)
+}
+
+// FactoryFromConfiguration returns a logger.LoggingClient based on configuration settings.
+func FactoryFromConfiguration(serviceKey string, config interfaces.Configuration) logger.LoggingClient {
+	var target string
+	bootstrapConfig := config.GetBootstrap()
+	if bootstrapConfig.Logging.EnableRemote {
+		target = bootstrapConfig.Clients["Logging"].Url() + clients.ApiLoggingRoute
+	} else {
+		target = bootstrapConfig.Logging.File
+	}
+	return logger.NewClient(serviceKey, bootstrapConfig.Logging.EnableRemote, target, config.GetLogLevel())
+}

--- a/internal/pkg/bootstrap/startup/timer.go
+++ b/internal/pkg/bootstrap/startup/timer.go
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package startup
+
+import "time"
+
+// Timer contains references to dependencies required by the startup timer implementation.
+type Timer struct {
+	startTime time.Time
+	duration  time.Duration
+	interval  time.Duration
+}
+
+// NewStartUpTimer is a factory method that returns an initialized Timer receiver struct.
+func NewStartUpTimer(retryIntervalInSeconds, maxWaitInSeconds int) Timer {
+	return Timer{
+		startTime: time.Now(),
+		duration:  time.Millisecond * time.Duration(maxWaitInSeconds),
+		interval:  time.Millisecond * time.Duration(retryIntervalInSeconds),
+	}
+}
+
+// SinceAsString returns the time since the timer was created as a string.
+func (t Timer) SinceAsString() string {
+	return time.Since(t.startTime).String()
+}
+
+// HasNotElapsed returns whether or not the duration specified during construction has elapsed.
+func (t Timer) HasNotElapsed() bool {
+	return time.Now().Before(t.startTime.Add(t.duration))
+}
+
+// SleepForInterval pauses execution for the interval specified during construction.
+func (t Timer) SleepForInterval() {
+	time.Sleep(t.interval)
+}

--- a/internal/pkg/endpoint/endpoint.go
+++ b/internal/pkg/endpoint/endpoint.go
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package startup
+package endpoint
 
 import (
 	"fmt"

--- a/internal/pkg/startup/bootstrap.go
+++ b/internal/pkg/startup/bootstrap.go
@@ -15,21 +15,26 @@ package startup
 
 import "sync"
 
-type RetryFunc func(UseRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error)
+// deprecated
+type RetryFunc func(UseRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error)
 
+// deprecated
 type LogFunc func(err error)
 
+// deprecated
 type BootParams struct {
 	UseRegistry bool
-	UseProfile  string
+	ConfigDir   string
+	ProfileDir  string
 	BootTimeout int
 }
 
+// deprecated
 func Bootstrap(params BootParams, retry RetryFunc, log LogFunc) {
 	deps := make(chan error, 2)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	go retry(params.UseRegistry, params.UseProfile, params.BootTimeout, &wg, deps)
+	go retry(params.UseRegistry, params.ConfigDir, params.ProfileDir, params.BootTimeout, &wg, deps)
 	go func(ch chan error) {
 		for {
 			select {

--- a/internal/pkg/startup/bootstrap_test.go
+++ b/internal/pkg/startup/bootstrap_test.go
@@ -39,7 +39,7 @@ func clearVars() {
 
 func testPass(t *testing.T) {
 	clearVars()
-	p := BootParams{true, "", timeoutPass}
+	p := BootParams{true, "", "", timeoutPass}
 	Bootstrap(p, mockRetry, mockLog)
 	if !checkInit {
 		t.Error("checkInit should be true.")
@@ -51,7 +51,7 @@ func testPass(t *testing.T) {
 
 func testFail(t *testing.T) {
 	clearVars()
-	p := BootParams{true, "", timeoutFail}
+	p := BootParams{true, "", "", timeoutFail}
 	Bootstrap(p, mockRetry, mockLog)
 	time.Sleep(time.Millisecond * time.Duration(25)) //goroutine timing
 	if checkInit {
@@ -66,7 +66,7 @@ func testFail(t *testing.T) {
 //Different test cases are toggled according to the timeout value
 //SUCCESS = short duration 100ms
 //FAIL = long duration 1000ms
-func mockRetry(UseRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func mockRetry(UseRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		if timeout == timeoutFail {

--- a/internal/security/proxy/init.go
+++ b/internal/security/proxy/init.go
@@ -29,13 +29,13 @@ import (
 var Configuration *ConfigurationStruct
 var LoggingClient logger.LoggingClient
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		var err error
 		// When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err
 				if !useRegistry {
@@ -63,10 +63,10 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 	return
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
 	// We currently have to load configuration from filesystem first in order to obtain Registry Host/Port
 	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
+	err := config.LoadFromFile(configDir, profileDir, configuration)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -28,13 +28,13 @@ import (
 var Configuration *ConfigurationStruct
 var LoggingClient logger.LoggingClient
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		var err error
 		// When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err
 				if !useRegistry {
@@ -62,10 +62,10 @@ func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGrou
 	return
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
 	// We currently have to load configuration from filesystem first in order to obtain Registry Host/Port
 	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
+	err := config.LoadFromFile(configDir, profileDir, configuration)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/security/setup/init.go
+++ b/internal/security/setup/init.go
@@ -37,7 +37,7 @@ func Init() error {
 	config.LoggingClient = lc
 
 	var err error
-	Configuration, err = initializeConfiguration(false, "") //These values are defaults. Preserved variables for possible later extension
+	Configuration, err = initializeConfiguration(false, "", "") //These values are defaults. Preserved variables for possible later extension
 	if err != nil {
 		lc.Error(err.Error())
 		return err
@@ -55,10 +55,10 @@ func Init() error {
 	return nil
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
 	// We currently have to load configuration from filesystem first in order to obtain Registry Host/Port
 	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
+	err := config.LoadFromFile(configDir, profileDir, configuration)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/seed/config/init.go
+++ b/internal/seed/config/init.go
@@ -37,13 +37,13 @@ var Registry registry.Client
 // The purpose of Retry is different here than in other services. In this case, we use a retry in order
 // to initialize the RegistryClient that will be used to write configuration information. Other services
 // use Retry to read their information. Config-seed writes information.
-func Retry(useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useProfile)
+			Configuration, err = initializeConfiguration(configDir, profileDir)
 			if err != nil {
 				ch <- err
 			} else {
@@ -82,9 +82,9 @@ func Init() bool {
 	return false
 }
 
-func initializeConfiguration(useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(configDir, profileDir string) (*ConfigurationStruct, error) {
 	conf := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, conf)
+	err := config.LoadFromFile(configDir, profileDir, conf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -33,14 +33,14 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	LoggingClient = newPrivateLogger()
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err
 				if !useRegistry {
@@ -99,10 +99,10 @@ func Destruct() {
 	}
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
 	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
 	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
+	err := config.LoadFromFile(configDir, profileDir, configuration)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/support/notifications/init.go
+++ b/internal/support/notifications/init.go
@@ -47,13 +47,13 @@ var registryClient registry.Client
 var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
 var registerUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err
 				if !useRegistry {
@@ -150,10 +150,10 @@ func newDBClient(dbType string) (interfaces.DBClient, error) {
 	}
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
 	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
 	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
+	err := config.LoadFromFile(configDir, profileDir, configuration)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -47,14 +47,14 @@ var registryUpdates chan interface{} //A channel for "config updates" sourced fr
 
 var ticker *time.Ticker
 
-func Retry(useRegistry bool, useProfile string, timeout int, wait *sync.WaitGroup, ch chan error) {
+func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
 	now := time.Now()
 	until := now.Add(time.Millisecond * time.Duration(timeout))
 	for time.Now().Before(until) {
 		var err error
 		//When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, useProfile)
+			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err
 				if !useRegistry {
@@ -136,10 +136,10 @@ func Destruct() {
 	}
 }
 
-func initializeConfiguration(useRegistry bool, useProfile string) (*ConfigurationStruct, error) {
+func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
 	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
 	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(useProfile, configuration)
+	err := config.LoadFromFile(configDir, profileDir, configuration)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/system/agent/clients_test.go
+++ b/internal/system/agent/clients_test.go
@@ -17,7 +17,7 @@ package agent
 import (
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
@@ -38,7 +38,7 @@ func TestGetForKnownReturnsExpectedValues(t *testing.T) {
 	const clientName = "clientName"
 
 	sut := NewGeneralClients()
-	client := general.NewGeneralClient(types.EndpointParams{}, startup.Endpoint{RegistryClient: nil})
+	client := general.NewGeneralClient(types.EndpointParams{}, endpoint.Endpoint{RegistryClient: nil})
 	sut.Set(clientName, client)
 
 	result, ok := sut.Get(clientName)

--- a/internal/system/agent/services.go
+++ b/internal/system/agent/services.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/response"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
@@ -96,7 +96,7 @@ func getConfig(
 				Interval:    internal.ClientMonitorDefault,
 			}
 			// Add the service key to the map where the value is the respective GeneralClient
-			client = general.NewGeneralClient(params, startup.Endpoint{RegistryClient: &registryClient})
+			client = general.NewGeneralClient(params, endpoint.Endpoint{RegistryClient: &registryClient})
 			genClients.Set(e.ServiceId, client)
 		}
 


### PR DESCRIPTION
Extensible common bootstrap package to be used by each core
service to replace the existing copy/paste implementations of init.go,
incorporate the existing internal/package/startup package, and provide a
unified approach to concurrency and related go routine clean up.

Implementation includes core-data service changes to leverage the new
package.

Fixes https://github.com/edgexfoundry/edgex-go/issues/1739
