### PR TITLE
SMA GenClients usage not thread-safe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,11 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.19
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.25
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/mux v1.7.0

--- a/internal/pkg/startup/endpoint.go
+++ b/internal/pkg/startup/endpoint.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
@@ -29,24 +28,32 @@ type Endpoint struct {
 }
 
 func (e Endpoint) Monitor(params types.EndpointParams, ch chan string) {
-	var endpoint registryTypes.ServiceEndpoint
-	var err error
 	for {
-
-		if e.RegistryClient != nil {
-			endpoint, err = (*e.RegistryClient).GetServiceEndpoint(params.ServiceKey)
-			if err != nil {
-				err = fmt.Errorf("unable to get Service endpoint for %s: %s", params.ServiceKey, err.Error())
-			}
-		} else {
-			err = fmt.Errorf("unable to get Service endpoint for %s: Registry client is nil", params.ServiceKey)
-		}
-
+		url, err := e.buildURL(params)
 		if err != nil {
 			fmt.Fprintln(os.Stdout, err.Error())
 		}
-		url := fmt.Sprintf("http://%s:%v%s", endpoint.Host, endpoint.Port, params.Path)
 		ch <- url
 		time.Sleep(time.Millisecond * time.Duration(params.Interval))
+	}
+}
+
+func (e Endpoint) Fetch(params types.EndpointParams) string {
+	url, err := e.buildURL(params)
+	if err != nil {
+		fmt.Fprintln(os.Stdout, err.Error())
+	}
+	return url
+}
+
+func (e Endpoint) buildURL(params types.EndpointParams) (string, error) {
+	if e.RegistryClient != nil {
+		endpoint, err := (*e.RegistryClient).GetServiceEndpoint(params.ServiceKey)
+		if err != nil {
+			return "", fmt.Errorf("unable to get Service endpoint for %s: %s", params.ServiceKey, err.Error())
+		}
+		return fmt.Sprintf("http://%s:%v%s", endpoint.Host, endpoint.Port, params.Path), nil
+	} else {
+		return "", fmt.Errorf("unable to get Service endpoint for %s: Registry client is nil", params.ServiceKey)
 	}
 }

--- a/internal/system/agent/clients.go
+++ b/internal/system/agent/clients.go
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package agent
+
+import (
+	"sync"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
+)
+
+// clientMap defines internal map structure to track multiple instances of general.GeneralClient.
+type clientMap map[string]general.GeneralClient
+
+// GeneralClients contains implementation structures for tracking multiple instances of general.GeneralClient.
+type GeneralClients struct {
+	clients clientMap
+	mutex   sync.RWMutex
+}
+
+// NewGeneralClients is a factory method that returns an initialized GeneralClients receiver struct.
+func NewGeneralClients() *GeneralClients {
+	return &GeneralClients{
+		clients: make(clientMap),
+		mutex:   sync.RWMutex{},
+	}
+}
+
+// Get returns the general.GeneralClient and ok = true for the requested client name if it exists, otherwise ok = false.
+func (c *GeneralClients) Get(clientName string) (client general.GeneralClient, ok bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	client, ok = c.clients[clientName]
+	return
+}
+
+// Set updates the list of clients to ensure the provided clientName key contains the provided general.GeneralClient value.
+func (c *GeneralClients) Set(clientName string, value general.GeneralClient) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.clients[clientName] = value
+}

--- a/internal/system/agent/clients_test.go
+++ b/internal/system/agent/clients_test.go
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyGetReturnsExpectedValues(t *testing.T) {
+	sut := NewGeneralClients()
+
+	result, ok := sut.Get("nonExistentKey")
+
+	assert.Equal(t, nil, result)
+	assert.Equal(t, false, ok)
+}
+
+func TestGetForKnownReturnsExpectedValues(t *testing.T) {
+	const clientName = "clientName"
+
+	sut := NewGeneralClients()
+	client := general.NewGeneralClient(types.EndpointParams{}, startup.Endpoint{RegistryClient: nil})
+	sut.Set(clientName, client)
+
+	result, ok := sut.Get(clientName)
+
+	assert.Equal(t, client, result)
+	assert.Equal(t, true, ok)
+}

--- a/internal/system/agent/direct/metrics.go
+++ b/internal/system/agent/direct/metrics.go
@@ -39,7 +39,7 @@ import (
 // metrics contains references to dependencies required to handle the metrics via direct service use case.
 type metrics struct {
 	loggingClient   logger.LoggingClient
-	genClients      agent.GeneralClients
+	genClients      *agent.GeneralClients
 	configClients   agent.ConfigurationClients
 	registryClient  registry.Client
 	serviceProtocol string
@@ -48,7 +48,7 @@ type metrics struct {
 // NewMetrics is a factory method that returns an initialized metrics receiver struct.
 func NewMetrics(
 	loggingClient logger.LoggingClient,
-	genClients agent.GeneralClients,
+	genClients *agent.GeneralClients,
 	configClients agent.ConfigurationClients,
 	registryClient registry.Client,
 	serviceProtocol string) *metrics {
@@ -62,11 +62,46 @@ func NewMetrics(
 	}
 }
 
-// fetchMetrics provides a common implementation to gather metrics from a service defined in genClients,
-// transform and normalize the cpuUsedPercent and memoryUsed fields provided by every executor (along with the raw
-// result returned by the service), and return a corresponding MetricsSuccessResult.
-func (m *metrics) fetchMetrics(serviceName string, ctx context.Context) (system.Result, error) {
-	result, err := m.genClients[serviceName].FetchMetrics(ctx)
+// metricsViaDirectService calls a service's metrics endpoint directly, interprets the response, and returns a Result.
+func (m *metrics) metricsViaDirectService(serviceName string, ctx context.Context) (system.Result, error) {
+	client, ok := m.genClients.Get(serviceName)
+	if !ok {
+		if m.registryClient == nil {
+			return nil, fmt.Errorf("registryClient not initialized; required to handle unknown service: %s", serviceName)
+		}
+
+		// Service unknown to SMA, so ask the Registry whether `serviceName` is available.
+		if err := m.registryClient.IsServiceAvailable(serviceName); err != nil {
+			return nil, err
+		}
+
+		m.loggingClient.Info(fmt.Sprintf("Registry responded with %s serviceName available", serviceName))
+
+		// Since serviceName is unknown to SMA, ask the Registry for a ServiceEndpoint associated with `serviceName`
+		endpoint, err := m.registryClient.GetServiceEndpoint(serviceName)
+		if err != nil {
+			return nil, fmt.Errorf("on attempting to get ServiceEndpoint for serviceName %s, got error: %v", serviceName, err.Error())
+		}
+
+		configClient := config.ClientInfo{
+			Protocol: m.serviceProtocol,
+			Host:     endpoint.Host,
+			Port:     endpoint.Port,
+		}
+		params := types.EndpointParams{
+			ServiceKey:  endpoint.ServiceId,
+			Path:        "/",
+			UseRegistry: true,
+			Url:         configClient.Url() + clients.ApiMetricsRoute,
+			Interval:    internal.ClientMonitorDefault,
+		}
+
+		// Add the serviceName key to the map where the value is the respective GeneralClient
+		client = general.NewGeneralClient(params, startup.Endpoint{RegistryClient: &m.registryClient})
+		m.genClients.Set(endpoint.ServiceId, client)
+	}
+
+	result, err := client.FetchMetrics(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -77,68 +112,6 @@ func (m *metrics) fetchMetrics(serviceName string, ctx context.Context) (system.
 	}
 
 	return system.MetricsSuccess(serviceName, ExecutorType, s.CpuBusyAvg, int64(s.Memory.Sys), []byte(result)), nil
-}
-
-// handleUnknownService fetches metrics from an unknown service (i.e. a service that does not have an entry in
-// genClients).  It leverages the registry -- assuming it is enabled -- to query for the unknown service's
-// endpoint settings.  If found, the service is added to genClients and the service's metrics are fetched and
-// returned.
-func (m *metrics) handleUnknownService(serviceName string, ctx context.Context) (system.Result, error) {
-	m.loggingClient.Info(fmt.Sprintf("service %s not known to SMA as being in the ready-made list of clients", serviceName))
-
-	if m.registryClient == nil {
-		return nil, fmt.Errorf("registryClient not initialized; required to handle unknown service %s", serviceName)
-	}
-
-	// Service unknown to SMA, so ask the Registry whether `serviceName` is available.
-	if err := m.registryClient.IsServiceAvailable(serviceName); err != nil {
-		return nil, err
-	}
-
-	m.loggingClient.Info(fmt.Sprintf("Registry responded with %s serviceName available", serviceName))
-
-	// Since serviceName is unknown to SMA, ask the Registry for a ServiceEndpoint associated with `serviceName`
-	endpoint, err := m.registryClient.GetServiceEndpoint(serviceName)
-	if err != nil {
-		return nil, fmt.Errorf("on attempting to get ServiceEndpoint for serviceName %s, got error: %v", serviceName, err.Error())
-	}
-
-	// add the specified key to the map where the value will be the respective GeneralClient
-	m.configClients[endpoint.ServiceId] = config.ClientInfo{
-		Protocol: m.serviceProtocol,
-		Host:     endpoint.Host,
-		Port:     endpoint.Port,
-	}
-
-	params := types.EndpointParams{
-		ServiceKey:  endpoint.ServiceId,
-		Path:        "/",
-		UseRegistry: true,
-		Url:         m.configClients[endpoint.ServiceId].Url() + clients.ApiMetricsRoute,
-		Interval:    internal.ClientMonitorDefault,
-	}
-
-	// Add the serviceName key to the map where the value is the respective GeneralClient
-	m.genClients[endpoint.ServiceId] = general.NewGeneralClient(params, startup.Endpoint{RegistryClient: &m.registryClient})
-
-	return m.fetchMetrics(endpoint.ServiceId, ctx)
-}
-
-// handleKnownService fetches metrics from a known service (i.e. a service that has an entry in genClients).
-func (m *metrics) handleKnownService(serviceName string, ctx context.Context) (system.Result, error) {
-	// Service is known to SMA, so no need to ask the Registry for a ServiceEndpoint associated with `serviceName`
-	// Simply use one of the ready-made list of clients.
-	m.loggingClient.Info(fmt.Sprintf("serviceName %s is known to SMA as being in the ready-made list of clients", serviceName))
-	return m.fetchMetrics(serviceName, ctx)
-}
-
-// metricsViaDirectService calls a service's metrics endpoint directly, interprets the endpoint's response, and returns
-// a Result value.
-func (m *metrics) metricsViaDirectService(serviceName string, ctx context.Context) (system.Result, error) {
-	if _, ok := m.genClients[serviceName]; ok {
-		return m.handleKnownService(serviceName, ctx)
-	}
-	return m.handleUnknownService(serviceName, ctx)
 }
 
 func (m *metrics) Get(services []string, ctx context.Context) interface{} {

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -26,20 +26,20 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+
 	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
-type GeneralClients map[string]general.GeneralClient
-
 // Instance contains what were global variables.
 type Instance struct {
 	Configuration  *ConfigurationStruct
-	GenClients     GeneralClients
+	GenClients     *GeneralClients
 	LoggingClient  logger.LoggingClient
 	RegistryClient registry.Client
 	chErrors       chan error       //A channel for "config wait error" sourced from Registry
@@ -227,30 +227,25 @@ func (instance *Instance) listenForConfigChanges() {
 }
 
 func (instance *Instance) initializeClients(useRegistry bool) {
-	instance.GenClients = make(GeneralClients)
-
-	var updateGenClients = func(serviceKey string, serviceName string) {
-		instance.GenClients[serviceKey] = general.NewGeneralClient(
-			types.EndpointParams{
-				ServiceKey:  serviceKey,
-				Path:        "/",
-				UseRegistry: useRegistry,
-				Url:         instance.Configuration.Clients[serviceName].Url(),
-				Interval:    internal.ClientMonitorDefault,
-			},
-			startup.Endpoint{RegistryClient: &instance.RegistryClient})
-	}
-
+	instance.GenClients = NewGeneralClients()
 	if useRegistry {
-		for serviceKey, serviceName := range config.ListDefaultServices() {
-			updateGenClients(serviceKey, serviceName)
-		}
+		// if we're using the registry, we'll create new general clients as we need them.
 		return
 	}
 
 	// if the registry is not being used, load clients from configurations; assume configuration key is service name
-	for key := range instance.Configuration.Clients {
-		updateGenClients(key, key)
+	for serviceKey := range instance.Configuration.Clients {
+		instance.GenClients.Set(
+			serviceKey,
+			general.NewGeneralClient(
+				types.EndpointParams{
+					ServiceKey:  serviceKey,
+					Path:        "/",
+					UseRegistry: useRegistry,
+					Url:         instance.Configuration.Clients[serviceKey].Url(),
+					Interval:    internal.ClientMonitorDefault,
+				},
+				startup.Endpoint{RegistryClient: &instance.RegistryClient}))
 	}
 }
 

--- a/internal/system/agent/services.go
+++ b/internal/system/agent/services.go
@@ -36,7 +36,7 @@ func getConfig(
 	services []string,
 	ctx context.Context,
 	loggingClient logger.LoggingClient,
-	genClients GeneralClients,
+	genClients *GeneralClients,
 	configClients ConfigurationClients,
 	registryClient registry.Client,
 	serviceProtocol string) (interface{}, error) {
@@ -49,75 +49,65 @@ func getConfig(
 
 	// Loop through requested actions, along with (any) respectively-supplied parameters.
 	for _, service := range services {
-
+		client, ok := genClients.Get(service)
 		// Check whether SMA does _not_ know of ServiceKey ("service") as being one for one of its ready-made list of clients.
-		if !IsKnownServiceKey(service) {
+		if !ok {
 			loggingClient.Info(fmt.Sprintf("service %s not known to SMA as being in the ready-made list of clients", service))
+
+			if registryClient == nil {
+				result.Configuration[service] = "registry is required to obtain configuration."
+				continue
+			}
 
 			// Service unknown to SMA, so ask the Registry whether `service` is available.
 			err := registryClient.IsServiceAvailable(service)
 			if err != nil {
 				result.Configuration[service] = fmt.Sprintf(err.Error())
 				loggingClient.Error(err.Error())
-			} else {
-				loggingClient.Info(fmt.Sprintf("Registry responded with %s service available", service))
-
-				// Since service is unknown to SMA, ask the Registry for a ServiceEndpoint associated with `service`
-				e, err := registryClient.GetServiceEndpoint(service)
-				if err != nil {
-					result.Configuration[service] = fmt.Sprintf("on attempting to get ServiceEndpoint for service %s, got error: %v", service, err.Error())
-					loggingClient.Error(err.Error())
-				} else {
-					// Preparing to add the specified key to the map where the value will be the respective GeneralClient
-					clientInfo := config.ClientInfo{}
-					clientInfo.Protocol = serviceProtocol
-					clientInfo.Host = e.Host
-					clientInfo.Port = e.Port
-
-					// This code will evolve to take into account a manifest-like functionality in future. So
-					// rather than assume that the runtime bool flag useRegistry has been initialized to true,
-					// given that the flow has reached this point, having already called functions on the Registry,
-					// such as RegistryClient.IsServiceAvailable(service), we test for its truthiness. I expect
-					// this code to be refactored as we evolve toward a manifest-like functionality in future.
-					usingRegistry := false
-					if registryClient != nil {
-						usingRegistry = true
-					}
-
-					configClients[e.ServiceId] = clientInfo
-					params := types.EndpointParams{
-						ServiceKey:  e.ServiceId,
-						Path:        "/",
-						UseRegistry: usingRegistry,
-						Url:         configClients[e.ServiceId].Url() + clients.ApiConfigRoute,
-						Interval:    internal.ClientMonitorDefault,
-					}
-					// Add the service key to the map where the value is the respective GeneralClient
-					genClients[e.ServiceId] = general.NewGeneralClient(params, startup.Endpoint{RegistryClient: &registryClient})
-
-					responseJSON, err := genClients[e.ServiceId].FetchConfiguration(ctx)
-					if err != nil {
-						result.Configuration[service] = fmt.Sprintf(err.Error())
-						loggingClient.Error(err.Error())
-					} else {
-						result.Configuration[service] = response.Process(responseJSON, loggingClient)
-					}
-					return result, nil
-				}
+				continue
 			}
-		} else {
-			// Service is known to SMA, so no need to ask the Registry for a ServiceEndpoint associated with `service`
-			// Simply use one of the ready-made list of clients.
-			loggingClient.Info(fmt.Sprintf("service %s is known to SMA as being in the ready-made list of clients", service))
 
-			responseJSON, err := genClients[service].FetchConfiguration(ctx)
+			loggingClient.Info(fmt.Sprintf("Registry responded with %s service available", service))
+
+			// Since service is unknown to SMA, ask the Registry for a ServiceEndpoint associated with `service`
+			e, err := registryClient.GetServiceEndpoint(service)
 			if err != nil {
-				result.Configuration[service] = fmt.Sprintf(err.Error())
+				result.Configuration[service] = fmt.Sprintf("on attempting to get ServiceEndpoint for service %s, got error: %v", service, err.Error())
 				loggingClient.Error(err.Error())
-			} else {
-				result.Configuration[service] = response.Process(responseJSON, loggingClient)
+				continue
 			}
+
+			// This code will evolve to take into account a manifest-like functionality in future. So
+			// rather than assume that the runtime bool flag useRegistry has been initialized to true,
+			// given that the flow has reached this point, having already called functions on the Registry,
+			// such as RegistryClient.IsServiceAvailable(service), we test for its truthiness. I expect
+			// this code to be refactored as we evolve toward a manifest-like functionality in future.
+			configClients[e.ServiceId] = config.ClientInfo{
+				Protocol: serviceProtocol,
+				Host:     e.Host,
+				Port:     e.Port,
+			}
+
+			params := types.EndpointParams{
+				ServiceKey:  e.ServiceId,
+				Path:        "/",
+				UseRegistry: registryClient != nil,
+				Url:         configClients[e.ServiceId].Url() + clients.ApiConfigRoute,
+				Interval:    internal.ClientMonitorDefault,
+			}
+			// Add the service key to the map where the value is the respective GeneralClient
+			client = general.NewGeneralClient(params, startup.Endpoint{RegistryClient: &registryClient})
+			genClients.Set(e.ServiceId, client)
 		}
+
+		responseJSON, err := client.FetchConfiguration(ctx)
+		if err != nil {
+			result.Configuration[service] = fmt.Sprintf(err.Error())
+			loggingClient.Error(err.Error())
+			continue
+		}
+
+		result.Configuration[service] = response.Process(responseJSON, loggingClient)
 	}
 	return result, nil
 }


### PR DESCRIPTION
GenClients is an unprotected map updated in multiple locations (as a
direct result of an HTTP request) and referenced elsewhere in the SMA.
Access to it should be protected by a mutex.

https://github.com/edgexfoundry/edgex-go/issues/1763
Signed-off-by: Michael Estrin <m.estrin@dell.com>