### PR TITLE
Removing dependency for a Device/Service List and use Configuration

### DIFF
--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -66,6 +66,7 @@ func main() {
 	startup.Bootstrap(params, proxy.Retry, logBeforeInit)
 
 	req := proxy.NewRequestor(insecureSkipVerify, proxy.Configuration.Writable.RequestTimeout)
+
 	s := proxy.NewService(req)
 
 	err := s.CheckProxyServiceStatus()
@@ -80,7 +81,7 @@ func main() {
 			os.Exit(1)
 		}
 		cert := proxy.NewCertificateLoader(req, proxy.Configuration.SecretService.CertPath, proxy.Configuration.SecretService.TokenPath)
-		err = s.Init(cert)
+		err = s.Init(cert) // Where the Service init is called
 		if err != nil {
 			proxy.LoggingClient.Error(err.Error())
 			os.Exit(1)

--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -91,12 +91,12 @@ SNIS = ["edgex-kong"]
   Host = "localhost"
   Port = 48085
 
-  [Clients.Rulesengine]
+  [Clients.RulesEngine]
   Protocol = "http"
   Host = "localhost"
   Port = 48075
 	
-  [Clients.Virtualdevice]
+  [Clients.VirtualDevice]
   Protocol = "http"
   Host = "localhost"
   Port = 49990

--- a/cmd/security-proxy-setup/res/docker/configuration.toml
+++ b/cmd/security-proxy-setup/res/docker/configuration.toml
@@ -91,12 +91,12 @@ SNIS = ["edgex-kong"]
   Host = "edgex-support-scheduler"
   Port = 48085
 
-  [Clients.Rulesengine]
+  [Clients.RulesEngine]
   Protocol = "http"
   Host = "edgex-support-rulesengine"
   Port = 48075
 
-  [Clients.Virtualdevice]
+  [Clients.VirtualDevice]
   Protocol = "http"
   Host = "edgex-device-virtual"
   Port = 49990


### PR DESCRIPTION
Fix #1662

- Modified the security-proxy-setup configuration.toml file(s) docker and local
- Removed the use of the go-mod-core-contracts use of the ServiceList "statically defined"
- Removed the use of the ClientInfo struct and included the new ServiceInfo struct "now featured in the toml config"
- Modified the security/proxy/service.go init func simplifying the KongRoute(s) creational process
- Updated any required helper func(s) as required for the change from ClientInfo to ServiceInfo

Signed-off-by: xmlviking <ecotter@gmail.com>