### PR TITLE
Convert API doc from RAML to OAS3

### DIFF
--- a/api/oas3.0/core-command.yaml
+++ b/api/oas3.0/core-command.yaml
@@ -1,0 +1,384 @@
+openapi: 3.0.0
+info:
+  title: core-command
+  version: 1.1.x-oas3
+servers:
+- url: http://localhost:48082/api
+paths:
+  /v1/config:
+    get:
+      description: Fetch the current state of the service's configuration.
+      responses:
+        200:
+          description: The service's configuration as JSON document
+  /v1/device:
+    get:
+      description: Retrieve a list of (all) devices and their command offerings. Throws
+        ServiceException (HTTP 500) for unanticipated or unknown issues encountered.
+      responses:
+        200:
+          description: List of CommandResponse (containing the devices and their commands)
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/commandresponse'
+        500:
+          description: for unanticipated or unknown issues encountered.
+  /v1/device/name/{name}:
+    get:
+      description: Retrieve a device (by name) and its command offerings. Throws ServiceException
+        (HTTP 500) for unanticipated or unknown issues encountered. Throws NotFoundException
+        (HTTP 404) if no device exists by the name provided.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: CommandResponse containing the device and its commands
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/commandresponse'
+        404:
+          description: if no device exists by the name provided.
+        500:
+          description: for unanticipated or unknown issues encountered.
+  /v1/device/name/{name}/command/{commandname}:
+    get:
+      description: Issue the get command referenced by the command name to the device/sensor
+        (also referenced by name). It is associated to via the device service. ServiceException
+        (HTTP 500) for unanticipated or unknown issues encountered. Throws NotFoundException
+        (HTTP 404) if device with given name does not exist or device doesn't have
+        command with the given commandname. Throws LockedException (HTTP 423) if device
+        adminState is locked.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: commandname
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: String as returned by the device/sensor via the device service.
+        400:
+          description: if the request is malformed or unparsable
+        404:
+          description: if device with given name does not exist or device doesn't
+            have command with the given commandname.
+        423:
+          description: if the device is locked (admin state).
+        500:
+          description: for unanticipated or unknown issues encountered.
+    put:
+      description: Issue the put command referenced by the command name to the device/sensor
+        (also referenced by name) it is associated to via the device service. ServiceException
+        (HTTP 500) for unanticipated or unknown issues encountered. Throws NotFoundException
+        (HTTP 404) if device with given name does not exist or device doesn't have
+        command with the given commandname. Throws LockedException (HTTP 423) if device
+        adminState is locked.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: commandname
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/setting'
+      responses:
+        200:
+          description: String as returned by the device/sensor via the device service.
+        400:
+          description: if the request is malformed or unparsable
+        404:
+          description: if device with given name does not exist or device doesn't
+            have a command with the given commandname.
+        423:
+          description: if the device is locked (admin state)
+        500:
+          description: for unanticipated or unknown issues encountered
+  /v1/device/{id}:
+    get:
+      description: Retrieve a device (by database generated id) and its command offerings.
+        Throws ServiceException (HTTP 500) for unanticipated or unknown issues encountered.
+        Throws NotFoundException (HTTP 404) if no device exists by the id provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: CommandResponse containing the device and its commands
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/commandresponse'
+        404:
+          description: if no device exists by the id provided.
+        500:
+          description: for unanticipated or unknown issues encountered.
+  /v1/device/{id}/command/{commandid}:
+    get:
+      description: Issue the get command referenced by the command id to the device/sensor
+        (also referenced by database generated id) it is associated to via the device
+        service. ServiceException (HTTP 500) for unanticipated or unknown issues encountered.
+        Throws NotFoundException (HTTP 404) if no device exists by the id provided.
+        Throws LockedException (HTTP 423) if the device is locked (admin state).
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: commandid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: String as returned by the device/sensor via the device service.
+        400:
+          description: if the request is malformed or unparsable
+        404:
+          description: if no device exists by the id provided
+        423:
+          description: if the device is locked (admin state).
+        500:
+          description: for unanticipated or unknown issues encountered.
+    put:
+      description: Issue the put command referenced by the command id to the device/sensor
+        (also referenced by database generated id) it is associated to via the device
+        service. ServiceException (HTTP 500) for unanticipated or unknown issues encountered.
+        Throws NotFoundException (HTTP 404) if no device exists by the id provided.
+        Throws LockedException (HTTP 423) if the device is locked (admin state).
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: commandid
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/setting'
+      responses:
+        200:
+          description: String as returned by the device/sensor via the device service.
+        400:
+          description: if the request is malformed or unparsable
+        404:
+          description: if no device exists by the id provided
+        423:
+          description: if the device is locked (admin state)
+        500:
+          description: for unanticipated or unknown issues encountered.
+  /v1/metrics:
+    get:
+      description: Fetch the current state of the service's metrics.
+      responses:
+        200:
+          description: The service's metrics as JSON document
+  /v1/ping:
+    get:
+      description: Test service providing an indication that the service is available.
+      responses:
+        200:
+          description: pong as a string
+        500:
+          description: for unanticipated or unknown issues encountered.
+  /version:
+    get:
+      description: Get the API version
+      responses:
+        200:
+          description: The service's API version as JSON document
+components:
+  schemas:
+    addressable:
+      title: addressable
+      type: object
+      properties:
+        address:
+          title: address
+          type: string
+        created:
+          title: created
+          type: integer
+        id:
+          title: id
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        password:
+          title: password
+          type: string
+        path:
+          title: path
+          type: string
+        port:
+          title: port
+          type: integer
+        protocol:
+          title: protocol
+          type: string
+        publisher:
+          title: publisher
+          type: string
+        topic:
+          title: topic
+          type: string
+        user:
+          title: user
+          type: string
+    commandresponse:
+      title: commandresponse
+      type: object
+      properties:
+        host:
+          title: host
+          type: string
+        device:
+          $ref: '#/components/schemas/device'
+    device:
+      title: device
+      type: object
+      properties:
+        addressable:
+          $ref: '#/components/schemas/device_addressable'
+        adminState:
+          title: adminState
+          type: string
+        created:
+          title: created
+          type: integer
+        description:
+          title: description
+          type: string
+        id:
+          title: id
+          type: string
+        labels:
+          title: labels
+          uniqueItems: false
+          type: array
+          items:
+            title: labels
+            type: string
+        lastConnected:
+          title: lastConnected
+          type: integer
+        lastReported:
+          title: lastReported
+          type: integer
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        operatingState:
+          title: operatingState
+          type: string
+        origin:
+          title: origin
+          type: integer
+      description: device or sensor supplying data and taking actuation commands
+    setting:
+      title: setting
+      type: object
+      additionalProperties:
+        type: string
+    device_addressable:
+      type: object
+      properties:
+        address:
+          title: address
+          type: string
+        created:
+          title: created
+          type: integer
+        id:
+          title: id
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        password:
+          title: password
+          type: string
+        path:
+          title: path
+          type: string
+        port:
+          title: port
+          type: integer
+        protocol:
+          title: protocol
+          type: string
+        publisher:
+          title: publisher
+          type: string
+        topic:
+          title: topic
+          type: string
+        user:
+          title: user
+          type: string
+  requestBodies:
+    setting:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/setting'
+      required: true

--- a/api/oas3.0/core-data.yaml
+++ b/api/oas3.0/core-data.yaml
@@ -1,0 +1,1136 @@
+openapi: 3.0.0
+info:
+  title: core-data
+  version: 1.1.x-oas3
+servers:
+- url: http://localhost:48080/api
+paths:
+  /v1/config:
+    get:
+      description: Fetch the current state of the service's configuration.
+      responses:
+        200:
+          description: The service's configuration as JSON document
+  /v1/event:
+    get:
+      description: Fetch all events with their associated readings. LimitExceededException
+        (HTTP 413) if the number of events exceeds the current max limit. ServiceException
+        (HTTP 500) for unknown or unanticipated issues.
+      responses:
+        200:
+          description: list of events
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/event'
+        413:
+          description: if the number of events exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues.
+    put:
+      description: Update the event data (not including updating the readings). NotFoundException
+        (HTTP 404) if the event cannot be found by id. ServiceException (HTTP 500)
+        for unknown or unanticipated issues.
+      requestBody:
+        $ref: '#/components/requestBodies/event'
+      responses:
+        200:
+          description: boolean on success of update request
+        400:
+          description: update request is invalid
+        404:
+          description: if the event cannot be found by id.
+        500:
+          description: for unknown or unanticipated issues.
+    post:
+      description: Add a new event (with its associated readings). Prefers the event
+        device is a device name but can also be a device id (database generated).
+        DataValidationException (HTTP 409) if the a reading is associated to a non-existent
+        value descriptor. ServiceException (HTTP 500) for unknown or unanticipated
+        issues.
+      requestBody:
+        $ref: '#/components/requestBodies/event'
+      responses:
+        200:
+          description: new event database generated id
+        400:
+          description: creation request is invalid
+        404:
+          description: if the a reading is associated to a non-existent value descriptor,
+            or if device verification is enabled and the device is not found.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/checksum/{checksum}:
+    put:
+      description: Update an existing event's pushed time
+      parameters:
+      - name: checksum
+        in: path
+        description: checksum value of the event provided by core-data via the message
+          bus
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: success no body returned
+        404:
+          description: if the event cannot be found by checksum.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/count:
+    get:
+      description: Return a count of the number of events in core data.  ServiceException
+        (HTTP 500) for unknown or unanticipated issues..
+      responses:
+        200:
+          description: number of events in the collection
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/count/{deviceId}:
+    get:
+      description: Return a count of the number of events in core data for a given
+        device - identified by id or name.  InternalServerError (HTTP 500) for unknown
+        or unanticipated issues..
+      parameters:
+      - name: deviceId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: number of events for the device
+        400:
+          description: query request is invalid
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/device/{deviceId}:
+    delete:
+      description: Delete all events (and their readings) associated to a device given
+        the device's id (either database generated id or name). ServiceException (HTTP
+        500) for unknown or unanticipated issues.   NotFoundException (HTTP 404) if
+        the meta data checks are on and no device is found for supplied id.
+      parameters:
+      - name: deviceId
+        in: path
+        description: the id (database generated id) or name of the device associated
+          to events
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: count of the number of events deleted
+        400:
+          description: could not unescape URL
+        404:
+          description: if the meta data checks are on and no device is found for supplied
+            id.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/device/{deviceId}/{limit}:
+    get:
+      description: 'Return list of events with their associated readings for a given
+        device, sorted by event modified date.  Newest events are at the top of list.  May
+        be an empty list if none are associated to the device.  Note: does not yet
+        handle device managers. LimitExceededException (HTTP 413) if the number of
+        events exceeds the current max limit. ServiceException (HTTP 500) for unknown
+        or unanticipated issues.  NotFoundException (HTTP 404) if the meta data checks
+        are on and no device is found for supplied id.'
+      parameters:
+      - name: limit
+        in: path
+        description: maximum number of events to fetch, must be < max limit
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: deviceId
+        in: path
+        description: the id (database generated id) or name of the device associated
+          to events
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of events associated to the matching device by id - limited
+            in size by the limit parameter
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/event'
+        400:
+          description: request is invalid or unparseable
+        404:
+          description: if the meta data checks are on and no device is found for supplied
+            id.
+        413:
+          description: if the number of events exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/id/{id}:
+    put:
+      description: Update the event to be pushed (out of EdgeX to an enterprise or
+        cloud system) by setting the pushed timestamp to the current time. NotFoundException
+        (HTTP 404) if the event cannot be found by id. ServiceException (HTTP 500)
+        for unknown or unanticipated issues.
+      parameters:
+      - name: id
+        in: path
+        description: database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean on success of update request
+        404:
+          description: if the event cannot be found by id
+        500:
+          description: for unknown or unanticipated issues.
+    delete:
+      description: Delete an event and all its readings given its database generated
+        id. NotFoundException (HTTP 404) if the event cannot be found by id. ServiceException
+        (HTTP 500) for unknown or unanticipated issues.
+      parameters:
+      - name: id
+        in: path
+        description: database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean on success of deletion request
+        404:
+          description: if the event cannot be found by id.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/removeold/age/{age}:
+    delete:
+      description: Remove all old events (and associated readings) based on delimiting
+        age.  ServiceException (HTTP 500) for unknown or unanticipated issues.  Should
+        only be used by the scrubber micro service
+      parameters:
+      - name: age
+        in: path
+        description: minimum age in milliseconds (from created timestamp) an event
+          should be in order to be removed
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      responses:
+        200:
+          description: count of the number of events removed
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/scrub:
+    delete:
+      description: Remove all pushed events and their associated readings.ServiceException
+        (HTTP 500) for unknown or unanticipated issues.  Should only be used by the
+        scrubber micro service
+      responses:
+        200:
+          description: count of the number of events scrubbed
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/{id}:
+    get:
+      description: 'Fetch a specific event by database specified id - returning null
+        if none are found. Note: does not yet handle device managers. ServiceException
+        (HTTP 500) for unknown or unanticipated issues'
+      parameters:
+      - name: id
+        in: path
+        description: database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: event
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/event'
+        404:
+          description: if the event cannot be found by id.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/event/{start}/{end}/{limit}:
+    get:
+      description: Return all events between a given begin and end date/time (in the
+        form of longs) sorted by event modified date.  Newest events are at the top
+        of list. LimitExceededException (HTTP 413) if the number of events exceeds
+        the current max limit. ServiceException (HTTP 500) for unknown or unanticipated
+        issues.
+      parameters:
+      - name: limit
+        in: path
+        description: maximum number of events to fetch, must be < max limit
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      responses:
+        200:
+          description: list of events between the specified dates
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/event'
+        400:
+          description: request is invalid or unparseable
+        413:
+          description: if the number of events exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/ping:
+    get:
+      description: Test service providing an indication that the service is available.
+      responses:
+        200:
+          description: return value of "pong"
+        503:
+          description: for unknown or unanticipated issues
+  /v1/reading:
+    get:
+      description: Return list of all readings. Sorts by reading id. LimitExceededException
+        (HTTP 413) if the number of readings exceeds the current max limit. ServiceException
+        (HTTP 500) for unknown or unanticipated issues.
+      responses:
+        200:
+          description: list of all readings
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/reading'
+        413:
+          description: if the number of readings exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues
+    put:
+      description: Update the reading.  Reading object needs to contain the database
+        generated id of the existing reading. NotFoundException (HTTP 404) if the
+        reading cannot be found by id. ServiceException (HTTP 500) for unknown or
+        unanticipated issues. DataValidationException if the associated value descriptor
+        is non-existent.
+      requestBody:
+        $ref: '#/components/requestBodies/reading'
+      responses:
+        200:
+          description: boolean indicating success of the update operation
+        400:
+          description: request is invalid or unparseable
+        404:
+          description: if the reading cannot be found by id
+        409:
+          description: if the associated value descriptor is non-existent.
+        500:
+          description: for unknown or unanticipated issues
+    post:
+      description: Add a new reading. ServiceException (HTTP 500) for unknown or unanticipated
+        issues. DataValidationException (HTTP 409) if the associated value descriptor
+        is non-existent.
+      requestBody:
+        $ref: '#/components/requestBodies/reading'
+      responses:
+        200:
+          description: String id (database id) of the new Reading
+        400:
+          description: request is invalid or unparseable
+        409:
+          description: if the associated value descriptor is non-existent
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/reading/count:
+    get:
+      description: Return a count of the number of readings in core dataServiceException
+        (HTTP 500) for unknown or unanticipated issues..
+      responses:
+        200:
+          description: number of readings in the collection
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/reading/device/{deviceId}/{limit}:
+    get:
+      description: 'Return list of all readings for a given device, sorted by the
+        readings modified date.  Newest readings are at the top of list.  Note: does
+        not yet handle device managers. LimitExceededException (HTTP 413) if the number
+        of readings exceeds the current max limit. ServiceException (HTTP 500) for
+        unknown or unanticipated issues. NotFoundException (HTTP 404) if meta checks
+        are in place and if the device id or name does not match any existing devices.'
+      parameters:
+      - name: limit
+        in: path
+        description: maximum number of readings requested (not to exceed max limit)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: deviceId
+        in: path
+        description: device database generated id or device name
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of readings for a device, could be an empty list if none
+            match
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/reading'
+        400:
+          description: request is invalid or unparseable
+        404:
+          description: if meta checks are in place and if the device id or name does
+            not match any existing devices
+        413:
+          description: if the number of readings exceeds the current max limit.
+        500:
+          description: or unknown or unanticipated issues
+  /v1/reading/id/{id}:
+    delete:
+      description: Delete the reading from persistent storage. NotFoundException (HTTP
+        404) if the reading cannot be found by id. ServiceException (HTTP 500) for
+        unknown or unanticipated issues.
+      parameters:
+      - name: id
+        in: path
+        description: database generated id of the reading to be deleted
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the delete operation
+        404:
+          description: if the reading cannot be found by id
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/reading/label/{label}/{limit}:
+    get:
+      description: Return a list of readings with an associated value descriptor of
+        the label specified, sorted by the readings modified date.  Newest readings
+        are at the top of list. LimitExceededException (HTTP 413) if the number of
+        readings exceeds the current max limit. ServiceException (HTTP 500) for unknown
+        or unanticipated issues.
+      parameters:
+      - name: limit
+        in: path
+        description: maximum number of readings to return (must not exceed max limit)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: label
+        in: path
+        description: label that should be in matching Value Descriptor's label array
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of matching readings having value descriptor with the
+            associated label. Could be an empty list if none match.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/reading'
+        400:
+          description: request is invalid or unparseable
+        413:
+          description: if the number of readings exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/reading/name/{name}/device/{device}/{limit}:
+    get:
+      description: Return a list of readings that are associated to a ValueDescripter
+        by name and Device by name (or id), sorted by the readings modified date.  Newest
+        readings are at the top of list.  LimitExceededException (HTTP 413) if the
+        number of readings exceeds the current max limit. ServiceException (HTTP 500)
+        for unknown or unanticipated issues.
+      parameters:
+      - name: limit
+        in: path
+        description: maximum number of readings to return (must not exceed max limit)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: name
+        in: path
+        description: name of the matching ValueDescriptor
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: device
+        in: path
+        description: name or id of the matching device (as the device is represented
+          in the associated event)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of readings matching on the value descriptor name and
+            device name (or id)
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/reading'
+        400:
+          description: request is invalid or unparseable
+        413:
+          description: if the number of readings exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/reading/name/{name}/{limit}:
+    get:
+      description: Return a list of readings that are associated to a ValueDescripter
+        by name, sorted by the readings modified date.  Newest readings are at the
+        top of list.  LimitExceededException (HTTP 413) if the number of readings
+        exceeds the current max limit. ServiceException (HTTP 500) for unknown or
+        unanticipated issues.
+      parameters:
+      - name: limit
+        in: path
+        description: maximum number of readings to return (must not exceed max limit)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: name
+        in: path
+        description: name of the matching ValueDescriptor
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of readings matching on the value descriptor name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/reading'
+        400:
+          description: request is invalid or unparseable
+        413:
+          description: if the number of readings exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/reading/type/{type}/{limit}:
+    get:
+      description: Return a list of readings with an associated value descriptor of
+        the type (IoTType) specified, sorted by the readings modified date.  Newest
+        readings are at the top of list. LimitExceededException (HTTP 413) if the
+        number of readings exceeds the current max limit. ServiceException (HTTP 500)
+        for unknown or unanticipated issues.
+      parameters:
+      - name: limit
+        in: path
+        description: maximum number of readings to be allowed to be returned
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: type
+        in: path
+        description: an IoTType in string form (one of I, B, F, S for integer, Boolean,
+          Floating point or String)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of matching readings having value descriptor of the types
+            specified. Could be an empty list if none match.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/reading'
+        400:
+          description: request is invalid or unparseable
+        413:
+          description: if the number of readings exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/reading/uomlabel/{uomLabel}/{limit}:
+    get:
+      description: Return a list of readings with an associated value descriptor of
+        the UoM label specified, sorted by the readings modified date.  Newest readings
+        are at the top of list. LimitExceededException (HTTP 413) if the number of
+        readings exceeds the current max limit. ServiceException (HTTP 500) for unknown
+        or unanticipated issues.
+      parameters:
+      - name: limit
+        in: path
+        description: exceed max limit)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: uomLabel
+        in: path
+        description: Unit of Measure label (UoMLabel) matching the ValueDescriptor
+          associated to the reading
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of matching readings having value descriptor with UoM
+            label specified
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/reading'
+        400:
+          description: request is invalid or unparseable
+        413:
+          description: if the number of readings exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/reading/{id}:
+    get:
+      description: Retrieve a reading by its database generated id.  NotFoundException
+        (HTTP 404) if reading not found by id.  ServiceException (HTTP 500) for unknown
+        or unanticipated issues
+      parameters:
+      - name: id
+        in: path
+        description: reading database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Reading
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/reading'
+        404:
+          description: if the reading cannot be found by id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/reading/{start}/{end}/{limit}:
+    get:
+      description: Return a list of readings between two timestamps - limited by the
+        number specified in the limit parameter, sorted by the readings modified date.  Newest
+        readings are at the top of list. LimitExceededException (HTTP 413) if the
+        number of readings exceeds the current max limit. ServiceException (HTTP 500)
+        for unknown or unanticipated issues.
+      parameters:
+      - name: limit
+        in: path
+        description: maximum number of readings to be allowed to be returned
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: start
+        in: path
+        description: millisecond (long) timestamp of the beginning of the time
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      - name: end
+        in: path
+        description: millisecond (long) timestamp of the end of the time rage
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: integer
+      responses:
+        200:
+          description: list of matching readings in this range (limited by the limit
+            parameter)
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/reading'
+        400:
+          description: request is invalid or unparseable
+        413:
+          description: if the number of readings exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/valuedescriptor:
+    get:
+      description: Return all ValueDescriptor objects. LimitExceededException (HTTP
+        413) if the number of value descriptors exceeds the current max limit. ServiceException
+        (HTTP 500) for unknown or unanticipated issues.
+      responses:
+        200:
+          description: list of ValueDescriptors
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/valueDescriptor'
+        413:
+          description: if the number of value descriptors exceeds the current max
+            limit
+        500:
+          description: for unknown or unanticipated issues.
+    put:
+      description: Update the ValueDescriptor identified by the id or name in the
+        object provided. Id is used first, name is used second for identification
+        purposes. ServiceException (HTTP 500) for unknown or unanticipated issues.
+        DataValidationException (HTTP 409) if the a formatting string of the value
+        descriptor is not a valid printf format. NotFoundException (404) if the value
+        descriptor cannot be located by the identifier.
+      requestBody:
+        $ref: '#/components/requestBodies/valueDescriptor'
+      responses:
+        200:
+          description: boolean indicating success of the update
+        400:
+          description: request is invalid or unparseable
+        404:
+          description: if the value descriptor cannot be located by the identifier.
+        500:
+          description: for unknown or unanticipated issues
+    post:
+      description: Add a new ValueDescriptor whose name must be unique. ServiceException
+        (HTTP 500) for unknown or unanticipated issues. DataValidationException (HTTP
+        409) if the a formatting string of the value descriptor is not a valid printf
+        format.
+      requestBody:
+        $ref: '#/components/requestBodies/valueDescriptor'
+      responses:
+        200:
+          description: database generated id of the new ValueDescriptor
+        400:
+          description: request is invalid or unparseable
+        409:
+          description: if the a formatting string of the value descriptor is not a
+            valid printf format or if the name is determined to not be unique with
+            regard to other value descriptors.
+        500:
+          description: for unknown or unanticipated issues
+  /v1/valuedescriptor/deviceid/{id}:
+    get:
+      description: Fetch all ValueDescriptors that are associated to a Device's command
+        set as either a put command parameter name or get/put response expected value.  NotFoundException
+        (HTTP 404) if the Device cannot be found by name.  ServiceException (HTTP
+        500) for unknown or unanticipated issues
+      parameters:
+      - name: id
+        in: path
+        description: database generated id of the device
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of ValueDescriptors
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/valueDescriptor'
+        400:
+          description: if the request is malformed or unparsable
+        404:
+          description: if the device cannot be found by the id provided
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/valuedescriptor/devicename/{name}:
+    get:
+      description: Fetch all ValueDescriptors that are associated to a Device's command
+        set as either a put command parameter name or get/put response expected value.  NotFoundException
+        (HTTP 404) if the Device cannot be found by name.  ServiceException (HTTP
+        500) for unknown or unanticipated issues
+      parameters:
+      - name: name
+        in: path
+        description: unique name of the device
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of ValueDescriptors
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/valueDescriptor'
+        400:
+          description: if the request is malformed or unparsable
+        404:
+          description: if the device cannot be found by the name provided
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/valuedescriptor/id/{id}:
+    delete:
+      description: Remove the ValueDescriptor designated by database generated identifier.
+        ServiceException (HTTP 500) for unknown or unanticipated issues. DataValidationException
+        (HTTP 409) if the value descriptor is still referenced in Readings. NotFoundException
+        (404) if the value descriptor cannot be located by the identifier.
+      parameters:
+      - name: id
+        in: path
+        description: Value descriptor database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: id is invalid or unparseable
+        404:
+          description: if the value descriptor cannot be located by the identifier.
+        409:
+          description: if the value descriptor is still referenced in Readings
+        500:
+          description: for unknown or unanticipated issues
+  /v1/valuedescriptor/label/{label}:
+    get:
+      description: Return ValueDescriptor objects with given label. ServiceException
+        (HTTP 500) for unknown or unanticipated issues.
+      parameters:
+      - name: label
+        in: path
+        description: tag or label
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of ValueDescriptor matching UoM Label
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/valueDescriptor'
+        400:
+          description: request is invalid or unparseable
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/valuedescriptor/name/{name}:
+    get:
+      description: Return ValueDescriptor object with given name. Could be null if
+        no value descriptors found by the name (name is unique across all value descriptors).  NotFoundException
+        (HTTP 404) if the value descriptor cannont be found by nmee.  ServiceException
+        (HTTP 500) for unknown or unanticipated issues.
+      parameters:
+      - name: name
+        in: path
+        description: Unique name of the value descriptor
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: ValueDescriptor having the provided name, could be null if
+            none are found.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/valueDescriptor'
+        400:
+          description: request is invalid or unparseable
+        404:
+          description: if the value descriptor cannot be located by the name
+        500:
+          description: for unknown or unanticipated issues.
+    delete:
+      description: Remove the ValueDescriptor designated by name. ServiceException
+        (HTTP 500) for unknown or unanticipated issues. DataValidationException (HTTP
+        409) if the value descriptor is still referenced in Readings. NotFoundException
+        (404) if the value descriptor cannot be located by the identifier.
+      parameters:
+      - name: name
+        in: path
+        description: Unique name of the value descriptor
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: request is invalid or unparseable
+        404:
+          description: if the value descriptor cannot be located by the identifier
+        409:
+          description: if the value descriptor is still referenced in Readings
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/valuedescriptor/uomlabel/{uomLabel}:
+    get:
+      description: Return ValueDescriptor objects with given UoM label. ServiceException
+        (HTTP 500) for unknown or unanticipated issues.
+      parameters:
+      - name: uomLabel
+        in: path
+        description: unit of measure
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of ValueDescriptor matching UoM Label
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/valueDescriptor'
+        400:
+          description: request is invalid or unparseable
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/valuedescriptor/usage:
+    get:
+      description: Get a list of value descripors and usage state. True if the value
+        descriptor is in use and should not be modified. Otherwise, false.
+      parameters:
+      - name: names
+        in: query
+        description: A comma separated list of value descriptor names for which to
+          perform the usage check.
+        required: true
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of ValueDescriptors and thier current usage state
+        400:
+          description: Malformed query parameters
+        413:
+          description: the maximum number of results has been exceeded
+        500:
+          description: for unknown or unanticipated issues
+  /v1/valuedescriptor/{id}:
+    get:
+      description: Fetch a specific ValueDescriptor by its database generated id.  NotFoundException
+        (HTTP 404) if the value descriptor cannot be found by id.  ServiceException
+        (HTTP 500) for unknown or unanticipated issues
+      parameters:
+      - name: id
+        in: path
+        description: database generated id for the value descriptor
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: ValueDescriptor
+        404:
+          description: if the value descriptor cannot be located by the identifier
+        500:
+          description: for unknown or unanticipated issues
+  /version:
+    get:
+      description: Get the API version
+      responses:
+        200:
+          description: The service's API version as JSON document
+components:
+  schemas:
+    event:
+      title: event
+      type: object
+      properties:
+        created:
+          title: created
+          type: integer
+        device:
+          title: device
+          type: string
+        id:
+          title: id
+          type: string
+        modified:
+          title: modified
+          type: integer
+        origin:
+          title: origin
+          type: integer
+        pushed:
+          title: pushed
+          type: integer
+        readings:
+          title: readings
+          uniqueItems: false
+          type: array
+          items:
+            $ref: '#/components/schemas/reading'
+      description: Core device/sensor event
+    reading:
+      title: reading
+      type: object
+      properties:
+        created:
+          title: created
+          type: integer
+        id:
+          title: id
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        pushed:
+          title: pushed
+          type: integer
+        value:
+          title: value
+          type: string
+      description: Core device/sensor reading
+    valueDescriptor:
+      title: valueDescriptor
+      type: object
+      properties:
+        created:
+          title: created
+          type: integer
+        defaultValue:
+          title: defaultValue
+          type: string
+        description:
+          title: description
+          type: string
+        formatting:
+          title: formatting
+          type: string
+        id:
+          title: id
+          type: string
+        labels:
+          title: labels
+          uniqueItems: false
+          type: array
+          items:
+            title: labels
+            type: string
+        max:
+          title: max
+          type: string
+        min:
+          title: min
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        type:
+          title: type
+          type: string
+        uomLabel:
+          title: uomLabel
+          type: string
+      description: Core and MetaData value descriptor - describes device/sensor data
+        sent and received
+  requestBodies:
+    event:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/event'
+      required: true
+    reading:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/reading'
+      required: true
+    valueDescriptor:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/valueDescriptor'
+      required: true

--- a/api/oas3.0/core-metadata.yaml
+++ b/api/oas3.0/core-metadata.yaml
@@ -1,0 +1,2638 @@
+openapi: 3.0.0
+info:
+  title: core-metadata
+  version: 1.1.x-oas3
+servers:
+- url: http://localhost:48081/api
+paths:
+  /v1/addressable:
+    get:
+      description: Return all addressable objects sorted by database generated id.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        Returns LimitExceededException (HTTP 413) if the number returned exceeds the
+        max limit.
+      responses:
+        200:
+          description: list of addressable
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/addressable'
+        413:
+          description: if the number returned exceeds the max limit.
+        500:
+          description: for unknown or unanticipated issues.
+    put:
+      description: Update the Addressable identified by the id or name in the object
+        provided. Id is used first, name is used second for identification purposes.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        Returns NotFoundException (HTTP 404) if no addressable with the provided id
+        is found.
+      requestBody:
+        $ref: '#/components/requestBodies/addressable'
+      responses:
+        200:
+          description: boolean indicating success of the update
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no addressable with the provided id is found.
+        409:
+          description: if the addressable is currently in use
+        500:
+          description: for unknown or unanticipated issues or for any duplicate name
+            (key) error.
+    post:
+      description: Add a new Addressable - name must be unique. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues.
+      requestBody:
+        $ref: '#/components/requestBodies/addressable'
+      responses:
+        200:
+          description: new database generated id for the new Addressable
+        400:
+          description: for malformed or unparsable requests
+        409:
+          description: if the name is determined to not be unique with regard to others
+        500:
+          description: for unknown or unanticipated issues or for any duplicate name
+            (key) error.
+  /v1/addressable/address/{address}:
+    get:
+      description: Return Addressable objects with given address. List may be empty
+        if none are associated to the address. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues.
+      parameters:
+      - name: address
+        in: path
+        description: address (as in URL address)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of addressable matching address
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/addressable'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/addressable/id/{id}:
+    delete:
+      description: Remove the Addressable designated by the database generated id
+        for the Addressable. Returns Internal Service Error (HTTP 500) for unknown
+        or unanticipated issues. Returns NotFoundException (HTTP 404) if no addressable
+        with the provided id is found.
+      parameters:
+      - name: id
+        in: path
+        description: database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        404:
+          description: if no addressable with the provided id is found.
+        409:
+          description: if the adressable is still in use
+        500:
+          description: for unknown or unanticipated issues
+  /v1/addressable/name/{name}:
+    get:
+      description: Return Addressable with matching name (name should be unique).
+        May be null if none match. Returns Internal Service Error (HTTP 500) for unknown
+        or unanticipated issues.  Returns NotFoundException (HTTP 404) if not found
+        by name.
+      parameters:
+      - name: name
+        in: path
+        description: unique name of addressable
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: addressable matching on name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/addressable'
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no addressable with the provided name is found
+        500:
+          description: for unknown or unanticipated issues.
+    delete:
+      description: Remove the Addressable designated by unique name identifier. Returns
+        Internal Service Error (HTTP 500) for unknown or unanticipated issues. Returns
+        NotFoundException (HTTP 404) if no addressable with the provided name is found.
+      parameters:
+      - name: name
+        in: path
+        description: unique name of addressable
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no addressable with the provided name is found.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/addressable/port/{port}:
+    get:
+      description: Return Addressable objects with given port. List may be empty if
+        none are associated to the port. Returns Internal Service Error (HTTP 500)
+        for unknown or unanticipated issues.
+      parameters:
+      - name: port
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of addressable matching port
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/addressable'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues
+  /v1/addressable/publisher/{publisher}:
+    get:
+      description: Return Addressable objects with given publisher. List may be empty
+        if none are associated to the publisher. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues.
+      parameters:
+      - name: publisher
+        in: path
+        description: publisher name (as in MQTT publisher)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of addressable matching publisher
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/addressable'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/addressable/topic/{topic}:
+    get:
+      description: Return Addressable objects with given topic. List may be empty
+        if none are associated to the topic. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues.
+      parameters:
+      - name: topic
+        in: path
+        description: topic name (as in MQTT topic name)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: list of addressable matching topic
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/addressable'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/addressable/{id}:
+    get:
+      description: Fetch a specific addressable by database generated id. May return
+        null if no addressable matches on id. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues.  Returns NotFoundException (HTTP
+        404) if not found by the id.
+      parameters:
+      - name: id
+        in: path
+        description: database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: addressable
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/addressable'
+        404:
+          description: if no addressable with the provided id is found
+        500:
+          description: for unknown or unanticipated issues
+  /v1/command:
+    get:
+      description: Return all command objects. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues. Returns LimitExceededException (HTTP
+        413) if the number returned exceeds the max limit.
+      responses:
+        200:
+          description: Successful Response
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/command'
+        413:
+          description: if the number returned exceeds the max limit.
+        500:
+          description: for unknown or unanticipated errors
+  /v1/command/device/{id}:
+    get:
+      description: Fetch commands by device id. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues. Returns NotFoundException (HTTP
+        404) if no command with the provided id is found.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Successful Response
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/command'
+        404:
+          description: if no device exists for the provided id.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/command/name/{name}:
+    get:
+      description: Return Command objects with given name. Name is not unique for
+        all of EdgeX but is unique per any associated Device Profile. Returns Internal
+        Service Error (HTTP 500) for unknown or unanticipated issues.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Successful Response
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/command'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/command/{id}:
+    get:
+      description: Fetch a specific command by database generated id. May return null
+        if no commands with the id is found. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues. Returns NotFoundException (HTTP
+        404) if no command with the provided id is found.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Successful Response
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/command'
+        404:
+          description: if no command with the provided id is found.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/config:
+    get:
+      description: Fetch the current state of the service's configuration.
+      responses:
+        200:
+          description: The service's configuration as JSON document
+  /v1/device:
+    get:
+      description: Return all devices sorted by id. Returns Internal Service Error
+        (HTTP 500) for unknown or unanticipated issues. Returns LimitExceededException
+        (HTTP 413) if the number returned exceeds the max limit.
+      responses:
+        200:
+          description: list of device
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/device'
+        413:
+          description: if the number returned exceeds the max limit
+        500:
+          description: for unknown or unanticipated issues
+    put:
+      description: Update the Device identified by the id or name stored in the object
+        provided. Id is used first, name is used second for identification purposes.
+        New device services & profiles cannot be created with a PUT, but the service
+        and profile can replaced by referring to a new device service or profile id
+        or name. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device cannot be found
+        by the identifier provided.
+      requestBody:
+        $ref: '#/components/requestBodies/device'
+      responses:
+        200:
+          description: boolean indicating success of the update
+        400:
+          description: if the request is malformed or unparsable
+        404:
+          description: if the device cannot be found by the identifier provided.
+        500:
+          description: for unknown or unanticipated issues.
+    post:
+      description: Add a new Device - name must be unique. Embedded objects (device,
+        service, profile, addressable) are all referenced in the new Device object
+        by id or name to associated objects. All other data in the embedded objects
+        will be ignored. Returns Internal Service Error (HTTP 500) for unknown or
+        unanticipated issues. Returns DataValidationException (HTTP 409) if an associated
+        object (Addressable, Profile, Service) cannot be found with the id or name
+        provided.
+      requestBody:
+        $ref: '#/components/requestBodies/device'
+      responses:
+        200:
+          description: database generated identifier for the new device
+        400:
+          description: if the request is malformed or unparsable or if an associated
+            object (Addressable, Profile, Service) cannot be found with the id or
+            name provided
+        409:
+          description: if the name is determined to not be unique with regard to others.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/check/{token}:
+    get:
+      description: Obtain a device by either name (preferred) or id. Id must be a
+        valid BSON identifier.
+      parameters:
+      - name: token
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: JSON payload representing the device
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: device was not found
+  /v1/device/id/{id}:
+    delete:
+      description: Remove the Device designated by database generated id. This does
+        not remove associated objects (addressable, service, profile, etc.). Returns
+        Internal Service Error (HTTP 500) for unknown or unanticipated issues. Returns
+        NotFoundException (HTTP 404) if the device cannot be found by the identifier
+        provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the id provided.
+  /v1/device/label/{label}:
+    get:
+      description: Find all Devices having at least one label matching the label provided.
+        List may be empty if no device match. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues.
+      parameters:
+      - name: label
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of Device matching on specified label
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/device'
+        400:
+          description: for incorrect or unparsable requests
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/name/{name}:
+    get:
+      description: Return Device matching given name (device names should be unique).
+        May be null if no device matches on the name provided. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. Returns NotFoundException
+        (HTTP 404) if the device cannot be found by the identifier provided.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device matching on name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/device'
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+    put:
+      description: Set the admin or operating state of the device by unique name of
+        the device. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device cannot be found
+        by the name provided.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/device'
+      responses:
+        200:
+          description: indicating success of the operation
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+    delete:
+      description: Remove the Device designated by unique name. This does not remove
+        associated objects (addressable, service, profile, etc.). Returns Internal
+        Service Error (HTTP 500) for unknown or unanticipated issues. Returns NotFoundException
+        (HTTP 404) if the device cannot be found by the identifier provided.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+  /v1/device/name/{name}/lastconnected/{time}:
+    put:
+      description: Update the last connected time of the device by unique name of
+        the device. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device cannot be found
+        by the name provided.
+      parameters:
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/name/{name}/lastconnected/{time}/{notify}:
+    put:
+      description: Update the last connected time of the device by unique name of
+        the device. The notify boolean indicates whether the owning device service
+        should be notified of the change. Returns Internal Service Error (HTTP 500)
+        for unknown or unanticipated issues. Returns NotFoundException (HTTP 404)
+        if the device cannot be found by the name provided.
+      parameters:
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: notify
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/name/{name}/lastreported/{time}:
+    put:
+      description: Update the last reported time of the device by unique name of the
+        device. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device cannot be found
+        by the name provided.
+      parameters:
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/name/{name}/lastreported/{time}/{notify}:
+    put:
+      description: Update the last reported time of the device by unique name of the
+        device. The notify boolean indicates whether the owning device service should
+        be notified of the change.  Returns Internal Service Error (HTTP 500) for
+        unknown or unanticipated issues. Returns NotFoundException (HTTP 404) if the
+        device cannot be found by the name provided.
+      parameters:
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: notify
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/profile/{profileId}:
+    get:
+      description: Find all devices associated to the DeviceProfile with the specified
+        profile database generated identifier. List may be empty if no device match.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        Returns NotFoundException (HTTP 404) if no DeviceProfile match on the id provided.
+      parameters:
+      - name: profileId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of Devices associated to the device profile
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/device'
+        404:
+          description: if no device profile match on the id provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/profilename/{profilename}:
+    get:
+      description: Find all devices associated to the DeviceProfile with the specified
+        profile name. List may be empty if no device match. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. Returns NotFoundException
+        (HTTP 404) if no DeviceProfile match on the name provided.
+      parameters:
+      - name: profilename
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of Devices associated to the profile
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/device'
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the identifier provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/service/{serviceId}:
+    get:
+      description: Find all devices associated to the DeviceService with the specified
+        DeviceService database generated identifier. List may be empty if no device
+        match. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if no DeviceService match on
+        the id provided.
+      parameters:
+      - name: serviceId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of Devices associated to the device service
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/device'
+        404:
+          description: if no device service match on the id provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/servicename/{servicename}:
+    get:
+      description: Find all devices associated to the DeviceService with the specified
+        service name (DeviceService names must be unique). List may be empty if no
+        device match. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if no DeviceService match on
+        the name provided.
+      parameters:
+      - name: servicename
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of Devices associated to the device service
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/device'
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/{id}:
+    get:
+      description: Fetch a specific device by database generated id. May return null
+        if no device with the id is found. Returns Internal Service Error (HTTP 500)
+        for unknown or unanticipated issues.  Returns NotFoundException (HTTP 404)
+        if the device cannot be found by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device matching on the id
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/device'
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+    put:
+      description: Set the admin or operating state of the device (as referenced by
+        the database generated id of the device) to the state provided (either enabled
+        or disabled). ServiceException (HTTP 500) for unanticipated or unknown issues
+        encountered. Throws NotFoundException (HTTP 404) if no device exists by the
+        id provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        $ref: '#/components/requestBodies/device'
+      responses:
+        200:
+          description: status code indicating success
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if no device exists by the id provided.
+        500:
+          description: for unanticipated or unknown issues encountered.
+  /v1/device/{id}/lastconnected/{time}:
+    put:
+      description: Update the last connected time of the device by database generated
+        identifier. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device cannot be found
+        by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/{id}/lastconnected/{time}/{notify}:
+    put:
+      description: Update the last connected time of the device by database generated
+        identifier. The notify boolean indicates whether the owning device service
+        should be notified of the change. Returns Internal Service Error (HTTP 500)
+        for unknown or unanticipated issues. Returns NotFoundException (HTTP 404)
+        if the device cannot be found by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: notify
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/{id}/lastreported/{time}:
+    put:
+      description: Update the last reported time of the device by database generated
+        identifier. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device cannot be found
+        by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/device/{id}/lastreported/{time}/{notify}:
+    put:
+      description: Update the last reported time of the device by database generated
+        identifier. The notify boolean indicates whether the owning device service
+        should be notified of the change. Returns Internal Service Error (HTTP 500)
+        for unknown or unanticipated issues. Returns NotFoundException (HTTP 404)
+        if the device cannot be found by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: notify
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for incorrect or unparsable requests
+        404:
+          description: if the device cannot be found by the name provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/deviceprofile:
+    get:
+      description: Return all profiles sorted by id. Returns Internal Service Error
+        (HTTP 500) for unknown or unanticipated issues. Returns LimitExceededException
+        (HTTP 413) if the number returned exceeds the max limit.
+      responses:
+        200:
+          description: list of profiles
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceprofile'
+        413:
+          description: if the number returned exceeds the max limit
+        500:
+          description: for unknown or unanticipated issues
+    put:
+      description: Update the DeviceProfile identified by the id or name stored in
+        the object provided. Id is used first, name is used second for identification
+        purposes. Associated commands must be updated directly. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. Returns NotFoundException
+        (HTTP 404) if the profile cannot be found by the identifier provided.
+      requestBody:
+        $ref: '#/components/requestBodies/deviceprofile'
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if the profile cannot be found by the identifier provided
+        409:
+          description: if the profile contains duplicate command or profile names,
+            or if the device profile is in use by one or more provision watchers or
+            devices.
+        500:
+          description: for unknown or unanticipated issues
+    post:
+      description: Add a new DeviceProfile (and associated Command objects) - name
+        must be unique. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns DataValidationException (HTTP 409) if an associated command's
+        name is a duplicate for the profile.
+      requestBody:
+        $ref: '#/components/requestBodies/deviceprofile'
+      responses:
+        200:
+          description: database generated identifier for the new device profile
+        400:
+          description: for malformed or unparsable requests
+        409:
+          description: if an associated command's name is a duplicate for the profile
+            or if the name is determined to not be unique with regard to others.
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/id/{id}:
+    delete:
+      description: Remove the DeviceProfile designated by database generated id. This
+        does not remove associated commands. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues. Returns NotFoundException (HTTP
+        404) if the device profile cannot be found by the identifier provided. Returns
+        DataValidationException (HTTP 413) if devices still reference the profile.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        404:
+          description: if the device profile cannot be found with the identifier provided
+        409:
+          description: if devices or provision watchers still reference the profile
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/label/{label}:
+    get:
+      description: Find all DeviceProfiles having at least one label matching the
+        label provided. List may be empty if no profiles match. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues.
+      parameters:
+      - name: label
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of DeviceProfile matching on specified label
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceprofile'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/manufacturer/{manufacturer}:
+    get:
+      description: Find all DeviceProfiles with a manufacture attribute matching that
+        provided. List may be empty if no profiles match. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues.
+      parameters:
+      - name: manufacturer
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of DeviceProfile matching on specified manufacturer.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceprofile'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/manufacturer/{manufacturer}/model/{model}:
+    get:
+      description: Find all DeviceProfiles with a manufacture or model attribute matching
+        that provided (either matching provides a hit). List may be empty if no profiles
+        match. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues.
+      parameters:
+      - name: model
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: manufacturer
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of DeviceProfile matching on specified manufacturer and/or
+            model.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/devicereport'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/model/{model}:
+    get:
+      description: Find all DeviceProfiles with a model attribute matching that provided.
+        List may be empty if no profiles match. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues.
+      parameters:
+      - name: model
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of DeviceProfile matching on specified model.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceprofile'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/name/{name}:
+    get:
+      description: Return the DeviceProfile matching given name (profile names should
+        be unique). May be null if no profiles matches on the name provided. Returns
+        Internal Service Error (HTTP 500) for unknown or unanticipated issues. Returns
+        NotFoundException (HTTP 404) if the device profile cannot be found by the
+        name provided.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device profile matching on name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceprofile'
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if the device profile cannot be found by the name provided
+        500:
+          description: for unknown or unanticipated issues
+    delete:
+      description: Remove the DeviceProfile designated by unique name. This does not
+        remove associated commands. Returns Internal Service Error (HTTP 500) for
+        unknown or unanticipated issues. Returns NotFoundException (HTTP 404) if the
+        device profile cannot be found by the name provided. Returns DataValidationException
+        (HTTP 409) if devices still reference the profile.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if the device profile cannot be found by the name provided
+        409:
+          description: if devices or provision watchers still reference the profile
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/upload:
+    post:
+      description: Add a new DeviceProfile (and associated Command objects) via YAML
+        content - name must be unique. Returns Internal Service Error (HTTP 500) for
+        unknown or unanticipated issues. Returns DataValidationException (HTTP 409)
+        if an associated command's name is a duplicate for the profile.
+      responses:
+        200:
+          description: database generated identifier for the new device profile
+        400:
+          description: if the YAML file is empty
+        409:
+          description: if an associated command's name is a duplicate for the profile
+            or if the name is determined to not be unique with regard to others
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/uploadfile:
+    post:
+      description: Add a new DeviceProfile (and associated Command objects) via YAML
+        profile file - name must be unique. Returns Internal Service Error (HTTP 500)
+        for unknown or unanticipated issues. Returns DataValidationException (HTTP
+        409) if an associated command's name is a duplicate for the profile. Returns
+        ClientException (HTTP 400) if the YAML file is empty.
+      responses:
+        200:
+          description: database generated identifier for the new device profile
+        400:
+          description: if the YAML file is empty
+        409:
+          description: if an associated command's name is a duplicate for the profile
+            or if the name is determined to not be unique with regard to others
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/yaml/name/{name}:
+    get:
+      description: Return, in yaml form, the DeviceProfiles matching given name (profile
+        names should be unique). May be null if no profiles matches on the name provided.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.  Returns
+        NotFoundException (HTTP 404) if the device profile cannot be found by the
+        name provided.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device profile in YAML matching on name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceprofile'
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if the device profile cannot be found by the name provided
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/yaml/{id}:
+    get:
+      description: Fetch the profile identified by database generated id and return
+        as a YAML string. Returns Internal Service Error (HTTP 500) for unknown or
+        unanticipated issues.  eturns NotFoundException (HTTP 404) if the device profile
+        cannot be found by the name provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device profile in YAML format
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceprofile'
+        404:
+          description: if the device profile cannot be found by the id provided
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceprofile/{id}:
+    get:
+      description: Fetch a specific profile by database generated id. May return null
+        if no profile with the id is found. Returns Internal Service Error (HTTP 500)
+        for unknown or unanticipated issues.  Returns NotFoundException (HTTP 404)
+        if the device profile cannot be found by the id provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device profile matching on id
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceprofile'
+        404:
+          description: if the device profile cannot be found by the id provided
+        500:
+          description: for unknown or unanticipated issues
+  /v1/devicereport:
+    get:
+      description: Return all device reports sorted by id. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. Returns LimitExceededException
+        (HTTP 413) if the number returned exceeds the max limit.
+      responses:
+        200:
+          description: list of device reports
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/devicereport'
+        413:
+          description: if the number returned exceeds the max limit.
+        500:
+          description: for unknown or unanticipated issues
+    put:
+      description: Update the DeviceReport identified by the id or name in the object
+        provided. Id is used first, name is used second for identification purposes.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        NotFoundException (HTTP 404) if any referenced object cannot be found by its
+        provided name.
+      requestBody:
+        $ref: '#/components/requestBodies/devicereport'
+      responses:
+        200:
+          description: boolean indicating success of the update
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if any referenced object cannot be found by its provided name
+        500:
+          description: for unknown or unanticipated issues
+    post:
+      description: Add a new DeviceReport - name must be unique. Referenced objects
+        (device, interval action) are all referenced in the new DeviceReport by name
+        and must already be persisted. Returns Internal Service Error (HTTP 500) for
+        unknown or unanticipated issues. NotFoundException (HTTP 404) if any referenced
+        object cannot be found by its provided name.
+      requestBody:
+        $ref: '#/components/requestBodies/devicereport'
+      responses:
+        200:
+          description: database generated identifier for the new device report
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if any referenced object cannot be found by its provided name
+        500:
+          description: for unknown or unanticipated issues
+  /v1/devicereport/devicename/{devicename}:
+    get:
+      description: Return DeviceReports with associated device matching given name
+        (device names should be unique). May be an empty list if no device matches
+        on the name provided. Returns Internal Service Error (HTTP 500) for unknown
+        or unanticipated issues.
+      parameters:
+      - name: devicename
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device reports matching on device name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/devicereport'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues
+  /v1/devicereport/id/{id}:
+    delete:
+      description: Remove the DevicReport designated by database generated id. Internal
+        Service Error (HTTP 500) for unknown or unanticipated issues. NotFoundException
+        (HTTP 404) if no DeviceReport is found with the provided id.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        404:
+          description: if no DeviceReport is found with the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/devicereport/name/{name}:
+    get:
+      description: Return DeviceReport matching given name (device report names should
+        be unique). May be null if no report matches on the name provided. Returns
+        Internal Service Error (HTTP 500) for unknown or unanticipated issues.  NotFoundException
+        (HTTP 404) if no DeviceReport is found with the provided name.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device report matching on name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/devicereport'
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no DeviceReport is found with the provided name
+        500:
+          description: for unknown or unanticipated issues
+    delete:
+      description: Remove the DevicReport designated by name. Internal Service Error
+        (HTTP 500) for unknown or unanticipated issues. NotFoundException (HTTP 404)
+        if no DeviceReport is found with the provided name.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no DeviceReport is found with the provided name
+        500:
+          description: for unknown or unanticipated issues
+  /v1/devicereport/valueDescriptorsFor/{devicename}:
+    get:
+      description: Return list of value descriptor names associated to device reports
+        associated to name of the device provided. May be an empty list if no device
+        matches on the name provided. Returns Internal Service Error (HTTP 500) for
+        unknown or unanticipated issues.
+      parameters:
+      - name: devicename
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: value descriptor names
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues
+  /v1/devicereport/{id}:
+    get:
+      description: Fetch a specific DeviceReport by database generated id. May return
+        null if no report with the id is found. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues.  NotFoundException (HTTP 404) if
+        no DeviceReport is found with the provided id.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device report matching on the id
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/devicereport'
+        404:
+          description: if no DeviceReport is found with the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice:
+    get:
+      description: Return all device services sorted by id. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. Returns LimitExceededException
+        (HTTP 413) if the number returned exceeds the max limit.
+      responses:
+        200:
+          description: list of profiles
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceservice'
+        413:
+          description: if the number of device services exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues
+    put:
+      description: Update the DeviceServcie identified by the id or name stored in
+        the object provided. Id is used first, name is used second for identification
+        purposes. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device service cannot
+        be found by the identifier provided.
+      requestBody:
+        $ref: '#/components/requestBodies/deviceservice'
+      responses:
+        200:
+          description: boolean indicating success of the update
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found with the provided name or id
+        503:
+          description: for unknown or unanticipated issues
+    post:
+      description: Add a new DeviceService - name must be unique.  The Addressable
+        must already exist and can be referenced by an included Addressable object
+        containing the Addressable's id or name. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues. Returns DataValidationException
+        (HTTP 409) if an associated addressable (by id or name) is not found.
+      requestBody:
+        $ref: '#/components/requestBodies/deviceservice'
+      responses:
+        200:
+          description: database generated identifier for the new device service
+        400:
+          description: no addressable was provided for the new device service
+        404:
+          description: if an associated addressable (by id or name) is not found
+        409:
+          description: if the addressable name is determined to not be unique with
+            regard to others
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/addressable/{addressableId}:
+    get:
+      description: Find all device servicess associated to the Addressable with the
+        specified addressable database generated identifier. List may be empty if
+        no device service match. Returns Internal Service Error (HTTP 500) for unknown
+        or unanticipated issues. Returns NotFoundException (HTTP 404) if no Addressable
+        match on the id provided.
+      parameters:
+      - name: addressableId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of DeviceServices associated to the addressable
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceservice'
+        404:
+          description: if no addressablee is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/addressablename/{addressablename}:
+    get:
+      description: Find all device serices associated to the Addressable with the
+        specified addressable name. List may be empty if no device services match.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        Returns NotFoundException (HTTP 404) if no Addressable match on the name provided.
+      parameters:
+      - name: addressablename
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of DeviceServices associated to the addressable
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceservice'
+        404:
+          description: if no addressable is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/id/{id}:
+    delete:
+      description: Remove the DeviceService designated by database generated id. Returns
+        Internal Service Error (HTTP 500) for unknown or unanticipated issues. Returns
+        NotFoundException (HTTP 404) if the device service cannot be found by the
+        identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        404:
+          description: if no device service is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/label/{label}:
+    get:
+      description: Find all DeviceServices having at least one label matching the
+        label provided. List may be empty if no device services match. Returns Internal
+        Service Error (HTTP 500) for unknown or unanticipated issues.
+      parameters:
+      - name: label
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of DeviceService matching on specified label
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceservice'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/name/{name}:
+    get:
+      description: Return the DeviceService matching given name (service names should
+        be unique). May be null if no services matches on the name provided. Returns
+        Internal Service Error (HTTP 500) for unknown or unanticipated issues. Returns
+        NotFoundException (HTTP 404) if the device service cannot be found by the
+        name provided.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device service matching on name
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+    delete:
+      description: Remove the DeviceService designated by name. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. Returns NotFoundException
+        (HTTP 404) if the device service cannot be found by the name provided.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        503:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/name/{name}/adminstate/{adminState}:
+    put:
+      description: Update the admin state of the device service by device service
+        name. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device service cannot
+        be found by the identifier provided.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: adminState
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/name/{name}/lastconnected/{time}:
+    put:
+      description: Update the last connected time of the device service by unique
+        name of the device service. Returns Internal Service Error (HTTP 500) for
+        unknown or unanticipated issues. Returns NotFoundException (HTTP 404) if the
+        device service cannot be found by the name provided.
+      parameters:
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        503:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/name/{name}/lastreported/{time}:
+    put:
+      description: Update the last reported time of the device service by unique name
+        of the device service. Returns Internal Service Error (HTTP 500) for unknown
+        or unanticipated issues. Returns NotFoundException (HTTP 404) if the device
+        service cannot be found by the name provided.
+      parameters:
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/name/{name}/opstate/{opState}:
+    put:
+      description: Update the op status time of the device service by unique name
+        of the device service. Returns Internal Service Error (HTTP 500) for unknown
+        or unanticipated issues. Returns NotFoundException (HTTP 404) if the device
+        service cannot be found by the name provided.
+      parameters:
+      - name: opState
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/{id}:
+    get:
+      description: Fetch a specific device service by database generated id. May return
+        null if no service with the id is found. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues. Returns NotFoundException (HTTP
+        404) if the device service cannot be found by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: device service matching on id
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/deviceservice'
+        404:
+          description: if no device service is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/{id}/adminstate/{adminState}:
+    put:
+      description: Update the admin state of the device service by database generated
+        identifier. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device service cannot
+        be found by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: adminState
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/{id}/lastconnected/{time}:
+    put:
+      description: Update the last connected time of the device service by database
+        generated identifier. Returns Internal Service Error (HTTP 500) for unknown
+        or unanticipated issues. Returns NotFoundException (HTTP 404) if the device
+        service cannot be found by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/{id}/lastreported/{time}:
+    put:
+      description: Update the last reported time of the device service by database
+        generated identifier. Returns Internal Service Error (HTTP 500) for unknown
+        or unanticipated issues. Returns NotFoundException (HTTP 404) if the device
+        service cannot be found by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: time
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of update
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        503:
+          description: for unknown or unanticipated issues
+  /v1/deviceservice/{id}/opstate/{opState}:
+    put:
+      description: Update the op state of the device service by database generated
+        identifier. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if the device service cannot
+        be found by the identifier provided.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: opState
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no device service is found for the provided id
+        500:
+          description: for unknown or unanticipated issues
+  /v1/ping:
+    get:
+      description: ping
+      responses:
+        200:
+          description: Successful Response
+  /v1/provisionwatcher:
+    get:
+      description: Return all provision watcher objects sorted by database generated
+        id. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns LimitExceededException (HTTP 413) if the number returned exceeds
+        the max limit.
+      responses:
+        200:
+          description: list of provision watcher
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/provisionwatcher'
+        413:
+          description: if the number returned exceeds the max limit.
+        500:
+          description: for unknown or unanticipated issues.
+    put:
+      description: Update the ProvisionWatcher identified by the id or name in the
+        object provided. Id is used first, name is used second for identification
+        purposes. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues. Returns NotFoundException (HTTP 404) if no provision watcher with
+        the provided id is found.
+      requestBody:
+        $ref: '#/components/requestBodies/provisionwatcher'
+      responses:
+        200:
+          description: boolean indicating success of the update
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no provision watcher with the provided id is found.
+        500:
+          description: for unknown or unanticipated issues or for any duplicate name
+            (key) error.
+    post:
+      description: Add a new ProvisionWatcher - name must be unique. Returns Internal
+        Service Error (HTTP 500) for unknown or unanticipated issues.  Returns DataValidationException
+        (HTTP 409) if profile service are unknown
+      requestBody:
+        $ref: '#/components/requestBodies/provisionwatcher'
+      responses:
+        200:
+          description: new database generated id for the new ProvisionWatcher
+        400:
+          description: for malformed or unparsable requests
+        409:
+          description: if an associated object (Profile, Service) cannot be found
+            with the id or name provided or if the watcher name is determined to not
+            be unique with regard to others
+        500:
+          description: for unknown or unanticipated issues or for any duplicate name
+            (key) error.
+  /v1/provisionwatcher/id/{id}:
+    delete:
+      description: Remove the ProvisionWatcher designated by the database generated
+        id for the ProvisionWatcher. Returns Internal Service Error (HTTP 500) for
+        unknown or unanticipated issues. Returns NotFoundException (HTTP 404) if no
+        provision watcher with the provided id is found.
+      parameters:
+      - name: id
+        in: path
+        description: database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        404:
+          description: if no provision watcher with the provided id is found.
+        500:
+          description: for unknown or unanticipated issues
+  /v1/provisionwatcher/identifier/{key}/{value}:
+    get:
+      description: Find the provision watchers associated to the identifier key/value
+        pair.  The identifier key/value pair identify a protocol and address of the
+        protocol to watch for by the Device Service. List may be none if no provision
+        watcher match. Returns Internal Service Error (HTTP 500) for unknown or unanticipated
+        issues.
+      parameters:
+      - name: key
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: value
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of ProvisionWatcher associated to the device service
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/provisionwatcher'
+        400:
+          description: for malformed or unparsable requests
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/provisionwatcher/name/{name}:
+    get:
+      description: Return ProvisionWatcher with matching name (name should be unique).
+        May be null if none match. Returns Internal Service Error (HTTP 500) for unknown
+        or unanticipated issues. Returns NotFoundException (HTTP 404) if no provision
+        watcher with the provided name is found.
+      parameters:
+      - name: name
+        in: path
+        description: unique name of provision watcher
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: provision watcher matching on name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/provisionwatcher'
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no provision watcher with the provided name is found.
+        500:
+          description: for unknown or unanticipated issues.
+    delete:
+      description: Remove the ProvisionWatcher designated by unique name identifier.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        Returns NotFoundException (HTTP 404) if no provision watcher with the provided
+        name is found.
+      parameters:
+      - name: name
+        in: path
+        description: unique name of provision watcher
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no provision watcher with the provided name is found.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/provisionwatcher/profile/{profileId}:
+    get:
+      description: Find all provision watchers associated to the DeviceProfile with
+        the specified profile database generated identifier. List may be empty if
+        no provision watchers match. Returns Internal Service Error (HTTP 500) for
+        unknown or unanticipated issues. Returns NotFoundException (HTTP 404) if no
+        DeviceProfile match on the id provided.
+      parameters:
+      - name: profileId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of ProvisionWatchers associated to the device profile
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/provisionwatcher'
+        404:
+          description: if no device profile match on the id provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/provisionwatcher/profilename/{profilename}:
+    get:
+      description: Find all provision watchers associated to the DeviceProfile with
+        the specified profile name. List may be empty if no provision watcher match.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        Returns NotFoundException (HTTP 404) if no DeviceProfile match on the name
+        provided.
+      parameters:
+      - name: profilename
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of ProvisionWatcher associated to the profile
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/provisionwatcher'
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no DeviceProfile match on the id provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/provisionwatcher/service/{serviceId}:
+    get:
+      description: Find the provision watchers associated to the DeviceService with
+        the specified service database generated identifier. List may be empty if
+        no provision watchers match. Returns Internal Service Error (HTTP 500) for
+        unknown or unanticipated issues. Returns NotFoundException (HTTP 404) if no
+        DeviceService match on the id provided.
+      parameters:
+      - name: serviceId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of ProvisionWatchers associated to the device service
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/provisionwatcher'
+        404:
+          description: if no device service match on the id provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/provisionwatcher/servicename/{servicename}:
+    get:
+      description: Find the provision watchers associated to the DeviceService with
+        the specified service name. List may be none if no provision watcher match.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        Returns NotFoundException (HTTP 404) if no DeviceService match on the name
+        provided.
+      parameters:
+      - name: servicename
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: List of ProvisionWatcher associated to the device service
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/provisionwatcher'
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no DeviceService match on the id provided.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/provisionwatcher/{id}:
+    get:
+      description: Fetch a specific provision watcher by database generated id. May
+        return null if no provision watcher matches on id. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues.  Returns NotFoundException
+        (HTTP 404) if no provision watcher with the provided id is found.
+      parameters:
+      - name: id
+        in: path
+        description: database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: provision watcher
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/provisionwatcher'
+        404:
+          description: if no provision watcher with the provided id is found.
+        500:
+          description: for unknown or unanticipated issues
+  /version:
+    get:
+      description: Get the API version
+      responses:
+        200:
+          description: The service's API version as JSON document
+components:
+  schemas:
+    addressable:
+      title: addressable
+      required:
+      - method
+      type: object
+      properties:
+        address:
+          title: address
+          type: string
+        created:
+          title: created
+          type: integer
+        id:
+          title: id
+          type: string
+        method:
+          title: method
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        password:
+          title: password
+          type: string
+        path:
+          title: path
+          type: string
+        port:
+          title: port
+          type: integer
+        protocol:
+          title: protocol
+          type: string
+        publisher:
+          title: publisher
+          type: string
+        topic:
+          title: topic
+          type: string
+        user:
+          title: user
+          type: string
+    command:
+      title: command
+      type: object
+      properties:
+        created:
+          title: created
+          type: integer
+        get:
+          $ref: '#/components/schemas/command_get'
+        id:
+          title: id
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        put:
+          $ref: '#/components/schemas/command_put'
+    device:
+      title: device
+      type: object
+      properties:
+        addressable:
+          $ref: '#/components/schemas/device_addressable'
+        adminState:
+          title: adminState
+          type: string
+        created:
+          title: created
+          type: integer
+        description:
+          title: description
+          type: string
+        id:
+          title: id
+          type: string
+        labels:
+          title: labels
+          uniqueItems: false
+          type: array
+          items:
+            title: labels
+            type: string
+        lastConnected:
+          title: lastConnected
+          type: integer
+        lastReported:
+          title: lastReported
+          type: integer
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        operatingState:
+          title: operatingState
+          type: string
+        origin:
+          title: origin
+          type: integer
+      description: device or sensor supplying data and taking actuation commands
+    deviceprofile:
+      title: deviceprofile
+      type: object
+      properties:
+        created:
+          title: created
+          type: integer
+        description:
+          title: description
+          type: string
+        id:
+          title: id
+          type: string
+        labels:
+          title: labels
+          uniqueItems: false
+          type: array
+          items:
+            title: labels
+            type: string
+        manufacturer:
+          title: manufacturer
+          type: string
+        model:
+          title: model
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        resources:
+          title: resources
+          uniqueItems: false
+          type: array
+          items:
+            title: resources
+            type: string
+      description: template describing devices and sensors of the same nature in reporting
+        the same data and offering the same commands
+    devicereport:
+      title: devicereport
+      type: object
+      properties:
+        action:
+          title: action
+          type: string
+        created:
+          title: created
+          type: integer
+        device:
+          title: device
+          type: string
+        expected:
+          title: expected
+          uniqueItems: false
+          type: array
+          items:
+            title: expected
+            type: string
+        id:
+          title: id
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+      description: description of values (value descriptors) that should be collected
+        per device on a interval action
+    deviceservice:
+      title: deviceservice
+      type: object
+      properties:
+        addressable:
+          $ref: '#/components/schemas/device_addressable'
+        adminState:
+          title: adminState
+          type: string
+        created:
+          title: created
+          type: integer
+        description:
+          title: description
+          type: string
+        id:
+          title: id
+          type: string
+        labels:
+          title: labels
+          uniqueItems: false
+          type: array
+          items:
+            title: labels
+            type: string
+        lastConnected:
+          title: lastConnected
+          type: integer
+        lastReported:
+          title: lastReported
+          type: integer
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        operatingState:
+          title: operatingState
+          type: string
+        origin:
+          title: origin
+          type: integer
+      description: manages devices and interfaces with core data
+    provisionwatcher:
+      title: provisionwatcher
+      type: object
+      properties:
+        created:
+          title: created
+          type: integer
+        id:
+          title: id
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+    command_get_responses:
+      type: object
+      properties:
+        code:
+          title: code
+          type: string
+        description:
+          title: description
+          type: string
+        expectedValues:
+          title: expectedValues
+          type: string
+    command_get:
+      type: object
+      properties:
+        responses:
+          $ref: '#/components/schemas/command_get_responses'
+        path:
+          title: path
+          type: string
+    command_put:
+      type: object
+      properties:
+        path:
+          title: path
+          type: string
+    device_addressable:
+      type: object
+      properties:
+        address:
+          title: address
+          type: string
+        created:
+          title: created
+          type: integer
+        id:
+          title: id
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        password:
+          title: password
+          type: string
+        path:
+          title: path
+          type: string
+        port:
+          title: port
+          type: integer
+        protocol:
+          title: protocol
+          type: string
+        publisher:
+          title: publisher
+          type: string
+        topic:
+          title: topic
+          type: string
+        user:
+          title: user
+          type: string
+  requestBodies:
+    deviceservice:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/deviceservice'
+      required: true
+    device:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/device'
+      required: true
+    provisionwatcher:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/provisionwatcher'
+      required: true
+    addressable:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/addressable'
+      required: true
+    deviceprofile:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/deviceprofile'
+      required: true
+    devicereport:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/devicereport'
+      required: true

--- a/api/oas3.0/support-logging.yaml
+++ b/api/oas3.0/support-logging.yaml
@@ -1,0 +1,482 @@
+openapi: 3.0.0
+info:
+  title: support-logging
+  version: 1.1.x-oas3
+servers:
+- url: http://localhost:48061/api
+paths:
+  /v1/config:
+    get:
+      description: Fetch the current state of the service's configuration.
+      responses:
+        200:
+          description: The service's configuration as JSON document
+  /v1/logs:
+    post:
+      description: Create a new LogEntry
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogEntry'
+        required: true
+      responses:
+        202:
+          description: accepted to clients with timestamp being accepted.
+        400:
+          description: creation request is malformed
+  /v1/logs/keywords/{keywords}/{start}/{end}:
+    delete:
+      parameters:
+      - name: keywords
+        in: path
+        description: accepting multiple keywords separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: count of the number of LogEntry being deleted
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/keywords/{keywords}/{start}/{end}/{limit}:
+    get:
+      parameters:
+      - name: keywords
+        in: path
+        description: accepting multiple keywords separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: limit
+        in: path
+        description: the maximum number of records to fetch
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: list a collection of LogEntry whose message containing any
+            of the specified keywords and being created between the specified start
+            and end dates - limited in size by the limit parameter
+        413:
+          description: if the number of events exceeds the current max limit
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/logLevels/{logLevels}/originServices/{originServices}/{start}/{end}:
+    delete:
+      parameters:
+      - name: logLevels
+        in: path
+        description: accepting multiple logLevels separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: originServices
+        in: path
+        description: accepting multiple originServices separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: count of the number of LogEntry being deleted
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/logLevels/{logLevels}/originServices/{originServices}/{start}/{end}/{limit}:
+    get:
+      parameters:
+      - name: logLevels
+        in: path
+        description: accepting multiple logLevels separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: originServices
+        in: path
+        description: accepting multiple originServices separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: limit
+        in: path
+        description: the maximum number of records to fetch
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: list a collection of LogEntry matching any of the specified
+            logLevels, originServices, and also being created between the specified
+            start and end dates - limited in size by the limit parameter
+        413:
+          description: if the number of events exceeds the current max limit
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/logLevels/{logLevels}/{start}/{end}:
+    delete:
+      parameters:
+      - name: logLevels
+        in: path
+        description: accepting multiple logLevels separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: count of the number of LogEntry being deleted
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/logLevels/{logLevels}/{start}/{end}/{limit}:
+    get:
+      parameters:
+      - name: logLevels
+        in: path
+        description: accepting multiple logLevels separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: limit
+        in: path
+        description: the maximum number of records to fetch
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: list a collection of LogEntry matching any of the specified
+            logLevels and being created between the specified start and end dates
+            - limited in size by the limit parameter
+        413:
+          description: if the number of events exceeds the current max limit
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/originServices/{originServices}/{start}/{end}:
+    delete:
+      parameters:
+      - name: originServices
+        in: path
+        description: accepting multiple originServices separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: count of the number of LogEntry being deleted
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/originServices/{originServices}/{start}/{end}/{limit}:
+    get:
+      parameters:
+      - name: originServices
+        in: path
+        description: accepting multiple originServices separated by comma
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: limit
+        in: path
+        description: the maximum number of records to fetch
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: list a collection of LogEntry matching any of the specified
+            originServices and being created between the specified start and end dates
+            - limited in size by the limit parameter
+        413:
+          description: if the number of events exceeds the current max limit
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/removeold/age/{age}:
+    delete:
+      parameters:
+      - name: age
+        in: path
+        description: minimum age in milliseconds (from created timestamp) a LogEntry
+          should be in order to be removed
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: count of the number of LogEntry being deleted
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/{limit}:
+    get:
+      parameters:
+      - name: limit
+        in: path
+        description: the maximum number of records to fetch
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: list a collection of LogEntry - limited in size by the limit
+            parameter
+        413:
+          description: if the number of events exceeds the current max limit
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/logs/{start}/{end}:
+    delete:
+      parameters:
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: count of the number of LogEntry being deleted
+        503:
+          description: for unknown or unanticipated issues.
+  /v1/logs/{start}/{end}/{limit}:
+    get:
+      parameters:
+      - name: start
+        in: path
+        description: start date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: end date in long form
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: limit
+        in: path
+        description: the maximimum number of records to fetch
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: list a collection of LogEntry created between the specified
+            start and end dates - limited in size by the limit parameter
+        413:
+          description: if the number of events exceeds the current max limit
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/ping:
+    get:
+      description: Test service providing an indication that the service is available.
+      responses:
+        200:
+          description: return value of "pong"
+        503:
+          description: for unknown or unanticipated issues
+  /version:
+    get:
+      description: Get the API version
+      responses:
+        200:
+          description: The service's API version as JSON document
+components:
+  schemas:
+    LogEntry:
+      title: LogEntry Schema
+      required:
+      - logLevel
+      - message
+      - originService
+      type: object
+      properties:
+        created:
+          minimum: 0
+          type: integer
+          description: The creation timestamp
+        logLevel:
+          type: string
+          enum:
+          - TRACE
+          - DEBUG
+          - INFO
+          - WARN
+          - ERROR
+        message:
+          type: string
+        originService:
+          type: string

--- a/api/oas3.0/support-notifications.yaml
+++ b/api/oas3.0/support-notifications.yaml
@@ -1,0 +1,1293 @@
+openapi: 3.0.0
+info:
+  title: support-notifications
+  version: 1.1.x-oas3
+servers:
+- url: http://localhost:48060/api
+paths:
+  /cleanup:
+    delete:
+      description: Delete all the Notifications if the current timestamp minus their
+        last modification timestamp is less than a default age setting, and the corresponding
+        Transmissions will also be deleted.
+      responses:
+        202:
+          description: Return 202 Accepted status code without content when receiving
+            the request, because it is an asynchronous operation.
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /cleanup/age/{age}:
+    delete:
+      description: Delete all the Notifications if the current timestamp minus their
+        last modification timestamp is less than the age parameter, and the corresponding
+        Transmissions will also be deleted.
+      parameters:
+      - name: age
+        in: path
+        description: Specify the age of <<typeName>>, and the format is in milliseconds.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        202:
+          description: Return 202 Accepted status code without content when receiving
+            the request, because it is an asynchronous operation.
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/notification:
+    post:
+      description: Receive Alerts or Notifications.  If the severity is CRITICAL,
+        the Notifications are processed (distributed) immediately.  Or, the Notification
+        is processed in batch.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Notification'
+        required: true
+      responses:
+        202:
+          description: If Alerts and Notifications Service is available, it always
+            returns 202 Accepted to clients with the new ID to indicate the Notification
+            has been received.
+        409:
+          description: The slug is duplicate.  Please try another one.
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/notification/age/{age}:
+    delete:
+      description: Delete the proccessed Notifications if the current timestamp minus
+        their last modification timestamp is less than the age parameter, and the
+        corresponding Transmissions will also be deteled.  Please notice this API
+        is only for proccessed Notifications (status = PROCCESSED).  If the deletion
+        purpose includes each kind of Notifications, please refer to /cleanup API.
+      parameters:
+      - name: age
+        in: path
+        description: Specify the age of Notification, and the format is in milliseconds.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return "True" to represent successful.
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/notification/end/{end}/{limit}:
+    get:
+      description: Query the Notifications by creation timestamp before end date.
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: End date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return a Notification array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NotificationArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/notification/labels/{labels}/{limit}:
+    get:
+      description: Query the Notifications by labels matching any one of them.
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: labels
+        in: path
+        description: Accept multiple labels separated by comma.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return a Notification array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NotificationArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/notification/new/{limit}:
+    get:
+      description: Fetch the unprocessed Notifications (status = NEW).
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return a Notification array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NotificationArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/notification/sender/{sender}/{limit}:
+    get:
+      description: Query the Notifications by sender name with limited returned records.
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: sender
+        in: path
+        description: The sender name of the Subscription, which could be partially
+          matched, and is case insensitive for query.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return a Notification array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NotificationArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/notification/slug/{slug}:
+    get:
+      description: Query a specific Notification by slug.
+      parameters:
+      - name: slug
+        in: path
+        description: Slug is a meaningful identifier provided by client, and is case
+          insensitive for query.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return a Notification
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Notification'
+        404:
+          description: The targeted resource is not found.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: Delete a specific Notification by slug.
+      parameters:
+      - name: slug
+        in: path
+        description: Slug is a meaningful identifier provided by client, and is case
+          insensitive for query.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return "True" to represent successful.
+        404:
+          description: The targeted resource is not found.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/notification/start/{start}/end/{end}/{limit}:
+    get:
+      description: Query the Notifications by creation timestamp between start date
+        and end date.
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: start
+        in: path
+        description: Start date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: End date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return a Notification array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NotificationArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/notification/start/{start}/{limit}:
+    get:
+      description: Query the Notifications by creation timestamp after start date.
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: start
+        in: path
+        description: Start date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return a Notification array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NotificationArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/ping:
+    get:
+      description: Test service providing an indication that the service is available.
+      responses:
+        200:
+          description: Return value of "pong."
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/subscription:
+    get:
+      description: List all Subscriptions.
+      responses:
+        200:
+          description: Return a Subscription array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/SubscriptionArray'
+    put:
+      description: Update a specific Subscription according to the slug in request
+        body, and the Boolean value "true" will be returned to indicate updating successfully.  If
+        the slug doesn't exit, the 404 NotFound error will be returned.
+      requestBody:
+        $ref: '#/components/requestBodies/Subscription'
+      responses:
+        200:
+          description: Return "True" to represent successful.
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      description: Create a new Subscritpion.
+      requestBody:
+        $ref: '#/components/requestBodies/Subscription'
+      responses:
+        201:
+          description: Return the slug when the Subscription has been created successfully.
+        409:
+          description: The slug is duplicate.  Please try another one.
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/subscription/categories/{categories}:
+    get:
+      description: Query the Subscription by subscribed categories matching any one
+        of them.
+      parameters:
+      - name: categories
+        in: path
+        description: The subscribed categories, accepting multiple categories separated
+          by comma.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return a Subscription array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/SubscriptionArray'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/subscription/categories/{categories}/labels/{labels}:
+    get:
+      description: Query the Subscription by subscribed categories and labels matching
+        any one of them.
+      parameters:
+      - name: categories
+        in: path
+        description: The subscribed categories, accepting multiple categories separated
+          by comma.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: labels
+        in: path
+        description: The subscribed labels, accepting multiple labels separated by
+          comma.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return a Subscription array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/SubscriptionArray'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/subscription/labels/{labels}:
+    get:
+      description: Query the Subscription by subscribed labels matching any one of
+        them.
+      parameters:
+      - name: labels
+        in: path
+        description: The subscribed labels, accepting multiple labels separated by
+          comma.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return a Subscription array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/SubscriptionArray'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/subscription/receiver/{receiver}:
+    get:
+      description: Query the Subscriptions by Receiver Name.
+      parameters:
+      - name: receiver
+        in: path
+        description: The receiver name of the Subscription, which could be partially
+          matched, and is case insensitive for query.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return a Subscription array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/SubscriptionArray'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/subscription/slug/{slug}:
+    get:
+      description: Query a specific Subscription by slug.
+      parameters:
+      - name: slug
+        in: path
+        description: Slug is a meaningful identifier provided by client, and is case
+          insensitive for query.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return a Subscription.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Subscription'
+        404:
+          description: The targeted resource is not found.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      description: Delete a specific Subscription by slug.
+      parameters:
+      - name: slug
+        in: path
+        description: Slug is a meaningful identifier provided by client, and is case
+          insensitive for query.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return "True" to represent successful.
+        404:
+          description: The targeted resource is not found.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/subscription/{id}:
+    get:
+      description: Fetch a specific subscription by database specified id - returning
+        null if none are found. ServiceException (HTTP 500) for unknown or unanticipated
+        issues
+      parameters:
+      - name: id
+        in: path
+        description: database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: subscription
+        404:
+          description: if the subscription cannot be found by id.
+        500:
+          description: for unknown or unanticipated issues.
+    delete:
+      description: Delete a subscription given its database generated ID. NotFoundException
+        (HTTP 404) if the subscription cannot be found by ID. ServiceException (HTTP
+        500) for unknown or unanticipated issues.
+      parameters:
+      - name: id
+        in: path
+        description: database generated id
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean on success of deletion request
+        404:
+          description: if the subscription cannot be found by id.
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/transmission/acknowledged/age/{age}:
+    delete:
+      description: Delete all the acknowledged Transmissions (status = ACKNOWLEDGED)
+        if the current timestamp minus their last modification timestamp is less than
+        the age parameter.
+      parameters:
+      - name: age
+        in: path
+        description: Specify the age of Transmission, and the format is in milliseconds.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return "True" to represent successful.
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/end/{end}/{limit}:
+    get:
+      description: Query the Transmissions by creation timestamp before end date.
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: End date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return a Transmission array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/TransmissionArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/escalated/age/{age}:
+    delete:
+      description: Delete all the escalated Transmissions (status = ESCALATED) if
+        the current timestamp minus their last modification timestamp is less than
+        the age parameter.
+      parameters:
+      - name: age
+        in: path
+        description: Specify the age of Transmission, and the format is in milliseconds.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return "True" to represent successful.
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/escalated/{limit}:
+    get:
+      description: Query the escalated Transmissions (status = ESCALATED)
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return a Transmission array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/TransmissionArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/failed/age/{age}:
+    delete:
+      description: Delete all the failed Transmissions (status = FAILED and resendCount
+        >= resend limit) if the current timestamp minus their last modification timestamp
+        is less than the age parameter.
+      parameters:
+      - name: age
+        in: path
+        description: Specify the age of Transmission, and the format is in milliseconds.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return "True" to represent successful.
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/failed/{limit}:
+    get:
+      description: Query the failed Transmissions (status = FAILED)
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return a Transmission array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/TransmissionArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/sent/age/{age}:
+    delete:
+      description: Delete all the sent Transmissions (status = SENT) if the current
+        timestamp minus their last modification timestamp is less than the age parameter.
+      parameters:
+      - name: age
+        in: path
+        description: Specify the age of Transmission, and the format is in milliseconds.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return "True" to represent successful.
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/slug/{slug}/start/{start}/end/{end}/{limit}:
+    get:
+      description: Query limited transmissions with specified slug and created date
+        range
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: slug
+        in: path
+        description: This is a Notification slug which is a meaningful identifier
+          provided by client, and it is case insensitive for query.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      - name: start
+        in: path
+        description: Start date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: End date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: list of transmissions
+        400:
+          description: request is invalid or unparseable
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: for unknown or unanticipated issues.
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/slug/{slug}/{limit}:
+    get:
+      description: Query the Transmissions associating a specific Notification by
+        the Notification slug.
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: slug
+        in: path
+        description: This is a Notification slug which is a meaningful identifier
+          provided by client, and it is case insensitive for query.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: Return a Transmission array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/TransmissionArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/start/{start}/end/{end}/{limit}:
+    get:
+      description: Query the Transmissions by creation timestamp between start date
+        and end date.
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: start
+        in: path
+        description: Start date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: end
+        in: path
+        description: End date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return a Transmission array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/TransmissionArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/transmission/start/{start}/{limit}:
+    get:
+      description: Query the Transmissions by creation timestamp after start date.
+      parameters:
+      - name: limit
+        in: path
+        description: The maximum number of records to fetch.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      - name: start
+        in: path
+        description: Start date in long form.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: number
+      responses:
+        200:
+          description: Return a Transmission array.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/TransmissionArray'
+        413:
+          description: The assigned limit perameter exceeds the current max limit.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: For unanticipated or unknown issues encountered.
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  /version:
+    get:
+      description: Get the API version
+      responses:
+        200:
+          description: The service's API version as JSON document
+components:
+  schemas:
+    Error:
+      title: Error Schema
+      required:
+      - error
+      - status
+      - timestamp
+      type: object
+      properties:
+        error:
+          type: string
+        exception:
+          type: string
+          description: The exception class in the code
+        message:
+          type: string
+        path:
+          type: string
+        status:
+          type: integer
+          description: HTTP status code
+        timestamp:
+          type: integer
+    Notification:
+      title: Notification Schema
+      required:
+      - category
+      - content
+      - sender
+      - severity
+      - slug
+      type: object
+      properties:
+        category:
+          type: string
+          enum:
+          - SECURITY
+          - HW_HEALTH
+          - SW_HEALTH
+        content:
+          type: string
+        created:
+          minimum: 0
+          type: integer
+          description: The creation timestamp
+        description:
+          type: string
+        id:
+          type: string
+          description: generated and used by system, and users can ignore this property
+        labels:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        modified:
+          minimum: 0
+          type: integer
+          description: The last modification timestamp
+        sender:
+          type: string
+        severity:
+          type: string
+          enum:
+          - CRITICAL
+          - NORMAL
+        slug:
+          type: string
+          description: A meaningful identifier provided by client
+        status:
+          type: string
+          enum:
+          - NEW
+          - PROCESSED
+          - ESCALATED
+    NotificationArray:
+      title: The Array of Notification
+      type: array
+      items:
+        $ref: '#/components/schemas/Notification'
+    Subscription:
+      title: Subscription Schema
+      required:
+      - channels
+      - receiver
+      - slug
+      type: object
+      properties:
+        channels:
+          uniqueItems: true
+          type: array
+          items:
+            type: object
+            anyOf:
+            - $ref: '#/components/schemas/RESTfulChannel'
+            - $ref: '#/components/schemas/EMAILChannel'
+        created:
+          minimum: 0
+          type: integer
+          description: The creation timestamp
+        description:
+          type: string
+        id:
+          type: string
+        modified:
+          minimum: 0
+          type: integer
+          description: The last modification timestamp
+        receiver:
+          type: string
+        slug:
+          type: string
+          description: A meaningful identifier provided by client
+        subscribedCategories:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+            enum:
+            - SECURITY
+            - HW_HEALTH
+            - SW_HEALTH
+        subscribedLabels:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+    SubscriptionArray:
+      title: The Array of Subscription
+      type: array
+      items:
+        $ref: '#/components/schemas/Subscription'
+    Transmission:
+      title: Transmission Schema
+      required:
+      - channel
+      - notification
+      - receiver
+      - records
+      - resendCount
+      - status
+      type: object
+      properties:
+        channel:
+          type: object
+          oneOf:
+          - $ref: '#/components/schemas/RESTfulChannel'
+          - $ref: '#/components/schemas/EMAILChannel'
+        created:
+          minimum: 0
+          type: integer
+          description: The creation timestamp
+        id:
+          type: string
+        modified:
+          minimum: 0
+          type: integer
+          description: The last modification timestamp
+        notification:
+          $ref: '#/components/schemas/Notification'
+        receiver:
+          type: string
+        records:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/TransmissionRecord'
+        resendCount:
+          minimum: 0
+          type: integer
+        status:
+          type: string
+          enum:
+          - FAILED
+          - SENT
+          - ACKNOWLEDGED
+          - TRXESCALATED
+    TransmissionArray:
+      title: The Array of Transmission
+      type: array
+      items:
+        $ref: '#/components/schemas/Transmission'
+    EMAILChannel:
+      required:
+      - mailAddresses
+      - type
+      type: object
+      properties:
+        mailAddresses:
+          minItems: 1
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        type:
+          type: string
+          enum:
+          - EMAIL
+    RESTfulChannel:
+      required:
+      - type
+      - url
+      type: object
+      properties:
+        contentType:
+          type: string
+        httpMethod:
+          type: string
+          enum:
+          - POST
+          - PUT
+        type:
+          type: string
+          enum:
+          - REST
+        url:
+          type: string
+    TransmissionRecord:
+      required:
+      - sent
+      - status
+      type: object
+      properties:
+        response:
+          type: string
+        sent:
+          minimum: 0
+          type: integer
+          description: The sending timestamp
+        status:
+          type: string
+          enum:
+          - FAILED
+          - SENT
+          - ACKNOWLEDGED
+  requestBodies:
+    Subscription:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Subscription'
+      required: true

--- a/api/oas3.0/support-scheduler.yaml
+++ b/api/oas3.0/support-scheduler.yaml
@@ -1,0 +1,488 @@
+openapi: 3.0.0
+info:
+  title: support-scheduler
+  version: 1.1.x-oas3
+servers:
+- url: http://localhost:48085/api
+paths:
+  /v1/info/{name}:
+    get:
+      description: Return Interval matching given name (interval names should be unique).
+        May be null if no interval matches on the name provided. Returns Internal
+        Service Error (HTTP 500) for unknown or unanticipated issues. NotFoundException
+        (HTTP 404) if no Interval is found with the provided name.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: interval matching on name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/interval'
+        404:
+          description: if no interval is found for the identifier provided.
+        500:
+          description: for unknown or unanticipated issues
+  /v1/interval:
+    get:
+      description: Return all intervals sorted by id. Returns Internal Service Error
+        (HTTP 500) for unknown or unanticipated issues. Returns LimitExceededException
+        (HTTP 413) if the number returned exceeds the max limit.
+      responses:
+        200:
+          description: list of intervals
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/interval'
+        400:
+          description: for malformed or unparsable requests
+        413:
+          description: if the number of intervals exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues
+    put:
+      description: Update an Interval identified by the id or name in the object provided.
+        Id is used first, name is used second for identification purposes. Returns
+        Internal Service Error (HTTP 500) for unknown or unanticipated issues. DataValidationException
+        (HTTP // 409) if any the time or frequency strings are not properly formatted.
+        NotFoundException (HTTP 404) if no interval is found for the id.
+      requestBody:
+        $ref: '#/components/requestBodies/interval'
+      responses:
+        200:
+          description: boolean indicating success of the update
+        400:
+          description: for malformed or unparsable requests
+        409:
+          description: if the start, end, or frequency strings are not properly formatted
+        500:
+          description: for unknown or unanticipated issues
+    post:
+      description: Add a new Interval - name must be unique. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. DataValidationException
+        (HTTP 409) if the cron expression string is not properly formatted.
+      requestBody:
+        $ref: '#/components/requestBodies/interval'
+      responses:
+        200:
+          description: database generated identifier for the new interval
+        400:
+          description: for malformed or unparsable requests
+        409:
+          description: if the start, end, or frequency strings are not properly formatted
+            or if the name is determined to not be unique with regard to others
+        500:
+          description: for unknown or unanticipated issues
+  /v1/interval/name/{name}:
+    get:
+      description: Return Interval matching given name (interval names should be unique).
+        May be null if no interval matches on the name provided. Returns Internal
+        Service Error (HTTP 500) for unknown or unanticipated issues. NotFoundException
+        (HTTP 404) if no Interval is found with the provided name.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: interval matching on name
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/interval'
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no interval is found for the identifier provided.
+        500:
+          description: for unknown or unanticipated issues
+    delete:
+      description: Remove the Interval designated by name. Internal Service Error
+        (HTTP 500) for unknown or unanticipated issues. NotFoundException (HTTP 404)
+        if no Interval is found with the provided name.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no interval is found for the name provided.
+        500:
+          description: for unknown or unanticipated issues
+  /v1/interval/{id}:
+    get:
+      description: Fetch a specific Interval by database generated id. May return
+        null if no interval with the id is found. Returns Internal Service Error (HTTP
+        500) for unknown or unanticipated issues. NotFoundException (HTTP 404) if
+        no Interval is found with the provided id.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: interval matching on the id
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/interval'
+        404:
+          description: if no interval is found for the identifier provided.
+        500:
+          description: for unknown or unanticipated issues
+    delete:
+      description: Remove the Interval designated by database generated id. Internal
+        Service Error (HTTP 500) for unknown or unanticipated issues. NotFoundException
+        (HTTP 404) if no Interval is found with the provided id.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        404:
+          description: if no interval is found for the identifier provided.
+        503:
+          description: for unknown or unanticipated issues
+  /v1/intervalaction:
+    get:
+      description: Return all interval events sorted by id. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. Returns LimitExceededException
+        (HTTP 413) if the number returned exceeds the max limit.
+      responses:
+        200:
+          description: list of interval events
+        413:
+          description: if the number of intervals exceeds the current max limit.
+        500:
+          description: for unknown or unanticipated issues
+    put:
+      description: Update the IntervalAction identified by the id or name in the object
+        provided. Id is used first, name is used second for identification purposes.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        DataValidationException (HTTP 409) if an attempt to change the name is made
+        when the interval action is still being referenced by device reports. NotFoundException
+        (HTTP 404) if no interval is found for the identifier provided.
+      requestBody:
+        $ref: '#/components/requestBodies/intervalAction'
+      responses:
+        200:
+          description: boolean indicating success of the update
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no interval is found for the identifier provided.
+        409:
+          description: if an attempt to change the name is made when the interval
+            action is still being referenced by device reports
+        500:
+          description: for unknown or unanticipated issues
+    post:
+      description: Add a new IntervalAction - name must be unique. Returns Internal
+        Service Error (HTTP 500) for unknown or unanticipated issues. NotFoundException
+        (HTTP 404) if the action's associated interval is not found (referenced by
+        name). DataValidationException (HTTP 409) if the interval was not provided.
+      requestBody:
+        $ref: '#/components/requestBodies/intervalAction'
+      responses:
+        200:
+          description: database generated identifier for the new interval
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if the action's associated interval is not found (referenced
+            by name)
+        409:
+          description: if the interval was not provided or if the name is determined
+            to not be unique with regard to others
+        500:
+          description: for unknown or unanticipated issues or if interval action name
+            is a duplicate
+  /v1/intervalaction/name/{name}:
+    get:
+      description: Return IntervalActions matching given name (interval names should
+        be unique). May be null if no interval events matches on the name provided.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        NotFoundException (HTTP 404) if no IntervalAction is found with the provided
+        name.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: interval action matching on name
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no IntervalAction is found with the provided name
+        500:
+          description: for unknown or unanticipated issues
+    delete:
+      description: Remove the IntervalAction designated by name. Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. NotFoundException (HTTP
+        404) if no IntervalAction is found with the provided name. DataValidationException
+        (HTTP 409) if an attempt to delete a interval action still being referenced
+        by device reports.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no IntervalAction is found with the provided name
+        409:
+          description: if an attempt to delete a interval action still being referenced
+            by device reports
+        500:
+          description: for unknown or unanticipated issues
+  /v1/intervalaction/target/{name}:
+    get:
+      description: Return IntervalActions matching given name (interval names should
+        be unique). May be null if no interval events matches on the name provided.
+        Returns Internal Service Error (HTTP 500) for unknown or unanticipated issues.
+        NotFoundException (HTTP 404) if no IntervalAction is found with the provided
+        name.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: interval action matching on name
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no IntervalAction is found with the provided name
+        500:
+          description: for unknown or unanticipated issues
+    delete:
+      description: Remove the IntervalAction(s) designated by name. Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. NotFoundException (HTTP
+        404) if no IntervalAction is found with the provided name. DataValidationException
+        (HTTP 409) if an attempt to delete a interval action still being referenced
+        by device reports.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        400:
+          description: for malformed or unparsable requests
+        404:
+          description: if no IntervalAction is found with the provided name
+        409:
+          description: if an attempt to delete a interval action still being referenced
+            by device reports
+        500:
+          description: for unknown or unanticipated issues
+  /v1/intervalaction/{id}:
+    get:
+      description: Fetch a specific IntervalAction by database generated id. May return
+        null if no interval action with the id is found. Returns Internal Service
+        Error (HTTP 500) for unknown or unanticipated issues. NotFoundException (HTTP
+        404) if no IntervalAction is found with the provided id.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: interval action matching on the id
+        404:
+          description: if no IntervalAction is found with the provided id
+        500:
+          description: for unknown or unanticipated issues
+    delete:
+      description: Remove the IntervalAction designated by database generated id.
+        Internal Service Error (HTTP 500) for unknown or unanticipated issues. NotFoundException
+        (HTTP 404) if no IntervalAction is found with the provided id. DataValidationException
+        (HTTP 409) if an attempt to delete a interval action still being referenced
+        by device reports.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: boolean indicating success of the remove operation
+        404:
+          description: if no IntervalAction is found with the provided id
+        409:
+          description: if an attempt to delete a interval action still being referenced
+            by device reports
+        503:
+          description: for unknown or unanticipated issues
+  /v1/ping:
+    get:
+      description: ping
+      responses:
+        200:
+          description: Successful Response
+  /version:
+    get:
+      description: Get the API version
+      responses:
+        200:
+          description: The service's API version as JSON document
+components:
+  schemas:
+    interval:
+      title: interval
+      type: object
+      properties:
+        created:
+          title: created
+          type: integer
+        end:
+          title: end
+          type: integer
+        frequency:
+          title: frequency
+          type: integer
+        id:
+          title: id
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        start:
+          title: start
+          type: integer
+      description: meta data around anything that needs to be scheduled (frequency
+        with optional start and end times).
+    intervalAction:
+      title: intervalAction
+      required:
+      - target
+      type: object
+      properties:
+        parameters:
+          title: parameters
+          type: string
+        address:
+          title: address
+          type: string
+        created:
+          title: created
+          type: integer
+        httpmethod:
+          title: httpmethod
+          type: string
+        id:
+          title: id
+          type: string
+        interval:
+          title: interval
+          type: string
+        modified:
+          title: modified
+          type: integer
+        name:
+          title: name
+          type: string
+        origin:
+          title: origin
+          type: integer
+        password:
+          title: password
+          type: string
+        path:
+          title: path
+          type: string
+        port:
+          title: port
+          type: integer
+        protocol:
+          title: protocol
+          type: string
+        publisher:
+          title: publisher
+          type: string
+        target:
+          title: target
+          type: string
+        topic:
+          title: topic
+          type: string
+        user:
+          title: user
+          type: string
+  requestBodies:
+    interval:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/interval'
+      required: true
+    intervalAction:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/intervalAction'
+      required: true

--- a/api/oas3.0/system-agent.yaml
+++ b/api/oas3.0/system-agent.yaml
@@ -1,0 +1,119 @@
+openapi: 3.0.0
+info:
+  title: system-agent
+  version: 1.1.x-oas3
+servers:
+- url: http://localhost:48090/api
+paths:
+  /v1/config/{services}:
+    get:
+      description: Fetch the configuration of the specified EdgeX services by their
+        unique names - returning null if none is found for the service. HTTP 500 for
+        unknown or unanticipated issues
+      parameters:
+      - name: services
+        in: path
+        description: EdgeX micro service names (the unique name of each service comma
+          delimited)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: an array of config
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/config'
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/metrics/{services}:
+    get:
+      description: Fetch the operating performance metrics of the specified EdgeX
+        services by their unique names - returning null if none is found for the service.
+        HTTP 500 for unknown or unanticipated issues
+      parameters:
+      - name: services
+        in: path
+        description: EdgeX micro service names (the unique name of each service comma
+          delimited)
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        200:
+          description: an array of metrics
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/metric'
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/operation:
+    post:
+      description: Issue a start, stop or restart action to the specified services.  HTTP
+        500 for unknown or unanticipated issues.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/operation'
+        required: true
+      responses:
+        500:
+          description: for unknown or unanticipated issues.
+  /v1/ping:
+    get:
+      description: Test service providing an indication that the service is available.
+      responses:
+        200:
+          description: return value of "pong"
+        503:
+          description: for unknown or unanticipated issues
+  /version:
+    get:
+      description: Get the API version
+      responses:
+        200:
+          description: The service's API version as JSON document
+components:
+  schemas:
+    config:
+      title: config
+      type: object
+      properties:
+        Config:
+          title: Config
+          type: string
+        Service:
+          title: Service
+          type: string
+      description: Service configuration
+    metric:
+      title: metric
+      type: object
+      properties:
+        Metrics:
+          title: Metrics
+          type: string
+        Service:
+          title: Service
+          type: string
+      description: Service metrics
+    operation:
+      title: operation
+      type: object
+      properties:
+        action:
+          title: Action
+          type: string
+        services:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+      description: Service operation


### PR DESCRIPTION
Convert the following API doc from RAML to OAS3.

- Core Command
- Core Data
- Core Metadata
- Support Logging
- Support Notification
- Support Scheduler
- System Management

Signed-off-by: Cherry Wang <cherry@iotechsys.com>

Fix #1785 