### PR TITLE
fix issue #1651: fixed typo for insecureskipverify; set the default value as false

### DIFF
--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -59,7 +59,7 @@ func main() {
 	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
 	startup.Bootstrap(params, proxy.Retry, logBeforeInit)
 
-	req := proxy.NewRequestor(insecureskipverify, proxy.Configuration.Writable.RequestTimeout)
+	req := proxy.NewRequestor(insecureSkipVerify, proxy.Configuration.Writable.RequestTimeout)
 	s := proxy.NewService(req)
 
 	err := s.CheckProxyServiceStatus()

--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -34,7 +34,7 @@ func main() {
 		usage.HelpCallbackSecurityProxy()
 	}
 	var initNeeded bool
-	var insecureskipverify bool
+	var insecureSkipVerify bool
 	var resetNeeded bool
 	var useProfile string
 	var userTobeCreated string
@@ -42,7 +42,7 @@ func main() {
 	var userToBeDeleted string
 	var useRegistry bool
 
-	flag.BoolVar(&insecureskipverify, "insureskipverify", false, "skip server side SSL verification, mainly for self-signed cert")
+	flag.BoolVar(&insecureSkipVerify, "insecureSkipVerify", false, "skip server side SSL verification, mainly for self-signed cert")
 	flag.BoolVar(&initNeeded, "init", false, "run init procedure for security service.")
 	flag.BoolVar(&resetNeeded, "reset", false, "reset reverse proxy by removing all services/routes/consumers")
 	flag.StringVar(&userTobeCreated, "useradd", "", "user that needs to be added to consume the edgex services")

--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -34,7 +34,7 @@ func main() {
 		usage.HelpCallbackSecurityProxy()
 	}
 	var initNeeded bool
-	var ensureSkipVerify bool
+	var insecureskipverify bool
 	var resetNeeded bool
 	var useProfile string
 	var userTobeCreated string
@@ -42,7 +42,7 @@ func main() {
 	var userToBeDeleted string
 	var useRegistry bool
 
-	flag.BoolVar(&ensureSkipVerify, "insureskipverify", true, "skip server side SSL verification, mainly for self-signed cert")
+	flag.BoolVar(&insecureskipverify, "insureskipverify", false, "skip server side SSL verification, mainly for self-signed cert")
 	flag.BoolVar(&initNeeded, "init", false, "run init procedure for security service.")
 	flag.BoolVar(&resetNeeded, "reset", false, "reset reverse proxy by removing all services/routes/consumers")
 	flag.StringVar(&userTobeCreated, "useradd", "", "user that needs to be added to consume the edgex services")
@@ -59,7 +59,7 @@ func main() {
 	params := startup.BootParams{UseRegistry: useRegistry, UseProfile: useProfile, BootTimeout: internal.BootTimeoutDefault}
 	startup.Bootstrap(params, proxy.Retry, logBeforeInit)
 
-	req := proxy.NewRequestor(ensureSkipVerify, proxy.Configuration.Writable.RequestTimeout)
+	req := proxy.NewRequestor(insecureskipverify, proxy.Configuration.Writable.RequestTimeout)
 	s := proxy.NewService(req)
 
 	err := s.CheckProxyServiceStatus()

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -55,7 +55,7 @@ Usage: %s [options]
 Server Options:	
     -p, --profile <name>            Indicate configuration profile other than default
     -r, --registry                  Indicates service should use Registry
-	--insureskipverify=true/false   Indicates if skipping the server side SSL cert verifcation, similar to -k of curl
+	--insecureskipverify=true/false   Indicates if skipping the server side SSL cert verifcation, similar to -k of curl
 	--init=true/false               Indicates if security service should be initialized
 	--reset=true/false              Indicate if security service should be reset to initialization status
 	--useradd=<username>            Create an account and return JWT

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -55,7 +55,7 @@ Usage: %s [options]
 Server Options:	
     -p, --profile <name>            Indicate configuration profile other than default
     -r, --registry                  Indicates service should use Registry
-	--insecureskipverify=true/false   Indicates if skipping the server side SSL cert verification, similar to -k of curl
+	--insecureSkipVerify=true/false   Indicates if skipping the server side SSL cert verification, similar to -k of curl
 	--init=true/false               Indicates if security service should be initialized
 	--reset=true/false              Indicate if security service should be reset to initialization status
 	--useradd=<username>            Create an account and return JWT

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -55,7 +55,7 @@ Usage: %s [options]
 Server Options:	
     -p, --profile <name>            Indicate configuration profile other than default
     -r, --registry                  Indicates service should use Registry
-	--insecureskipverify=true/false   Indicates if skipping the server side SSL cert verifcation, similar to -k of curl
+	--insecureskipverify=true/false   Indicates if skipping the server side SSL cert verification, similar to -k of curl
 	--init=true/false               Indicates if security service should be initialized
 	--reset=true/false              Indicate if security service should be reset to initialization status
 	--useradd=<username>            Create an account and return JWT


### PR DESCRIPTION
Fix #1651 

correct the typo for insecureskipverify in the security-proxy-setup project, and set the default value as false.

Signed-off-by: Tingyu Zeng <tingyu.zeng@rsa.com>