### PR TITLE
#1735 Populate global security configuration in registry

### DIFF
--- a/cmd/config-seed/Attribution.txt
+++ b/cmd/config-seed/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/config-seed/Attribution.txt
+++ b/cmd/config-seed/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/config-seed/main.go
+++ b/cmd/config-seed/main.go
@@ -63,6 +63,11 @@ func main() {
 		config.LoggingClient.Error(err.Error())
 	}
 
+	err = config.ImportSecurityConfiguration()
+	if err != nil {
+		config.LoggingClient.Error(err.Error())
+	}
+
 	os.Exit(0)
 }
 

--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/core-data/Attribution.txt
+++ b/cmd/core-data/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/core-data/Attribution.txt
+++ b/cmd/core-data/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/export-client/Attribution.txt
+++ b/cmd/export-client/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/export-client/Attribution.txt
+++ b/cmd/export-client/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/export-distro/Attribution.txt
+++ b/cmd/export-distro/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/export-distro/Attribution.txt
+++ b/cmd/export-distro/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/security-proxy-setup/Attribution.txt
+++ b/cmd/security-proxy-setup/Attribution.txt
@@ -60,6 +60,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/security-proxy-setup/Attribution.txt
+++ b/cmd/security-proxy-setup/Attribution.txt
@@ -57,11 +57,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/security-secrets-setup/Attribution.txt
+++ b/cmd/security-secrets-setup/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/security-secrets-setup/Attribution.txt
+++ b/cmd/security-secrets-setup/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/security-secretstore-setup/Attribution.txt
+++ b/cmd/security-secretstore-setup/Attribution.txt
@@ -60,7 +60,7 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -60,6 +60,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -57,11 +57,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/cmd/sys-mgmt-executor/Attribution.txt
+++ b/cmd/sys-mgmt-executor/Attribution.txt
@@ -63,6 +63,9 @@ https://github.com/cenkalti/backoff/blob/master/LICENSE
 hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
 https://github.com/hashicorp/consul/blob/master/LICENSE
 
+Nested consul packages are not separately licensed:
+github.com/hashicorp/consul/api
+
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
 

--- a/cmd/sys-mgmt-executor/Attribution.txt
+++ b/cmd/sys-mgmt-executor/Attribution.txt
@@ -60,11 +60,8 @@ https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
 cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
 https://github.com/cenkalti/backoff/blob/master/LICENSE
 
-hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
 https://github.com/hashicorp/consul/blob/master/LICENSE
-
-Nested consul packages are not separately licensed:
-github.com/hashicorp/consul/api
 
 hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
 https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.1.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.19
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
-	github.com/edgexfoundry/go-mod-registry v0.1.9
+	github.com/edgexfoundry/go-mod-registry v0.1.12
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0
 	github.com/go-stack/stack v1.8.0 // indirect

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -17,7 +17,9 @@ const (
 	BootTimeoutDefault             = 30000
 	ClientMonitorDefault           = 15000
 	ConfigFileName                 = "configuration.toml"
-	ConfigRegistryStem             = "edgex/core/1.0/"
+	ConfigRegistryStemCore         = "edgex/core/"
+	ConfigRegistryStemSecurity     = "edgex/security/"
+	ConfigMajorVersion             = "1.0/"
 	LogDurationKey                 = "duration"
 	SecuritySecretsSetupServiceKey = "edgex-security-secrets-setup"
 	SecurityProxySetupServiceKey   = "edgex-security-proxy-setup"

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -170,7 +170,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		ServiceProtocol: conf.Service.Protocol,
 		CheckInterval:   conf.Service.CheckInterval,
 		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStem,
+		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 	}
 
 	registryClient, err = registry.NewRegistryClient(registryConfig)

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -225,7 +225,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		ServiceProtocol: conf.Service.Protocol,
 		CheckInterval:   conf.Service.CheckInterval,
 		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStem,
+		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 	}
 
 	registryClient, err = registry.NewRegistryClient(registryConfig)

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -161,7 +161,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		ServiceProtocol: conf.Service.Protocol,
 		CheckInterval:   conf.Service.CheckInterval,
 		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStem,
+		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 	}
 
 	registryClient, err = registry.NewRegistryClient(registryConfig)

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -210,7 +210,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		ServiceProtocol: conf.Service.Protocol,
 		CheckInterval:   conf.Service.CheckInterval,
 		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStem,
+		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 	}
 
 	registryClient, err = registry.NewRegistryClient(registryConfig)

--- a/internal/export/distro/init.go
+++ b/internal/export/distro/init.go
@@ -137,7 +137,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		ServiceProtocol: conf.Service.Protocol,
 		CheckInterval:   conf.Service.CheckInterval,
 		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStem,
+		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 	}
 
 	registryClient, err = registry.NewRegistryClient(registryConfig)

--- a/internal/seed/config/environment.go
+++ b/internal/seed/config/environment.go
@@ -69,3 +69,18 @@ func (e *environment) OverrideFromEnvironment(serviceName string, tree *toml.Tre
 	}
 	return tree
 }
+
+func (e *environment) InitFromEnvironment(namespace string) (*toml.Tree, error) {
+	tree, err := toml.TreeFromMap(map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range e.env {
+		if strings.HasPrefix(k, namespace) {
+			tree.Set(strings.TrimPrefix(k, namespace), v)
+		}
+	}
+
+	return tree, nil
+}

--- a/internal/seed/config/environment_test.go
+++ b/internal/seed/config/environment_test.go
@@ -102,3 +102,37 @@ func TestNonMatchingKeyDoesNotOverwritesValue(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironment_InitFromEnvironment(t *testing.T) {
+	const namespace = "name.space."
+	var tests = []struct {
+		name          string
+		key           string
+		envKey        string
+		value         string
+		expectedValue interface{}
+	}{
+		{"root", rootKey, namespace + rootKey, rootValue, rootValue},
+		{"sub", sub + "." + subKey, namespace + sub + "." + subKey, subValue, subValue},
+		{"non-matching key", rootKey, rootKey, rootValue, nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var tree *toml.Tree
+			var err error
+			os.Clearenv()
+			if err = os.Setenv(test.envKey, test.value); err != nil {
+				t.Fail()
+			}
+
+			env := NewEnvironment()
+			if tree, err = env.InitFromEnvironment(namespace); err != nil {
+				t.Fail()
+			}
+
+			assert.Equal(t, tree.Get(test.key), test.expectedValue)
+
+		})
+	}
+}

--- a/internal/seed/config/populate.go
+++ b/internal/seed/config/populate.go
@@ -119,7 +119,7 @@ func ImportConfiguration(root string, profile string, overwrite bool) error {
 			Host:       Configuration.Registry.Host,
 			Port:       Configuration.Registry.Port,
 			Type:       Configuration.Registry.Type,
-			Stem:       internal.ConfigRegistryStem,
+			Stem:       internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 			ServiceKey: clients.ServiceKeyPrefix + serviceName,
 		}
 		Registry, err = registry.NewRegistryClient(registryConfig)
@@ -128,6 +128,31 @@ func ImportConfiguration(root string, profile string, overwrite bool) error {
 		}
 
 		Registry.PutConfigurationToml(environment.OverrideFromEnvironment(serviceName, configuration), overwrite)
+	}
+
+	return nil
+}
+
+func ImportSecurityConfiguration() error {
+	registryConfig := types.Config{
+		Host: Configuration.Registry.Host,
+		Port: Configuration.Registry.Port,
+		Type: Configuration.Registry.Type,
+		Stem: internal.ConfigRegistryStemSecurity + internal.ConfigMajorVersion,
+	}
+
+	reg, err := registry.NewRegistryClient(registryConfig)
+	if err != nil {
+		return err
+	}
+
+	env := NewEnvironment()
+	namespace := strings.Replace(internal.ConfigRegistryStemSecurity, "/", ".", -1)
+	tree, err := env.InitFromEnvironment(namespace)
+
+	err = reg.PutConfigurationToml(tree, false)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -146,7 +146,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		ServiceProtocol: conf.Service.Protocol,
 		CheckInterval:   conf.Service.CheckInterval,
 		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStem,
+		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 	}
 
 	registryClient, err = registry.NewRegistryClient(registryConfig)

--- a/internal/support/notifications/init.go
+++ b/internal/support/notifications/init.go
@@ -197,7 +197,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		ServiceProtocol: conf.Service.Protocol,
 		CheckInterval:   conf.Service.CheckInterval,
 		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStem,
+		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 	}
 
 	registryClient, err = registry.NewRegistryClient(registryConfig)

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -183,7 +183,7 @@ func connectToRegistry(conf *ConfigurationStruct) error {
 		ServiceProtocol: conf.Service.Protocol,
 		CheckInterval:   conf.Service.CheckInterval,
 		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStem,
+		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 	}
 
 	registryClient, err = registry.NewRegistryClient(registryConfig)

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -164,7 +164,7 @@ func (instance *Instance) connectToRegistry(conf *ConfigurationStruct) error {
 		ServiceProtocol: conf.Service.Protocol,
 		CheckInterval:   conf.Service.CheckInterval,
 		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStem,
+		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
 	}
 
 	instance.RegistryClient, err = registry.NewRegistryClient(registryConfig)


### PR DESCRIPTION
Fixes #1735 

Adds mechanism for config-seed to read security configuration
environment variables and write them to the registry.

To test, run config-seed command with consul running like this:

`edgex_security_SecretStore="false" edgex_security_nested_Key="value" ./config-seed`

You should end up with two values in the consul KV storage (by default located at http://localhost:8500/ui/dc1/kv/edgex/security/1.0/ if running the consul dev agent locally)

Note: I've had some discussions with @tsconn23 and @michaelestrin and we think it would be good if the "global" security configuration settings were stored in a config file for Geneva, likely in a config-seed/res subdirectory.  This will provide some documentation of what settings are expected/available and sensible defaults.  This change will be backwards compatible to the solution presented in this PR, because environment variables will override the config file values.  An issue to track this work will be created when this is merged in.

Signed-off-by: Daniel Harms <jdharms@gmail.com>