### PR TITLE
Implement the design: SMA Sets Configuration (Writable) Without Restart.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.25
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.27
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8

--- a/internal/system/agent/get_config.go
+++ b/internal/system/agent/get_config.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal"
+	conf "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+	responses "github.com/edgexfoundry/go-mod-core-contracts/responses/configuration"
+	"github.com/edgexfoundry/go-mod-registry/registry"
+)
+
+type getConf struct {
+	genClients      *GeneralClients
+	configClients   ConfigurationClients
+	registryClient  registry.Client
+	loggingClient   logger.LoggingClient
+	serviceProtocol string
+}
+
+func NewGetConfig(genClients *GeneralClients,
+	configClients ConfigurationClients,
+	registryClient registry.Client,
+	loggingClient logger.LoggingClient,
+	serviceProtocol string) *getConf {
+	return &getConf{
+		genClients:      genClients,
+		configClients:   configClients,
+		registryClient:  registryClient,
+		loggingClient:   loggingClient,
+		serviceProtocol: serviceProtocol,
+	}
+}
+
+func (c getConf) GetConfig(serviceName string, ctx context.Context) (string, error) {
+	var result string
+	client, ok := c.genClients.Get(serviceName)
+	if !ok {
+		if c.registryClient == nil {
+			return "", fmt.Errorf("registryClient not initialized; required to handle unknown service: %s", serviceName)
+		}
+
+		// Service unknown to SMA, so ask the Registry whether `serviceName` is available.
+		if err := c.registryClient.IsServiceAvailable(serviceName); err != nil {
+			return "", err
+		}
+
+		c.loggingClient.Info(fmt.Sprintf("Registry responded with %s available", serviceName))
+
+		// Since serviceName is unknown to SMA, ask the Registry for a ServiceEndpoint associated with `serviceName`
+		ep, err := c.registryClient.GetServiceEndpoint(serviceName)
+		if err != nil {
+			return "", fmt.Errorf("on attempting to get ServiceEndpoint for %s, got error: %v", serviceName, err.Error())
+		}
+
+		configClient := conf.ClientInfo{
+			Protocol: c.serviceProtocol,
+			Host:     ep.Host,
+			Port:     ep.Port,
+		}
+		params := types.EndpointParams{
+			ServiceKey:  ep.ServiceId,
+			Path:        "/",
+			UseRegistry: true,
+			Url:         configClient.Url() + clients.ApiConfigRoute,
+			Interval:    internal.ClientMonitorDefault,
+		}
+
+		// Add the serviceName key to the map where the value is the respective GeneralClient
+		client = general.NewGeneralClient(params, endpoint.Endpoint{RegistryClient: &c.registryClient})
+		c.genClients.Set(ep.ServiceId, client)
+	}
+
+	result, err := client.FetchConfiguration(ctx)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+func (c getConf) createErrorResponse(description string) responses.SetConfigResponse {
+	c.loggingClient.Error(description)
+	return responses.SetConfigResponse{
+		Success:     false,
+		Description: description,
+	}
+}

--- a/internal/system/agent/getexecutor.go
+++ b/internal/system/agent/getexecutor.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/response"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-registry/registry"
+)
+
+type getExecutor struct {
+	executor        interfaces.GetExecutor
+	genClients      *GeneralClients
+	configClients   ConfigurationClients
+	registryClient  registry.Client
+	loggingClient   logger.LoggingClient
+	serviceProtocol string
+}
+
+func NewGetExecutor(executor interfaces.GetExecutor,
+	genClients *GeneralClients,
+	configClients ConfigurationClients,
+	registryClient registry.Client,
+	loggingClient logger.LoggingClient,
+	serviceProtocol string) *getExecutor {
+
+	return &getExecutor{
+		executor:        executor,
+		genClients:      genClients,
+		configClients:   configClients,
+		registryClient:  registryClient,
+		loggingClient:   loggingClient,
+		serviceProtocol: serviceProtocol,
+	}
+}
+
+// Get provides the callout to the config service executor.
+func (ge getExecutor) Get(services []string, ctx context.Context) interface{} {
+	result := struct {
+		Configuration map[string]interface{} `json:"configuration"`
+	}{
+		Configuration: map[string]interface{}{},
+	}
+	for _, service := range services {
+		config, err := ge.executor(service, ctx)
+		if err != nil {
+			ge.loggingClient.Error(fmt.Sprintf(err.Error()))
+			result.Configuration[service] = fmt.Sprintf(err.Error())
+			continue
+		}
+		result.Configuration[service] = response.Process(config, ge.loggingClient)
+	}
+	return result
+}

--- a/internal/system/agent/interfaces/getexecutor.go
+++ b/internal/system/agent/interfaces/getexecutor.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2018 Dell Technologies Inc.
+ * Copyright 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,30 +10,12 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- *
  *******************************************************************************/
 
-package agent
+package interfaces
 
 import (
-	"github.com/edgexfoundry/go-mod-registry/registry"
+	"context"
 )
 
-func getHealth(services []string, registryClient registry.Client) (map[string]interface{}, error) {
-	health := make(map[string]interface{})
-	for _, service := range services {
-		if registryClient == nil {
-			health[service] = "registry is required to obtain service health status."
-			continue
-		}
-
-		// the registry service returns nil for a healthy service
-		if err := registryClient.IsServiceAvailable(service); err != nil {
-			health[service] = err.Error()
-			continue
-		}
-
-		health[service] = true
-	}
-	return health, nil
-}
+type GetExecutor func(service string, ctx context.Context) (string, error)

--- a/internal/system/agent/interfaces/setexecutor.go
+++ b/internal/system/agent/interfaces/setexecutor.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2018 Dell Technologies Inc.
+ * Copyright 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,30 +10,13 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- *
  *******************************************************************************/
 
-package agent
+package interfaces
 
 import (
-	"github.com/edgexfoundry/go-mod-registry/registry"
+	requests "github.com/edgexfoundry/go-mod-core-contracts/requests/configuration"
+	responses "github.com/edgexfoundry/go-mod-core-contracts/responses/configuration"
 )
 
-func getHealth(services []string, registryClient registry.Client) (map[string]interface{}, error) {
-	health := make(map[string]interface{})
-	for _, service := range services {
-		if registryClient == nil {
-			health[service] = "registry is required to obtain service health status."
-			continue
-		}
-
-		// the registry service returns nil for a healthy service
-		if err := registryClient.IsServiceAvailable(service); err != nil {
-			health[service] = err.Error()
-			continue
-		}
-
-		health[service] = true
-	}
-	return health, nil
-}
+type SetExecutor func(service string, sc requests.SetConfigRequest) responses.SetConfigResponse

--- a/internal/system/agent/set_config.go
+++ b/internal/system/agent/set_config.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	requests "github.com/edgexfoundry/go-mod-core-contracts/requests/configuration"
+	responses "github.com/edgexfoundry/go-mod-core-contracts/responses/configuration"
+	"github.com/edgexfoundry/go-mod-registry/pkg/types"
+	"github.com/edgexfoundry/go-mod-registry/registry"
+	"strings"
+)
+
+type setConf struct {
+	loggingClient logger.LoggingClient
+	configuration *ConfigurationStruct
+}
+
+func NewSetConfig(loggingClient logger.LoggingClient, configuration *ConfigurationStruct) *setConf {
+	return &setConf{
+		loggingClient: loggingClient,
+		configuration: configuration,
+	}
+}
+
+func (c setConf) SetConfig(service string, sc requests.SetConfigRequest) responses.SetConfigResponse {
+
+	// The SMA will set configuration via Consul if EdgeX has been launched with the "--registry" flag.
+	c.loggingClient.Info(fmt.Sprintf("the SMA has been requested to set (aka PUT/UPDATE) the config for: %s", service))
+	c.loggingClient.Debug(fmt.Sprintf("key %s to use for config updated", sc.Key))
+	c.loggingClient.Debug(fmt.Sprintf("value %s to use for config updated", sc.Value))
+
+	// create a registryClient specific to the service and connect to the registry as if we are that service so
+	// that we can update the service's corresponding key based on the request we received.
+	var serviceSpecificRegistryClient registry.Client
+	serviceSpecificRegistryClient, err := registry.NewRegistryClient(
+		types.Config{
+			Host:       c.configuration.Registry.Host,
+			Port:       c.configuration.Registry.Port,
+			Type:       c.configuration.Registry.Type,
+			Stem:       internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
+			ServiceKey: service,
+		})
+	if err != nil {
+		return c.createErrorResponse("unable to create new registry client")
+	}
+
+	// Validate whether the key exists.
+	key := strings.Replace(sc.Key, ".", "/", -1)
+	exists, err := serviceSpecificRegistryClient.ConfigurationValueExists(key)
+	switch {
+	case err != nil:
+		return c.createErrorResponse(err.Error())
+	case !exists:
+		return c.createErrorResponse("key does not exist")
+	default:
+		if err := serviceSpecificRegistryClient.PutConfigurationValue(key, []byte(sc.Value)); err != nil {
+			return c.createErrorResponse("unable to update key")
+		}
+
+		return responses.SetConfigResponse{
+			Success: true,
+		}
+	}
+}
+
+func (c setConf) createErrorResponse(description string) responses.SetConfigResponse {
+	c.loggingClient.Error(description)
+	return responses.SetConfigResponse{
+		Success:     false,
+		Description: description,
+	}
+}

--- a/internal/system/agent/setexecutor.go
+++ b/internal/system/agent/setexecutor.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	requests "github.com/edgexfoundry/go-mod-core-contracts/requests/configuration"
+	responses "github.com/edgexfoundry/go-mod-core-contracts/responses/configuration"
+)
+
+type setExecutor struct {
+	executor      interfaces.SetExecutor
+	loggingClient logger.LoggingClient
+	configuration *ConfigurationStruct
+}
+
+func NewSetExecutor(executor interfaces.SetExecutor,
+	loggingClient logger.LoggingClient,
+	configuration *ConfigurationStruct) *setExecutor {
+	return &setExecutor{
+		executor:      executor,
+		loggingClient: loggingClient,
+		configuration: configuration,
+	}
+}
+
+// Set provides the callout to the set config service executor.
+func (se setExecutor) Set(services []string, sc requests.SetConfigRequest) interface{} {
+	result := struct {
+		Configuration map[string]responses.SetConfigResponse `json:"configuration"`
+	}{
+		Configuration: map[string]responses.SetConfigResponse{},
+	}
+
+	// Loop over services and accumulate the response (i.e. "result") to return to requester.
+	for _, service := range services {
+		result.Configuration[service] = se.executor(service, sc)
+	}
+	return result
+}

--- a/internal/system/agent/setexecutor_stub.go
+++ b/internal/system/agent/setexecutor_stub.go
@@ -1,0 +1,36 @@
+package agent
+
+import (
+	requests "github.com/edgexfoundry/go-mod-core-contracts/requests/configuration"
+	responses "github.com/edgexfoundry/go-mod-core-contracts/responses/configuration"
+)
+
+type stubCallSet struct {
+	expectedArgsSet []string                    // expected arg value for specific executor call
+	outString       responses.SetConfigResponse // return value for specific executor call
+}
+
+type expectedArgsSet struct {
+	service string
+	sc      requests.SetConfigRequest
+}
+
+type StubSet struct {
+	Called         int               // number of times stub is called
+	capturedArgs   []expectedArgsSet // captures arg values for each stub call
+	perCallResults stubCallSet       // expected arg value and return values for each stub call
+}
+
+func NewStubSet(results stubCallSet) StubSet {
+	return StubSet{
+		perCallResults: results,
+	}
+}
+
+// This is a stub implementation of the SetExecutor interface.
+func (m *StubSet) SetExecutor(service string,
+	sc requests.SetConfigRequest) responses.SetConfigResponse {
+	m.Called++
+	m.capturedArgs = append(m.capturedArgs, expectedArgsSet{service, sc})
+	return m.perCallResults.outString
+}

--- a/internal/system/agent/setexecutor_test.go
+++ b/internal/system/agent/setexecutor_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	requests "github.com/edgexfoundry/go-mod-core-contracts/requests/configuration"
+	responses "github.com/edgexfoundry/go-mod-core-contracts/responses/configuration"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSetExecutorWithNoServices(t *testing.T) {
+
+	loggingClient := logger.NewMockClient()
+	executor := NewStubSet(stubCallSet{})
+	sut := NewSetExecutor(executor.SetExecutor, loggingClient, &ConfigurationStruct{})
+	sc := requests.SetConfigRequest{}
+	actual := sut.Set([]string{}, sc)
+
+	expectedResult := struct {
+		Configuration map[string]responses.SetConfigResponse "json:\"configuration\""
+	}(struct {
+		Configuration map[string]responses.SetConfigResponse "json:\"configuration\""
+	}{
+		Configuration: map[string]responses.SetConfigResponse{}})
+
+	assert.Equal(t, expectedResult, actual)
+	assert.Equal(t, executor.Called, 0)
+}
+
+func TestSetExecutorWithServices(t *testing.T) {
+
+	const (
+		service1Name = "service1Name"
+	)
+
+	service1ExpectedResult := struct {
+		Configuration map[string]responses.SetConfigResponse "json:\"configuration\""
+	}{Configuration: map[string]responses.SetConfigResponse{"service1Name": {Success: false, Description: ""}}}
+
+	loggingClient := logger.NewMockClient()
+	sc := requests.SetConfigRequest{Key: "Writable.LogLevel", Value: "INFO"}
+
+	tests := []struct {
+		name           string
+		services       []string
+		expectedResult struct {
+			Configuration map[string]responses.SetConfigResponse `json:"configuration"`
+		}
+		executorCalls stubCallSet
+	}{
+		{
+			"one service is the target of the set operation",
+			[]string{service1Name},
+			service1ExpectedResult,
+			stubCallSet{[]string{service1Name}, responses.SetConfigResponse{}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			executor := NewStubSet(test.executorCalls)
+			sut := NewSetExecutor(executor.SetExecutor, loggingClient, &ConfigurationStruct{})
+			actualResult := sut.Set(test.services, sc)
+			assert.Equal(t, test.expectedResult, actualResult)
+		})
+	}
+}


### PR DESCRIPTION
Fix #1432 
- For the `Fuji` release, the SMA will set configuration via Consul if EdgeX has been launched with the "--registry" flag (More details in the related issue).
> Here are some DEV test results:
- When accessing the SMA API (`http://localhost:48090/api/v1/config/edgex-support-notifications,edgex-core-data,edgex-core-command`) with the following body for the PUT operation...
```
    {
        "key": "Writable.LogLevel",
        "value": "INFO"
    }
```
...the response obtained is:
```
{
    "configuration": {
        "edgex-core-command": {
            "success": true
        },
        "edgex-core-data": {
            "success": true
        },
        "edgex-support-notifications": {
            "success": true
        }
    }
}
```
...and it was verified (via `Consul`) that the Registry was updated as expected (for the KVP for the requested services).
- When accessing the SMA API (`http://localhost:48090/api/v1/config/edgex-core-data,edgex-support-notifications`) with the GET operation, the response obtained is as expected:
```
{
    "configuration": {
        "edgex-core-data": {
            "Clients": {
                "Logging": {
                    "Host": "localhost",
                    "Port": 48061,
                    "Protocol": "http"
                },
                "Metadata": {
                    "Host": "localhost",
                    "Port": 48081,
                    "Protocol": "http"
                }
            },
            "Databases": {
                "Primary": {
...
...
        "edgex-support-notifications": {
            "Clients": {
                "Logging": {
                    "Host": "localhost",
                    "Port": 48061,
                    "Protocol": "http"
                }
            },
            "Databases": {
                "Primary": {
...
...
    }
}
```
- As a future task (to further improve the code), the advice received is to move these two factory methods (from `router.go`) up to `init.go` for execution at creation-time:  
1.  `NewGetExecutor()`
2.  `NewSetExecutor()`
- Another future task would be to extract the SMA `config functionality` into its own folder (This was attempted a couple of times but abandoned because of issue with cycles in import of packages).
- Finally, the creation of unit tests for `Get Config` (which is outside the scope of the current PR) should be undertaken in the future.