### PR TITLE
Creates authtokenreader interface for Vault client token (part 2 of 6 merges for #1677)

### DIFF
--- a/internal/security/authtokenloader/interface.go
+++ b/internal/security/authtokenloader/interface.go
@@ -1,0 +1,23 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenloader
+
+// AuthTokenLoader returns authorization token for secret store
+type AuthTokenLoader interface {
+	// Load loads and returns authorization token
+	Load(path string) (string, error)
+}

--- a/internal/security/authtokenloader/methods.go
+++ b/internal/security/authtokenloader/methods.go
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenloader
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+)
+
+type tokenProvider struct {
+	fileOpener fileioperformer.FileIoPerformer
+}
+
+// NewAuthTokenLoader creates a new TokenParser
+func NewAuthTokenLoader(opener fileioperformer.FileIoPerformer) AuthTokenLoader {
+	return &tokenProvider{fileOpener: opener}
+}
+
+func (p *tokenProvider) Load(path string) (authToken string, err error) {
+	reader, err := p.fileOpener.OpenFileReader(path, os.O_RDONLY, 0400)
+	if err != nil {
+		return
+	}
+	readCloser := fileioperformer.MakeReadCloser(reader)
+	fileContents, err := ioutil.ReadAll(readCloser)
+	if err != nil {
+		return
+	}
+	defer readCloser.Close()
+
+	var parsedContents vaultTokenFile
+	err = json.Unmarshal(fileContents, &parsedContents)
+	if err != nil {
+		return
+	}
+
+	// Look for token first in "auth"/"client_token"
+	// and then in "root_token"
+	// and fail if no token is found at all
+	if parsedContents.Auth.ClientToken != "" {
+		authToken = parsedContents.Auth.ClientToken
+	} else if parsedContents.RootToken != "" {
+		authToken = parsedContents.RootToken
+	} else {
+		err = fmt.Errorf("Unable to find authentication token in %s", path)
+	}
+	return
+}

--- a/internal/security/authtokenloader/methods_test.go
+++ b/internal/security/authtokenloader/methods_test.go
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenloader
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileioperformer/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+const createTokenJSON = `{"auth":{"client_token":"some-token-value"}}`
+const vaultInitJSON = `{"root_token":"some-token-value"}`
+const expectedToken = "some-token-value"
+
+func TestReadCreateTokenJSON(t *testing.T) {
+	stringReader := strings.NewReader(createTokenJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewAuthTokenLoader(mockFileIoPerformer)
+
+	token, err := p.Load("/dev/null")
+	assert.Nil(t, err)
+	assert.Equal(t, expectedToken, token)
+}
+
+func TestReadVaultInitJSON(t *testing.T) {
+	stringReader := strings.NewReader(vaultInitJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewAuthTokenLoader(mockFileIoPerformer)
+
+	token, err := p.Load("/dev/null")
+	assert.Nil(t, err)
+	assert.Equal(t, expectedToken, token)
+}
+
+func TestReadEmptyJSON(t *testing.T) {
+	stringReader := strings.NewReader("{}")
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewAuthTokenLoader(mockFileIoPerformer)
+
+	_, err := p.Load("/dev/null")
+	assert.EqualError(t, err, "Unable to find authentication token in /dev/null")
+}
+
+func TestFailOpen(t *testing.T) {
+	stringReader := strings.NewReader("")
+	myerr := errors.New("error")
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "/dev/null", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, myerr)
+
+	p := NewAuthTokenLoader(mockFileIoPerformer)
+
+	_, err := p.Load("/dev/null")
+	assert.Equal(t, myerr, err)
+}

--- a/internal/security/authtokenloader/mocks/mock.go
+++ b/internal/security/authtokenloader/mocks/mock.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type MockAuthTokenLoader struct {
+	mock.Mock
+}
+
+func (m *MockAuthTokenLoader) Load(path string) (string, error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(path)
+	return arguments.String(0), arguments.Error(1)
+}

--- a/internal/security/authtokenloader/mocks/mock_test.go
+++ b/internal/security/authtokenloader/mocks/mock_test.go
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/authtokenloader"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface AuthTokenLoader = &MockAuthTokenLoader{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockLoad(t *testing.T) {
+	o := &MockAuthTokenLoader{}
+	o.On("Load", "path").Return("abcd", nil)
+
+	token, err := o.Load("path")
+
+	o.AssertExpectations(t)
+	assert.Nil(t, err)
+	assert.Equal(t, "abcd", token)
+}

--- a/internal/security/authtokenloader/types.go
+++ b/internal/security/authtokenloader/types.go
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package authtokenloader
+
+type vaultTokenFile struct {
+	// Auth comes from the create token API
+	Auth authObject `json:"auth"`
+	// RootToken comes from the vault-init response
+	RootToken string `json:"root_token"`
+}
+
+type authObject struct {
+	ClientToken string `json:"client_token"`
+}


### PR DESCRIPTION
Creates an interface and package that reads a Vault 
token out of a JSON file.  The JSON file can either be
the output of the Vault init command (containing a 
root token) or the output of the token create API
(containing a service token). 

This package is used as a mockable dependency in the
vault client to faciliitate unit testing.

This is part 2 of 6 merges to resolve #1677

Testing instructions: Run "go test" to run init tests.

Preqrequisites:
  * https://github.com/edgexfoundry/edgex-go/pull/1788

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>