### PR TITLE
SMA Health Check should not be limited to "known" services

### DIFF
--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -122,7 +122,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request, instance *Instance) {
 	var services []string
 	services = strings.Split(list, ",")
 
-	send, err := getHealth(services, instance.LoggingClient, instance.RegistryClient)
+	send, err := getHealth(services, instance.RegistryClient)
 	if err != nil {
 		instance.LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Refactored getHealth(); removed IsKnownServiceKey().

https://github.com/edgexfoundry/edgex-go/issues/1771

Signed-off-by: Michael Estrin <m.estrin@dell.com>