### PR TITLE
SMA /health faults if --registry not set

### DIFF
--- a/internal/system/agent/services.go
+++ b/internal/system/agent/services.go
@@ -130,6 +130,10 @@ func getHealth(
 	health := make(map[string]interface{})
 
 	for _, service := range services {
+		if registryClient == nil {
+			health[service] = "registry is required to obtain service health status."
+			continue
+		}
 
 		if !IsKnownServiceKey(service) {
 			loggingClient.Warn(fmt.Sprintf("unknown service %s found while getting health", service))


### PR DESCRIPTION
Updated to return error message when --registry flag not set during
service start up.  Expect this code to be further refactored in
follow-on https://github.com/edgexfoundry/edgex-go/issues/1771.

https://github.com/edgexfoundry/edgex-go/issues/1770

Signed-off-by: Michael Estrin <m.estrin@dell.com>