### PR TITLE
Creates fileioperformer I/O abstraction layer (part 1 of 6 merges for #1677)

### DIFF
--- a/internal/security/fileioperformer/interface.go
+++ b/internal/security/fileioperformer/interface.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileioperformer
+
+import (
+	"io"
+	"os"
+)
+
+type FileIoPerformer interface {
+	// OpenFileReader is a function that opens a file and returns an io.Reader (at a minimum)
+	OpenFileReader(name string, flag int, perm os.FileMode) (io.Reader, error)
+	// OpenFileWriter is a function that opens a file and returns an io.WriteCloser (at a minimum)
+	OpenFileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error)
+	// MkdirAll creates a directory tree (see os.MkdirAll)
+	MkdirAll(path string, perm os.FileMode) error
+}

--- a/internal/security/fileioperformer/methods.go
+++ b/internal/security/fileioperformer/methods.go
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileioperformer
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type defaultFileIoPerformer struct{}
+
+func NewDefaultFileIoPerformer() FileIoPerformer {
+	return &defaultFileIoPerformer{}
+}
+
+func (*defaultFileIoPerformer) OpenFileReader(name string, flag int, perm os.FileMode) (io.Reader, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (*defaultFileIoPerformer) OpenFileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func (*defaultFileIoPerformer) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// MakeReadCloser will turn an an io.Reader into an io.ReadCloser
+// if the underlying object does not already support io.ReadCloser
+func MakeReadCloser(reader io.Reader) io.ReadCloser {
+	rc, ok := reader.(io.ReadCloser)
+	if !ok && reader != nil {
+		rc = ioutil.NopCloser(reader)
+	}
+	return rc
+}

--- a/internal/security/fileioperformer/methods_test.go
+++ b/internal/security/fileioperformer/methods_test.go
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileioperformer
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//
+// Note: these tests do real I/O.
+// Filenames are chosen so as to make this I/O harmless
+//
+
+func TestFileIoPerformerReader(t *testing.T) {
+
+	fileio := NewDefaultFileIoPerformer()
+
+	reader, err := fileio.OpenFileReader("/dev/null", os.O_RDONLY, 0400)
+	assert.Nil(t, err)
+	assert.NotNil(t, fileio)
+	assert.NotNil(t, reader)
+}
+
+func TestFileIoPerformerWriter(t *testing.T) {
+
+	fileio := NewDefaultFileIoPerformer()
+
+	writer, err := fileio.OpenFileWriter("/dev/null", os.O_RDONLY, 0400)
+	assert.Nil(t, err)
+	assert.NotNil(t, fileio)
+	assert.NotNil(t, writer)
+}
+
+func TestFileIoPerformerMkdirAll(t *testing.T) {
+
+	fileio := NewDefaultFileIoPerformer()
+
+	err := fileio.MkdirAll("/tmp", 0777)
+	assert.Nil(t, err)
+}
+
+func TestMakeReadCloserPassThru(t *testing.T) {
+
+	var mockReadCloser io.ReadCloser = &mockReadCloser{}
+	var mockReader = mockReadCloser.(io.Reader)
+
+	result := MakeReadCloser(mockReader)
+	result2 := MakeReadCloser(mockReadCloser)
+
+	// In all cases, should just get the original object back
+
+	assert.Implements(t, (*io.ReadCloser)(nil), result)
+	assert.Implements(t, (*io.ReadCloser)(nil), result2)
+
+	assert.Equal(t, mockReadCloser, result)
+	assert.Equal(t, mockReadCloser, result2)
+}
+
+func TestMakeReadCloserNopCloser(t *testing.T) {
+
+	var mockReader = &mockReader{}
+
+	result := MakeReadCloser(mockReader)
+
+	// Should get back an object with a NopCloser wrapper
+
+	assert.Implements(t, (*io.ReadCloser)(nil), result)
+}
+
+//
+// mocking support
+//
+
+type mockReadCloser struct{}
+
+func (rc *mockReadCloser) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (rc *mockReadCloser) Close() error {
+	return nil
+}
+
+type mockReader struct{}
+
+func (rc *mockReader) Read(p []byte) (n int, err error) {
+	return 0, nil
+}

--- a/internal/security/fileioperformer/mocks/mock.go
+++ b/internal/security/fileioperformer/mocks/mock.go
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"io"
+	"os"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockFileIoPerformer struct {
+	mock.Mock
+}
+
+func (m *MockFileIoPerformer) OpenFileReader(name string, flag int, perm os.FileMode) (io.Reader, error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(name, flag, perm)
+	return arguments.Get(0).(io.Reader), arguments.Error(1)
+}
+
+func (m *MockFileIoPerformer) OpenFileWriter(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(name, flag, perm)
+	return arguments.Get(0).(io.WriteCloser), arguments.Error(1)
+}
+
+func (m *MockFileIoPerformer) MkdirAll(path string, perm os.FileMode) error {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(path, perm)
+	return arguments.Error(0)
+}

--- a/internal/security/fileioperformer/mocks/mock_test.go
+++ b/internal/security/fileioperformer/mocks/mock_test.go
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface FileIoPerformer = &MockFileIoPerformer{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockOpenFileReader(t *testing.T) {
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(&fakeReaderWriter{}, nil)
+
+	obj, err := mockFileIoPerformer.OpenFileReader("/dev/null", os.O_RDONLY, os.FileMode(0400))
+	assert.NotNil(t, obj)
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+}
+
+func TestMockOpenFileWriter(t *testing.T) {
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileWriter", "/dev/null", os.O_WRONLY, os.FileMode(0500)).Return(&fakeReaderWriter{}, nil)
+
+	obj, err := mockFileIoPerformer.OpenFileWriter("/dev/null", os.O_WRONLY, os.FileMode(0500))
+	assert.NotNil(t, obj)
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+}
+
+func TestMockMkdirAll(t *testing.T) {
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("MkdirAll", "/tmp/foo", os.FileMode(0700)).Return(nil)
+
+	err := mockFileIoPerformer.MkdirAll("/tmp/foo", os.FileMode(0700))
+	assert.Nil(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+}
+
+//
+// fakes
+//
+
+type fakeReaderWriter struct{}
+
+func (*fakeReaderWriter) Close() error {
+	return nil
+}
+
+func (m *fakeReaderWriter) Read(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (m *fakeReaderWriter) Write(p []byte) (n int, err error) {
+	return 0, nil
+}


### PR DESCRIPTION
Creates an file I/O abstraction layer that enables
unit testing by mocking file I/O reads and writes
other other file system operations that would
normally be difficult to unit test.

This is part 1 of 6 merges to resolve #1677

Testing instructions: Run "go test" to run init tests.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>