### PR TITLE
Core Services REST Handler code duplication reduction

### DIFF
--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/gorilla/mux"
 )
 
@@ -47,7 +48,7 @@ func issueDeviceCommand(w http.ResponseWriter, r *http.Request, isPutCommand boo
 		http.Error(w, body, status)
 	} else {
 		if len(body) > 0 {
-			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		}
 		w.Write([]byte(body))
 	}
@@ -81,7 +82,7 @@ func issueDeviceCommandByNames(w http.ResponseWriter, r *http.Request, isPutComm
 		http.Error(w, body, status)
 	} else {
 		if len(body) > 0 {
-			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		}
 		w.Write([]byte(body))
 	}
@@ -100,7 +101,7 @@ func restGetCommandsByDeviceID(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(status)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(&device)
 }
 
@@ -117,7 +118,7 @@ func restGetCommandsByDeviceName(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(status)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(&devices)
 }
 
@@ -131,6 +132,6 @@ func restGetAllCommands(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(status)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(devices)
 }

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -184,7 +184,7 @@ func eventByAgeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(strconv.Itoa(count)))
 }
@@ -281,7 +281,7 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 	}
@@ -434,7 +434,7 @@ func eventIdHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 		break
@@ -453,7 +453,7 @@ func eventIdHandler(w http.ResponseWriter, r *http.Request) {
 			LoggingClient.Error(err.Error())
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 	}
@@ -533,7 +533,7 @@ func deleteByDeviceIdHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(strconv.Itoa(count)))
 	}
@@ -606,7 +606,7 @@ func scrubHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(strconv.Itoa(count)))
 	}
@@ -614,7 +614,7 @@ func scrubHandler(w http.ResponseWriter, r *http.Request) {
 
 // Test if the service is working
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
 }
 
@@ -729,7 +729,7 @@ func readingHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 	}
@@ -805,7 +805,7 @@ func deleteReadingByIdHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 	}
@@ -1249,7 +1249,7 @@ func valueDescriptorHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 	}
@@ -1286,7 +1286,7 @@ func deleteValueDescriptorByIdHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -1338,7 +1338,7 @@ func valueDescriptorByNameHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 	}

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -27,6 +27,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
@@ -42,6 +43,9 @@ var dbClient interfaces.DBClient
 var LoggingClient logger.LoggingClient
 var nc notifications.NotificationsClient
 var vdc coredata.ValueDescriptorClient
+
+// Global ErrorConcept variables
+var httpErrorHandler errorconcept.ErrorHandler
 
 type server interface {
 	IsRunning() bool
@@ -117,6 +121,7 @@ func (s ServiceInit) BootstrapHandler(
 
 	// update global variables.
 	LoggingClient = logging
+	httpErrorHandler = errorconcept.NewErrorHandler(logging)
 
 	// initialize clients required by service.
 	s.initializeClients(registry != nil, registry)

--- a/internal/core/metadata/operators/device/notify.go
+++ b/internal/core/metadata/operators/device/notify.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -108,7 +109,7 @@ func (op deviceNotifier) callback(service models.DeviceService, id string, actio
 		if err != nil {
 			return err
 		}
-		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add(clients.ContentType, clients.ContentTypeJSON)
 		go op.requester.Execute(req)
 	} else {
 		op.logger.Error("callback::no addressable for " + service.Name)

--- a/internal/core/metadata/rest_addressable_test.go
+++ b/internal/core/metadata/rest_addressable_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -53,6 +54,7 @@ var ErrorPortPathParam = "abc"
 
 func TestMain(m *testing.M) {
 	LoggingClient = logger.NewMockClient()
+	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
 	os.Exit(m.Run())
 }
 

--- a/internal/core/metadata/rest_command_test.go
+++ b/internal/core/metadata/rest_command_test.go
@@ -2,9 +2,6 @@ package metadata
 
 import (
 	"fmt"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
-	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,8 +9,11 @@ import (
 	types "github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces/mocks"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 )
 
 func TestGetCommandsByDeviceId(t *testing.T) {

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -11,44 +11,36 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package metadata
 
 import (
 	"encoding/json"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
-	"github.com/gorilla/mux"
-	"gopkg.in/yaml.v2"
-
-	dataErrors "github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/operators/device"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/operators/device_profile"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/gorilla/mux"
 )
 
 func restGetAllDeviceProfiles(w http.ResponseWriter, _ *http.Request) {
 	op := device_profile.NewGetAllExecutor(Configuration.Service, dbClient, LoggingClient)
 	res, err := op.Execute()
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		switch err.(type) {
-		case errors.ErrLimitExceeded:
-			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
-			return
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.LimitExceeded, errorconcept.Default.InternalServerError)
+		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(&res)
 }
 
@@ -56,8 +48,7 @@ func restAddDeviceProfile(w http.ResponseWriter, r *http.Request) {
 	var dp models.DeviceProfile
 
 	if err := json.NewDecoder(r.Body).Decode(&dp); err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
@@ -68,21 +59,14 @@ func restAddDeviceProfile(w http.ResponseWriter, r *http.Request) {
 		_, err := nameOp.Execute()
 		// The operator will return an ItemNotFound error if the DeviceProfile can not be found.
 		if err == nil {
-			http.Error(w, "Duplicate name for device profile", http.StatusConflict)
+			httpErrorHandler.Handle(w, err, errorconcept.DeviceProfile.DuplicateName)
 			return
 		}
 
 		op := device_profile.NewAddValueDescriptorExecutor(r.Context(), vdc, LoggingClient, dp.DeviceResources...)
 		err = op.Execute()
 		if err != nil {
-			LoggingClient.Error(err.Error())
-			switch err.(type) {
-			case types.ErrServiceClient:
-				http.Error(w, err.Error(), err.(types.ErrServiceClient).StatusCode)
-			default:
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-
+			httpErrorHandler.HandleOneVariant(w, err, errorconcept.NewServiceClientHttpError(err), errorconcept.Default.InternalServerError)
 			return
 		}
 	}
@@ -95,8 +79,7 @@ func restUpdateDeviceProfile(w http.ResponseWriter, r *http.Request) {
 
 	var from models.DeviceProfile
 	if err := json.NewDecoder(r.Body).Decode(&from); err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
@@ -104,20 +87,16 @@ func restUpdateDeviceProfile(w http.ResponseWriter, r *http.Request) {
 		vdOp := device_profile.NewUpdateValueDescriptorExecutor(from, dbClient, vdc, LoggingClient, r.Context())
 		err := vdOp.Execute()
 		if err != nil {
-			LoggingClient.Error(err.Error())
-			switch err.(type) {
-			case types.ErrServiceClient:
-				http.Error(w, err.Error(), err.(types.ErrServiceClient).StatusCode)
-			case errors.ErrDeviceProfileNotFound:
-				http.Error(w, err.Error(), http.StatusNotFound)
-			case dataErrors.ErrValueDescriptorsInUse:
-				http.Error(w, err.Error(), http.StatusConflict)
-			case errors.ErrDeviceProfileInvalidState:
-				http.Error(w, err.Error(), http.StatusConflict)
-			default:
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-
+			httpErrorHandler.HandleManyVariants(
+				w,
+				err,
+				[]errorconcept.ErrorConceptType{
+					errorconcept.NewServiceClientHttpError(err),
+					errorconcept.DeviceProfile.NotFound,
+					errorconcept.ValueDescriptors.InUse,
+					errorconcept.DeviceProfile.InvalidState_StatusConflict,
+				},
+				errorconcept.Default.InternalServerError)
 			return
 		}
 	}
@@ -125,16 +104,14 @@ func restUpdateDeviceProfile(w http.ResponseWriter, r *http.Request) {
 	op := device_profile.NewUpdateDeviceProfileExecutor(dbClient, from)
 	dp, err := op.Execute()
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		switch err.(type) {
-		case errors.ErrDeviceProfileNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		case errors.ErrDeviceProfileInvalidState:
-			http.Error(w, err.Error(), http.StatusConflict)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-
+		httpErrorHandler.HandleManyVariants(
+			w,
+			err,
+			[]errorconcept.ErrorConceptType{
+				errorconcept.DeviceProfile.NotFound,
+				errorconcept.DeviceProfile.InvalidState_StatusConflict,
+			},
+			errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -146,7 +123,7 @@ func restUpdateDeviceProfile(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Warn("Error while notifying profile associates of update: ", err.Error())
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -158,15 +135,10 @@ func restGetProfileByProfileId(w http.ResponseWriter, r *http.Request) {
 	op := device_profile.NewGetProfileID(did, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Database.NotFound, errorconcept.Default.InternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -177,20 +149,18 @@ func restDeleteProfileByProfileId(w http.ResponseWriter, r *http.Request) {
 	op := device_profile.NewDeleteByIDExecutor(dbClient, did)
 	err := op.Execute()
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		switch err.(type) {
-		case errors.ErrDeviceProfileNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		case errors.ErrDeviceProfileInvalidState:
-			http.Error(w, err.Error(), http.StatusConflict)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-
+		httpErrorHandler.HandleManyVariants(
+			w,
+			err,
+			[]errorconcept.ErrorConceptType{
+				errorconcept.DeviceProfile.NotFound,
+				errorconcept.DeviceProfile.InvalidState_StatusConflict,
+			},
+			errorconcept.Default.InternalServerError)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -200,28 +170,25 @@ func restDeleteProfileByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	op := device_profile.NewDeleteByNameExecutor(dbClient, n)
 	err = op.Execute()
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		switch err.(type) {
-		case errors.ErrDeviceProfileNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		case errors.ErrDeviceProfileInvalidState:
-			http.Error(w, err.Error(), http.StatusConflict)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-
+		httpErrorHandler.HandleManyVariants(
+			w,
+			err,
+			[]errorconcept.ErrorConceptType{
+				errorconcept.DeviceProfile.NotFound,
+				errorconcept.DeviceProfile.InvalidState_StatusConflict,
+			},
+			errorconcept.Default.InternalServerError)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -229,29 +196,18 @@ func restDeleteProfileByName(w http.ResponseWriter, r *http.Request) {
 func restAddProfileByYaml(w http.ResponseWriter, r *http.Request) {
 	f, _, err := r.FormFile("file")
 	if err != nil {
-		switch err {
-		case http.ErrMissingFile:
-			err := errors.NewErrEmptyFile("YAML")
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			LoggingClient.Error(err.Error())
-			return
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
-		}
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.DeviceProfile.MissingFile, errorconcept.Default.InternalServerError)
+		return
 	}
 
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceProfile.ReadFile)
 		return
 	}
 	if len(data) == 0 {
 		err := errors.NewErrEmptyFile("YAML")
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceProfile.MissingFile)
 		return
 	}
 
@@ -259,8 +215,7 @@ func restAddProfileByYaml(w http.ResponseWriter, r *http.Request) {
 
 	err = yaml.Unmarshal(data, &dp)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceProfile.UnmarshalYaml_StatusInternalServer)
 		return
 	}
 
@@ -272,19 +227,16 @@ func restAddProfileByYaml(w http.ResponseWriter, r *http.Request) {
 	id, err := op.Execute()
 
 	if err != nil {
-		switch err.(type) {
-		case errors.ErrDeviceProfileInvalidState:
-			http.Error(w, err.Error(), http.StatusBadRequest)
-		case models.ErrContractInvalid:
-			http.Error(w, err.Error(), http.StatusConflict)
-		case errors.ErrDuplicateName:
-			http.Error(w, err.Error(), http.StatusConflict)
-		case errors.ErrEmptyDeviceProfileName:
-			http.Error(w, err.Error(), http.StatusBadRequest)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleManyVariants(
+			w,
+			err,
+			[]errorconcept.ErrorConceptType{
+				errorconcept.DeviceProfile.InvalidState_StatusBadRequest,
+				errorconcept.DeviceProfile.ContractInvalid_StatusConflict,
+				errorconcept.Common.DuplicateName,
+				errorconcept.DeviceProfile.EmptyName,
+			},
+			errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -298,8 +250,7 @@ func restAddProfileByYamlRaw(w http.ResponseWriter, r *http.Request) {
 	// Get the YAML string
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceProfile.ReadFile)
 		return
 	}
 
@@ -307,8 +258,7 @@ func restAddProfileByYamlRaw(w http.ResponseWriter, r *http.Request) {
 
 	err = yaml.Unmarshal(body, &dp)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceProfile.UnmarshalYaml_StatusServiceUnavailable)
 		return
 	}
 
@@ -321,19 +271,16 @@ func addDeviceProfile(dp models.DeviceProfile, dbClient interfaces.DBClient, w h
 	id, err := op.Execute()
 
 	if err != nil {
-		switch err.(type) {
-		case models.ErrContractInvalid:
-			http.Error(w, err.Error(), http.StatusBadRequest)
-		case errors.ErrDeviceProfileInvalidState:
-			http.Error(w, err.Error(), http.StatusBadRequest)
-		case errors.ErrDuplicateName:
-			http.Error(w, err.Error(), http.StatusConflict)
-		case errors.ErrEmptyDeviceProfileName:
-			http.Error(w, err.Error(), http.StatusBadRequest)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleManyVariants(
+			w,
+			err,
+			[]errorconcept.ErrorConceptType{
+				errorconcept.Common.ContractInvalid_StatusBadRequest,
+				errorconcept.DeviceProfile.InvalidState_StatusBadRequest,
+				errorconcept.Common.DuplicateName,
+				errorconcept.DeviceProfile.EmptyName,
+			},
+			errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -345,20 +292,18 @@ func restGetProfileByModel(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	an, err := url.QueryUnescape(vars[MODEL])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	op := device_profile.NewGetModelExecutor(an, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -367,20 +312,18 @@ func restGetProfileWithLabel(w http.ResponseWriter, r *http.Request) {
 
 	label, err := url.QueryUnescape(vars[LABEL])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	op := device_profile.NewGetLabelExecutor(label, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -388,27 +331,24 @@ func restGetProfileByManufacturerModel(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	man, err := url.QueryUnescape(vars[MANUFACTURER])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	mod, err := url.QueryUnescape(vars[MODEL])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	op := device_profile.NewGetManufacturerModelExecutor(man, mod, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -416,20 +356,18 @@ func restGetProfileByManufacturer(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	man, err := url.QueryUnescape(vars[MANUFACTURER])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	op := device_profile.NewGetManufacturerExecutor(man, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -437,8 +375,7 @@ func restGetProfileByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	dn, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
@@ -446,16 +383,11 @@ func restGetProfileByName(w http.ResponseWriter, r *http.Request) {
 	op := device_profile.NewGetProfileName(dn, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Database.NotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -463,8 +395,7 @@ func restGetYamlProfileByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
@@ -472,21 +403,14 @@ func restGetYamlProfileByName(w http.ResponseWriter, r *http.Request) {
 	op := device_profile.NewGetProfileName(name, dbClient)
 	dp, err := op.Execute()
 	if err != nil {
-		// Not found, return nil
-		if err == db.ErrNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Database.NotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
 	// Marshal into yaml
 	out, err := yaml.Marshal(dp)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceProfile.MarshalYaml)
 		return
 	}
 
@@ -511,11 +435,11 @@ func restGetYamlProfileById(w http.ResponseWriter, r *http.Request) {
 	dp, err := op.Execute()
 	if err != nil {
 		if err == db.ErrNotFound {
-			w.WriteHeader(http.StatusNotFound)
+			httpErrorHandler.Handle(w, err, errorconcept.Default.NotFound)
 			w.Write([]byte(nil))
 			return
 		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			httpErrorHandler.Handle(w, err, errorconcept.Default.InternalServerError)
 		}
 		LoggingClient.Error(err.Error())
 		return
@@ -524,8 +448,7 @@ func restGetYamlProfileById(w http.ResponseWriter, r *http.Request) {
 	// Marshal the device profile into YAML
 	out, err := yaml.Marshal(dp)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceProfile.MarshalYaml)
 		return
 	}
 

--- a/internal/core/metadata/rest_deviceprofile_test.go
+++ b/internal/core/metadata/rest_deviceprofile_test.go
@@ -14,16 +14,16 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-	"github.com/gorilla/mux"
-	"github.com/stretchr/testify/mock"
-	"gopkg.in/yaml.v2"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
-
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/mock"
+	"gopkg.in/yaml.v2"
 )
 
 var TestLabelError1 = "TestErrorLabel1"

--- a/internal/core/metadata/rest_deviceservice.go
+++ b/internal/core/metadata/rest_deviceservice.go
@@ -23,11 +23,10 @@ import (
 	"net/url"
 	"strconv"
 
-	types "github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/operators/device_service"
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-
+	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/mux"
@@ -37,12 +36,7 @@ func restGetAllDeviceServices(w http.ResponseWriter, _ *http.Request) {
 	op := device_service.NewDeviceServiceLoadAll(Configuration.Service, dbClient, LoggingClient)
 	services, err := op.Execute()
 	if err != nil {
-		switch err.(type) {
-		case types.ErrLimitExceeded:
-			http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.LimitExceeded, errorconcept.Default.InternalServerError)
 		return
 	}
 	pkg.Encode(services, w, LoggingClient)
@@ -53,17 +47,14 @@ func restAddDeviceService(w http.ResponseWriter, r *http.Request) {
 	var ds models.DeviceService
 	err := json.NewDecoder(r.Body).Decode(&ds)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	// Addressable Check
 	// No ID or Name given for addressable
 	if ds.Addressable.Id == "" && ds.Addressable.Name == "" {
-		err = errors.New("Must provide an Addressable for Device Service")
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceService.EmptyAddressable)
 		return
 	}
 
@@ -73,25 +64,14 @@ func restAddDeviceService(w http.ResponseWriter, r *http.Request) {
 		addressable, err = dbClient.GetAddressableById(ds.Addressable.Id)
 	}
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Addressable not found by ID or Name", http.StatusNotFound)
-			LoggingClient.Error("Addressable not found by ID or Name: " + err.Error())
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-		}
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.DeviceService.AddressableNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 	ds.Addressable = addressable
 
 	// Add the device service
 	if ds.Id, err = dbClient.AddDeviceService(ds); err != nil {
-		if err == db.ErrNotUnique {
-			http.Error(w, "Duplicate name for the device service", http.StatusConflict)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.DeviceService.NotUnique, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -104,8 +84,7 @@ func restUpdateDeviceService(w http.ResponseWriter, r *http.Request) {
 	var from models.DeviceService
 	err := json.NewDecoder(r.Body).Decode(&from)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
@@ -118,8 +97,7 @@ func restUpdateDeviceService(w http.ResponseWriter, r *http.Request) {
 	if from.Id == "" || err != nil {
 		// Try by Name
 		if to, err = dbClient.GetDeviceServiceByName(from.Name); err != nil {
-			http.Error(w, "Device service not found", http.StatusNotFound)
-			LoggingClient.Error(err.Error())
+			httpErrorHandler.Handle(w, err, errorconcept.DeviceService.NotFound)
 			return
 		}
 	}
@@ -130,8 +108,7 @@ func restUpdateDeviceService(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := dbClient.UpdateDeviceService(to); err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.UpdateError_StatusInternalServer)
 		return
 	}
 
@@ -176,21 +153,7 @@ func updateDeviceServiceFields(from models.DeviceService, to *models.DeviceServi
 		// Check if the new name is unique
 		checkDS, err := dbClient.GetDeviceServiceByName(from.Name)
 		if err != nil {
-			// A problem occurred accessing database
-			if err != db.ErrNotFound {
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
-				return err
-			}
-		}
-
-		// Found a device service, make sure its the one we're trying to update
-		if err != db.ErrNotFound {
-			// Different IDs -> Name is not unique
-			if checkDS.Id != to.Id {
-				err = errors.New("Duplicate name for Device Service")
-				http.Error(w, err.Error(), http.StatusConflict)
-				return err
-			}
+			httpErrorHandler.HandleOneVariant(w, err, errorconcept.NewDeviceServiceDuplicate(checkDS.Id, to.Id), errorconcept.Default.ServiceUnavailable)
 		}
 	}
 
@@ -206,21 +169,14 @@ func restGetServiceByAddressableName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	an, err := url.QueryUnescape(vars[ADDRESSABLENAME])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	op := device_service.NewDeviceServiceLoadByAddressableName(an, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		switch err.(type) {
-		case types.ErrItemNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -235,17 +191,11 @@ func restGetServiceByAddressableId(w http.ResponseWriter, r *http.Request) {
 	op := device_service.NewDeviceServiceLoadByAddressableID(sid, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		switch err.(type) {
-		case types.ErrItemNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -253,19 +203,17 @@ func restGetServiceWithLabel(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	l, err := url.QueryUnescape(vars[LABEL])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	res := make([]models.DeviceService, 0)
 	if res, err = dbClient.GetDeviceServicesWithLabel(l); err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -273,21 +221,14 @@ func restGetServiceByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	dn, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	op := device_service.NewDeviceServiceLoadByName(dn, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		switch err.(type) {
-		case types.ErrItemNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -302,12 +243,7 @@ func restDeleteServiceById(w http.ResponseWriter, r *http.Request) {
 	// Check if the device service exists and get it
 	ds, err := dbClient.GetDeviceServiceById(id)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Device service not found", http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.DeviceService.NotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -316,7 +252,7 @@ func restDeleteServiceById(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error(err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.Write([]byte("true"))
 }
 
@@ -324,20 +260,14 @@ func restDeleteServiceByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	// Check if the device service exists
 	ds, err := dbClient.GetDeviceServiceByName(n)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Device service not found", http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.DeviceService.NotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -347,7 +277,7 @@ func restDeleteServiceByName(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error(err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -359,7 +289,7 @@ func deleteDeviceService(ds models.DeviceService, w http.ResponseWriter, ctx con
 	// Delete the associated devices
 	devices, err := dbClient.GetDevicesByServiceId(ds.Id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusServiceUnavailable)
 		return err
 	}
 	for _, device := range devices {
@@ -371,7 +301,7 @@ func deleteDeviceService(ds models.DeviceService, w http.ResponseWriter, ctx con
 	// Delete the associated provision watchers
 	watchers, err := dbClient.GetProvisionWatchersByServiceId(ds.Id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusServiceUnavailable)
 		return err
 	}
 	for _, watcher := range watchers {
@@ -382,7 +312,7 @@ func deleteDeviceService(ds models.DeviceService, w http.ResponseWriter, ctx con
 
 	// Delete the device service
 	if err = dbClient.DeleteDeviceServiceById(ds.Id); err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.DeleteError)
 		return err
 	}
 
@@ -395,20 +325,14 @@ func restUpdateServiceLastConnectedById(w http.ResponseWriter, r *http.Request) 
 	var vlc string = vars[LASTCONNECTED]
 	lc, err := strconv.ParseInt(vlc, 10, 64)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	// Check if the device service exists
 	ds, err := dbClient.GetDeviceServiceById(id)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Device service not found", http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.DeviceService.NotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -416,7 +340,7 @@ func restUpdateServiceLastConnectedById(w http.ResponseWriter, r *http.Request) 
 		LoggingClient.Error(err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -425,27 +349,20 @@ func restUpdateServiceLastConnectedByName(w http.ResponseWriter, r *http.Request
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 	var vlc string = vars[LASTCONNECTED]
 	lc, err := strconv.ParseInt(vlc, 10, 64)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceService.InvalidRequest_StatusInternalServer)
 		return
 	}
 
 	// Check if the device service exists
 	ds, err := dbClient.GetDeviceServiceByName(n)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Device service not found", http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.DeviceService.NotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -454,7 +371,7 @@ func restUpdateServiceLastConnectedByName(w http.ResponseWriter, r *http.Request
 		LoggingClient.Error(err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -464,7 +381,7 @@ func updateServiceLastConnected(ds models.DeviceService, lc int64, w http.Respon
 	ds.LastConnected = lc
 
 	if err := dbClient.UpdateDeviceService(ds); err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.UpdateError_StatusServiceUnavailable)
 		return err
 	}
 
@@ -478,13 +395,7 @@ func restGetServiceById(w http.ResponseWriter, r *http.Request) {
 	op := device_service.NewDeviceServiceLoadById(did, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		switch err.(type) {
-		case types.ErrItemNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -501,20 +412,13 @@ func restUpdateServiceOpStateById(w http.ResponseWriter, r *http.Request) {
 	newOs, f := models.GetOperatingState(os)
 	if !f {
 		err := errors.New("Invalid State: " + os + " Must be 'ENABLED' or 'DISABLED'")
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceService.InvalidState)
 		return
 	}
 
 	op := device_service.NewUpdateOpStateByIdExecutor(id, newOs, dbClient)
 	if err := op.Execute(); err != nil {
-		switch err.(type) {
-		case types.ErrItemNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -526,8 +430,7 @@ func restUpdateServiceOpStateByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 	var os = vars[OPSTATE]
@@ -536,20 +439,13 @@ func restUpdateServiceOpStateByName(w http.ResponseWriter, r *http.Request) {
 	newOs, f := models.GetOperatingState(os)
 	if !f {
 		err = errors.New("Invalid State: " + os + " Must be 'ENABLED' or 'DISABLED'")
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceService.InvalidState)
 		return
 	}
 
 	op := device_service.NewUpdateOpStateByNameExecutor(n, newOs, dbClient)
 	if err := op.Execute(); err != nil {
-		switch err.(type) {
-		case types.ErrItemNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -566,20 +462,13 @@ func restUpdateServiceAdminStateById(w http.ResponseWriter, r *http.Request) {
 	newAs, f := models.GetAdminState(as)
 	if !f {
 		err := errors.New("Invalid state: " + as + " Must be 'LOCKED' or 'UNLOCKED'")
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceService.InvalidState)
 		return
 	}
 
 	op := device_service.NewUpdateAdminStateByIdExecutor(id, newAs, dbClient)
 	if err := op.Execute(); err != nil {
-		switch err.(type) {
-		case types.ErrItemNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -591,8 +480,7 @@ func restUpdateServiceAdminStateByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 	var as = vars[ADMINSTATE]
@@ -601,20 +489,13 @@ func restUpdateServiceAdminStateByName(w http.ResponseWriter, r *http.Request) {
 	newAs, f := models.GetAdminState(as)
 	if !f {
 		err := errors.New("Invalid state: " + as + " Must be 'LOCKED' or 'UNLOCKED'")
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.DeviceService.InvalidState)
 		return
 	}
 
 	op := device_service.NewUpdateAdminStateByNameExecutor(n, newAs, dbClient)
 	if err := op.Execute(); err != nil {
-		switch err.(type) {
-		case types.ErrItemNotFound:
-			http.Error(w, err.Error(), http.StatusNotFound)
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -628,20 +509,14 @@ func restUpdateServiceLastReportedById(w http.ResponseWriter, r *http.Request) {
 	var vlr string = vars[LASTREPORTED]
 	lr, err := strconv.ParseInt(vlr, 10, 64)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
-	// Check if the devicde service exists
+	// Check if the device service exists
 	ds, err := dbClient.GetDeviceServiceById(id)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Device service not found", http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.DeviceService.NotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -649,7 +524,7 @@ func restUpdateServiceLastReportedById(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error(err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -658,27 +533,20 @@ func restUpdateServiceLastReportedByName(w http.ResponseWriter, r *http.Request)
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 	var vlr string = vars[LASTREPORTED]
 	lr, err := strconv.ParseInt(vlr, 10, 64)
 	if err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	// Check if the device service exists
 	ds, err := dbClient.GetDeviceServiceByName(n)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Device service not found", http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.DeviceService.NotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -686,7 +554,7 @@ func restUpdateServiceLastReportedByName(w http.ResponseWriter, r *http.Request)
 		LoggingClient.Error(err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -695,7 +563,7 @@ func restUpdateServiceLastReportedByName(w http.ResponseWriter, r *http.Request)
 func updateServiceLastReported(ds models.DeviceService, lr int64, w http.ResponseWriter) error {
 	ds.LastReported = lr
 	if err := dbClient.UpdateDeviceService(ds); err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.UpdateError_StatusServiceUnavailable)
 		return err
 	}
 
@@ -727,7 +595,7 @@ func callback(service models.DeviceService, id string, action string, actionType
 		if err != nil {
 			return err
 		}
-		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add(clients.ContentType, clients.ContentTypeJSON)
 
 		go makeRequest(client, req)
 	} else {

--- a/internal/core/metadata/rest_provisionwatcher.go
+++ b/internal/core/metadata/rest_provisionwatcher.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package metadata
 
 import (
@@ -19,7 +20,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/mux"
 )
@@ -27,20 +29,17 @@ import (
 func restGetProvisionWatchers(w http.ResponseWriter, _ *http.Request) {
 	res, err := dbClient.GetAllProvisionWatchers()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusServiceUnavailable)
 		return
 	}
 
 	// Check the length
 	if len(res) > Configuration.Service.MaxResultCount {
-		err := errors.New("Max limit exceeded")
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+		httpErrorHandler.Handle(w, errors.New("Max limit exceeded"), errorconcept.Default.RequestEntityTooLarge)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(&res)
 }
 
@@ -51,20 +50,16 @@ func restDeleteProvisionWatcherById(w http.ResponseWriter, r *http.Request) {
 	// Check if the provision watcher exists
 	pw, err := dbClient.GetProvisionWatcherById(id)
 	if err != nil {
-		errMessage := "Provision Watcher not found by ID: " + err.Error()
-		LoggingClient.Error(errMessage)
-		http.Error(w, errMessage, http.StatusNotFound)
+		httpErrorHandler.Handle(w, err, errorconcept.ProvisionWatcher.NotFoundById)
 		return
 	}
 
 	err = deleteProvisionWatcher(pw, w)
 	if err != nil {
-		errMessage := "Error deleting provision watcher"
-		LoggingClient.Error(errMessage)
-		http.Error(w, errMessage, http.StatusInternalServerError)
+		httpErrorHandler.Handle(w, err, errorconcept.ProvisionWatcher.DeleteError_StatusInternalServer)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.Write([]byte("true"))
 }
 
@@ -72,22 +67,14 @@ func restDeleteProvisionWatcherByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	// Check if the provision watcher exists
 	pw, err := dbClient.GetProvisionWatcherByName(n)
 	if err != nil {
-		if err == db.ErrNotFound {
-			errMessage := "Provision watcher not found: " + err.Error()
-			http.Error(w, errMessage, http.StatusNotFound)
-			LoggingClient.Error(errMessage)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.ProvisionWatcher.NotFoundByName, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -95,7 +82,7 @@ func restDeleteProvisionWatcherByName(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error("Problem deleting provision watcher: " + err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -103,7 +90,7 @@ func restDeleteProvisionWatcherByName(w http.ResponseWriter, r *http.Request) {
 // Delete the provision watcher
 func deleteProvisionWatcher(pw models.ProvisionWatcher, w http.ResponseWriter) error {
 	if err := dbClient.DeleteProvisionWatcherById(pw.Id); err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.DeleteError)
 		return err
 	}
 
@@ -120,18 +107,11 @@ func restGetProvisionWatcherById(w http.ResponseWriter, r *http.Request) {
 
 	res, err := dbClient.GetProvisionWatcherById(id)
 	if err != nil {
-		if err == db.ErrNotFound {
-			errMessage := "Problem getting provision watcher by ID: " + err.Error()
-			LoggingClient.Error(errMessage)
-			http.Error(w, errMessage, http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-		}
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.ProvisionWatcher.NotFoundById, errorconcept.Default.InternalServerError)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -139,24 +119,17 @@ func restGetProvisionWatcherByName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Default.BadRequest)
 		return
 	}
 
 	res, err := dbClient.GetProvisionWatcherByName(n)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-			LoggingClient.Error("Provision watcher not found: " + err.Error())
-		} else {
-			LoggingClient.Error(err.Error())
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.ProvisionWatcher.NotFoundByName, errorconcept.Default.InternalServerError)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -166,19 +139,17 @@ func restGetProvisionWatchersByProfileId(w http.ResponseWriter, r *http.Request)
 
 	// Check if the device profile exists
 	if _, err := dbClient.GetDeviceProfileById(pid); err != nil {
-		LoggingClient.Error("Device profile not found: " + err.Error())
-		http.Error(w, err.Error(), http.StatusNotFound)
+		httpErrorHandler.Handle(w, err, errorconcept.ProvisionWatcher.DeviceProfileNotFound_StatusNotFound)
 		return
 	}
 
 	res, err := dbClient.GetProvisionWatchersByProfileId(pid)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error("Problem getting provision watcher: " + err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -186,32 +157,24 @@ func restGetProvisionWatchersByProfileName(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	pn, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	// Check if the device profile exists
 	dp, err := dbClient.GetDeviceProfileByName(pn)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Device profile not found", http.StatusNotFound)
-			LoggingClient.Error("Device profile not found: " + err.Error())
-		} else {
-			LoggingClient.Error("Problem getting device profile: " + err.Error())
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.ProvisionWatcher.DeviceProfileNotFound_StatusNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
 	res, err := dbClient.GetProvisionWatchersByProfileId(dp.Id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error("Problem getting provision watcher: " + err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -221,19 +184,17 @@ func restGetProvisionWatchersByServiceId(w http.ResponseWriter, r *http.Request)
 
 	// Check if the device service exists
 	if _, err := dbClient.GetDeviceServiceById(sid); err != nil {
-		http.Error(w, "Device Service not found", http.StatusNotFound)
-		LoggingClient.Error("Device service not found: " + err.Error())
+		httpErrorHandler.Handle(w, errors.New("Device Service not found"), errorconcept.Default.NotFound)
 		return
 	}
 
 	res, err := dbClient.GetProvisionWatchersByServiceId(sid)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error("Problem getting provision watcher: " + err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -241,33 +202,25 @@ func restGetProvisionWatchersByServiceName(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	sn, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	// Check if the device service exists
 	ds, err := dbClient.GetDeviceServiceByName(sn)
 	if err != nil {
-		if err == db.ErrNotFound {
-			http.Error(w, "Device service not found", http.StatusNotFound)
-			LoggingClient.Error("Device service not found: " + err.Error())
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error("Problem getting device service: " + err.Error())
-		}
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.ProvisionWatcher.DeviceServiceNotFound_StatusNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
 
 	// Get the provision watchers
 	res, err := dbClient.GetProvisionWatchersByServiceId(ds.Id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		LoggingClient.Error("Problem getting provision watcher: " + err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.ProvisionWatcher.RetrieveError_StatusNotFound)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -275,25 +228,22 @@ func restGetProvisionWatchersByIdentifier(w http.ResponseWriter, r *http.Request
 	vars := mux.Vars(r)
 	k, err := url.QueryUnescape(vars[KEY])
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 	v, err := url.QueryUnescape(vars[VALUE])
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		LoggingClient.Error(err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
 
 	res, err := dbClient.GetProvisionWatchersByIdentifier(k, v)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		LoggingClient.Error("Problem getting provision watchers: " + err.Error())
+		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(res)
 }
 
@@ -303,16 +253,13 @@ func restAddProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	var err error
 
 	if err = json.NewDecoder(r.Body).Decode(&pw); err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusServiceUnavailable)
 		return
 	}
 
 	// Check if the name exists
 	if pw.Name == "" {
-		err = errors.New("No name provided for new provision watcher")
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusConflict)
+		httpErrorHandler.HandleOneVariant(w, errors.New("No name provided for new provision watcher"), nil, errorconcept.Default.Conflict)
 		return
 	}
 
@@ -325,13 +272,7 @@ func restAddProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	if pw.Profile.Id == "" || err != nil {
 		// Try by name
 		if profile, err = dbClient.GetDeviceProfileByName(pw.Profile.Name); err != nil {
-			if err == db.ErrNotFound {
-				LoggingClient.Error("Device profile not found for provision watcher: " + err.Error())
-				http.Error(w, "Device profile not found for provision watcher", http.StatusConflict)
-			} else {
-				LoggingClient.Error("Problem getting device profile: " + err.Error())
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
-			}
+			httpErrorHandler.HandleOneVariant(w, err, errorconcept.ProvisionWatcher.DeviceProfileNotFound_StatusConflict, errorconcept.Default.ServiceUnavailable)
 			return
 		}
 	}
@@ -346,13 +287,7 @@ func restAddProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	if pw.Service.Id == "" || err != nil {
 		// Try by name
 		if service, err = dbClient.GetDeviceServiceByName(pw.Service.Name); err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Device service not found for provision watcher", http.StatusConflict)
-				LoggingClient.Error("Device service not found for provision watcher: " + err.Error())
-			} else {
-				LoggingClient.Error("Problem getting device service for provision watcher: " + err.Error())
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
-			}
+			httpErrorHandler.HandleOneVariant(w, err, errorconcept.ProvisionWatcher.DeviceServiceNotFound_StatusConflict, errorconcept.Default.ServiceUnavailable)
 			return
 		}
 	}
@@ -360,13 +295,7 @@ func restAddProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 
 	id, err := dbClient.AddProvisionWatcher(pw)
 	if err != nil {
-		if err == db.ErrNotUnique {
-			LoggingClient.Error("Duplicate name for the provision watcher: " + err.Error())
-			http.Error(w, "Duplicate name for the provision watcher", http.StatusConflict)
-		} else {
-			LoggingClient.Error("Problem adding provision watcher: " + err.Error())
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
-		}
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.ProvisionWatcher.NotUnique, errorconcept.Default.ServiceUnavailable)
 		return
 	}
 
@@ -386,8 +315,7 @@ func restUpdateProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	var from models.ProvisionWatcher
 	if err := json.NewDecoder(r.Body).Decode(&from); err != nil {
-		LoggingClient.Error(err.Error())
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusServiceUnavailable)
 		return
 	}
 
@@ -397,13 +325,7 @@ func restUpdateProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Try by name
 		if to, err = dbClient.GetProvisionWatcherByName(from.Name); err != nil {
-			if err == db.ErrNotFound {
-				http.Error(w, "Provision watcher not found", http.StatusNotFound)
-				LoggingClient.Error("Provision watcher not found: " + err.Error())
-			} else {
-				LoggingClient.Error("Problem getting provision watcher: " + err.Error())
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
-			}
+			httpErrorHandler.HandleOneVariant(w, err, errorconcept.ProvisionWatcher.NotFoundByName, errorconcept.Common.RetrieveError_StatusServiceUnavailable)
 			return
 		}
 	}
@@ -414,8 +336,7 @@ func restUpdateProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := dbClient.UpdateProvisionWatcher(to); err != nil {
-		LoggingClient.Error("Problem updating provision watcher: " + err.Error())
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		httpErrorHandler.Handle(w, err, errorconcept.Common.UpdateError_StatusServiceUnavailable)
 		return
 	}
 
@@ -423,7 +344,7 @@ func restUpdateProvisionWatcher(w http.ResponseWriter, r *http.Request) {
 	if err := notifyProvisionWatcherAssociates(to, http.MethodPut); err != nil {
 		LoggingClient.Error("Problem notifying associated device services for provision watcher: " + err.Error())
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -440,18 +361,8 @@ func updateProvisionWatcherFields(from models.ProvisionWatcher, to *models.Provi
 		// Check that the name is unique
 		checkPW, err := dbClient.GetProvisionWatcherByName(from.Name)
 		if err != nil {
-			if err != db.ErrNotFound {
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
-				return err
-			}
-		}
-		// Found one, compare the IDs to see if its another provision watcher
-		if err != db.ErrNotFound {
-			if checkPW.Id != to.Id {
-				err = errors.New("Duplicate name for the provision watcher")
-				http.Error(w, err.Error(), http.StatusConflict)
-				return err
-			}
+			// DuplicateProvisionWatcherErrorConcept will evaluate to true if the ID is a duplicate
+			httpErrorHandler.HandleOneVariant(w, err, errorconcept.NewProvisionWatcherDuplicateErrorConcept(checkPW.Id, to.Id), errorconcept.Default.ServiceUnavailable)
 		}
 		to.Name = from.Name
 	}

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -215,7 +215,7 @@ func loadCommandRoutes(b *mux.Router) {
 	d.HandleFunc("/{"+ID+"}", restGetCommandsByDeviceId).Methods(http.MethodGet)
 }
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
 }
 

--- a/internal/export/client/router.go
+++ b/internal/export/client/router.go
@@ -19,7 +19,7 @@ import (
 
 // Test if the service is working
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
 }
 

--- a/internal/export/distro/router.go
+++ b/internal/export/distro/router.go
@@ -24,7 +24,7 @@ import (
 
 // Test if the service is working
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
 }
 

--- a/internal/pkg/errorconcept/addressable.go
+++ b/internal/pkg/errorconcept/addressable.go
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
+)
+
+var Addressable addressableErrorConcept
+
+// AddressableErrorConcept encapsulates error concepts which pertain to addressables
+type addressableErrorConcept struct {
+	EmptyName                           addressableEmptyName
+	InUse                               addressableInUse
+	InvalidRequest_StatusInternalServer addressableInvalidRequest_StatusInternalServer
+	NotFound                            addressableNotFound
+}
+
+type addressableEmptyName struct{}
+
+func (r addressableEmptyName) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r addressableEmptyName) isA(err error) bool {
+	_, ok := err.(errors.ErrEmptyAddressableName)
+	return ok
+}
+
+func (r addressableEmptyName) message(err error) string {
+	return err.Error()
+}
+
+type addressableInUse struct{}
+
+func (r addressableInUse) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r addressableInUse) isA(err error) bool {
+	_, ok := err.(errors.ErrAddressableInUse)
+	return ok
+}
+
+func (r addressableInUse) message(err error) string {
+	return err.Error()
+}
+
+type addressableNotFound struct{}
+
+func (r addressableNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r addressableNotFound) isA(err error) bool {
+	_, ok := err.(errors.ErrAddressableNotFound)
+	return ok
+}
+
+func (r addressableNotFound) message(err error) string {
+	return err.Error()
+}
+
+type addressableInvalidRequest_StatusInternalServer struct{}
+
+func (r addressableInvalidRequest_StatusInternalServer) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r addressableInvalidRequest_StatusInternalServer) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r addressableInvalidRequest_StatusInternalServer) message(err error) string {
+	return err.Error()
+}

--- a/internal/pkg/errorconcept/common.go
+++ b/internal/pkg/errorconcept/common.go
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+var Common commonErrorConcept
+
+// CommonErrorConcept represents error concepts which apply across core-services
+type commonErrorConcept struct {
+	ContractInvalid_StatusBadRequest        contractInvalid_StatusBadRequest
+	DeleteError                             deleteError
+	DuplicateName                           duplicateName
+	InvalidRequest_StatusBadRequest         invalidRequest_BadRequest
+	InvalidRequest_StatusServiceUnavailable invalidRequest_StatusServiceUnavailable
+	ItemNotFound                            itemNotFound
+	LimitExceeded                           errLimitExceeded
+	RetrieveError_StatusInternalServer      retrieveError_StatusInternalServer
+	RetrieveError_StatusServiceUnavailable  retrieveError_ServiceUnavailable
+	UpdateError_StatusInternalServer        updateError_StatusInternalServer
+	UpdateError_StatusServiceUnavailable    updateError_StatusServiceUnavailable
+}
+
+type contractInvalid_StatusBadRequest struct{}
+
+func (r contractInvalid_StatusBadRequest) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r contractInvalid_StatusBadRequest) isA(err error) bool {
+	_, ok := err.(models.ErrContractInvalid)
+	return ok
+}
+
+func (r contractInvalid_StatusBadRequest) message(err error) string {
+	return err.Error()
+}
+
+type deleteError struct{}
+
+func (r deleteError) httpErrorCode() int {
+	return http.StatusServiceUnavailable
+}
+
+func (r deleteError) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deleteError) message(err error) string {
+	return err.Error()
+}
+
+type duplicateName struct{}
+
+func (r duplicateName) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r duplicateName) isA(err error) bool {
+	_, ok := err.(errors.ErrDuplicateName)
+	return ok
+}
+
+func (r duplicateName) message(err error) string {
+	return err.Error()
+}
+
+type invalidRequest_BadRequest struct{}
+
+func (r invalidRequest_BadRequest) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r invalidRequest_BadRequest) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r invalidRequest_BadRequest) message(err error) string {
+	return err.Error()
+}
+
+type invalidRequest_StatusServiceUnavailable struct{}
+
+func (r invalidRequest_StatusServiceUnavailable) httpErrorCode() int {
+	return http.StatusServiceUnavailable
+}
+
+func (r invalidRequest_StatusServiceUnavailable) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r invalidRequest_StatusServiceUnavailable) message(err error) string {
+	return err.Error()
+}
+
+type itemNotFound struct{}
+
+func (r itemNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r itemNotFound) isA(err error) bool {
+	_, ok := err.(errors.ErrItemNotFound)
+	return ok
+}
+
+func (r itemNotFound) message(err error) string {
+	return err.Error()
+}
+
+type errLimitExceeded struct{}
+
+func (r errLimitExceeded) httpErrorCode() int {
+	return http.StatusRequestEntityTooLarge
+}
+
+func (r errLimitExceeded) isA(err error) bool {
+	_, ok := err.(errors.ErrLimitExceeded)
+	return ok
+}
+
+func (r errLimitExceeded) message(err error) string {
+	return err.Error()
+}
+
+type retrieveError_StatusInternalServer struct{}
+
+func (r retrieveError_StatusInternalServer) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r retrieveError_StatusInternalServer) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r retrieveError_StatusInternalServer) message(err error) string {
+	return err.Error()
+}
+
+type retrieveError_ServiceUnavailable struct{}
+
+func (r retrieveError_ServiceUnavailable) httpErrorCode() int {
+	return http.StatusServiceUnavailable
+}
+
+func (r retrieveError_ServiceUnavailable) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r retrieveError_ServiceUnavailable) message(err error) string {
+	return err.Error()
+}
+
+type updateError_StatusInternalServer struct{}
+
+func (r updateError_StatusInternalServer) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r updateError_StatusInternalServer) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r updateError_StatusInternalServer) message(err error) string {
+	return err.Error()
+}
+
+type updateError_StatusServiceUnavailable struct{}
+
+func (r updateError_StatusServiceUnavailable) httpErrorCode() int {
+	return http.StatusServiceUnavailable
+}
+
+func (r updateError_StatusServiceUnavailable) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r updateError_StatusServiceUnavailable) message(err error) string {
+	return err.Error()
+}

--- a/internal/pkg/errorconcept/const.go
+++ b/internal/pkg/errorconcept/const.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019 VMware Inc.
+ * Copyright 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,25 +11,9 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package pkg
 
-import (
-	"encoding/json"
-	"net/http"
+package errorconcept
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+const (
+	METHOD_NOT_ALLOWED = "isA should not be invoked, this is to only be used as a default error concept"
 )
-
-func Encode(i interface{}, w http.ResponseWriter, LoggingClient logger.LoggingClient) {
-	w.Header().Add(clients.ContentType, clients.ContentTypeJSON)
-
-	enc := json.NewEncoder(w)
-	err := enc.Encode(i)
-	// Problems encoding
-	if err != nil {
-		LoggingClient.Error("Error encoding the data: " + err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-}

--- a/internal/pkg/errorconcept/db.go
+++ b/internal/pkg/errorconcept/db.go
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+)
+
+var Database databaseErrorConcept
+
+// DatabaseErrorConcept represents a collection of database error concepts
+type databaseErrorConcept struct {
+	NotFound        dbNotFound
+	NotUnique       dbNotUnique
+	InvalidObjectId dbInvalidObjectId
+}
+
+type dbNotFound struct{}
+
+func (r dbNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r dbNotFound) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r dbNotFound) message(err error) string {
+	return err.Error()
+}
+
+type dbNotUnique struct{}
+
+func (r dbNotUnique) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r dbNotUnique) isA(err error) bool {
+	return err == db.ErrNotUnique
+}
+
+func (r dbNotUnique) message(err error) string {
+	return err.Error()
+}
+
+type dbInvalidObjectId struct{}
+
+func (r dbInvalidObjectId) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r dbInvalidObjectId) isA(err error) bool {
+	return err == db.ErrInvalidObjectId
+}
+
+func (r dbInvalidObjectId) message(err error) string {
+	return err.Error()
+}

--- a/internal/pkg/errorconcept/default.go
+++ b/internal/pkg/errorconcept/default.go
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+)
+
+var Default defaultErrorConcept
+
+// DefaultErrorConcept represents a fallback error concept only
+type defaultErrorConcept struct {
+	BadRequest            badRequest
+	RequestEntityTooLarge requestEntityTooLarge
+	InternalServerError   internalServerError
+	ServiceUnavailable    serviceUnavailable
+	NotFound              notFound
+	Conflict              conflict
+}
+
+type badRequest struct{}
+
+func (r badRequest) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r badRequest) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r badRequest) message(err error) string {
+	return err.Error()
+}
+
+type requestEntityTooLarge struct{}
+
+func (r requestEntityTooLarge) httpErrorCode() int {
+	return http.StatusRequestEntityTooLarge
+}
+
+func (r requestEntityTooLarge) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r requestEntityTooLarge) message(err error) string {
+	return err.Error()
+}
+
+type internalServerError struct{}
+
+func (r internalServerError) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r internalServerError) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r internalServerError) message(err error) string {
+	return err.Error()
+}
+
+type serviceUnavailable struct{}
+
+func (r serviceUnavailable) httpErrorCode() int {
+	return http.StatusServiceUnavailable
+}
+
+func (r serviceUnavailable) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r serviceUnavailable) message(err error) string {
+	return err.Error()
+}
+
+type notFound struct{}
+
+func (r notFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r notFound) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r notFound) message(err error) string {
+	return err.Error()
+}
+
+type conflict struct{}
+
+func (r conflict) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r conflict) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r conflict) message(err error) string {
+	return err.Error()
+}

--- a/internal/pkg/errorconcept/device.go
+++ b/internal/pkg/errorconcept/device.go
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+)
+
+var Device deviceErrorConcept
+
+// DeviceErrorConcept represents the accessor for the device-specific error concepts
+type deviceErrorConcept struct {
+	NotFound       deviceNotFound
+	NotifyError    deviceNotify
+	RequesterError deviceRequester
+}
+
+type deviceNotFound struct{}
+
+func (r deviceNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r deviceNotFound) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceNotFound) message(err error) string {
+	return err.Error()
+}
+
+type deviceNotify struct{}
+
+func (r deviceNotify) httpErrorCode() int {
+	return http.StatusServiceUnavailable
+}
+
+func (r deviceNotify) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceNotify) message(err error) string {
+	return err.Error()
+}
+
+type deviceRequester struct{}
+
+func (r deviceRequester) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r deviceRequester) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceRequester) message(err error) string {
+	return err.Error()
+}

--- a/internal/pkg/errorconcept/device_profile.go
+++ b/internal/pkg/errorconcept/device_profile.go
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+
+	metadataErrors "github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+var DeviceProfile deviceProfileErrorConcept
+
+// DeviceProfileErrorConcept represents the accessor for the device-profile-specific error concepts
+type deviceProfileErrorConcept struct {
+	ContractInvalid_StatusConflict         deviceProfileContractInvalid_StatusConflict
+	DuplicateName                          deviceProfileDuplicateName
+	EmptyName                              deviceProfileEmptyName
+	InvalidState_StatusBadRequest          deviceProfileInvalidState_StatusBadRequest
+	InvalidState_StatusConflict            deviceProfileInvalidState_StatusConflict
+	MarshalYaml                            deviceProfileMarshalYaml
+	MissingFile                            deviceProfileMissingFile
+	NotFound                               deviceProfileNotFound
+	ReadFile                               deviceProfileReadFile
+	UnmarshalYaml_StatusInternalServer     deviceProfileUnmarshalYaml_StatusInternalServer
+	UnmarshalYaml_StatusServiceUnavailable deviceProfileUnmarshalYaml_StatusServiceUnavailable
+}
+
+type deviceProfileContractInvalid_StatusConflict struct{}
+
+func (r deviceProfileContractInvalid_StatusConflict) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r deviceProfileContractInvalid_StatusConflict) isA(err error) bool {
+	_, ok := err.(models.ErrContractInvalid)
+	return ok
+}
+
+func (r deviceProfileContractInvalid_StatusConflict) message(err error) string {
+	return err.Error()
+}
+
+type deviceProfileDuplicateName struct {
+	err error
+}
+
+func (r deviceProfileDuplicateName) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r deviceProfileDuplicateName) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceProfileDuplicateName) message(err error) string {
+	return "Duplicate name for device profile"
+}
+
+type deviceProfileEmptyName struct{}
+
+func (r deviceProfileEmptyName) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r deviceProfileEmptyName) isA(err error) bool {
+	_, ok := err.(metadataErrors.ErrEmptyDeviceProfileName)
+	return ok
+}
+
+func (r deviceProfileEmptyName) message(err error) string {
+	return err.Error()
+}
+
+type deviceProfileInvalidState_StatusBadRequest struct{}
+
+func (r deviceProfileInvalidState_StatusBadRequest) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r deviceProfileInvalidState_StatusBadRequest) isA(err error) bool {
+	_, ok := err.(metadataErrors.ErrDeviceProfileInvalidState)
+	return ok
+}
+
+func (r deviceProfileInvalidState_StatusBadRequest) message(err error) string {
+	return err.Error()
+}
+
+type deviceProfileInvalidState_StatusConflict struct{}
+
+func (r deviceProfileInvalidState_StatusConflict) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r deviceProfileInvalidState_StatusConflict) isA(err error) bool {
+	_, ok := err.(metadataErrors.ErrDeviceProfileInvalidState)
+	return ok
+}
+
+func (r deviceProfileInvalidState_StatusConflict) message(err error) string {
+	return err.Error()
+}
+
+type deviceProfileMarshalYaml struct{}
+
+func (r deviceProfileMarshalYaml) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r deviceProfileMarshalYaml) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceProfileMarshalYaml) message(err error) string {
+	return err.Error()
+}
+
+type deviceProfileMissingFile struct{}
+
+func (r deviceProfileMissingFile) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r deviceProfileMissingFile) isA(err error) bool {
+	return err == http.ErrMissingFile
+}
+
+func (r deviceProfileMissingFile) message(err error) string {
+	return metadataErrors.NewErrEmptyFile("YAML").Error()
+}
+
+type deviceProfileNotFound struct{}
+
+func (r deviceProfileNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r deviceProfileNotFound) isA(err error) bool {
+	_, ok := err.(metadataErrors.ErrDeviceProfileNotFound)
+	return ok
+}
+
+func (r deviceProfileNotFound) message(err error) string {
+	return err.Error()
+}
+
+type deviceProfileReadFile struct{}
+
+func (r deviceProfileReadFile) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r deviceProfileReadFile) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceProfileReadFile) message(err error) string {
+	return err.Error()
+}
+
+type deviceProfileUnmarshalYaml_StatusInternalServer struct{}
+
+func (r deviceProfileUnmarshalYaml_StatusInternalServer) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r deviceProfileUnmarshalYaml_StatusInternalServer) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceProfileUnmarshalYaml_StatusInternalServer) message(err error) string {
+	return err.Error()
+}
+
+type deviceProfileUnmarshalYaml_StatusServiceUnavailable struct{}
+
+func (r deviceProfileUnmarshalYaml_StatusServiceUnavailable) httpErrorCode() int {
+	return http.StatusServiceUnavailable
+}
+
+func (r deviceProfileUnmarshalYaml_StatusServiceUnavailable) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceProfileUnmarshalYaml_StatusServiceUnavailable) message(err error) string {
+	return err.Error()
+}

--- a/internal/pkg/errorconcept/device_report.go
+++ b/internal/pkg/errorconcept/device_report.go
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+)
+
+var DeviceReport deviceReportErrorConcept
+
+// DeviceReportErrorConcept represents the accessor for the device-report-specific error concepts
+type deviceReportErrorConcept struct {
+	DeviceNotFound deviceReportDeviceNotFound
+	NotUnique      deviceReportNotUnique
+}
+
+type deviceReportDeviceNotFound struct{}
+
+func (r deviceReportDeviceNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r deviceReportDeviceNotFound) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r deviceReportDeviceNotFound) message(err error) string {
+	return "Device referenced by Device Report doesn't exist"
+}
+
+type deviceReportNotUnique struct{}
+
+func (r deviceReportNotUnique) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r deviceReportNotUnique) isA(err error) bool {
+	return err == db.ErrNotUnique
+}
+
+func (r deviceReportNotUnique) message(err error) string {
+	return "Duplicate Name for the device report"
+}

--- a/internal/pkg/errorconcept/device_service.go
+++ b/internal/pkg/errorconcept/device_service.go
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+)
+
+var DeviceService deviceServiceErrorConcept
+
+// DeviceServiceErrorConcept represents the accessor for the device-service-specific error concepts
+type deviceServiceErrorConcept struct {
+	AddressableNotFound                 deviceServiceAddressableNotFound
+	EmptyAddressable                    deviceServiceEmptyAddressable
+	InvalidRequest_StatusInternalServer deviceServiceInvalidRequest_StatusInternalServer
+	InvalidState                        deviceServiceInvalidState
+	NotUnique                           deviceServiceNotUnique
+	NotFound                            deviceServiceNotFound
+}
+
+type deviceServiceAddressableNotFound struct{}
+
+func (r deviceServiceAddressableNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r deviceServiceAddressableNotFound) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r deviceServiceAddressableNotFound) message(err error) string {
+	return "Addressable not found by ID or Name"
+}
+
+type deviceServiceEmptyAddressable struct{}
+
+func (r deviceServiceEmptyAddressable) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r deviceServiceEmptyAddressable) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceServiceEmptyAddressable) message(err error) string {
+	return "Must provide an Addressable for Device Service"
+}
+
+type deviceServiceInvalidRequest_StatusInternalServer struct{}
+
+func (r deviceServiceInvalidRequest_StatusInternalServer) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r deviceServiceInvalidRequest_StatusInternalServer) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceServiceInvalidRequest_StatusInternalServer) message(err error) string {
+	return err.Error()
+}
+
+type deviceServiceInvalidState struct{}
+
+func (r deviceServiceInvalidState) httpErrorCode() int {
+	return http.StatusBadRequest
+}
+
+func (r deviceServiceInvalidState) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r deviceServiceInvalidState) message(err error) string {
+	return err.Error()
+}
+
+// NewDeviceServiceDuplicate instantiates a new deviceServiceDuplicate error concept in effort to handle stateful
+// DeviceService duplicate errors
+func NewDeviceServiceDuplicate(currentDSId string, newDSId string) deviceServiceDuplicate {
+	return deviceServiceDuplicate{CurrentDSId: currentDSId, NewDSId: newDSId}
+}
+
+type deviceServiceDuplicate struct {
+	CurrentDSId string
+	NewDSId     string
+}
+
+func (r deviceServiceDuplicate) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r deviceServiceDuplicate) isA(err error) bool {
+	return r.CurrentDSId != r.NewDSId
+}
+
+func (r deviceServiceDuplicate) message(err error) string {
+	return "Duplicate name for Device Service"
+}
+
+type deviceServiceNotUnique struct{}
+
+func (r deviceServiceNotUnique) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r deviceServiceNotUnique) isA(err error) bool {
+	return err == db.ErrNotUnique
+}
+
+func (r deviceServiceNotUnique) message(err error) string {
+	return "Duplicate name for the device service"
+}
+
+type deviceServiceNotFound struct{}
+
+func (r deviceServiceNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r deviceServiceNotFound) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r deviceServiceNotFound) message(err error) string {
+	return "Device service not found"
+}

--- a/internal/pkg/errorconcept/handler.go
+++ b/internal/pkg/errorconcept/handler.go
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+type ErrorConceptType interface {
+	httpErrorCode() int
+	isA(err error) bool
+	message(err error) string
+}
+
+type handler struct {
+	logger logger.LoggingClient
+}
+
+type ErrorHandler interface {
+	Handle(w http.ResponseWriter, err error, ec ErrorConceptType)
+	HandleManyVariants(w http.ResponseWriter, err error, allowableErrors []ErrorConceptType, defaultError ErrorConceptType)
+	HandleOneVariant(w http.ResponseWriter, err error, allowableError ErrorConceptType, defaultError ErrorConceptType)
+}
+
+func NewErrorHandler(l logger.LoggingClient) ErrorHandler {
+	h := handler{l}
+	return &h
+}
+
+// Handle applies the specified error and error concept tot he HTTP response writer
+func (e *handler) Handle(w http.ResponseWriter, err error, ec ErrorConceptType) {
+	message := ec.message(err)
+	e.logger.Error(message)
+	http.Error(w, message, ec.httpErrorCode())
+}
+
+// HandleOneVariant applies general error-handling with a single allowable error and a default error to be used as a
+// fallback when none of the allowable errors are matched
+func (e *handler) HandleOneVariant(w http.ResponseWriter, err error, allowableError ErrorConceptType, defaultError ErrorConceptType) {
+	if allowableError != nil && allowableError.isA(err) {
+		e.Handle(w, err, allowableError)
+		return
+	}
+	e.Handle(w, err, defaultError)
+}
+
+// HandleManyVariants applies general error-handling for the specified set of allowable errors and a default error to be used
+// as a fallback when none of the allowable errors are matched
+func (e *handler) HandleManyVariants(w http.ResponseWriter, err error, allowableErrors []ErrorConceptType, defaultError ErrorConceptType) {
+	for key := range allowableErrors {
+		if allowableErrors[key].isA(err) {
+			e.Handle(w, err, allowableErrors[key])
+			return
+		}
+	}
+	e.Handle(w, err, defaultError)
+}

--- a/internal/pkg/errorconcept/provision_watcher.go
+++ b/internal/pkg/errorconcept/provision_watcher.go
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+)
+
+var ProvisionWatcher provisionWatcherErrorConcept
+
+// ProvisionWatcherErrorConcept represents the accessor for provision-watcher-specific error concepts
+type provisionWatcherErrorConcept struct {
+	DeleteError_StatusInternalServer     provisionWatcherDeleteError_StatusInternalServer
+	DeviceProfileNotFound_StatusConflict provisionWatcherDeviceProfileNotFound_StatusConflict
+	DeviceProfileNotFound_StatusNotFound provisionWatcherDeviceProfileNotFound_StatusNotFound
+	DeviceServiceNotFound_StatusConflict provisionWatcherDeviceServiceNotFound_StatusConflict
+	DeviceServiceNotFound_StatusNotFound provisionWatcherDeviceServiceNotFound_StatusNotFound
+	NotFoundById                         provisionWatcherNotFoundById
+	NotFoundByName                       provisionWatcherNotFoundByName
+	NotUnique                            provisionWatcherNotUnique
+	RetrieveError_StatusNotFound         provisionWatcherRetrieveError_StatusNotFound
+}
+
+type provisionWatcherDeleteError_StatusInternalServer struct{}
+
+func (r provisionWatcherDeleteError_StatusInternalServer) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r provisionWatcherDeleteError_StatusInternalServer) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r provisionWatcherDeleteError_StatusInternalServer) message(err error) string {
+	return "Error deleting provision watcher"
+}
+
+type provisionWatcherDeviceProfileNotFound_StatusConflict struct{}
+
+func (r provisionWatcherDeviceProfileNotFound_StatusConflict) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r provisionWatcherDeviceProfileNotFound_StatusConflict) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r provisionWatcherDeviceProfileNotFound_StatusConflict) message(err error) string {
+	return "Device profile not found for provision watcher"
+}
+
+type provisionWatcherDeviceProfileNotFound_StatusNotFound struct{}
+
+func (r provisionWatcherDeviceProfileNotFound_StatusNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r provisionWatcherDeviceProfileNotFound_StatusNotFound) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r provisionWatcherDeviceProfileNotFound_StatusNotFound) message(err error) string {
+	return "Device profile not found"
+}
+
+type provisionWatcherDeviceServiceNotFound_StatusConflict struct{}
+
+func (r provisionWatcherDeviceServiceNotFound_StatusConflict) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r provisionWatcherDeviceServiceNotFound_StatusConflict) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r provisionWatcherDeviceServiceNotFound_StatusConflict) message(err error) string {
+	return "Device service not found for provision watcher"
+}
+
+type provisionWatcherDeviceServiceNotFound_StatusNotFound struct{}
+
+func (r provisionWatcherDeviceServiceNotFound_StatusNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r provisionWatcherDeviceServiceNotFound_StatusNotFound) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r provisionWatcherDeviceServiceNotFound_StatusNotFound) message(err error) string {
+	return "Device service not found"
+}
+
+type provisionWatcherNotFoundById struct{}
+
+func (r provisionWatcherNotFoundById) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r provisionWatcherNotFoundById) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r provisionWatcherNotFoundById) message(err error) string {
+	return "Provision Watcher not found by ID: " + err.Error()
+}
+
+type provisionWatcherNotFoundByName struct{}
+
+func (r provisionWatcherNotFoundByName) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r provisionWatcherNotFoundByName) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r provisionWatcherNotFoundByName) message(err error) string {
+	return "Provision Watcher not found: " + err.Error()
+}
+
+// NewProvisionWatcherDuplicateErrorConcept instantiates a new error concept for a given set of ids
+func NewProvisionWatcherDuplicateErrorConcept(currentId string, newId string) provisionWatcherDuplicate {
+	return provisionWatcherDuplicate{currentId: currentId, newId: newId}
+}
+
+type provisionWatcherDuplicate struct {
+	currentId string
+	newId     string
+}
+
+func (r provisionWatcherDuplicate) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r provisionWatcherDuplicate) isA(err error) bool {
+	return err != db.ErrNotFound && r.currentId != r.newId
+}
+
+func (r provisionWatcherDuplicate) message(err error) string {
+	return "Duplicate name for the provision watcher"
+}
+
+type provisionWatcherNotUnique struct{}
+
+func (r provisionWatcherNotUnique) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r provisionWatcherNotUnique) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r provisionWatcherNotUnique) message(err error) string {
+	return "Duplicate name for the provision watcher"
+}
+
+type provisionWatcherRetrieveError_StatusNotFound struct{}
+
+func (r provisionWatcherRetrieveError_StatusNotFound) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r provisionWatcherRetrieveError_StatusNotFound) isA(err error) bool {
+	panic(METHOD_NOT_ALLOWED)
+}
+
+func (r provisionWatcherRetrieveError_StatusNotFound) message(err error) string {
+	return err.Error()
+}

--- a/internal/pkg/errorconcept/service_client.go
+++ b/internal/pkg/errorconcept/service_client.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019 VMware Inc.
+ * Copyright 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,25 +11,29 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package pkg
 
-import (
-	"encoding/json"
-	"net/http"
+package errorconcept
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-)
+import "github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 
-func Encode(i interface{}, w http.ResponseWriter, LoggingClient logger.LoggingClient) {
-	w.Header().Add(clients.ContentType, clients.ContentTypeJSON)
+// NewServiceClientHttpError represents the accessor for the service-client-specific error concepts
+func NewServiceClientHttpError(err error) *serviceClientHttpError {
+	return &serviceClientHttpError{Err: err}
+}
 
-	enc := json.NewEncoder(w)
-	err := enc.Encode(i)
-	// Problems encoding
-	if err != nil {
-		LoggingClient.Error("Error encoding the data: " + err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
+type serviceClientHttpError struct {
+	Err error
+}
+
+func (r serviceClientHttpError) httpErrorCode() int {
+	return r.Err.(types.ErrServiceClient).StatusCode
+}
+
+func (r serviceClientHttpError) isA(err error) bool {
+	_, ok := err.(types.ErrServiceClient)
+	return ok
+}
+
+func (r serviceClientHttpError) message(err error) string {
+	return err.Error()
 }

--- a/internal/pkg/errorconcept/value_descriptors.go
+++ b/internal/pkg/errorconcept/value_descriptors.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019 VMware Inc.
+ * Copyright 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,25 +11,33 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package pkg
+
+package errorconcept
 
 import (
-	"encoding/json"
 	"net/http"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 )
 
-func Encode(i interface{}, w http.ResponseWriter, LoggingClient logger.LoggingClient) {
-	w.Header().Add(clients.ContentType, clients.ContentTypeJSON)
+var ValueDescriptors valueDescriptorsErrorConcept
 
-	enc := json.NewEncoder(w)
-	err := enc.Encode(i)
-	// Problems encoding
-	if err != nil {
-		LoggingClient.Error("Error encoding the data: " + err.Error())
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
+// ValueDescriptorsErrorConcept represents the accessor for the value-descriptor-specific error concepts
+type valueDescriptorsErrorConcept struct {
+	InUse valueDescriptorsInUse
+}
+
+type valueDescriptorsInUse struct{}
+
+func (r valueDescriptorsInUse) httpErrorCode() int {
+	return http.StatusConflict
+}
+
+func (r valueDescriptorsInUse) isA(err error) bool {
+	_, ok := err.(errors.ErrValueDescriptorsInUse)
+	return ok
+}
+
+func (r valueDescriptorsInUse) message(err error) string {
+	return err.Error()
 }

--- a/internal/support/logging/router.go
+++ b/internal/support/logging/router.go
@@ -28,7 +28,7 @@ import (
 
 // Test if the service is working
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
 }
 

--- a/internal/support/notifications/cleanup.go
+++ b/internal/support/notifications/cleanup.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/gorilla/mux"
 )
 
@@ -55,7 +56,7 @@ func cleanupHandlerCloser(w http.ResponseWriter, err error) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusAccepted)
 	w.Write([]byte("true"))
 }

--- a/internal/support/notifications/rest_notification.go
+++ b/internal/support/notifications/rest_notification.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications/errors"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications/operators/notification"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/mux"
 )
@@ -125,7 +126,7 @@ func restDeleteNotificationBySlug(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -178,7 +179,7 @@ func restDeleteNotificationByID(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -203,7 +204,7 @@ func restDeleteNotificationsByAge(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error(err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }

--- a/internal/support/notifications/rest_subscription.go
+++ b/internal/support/notifications/rest_subscription.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications/errors"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications/operators/subscription"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/mux"
 )
@@ -90,7 +91,7 @@ func subscriptionHandler(w http.ResponseWriter, r *http.Request) {
 			LoggingClient.Error(err.Error())
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 
@@ -175,7 +176,7 @@ func restDeleteSubscriptionByID(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -228,7 +229,7 @@ func restDeleteSubscriptionBySlug(w http.ResponseWriter, r *http.Request) {
 		LoggingClient.Error(err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }

--- a/internal/support/notifications/rest_transmission.go
+++ b/internal/support/notifications/rest_transmission.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/mux"
 )
@@ -316,7 +317,7 @@ func transmissionByAgeStatusHandler(w http.ResponseWriter, r *http.Request, stat
 		LoggingClient.Error(err.Error())
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 

--- a/internal/support/notifications/utils.go
+++ b/internal/support/notifications/utils.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 )
 
 // Printing function purely for debugging purposes
@@ -38,6 +40,6 @@ func printBody(r io.ReadCloser) {
 
 // Test if the service is working
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
 }

--- a/internal/support/scheduler/rest_interval.go
+++ b/internal/support/scheduler/rest_interval.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/errors"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/operators/interval"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/mux"
@@ -79,7 +80,7 @@ func restUpdateInterval(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -174,7 +175,7 @@ func restDeleteIntervalByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -240,7 +241,7 @@ func restDeleteIntervalByName(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("true"))
 }
@@ -257,7 +258,7 @@ func restScrubAllIntervals(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(strconv.Itoa(count)))
 

--- a/internal/support/scheduler/router.go
+++ b/internal/support/scheduler/router.go
@@ -78,7 +78,7 @@ func LoadRestRoutes() *mux.Router {
 
 // Test if the service is working
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
 }
 
@@ -186,7 +186,7 @@ func intervalActionHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 	}
@@ -238,7 +238,7 @@ func intervalActionByIdHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 	}
@@ -290,7 +290,7 @@ func intervalActionByNameHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("true"))
 	}
@@ -375,7 +375,7 @@ func scrubIntervalActionsHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(strconv.Itoa(count)))
 	}

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -56,7 +56,7 @@ func LoadRestRoutes(
 
 // pingHandler implements a controller to execute a ping request.
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
 }
 


### PR DESCRIPTION
Fixes #1745 
Fixes #1712

Resolve the following Sonar Cloud code duplication issues in REST Handlers:

- Writing the Content-Type header and values using constants.

- Create and leverage utility methods which perform error type-checking.

- Remove superfluous logging of error via LoggingClient.

- Create and leverage utility methods which parse URL/query parameters.

Signed-off-by Jason Bonafide <jbonafide623@gmail.com>