### PR TITLE
Refactor vault client into standalone package with mocks (part 3 of 6 merges for #1677)

### DIFF
--- a/internal/security/secretstoreclient/const.go
+++ b/internal/security/secretstoreclient/const.go
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author: Tingyu Zeng, Dell
+ *******************************************************************************/
+package secretstoreclient
+
+const (
+	VaultToken       = "X-Vault-Token"
+	VaultHealthAPI   = "/v1/sys/health"
+	VaultInitAPI     = "/v1/sys/init"
+	VaultUnsealAPI   = "/v1/sys/unseal"
+	JSONContentType  = "application/json"
+	CreatePolicyPath = "/v1/sys/policies/acl/%s"
+	CreateTokenAPI   = "/v1/auth/token/create"
+)

--- a/internal/security/secretstoreclient/interface.go
+++ b/internal/security/secretstoreclient/interface.go
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package secretstoreclient
+
+import (
+	"io"
+)
+
+// SecretStoreClient is interface to Vault
+type SecretStoreClient interface {
+	HealthCheck() (statusCode int, err error)
+	Init(config SecretServiceInfo, vmkWriter io.Writer) (statusCode int, err error)
+	Unseal(config SecretServiceInfo, vmkReader io.Reader) (statusCode int, err error)
+	InstallPolicy(token string,
+		policyName string, policyDocument string) (statusCode int, err error)
+	CreateToken(token string,
+		parameters map[string]interface{}, response interface{}) (statusCode int, err error)
+}

--- a/internal/security/secretstoreclient/mocks/mock.go
+++ b/internal/security/secretstoreclient/mocks/mock.go
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"io"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockSecretStoreClient struct {
+	mock.Mock
+}
+
+func (m *MockSecretStoreClient) HealthCheck() (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called()
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockSecretStoreClient) Init(config SecretServiceInfo, vmkWriter io.Writer) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(config, vmkWriter)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockSecretStoreClient) Unseal(config SecretServiceInfo, vmkReader io.Reader) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(config, vmkReader)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockSecretStoreClient) InstallPolicy(token string, policyName string, policyDocument string) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(token, policyName, policyDocument)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockSecretStoreClient) CreateToken(token string, parameters map[string]interface{}, response interface{}) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(token, parameters, response)
+	return arguments.Int(0), arguments.Error(1)
+}

--- a/internal/security/secretstoreclient/mocks/mock_test.go
+++ b/internal/security/secretstoreclient/mocks/mock_test.go
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface SecretStoreClient = &MockSecretStoreClient{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockHealthCheck(t *testing.T) {
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("HealthCheck").Return(http.StatusOK, nil)
+
+	rc, err := mockClient.HealthCheck()
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockInit(t *testing.T) {
+	config := SecretServiceInfo{}
+	scratchBuffer := new(bytes.Buffer)
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("Init", config, scratchBuffer).Return(http.StatusOK, nil)
+
+	rc, err := mockClient.Init(config, scratchBuffer)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockUnseal(t *testing.T) {
+	config := SecretServiceInfo{}
+	scratchBuffer := new(bytes.Buffer)
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("Unseal", config, scratchBuffer).Return(http.StatusOK, nil)
+
+	rc, err := mockClient.Unseal(config, scratchBuffer)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockInstallPolicy(t *testing.T) {
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("InstallPolicy", "fake-token", "foo", "bar").Return(http.StatusOK, nil)
+
+	rc, err := mockClient.InstallPolicy("fake-token", "foo", "bar")
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockCreateToken(t *testing.T) {
+	params := make(map[string]interface{})
+	response := make(map[string]interface{})
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("CreateToken", "fake-token", params, response).Return(http.StatusOK, nil)
+
+	rc, err := mockClient.CreateToken("fake-token", params, response)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}

--- a/internal/security/secretstoreclient/requestor.go
+++ b/internal/security/secretstoreclient/requestor.go
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author: Tingyu Zeng, Dell
+ *******************************************************************************/
+
+package secretstoreclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+type HTTPSRequestor interface {
+	Insecure() internal.HttpCaller
+	WithTLS(io.Reader, string) internal.HttpCaller
+}
+
+type fluentRequestor struct {
+	logger logger.LoggingClient
+}
+
+func NewRequestor(logger logger.LoggingClient) HTTPSRequestor {
+	return &fluentRequestor{logger}
+}
+
+func (r *fluentRequestor) Insecure() internal.HttpCaller {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return &http.Client{Timeout: 10 * time.Second, Transport: tr}
+}
+
+func (r *fluentRequestor) WithTLS(caReader io.Reader, serverName string) internal.HttpCaller {
+	readCloser := fileioperformer.MakeReadCloser(caReader)
+	caCert, err := ioutil.ReadAll(readCloser)
+	defer readCloser.Close()
+	if err != nil {
+		r.logger.Error("failed to load rootCA certificate.")
+		return nil
+	}
+	r.logger.Info("successful loading the rootCA certificate.")
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:            caCertPool,
+			InsecureSkipVerify: false,
+			ServerName:         serverName,
+		},
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	return &http.Client{Timeout: 10 * time.Second, Transport: tr}
+}

--- a/internal/security/secretstoreclient/requestor_test.go
+++ b/internal/security/secretstoreclient/requestor_test.go
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+
+ *******************************************************************************/
+
+package secretstoreclient
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInsecureRequestor(t *testing.T) {
+	mockLogger := logger.MockLogger{}
+
+	caller := NewRequestor(mockLogger).Insecure()
+	assert.NotNil(t, caller)
+}
+
+func TestSecureRequestor(t *testing.T) {
+	mockLogger := logger.MockLogger{}
+
+	caller := NewRequestor(mockLogger).WithTLS(strings.NewReader(""), "str")
+	assert.NotNil(t, caller)
+}

--- a/internal/security/secretstoreclient/testdata/test-resp-init.json
+++ b/internal/security/secretstoreclient/testdata/test-resp-init.json
@@ -1,0 +1,9 @@
+{
+	"keys": [
+	  "test-keys"
+	],
+	"keys_base64": [
+	  "test-keys-base64"
+	],
+	"root_token": "test-root-token"
+}

--- a/internal/security/secretstoreclient/types.go
+++ b/internal/security/secretstoreclient/types.go
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package secretstoreclient
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type SecretServiceInfo struct {
+	Scheme               string
+	Server               string
+	Port                 int
+	CertPath             string
+	CaFilePath           string
+	CertFilePath         string
+	KeyFilePath          string
+	TokenFolderPath      string
+	TokenFile            string
+	VaultSecretShares    int
+	VaultSecretThreshold int
+}
+
+func (s SecretServiceInfo) GetSecretSvcBaseURL() string {
+	url := &url.URL{
+		Scheme: s.Scheme,
+		Host:   fmt.Sprintf("%s:%v", s.Server, s.Port),
+		Path:   "/",
+	}
+	return url.String()
+}

--- a/internal/security/secretstoreclient/types_test.go
+++ b/internal/security/secretstoreclient/types_test.go
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+
+ *******************************************************************************/
+
+package secretstoreclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBaseURL(t *testing.T) {
+	theURL := SecretServiceInfo{
+		Scheme: "http",
+		Server: "my-server",
+		Port:   1234,
+	}.GetSecretSvcBaseURL()
+
+	assert.Equal(t, "http://my-server:1234/", theURL)
+}

--- a/internal/security/secretstoreclient/vault.go
+++ b/internal/security/secretstoreclient/vault.go
@@ -1,0 +1,274 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author: Tingyu Zeng, Dell / Alain Pulluelo, ForgeRock AS
+ *******************************************************************************/
+
+package secretstoreclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// InitRequest contains a Vault init request regarding the Shamir Secret Sharing (SSS) parameters
+type InitRequest struct {
+	SecretShares    int `json:"secret_shares"`
+	SecretThreshold int `json:"secret_threshold"`
+}
+
+// InitResponse contains a Vault init response
+type InitResponse struct {
+	Keys       []string `json:"keys"`
+	KeysBase64 []string `json:"keys_base64"`
+	RootToken  string   `json:"root_token"`
+}
+
+// UnsealRequest contains a Vault unseal request
+type UnsealRequest struct {
+	Key   string `json:"key"`
+	Reset bool   `json:"reset"`
+}
+
+// UnsealResponse contains a Vault unseal response
+type UnsealResponse struct {
+	Sealed   bool `json:"sealed"`
+	T        int  `json:"t"`
+	N        int  `json:"n"`
+	Progress int  `json:"progress"`
+}
+
+// UpdateACLPolicyRequest contains a ACL policy create/update request
+type UpdateACLPolicyRequest struct {
+	Policy string `json:"policy"`
+}
+
+type vaultClient struct {
+	logger logger.LoggingClient
+	client internal.HttpCaller
+	scheme string
+	host   string
+}
+
+func NewSecretStoreClient(logger logger.LoggingClient, r internal.HttpCaller, s string, h string) SecretStoreClient {
+	return &vaultClient{
+		logger: logger,
+		client: r,
+		scheme: s,
+		host:   h,
+	}
+}
+
+func (vc *vaultClient) HealthCheck() (statusCode int, err error) {
+	url := vc.buildURL(VaultHealthAPI)
+	empty := struct{}{}
+	resp, err := vc.commonRequest(nil, http.MethodGet, url, &empty)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed on checking status of secret store: %s", err.Error()))
+		return 0, err
+	}
+	defer resp.Body.Close()
+	vc.logger.Info(fmt.Sprintf("vault health check HTTP status: %s (StatusCode: %d)", resp.Status, resp.StatusCode))
+	return resp.StatusCode, nil
+}
+
+func (vc *vaultClient) Init(config SecretServiceInfo, vmkWriter io.Writer) (statusCode int, err error) {
+	initRequest := InitRequest{
+		SecretShares:    config.VaultSecretShares,
+		SecretThreshold: config.VaultSecretThreshold,
+	}
+
+	vc.logger.Info(fmt.Sprintf("vault init strategy (SSS parameters): shares=%d threshold=%d", initRequest.SecretShares, initRequest.SecretThreshold))
+
+	url := vc.buildURL(VaultInitAPI)
+	resp, err := vc.commonRequest(nil, http.MethodPost, url, &initRequest)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to send Vault init request: %s", err.Error()))
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		vc.logger.Error(fmt.Sprintf("vault init request failed with status: %s", resp.Status))
+		return resp.StatusCode, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to fetch the Vault init request response body: %s", err.Error()))
+		return 0, err
+	}
+
+	initResp := InitResponse{}
+	if err = json.Unmarshal(body, &initResp); err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to build the JSON structure from the init request response body: %s", err.Error()))
+		return 0, err
+	}
+
+	_, err = vmkWriter.Write(body)
+
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to create Vault init response %s file, HTTP status: %s", config.TokenFolderPath+"/"+config.TokenFile, err.Error()))
+		return 0, err
+	}
+
+	vc.logger.Info("Vault initialization complete.")
+	return resp.StatusCode, nil
+}
+
+func (vc *vaultClient) Unseal(config SecretServiceInfo, vmkReader io.Reader) (statusCode int, err error) {
+	vc.logger.Info(fmt.Sprintf("Vault unsealing Process. Applying key shares."))
+	initResp := InitResponse{}
+	readCloser := fileioperformer.MakeReadCloser(vmkReader)
+	rawBytes, err := ioutil.ReadAll(readCloser)
+	defer readCloser.Close()
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to read the Vault JSON response init file: %s", err.Error()))
+		return 0, err
+	}
+
+	if err = json.Unmarshal(rawBytes, &initResp); err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to build the JSON structure from the init response body: %s", err.Error()))
+		return 0, err
+	}
+
+	url := vc.buildURL(VaultUnsealAPI)
+
+	keyCounter := 1
+	for _, key := range initResp.KeysBase64 {
+		unsealRequest := UnsealRequest{
+			Key: key,
+		}
+		resp, err := vc.commonRequest(nil, http.MethodPost, url, &unsealRequest)
+		if err != nil {
+			vc.logger.Error(fmt.Sprintf("failed to send the Vault init request: %s", err.Error()))
+			return 0, err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			vc.logger.Error(fmt.Sprintf("vault unseal request failed with status code: %s", resp.Status))
+			return resp.StatusCode, err
+		}
+
+		unsealedBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			vc.logger.Error(fmt.Sprintf("failed to fetch the Vault unseal request response body: %s", err.Error()))
+			return 0, err
+		}
+		unsealResponse := UnsealResponse{}
+		if err = json.Unmarshal(unsealedBody, &unsealResponse); err != nil {
+			vc.logger.Error(fmt.Sprintf("failed to build the JSON structure from the unseal request response body: %s", err.Error()))
+			return 0, err
+		}
+
+		vc.logger.Info(fmt.Sprintf("Vault key share %d/%d successfully applied.", keyCounter, config.VaultSecretShares))
+		if !unsealResponse.Sealed {
+			vc.logger.Info("Vault key share threshold reached. Unsealing complete.")
+			return resp.StatusCode, nil
+		}
+		keyCounter++
+	}
+	return 0, fmt.Errorf("%d", 1)
+}
+
+func (vc *vaultClient) InstallPolicy(
+	token string,
+	policyName string,
+	policyDocument string) (statusCode int, err error) {
+
+	path := fmt.Sprintf(CreatePolicyPath, url.PathEscape(policyName))
+	url := vc.buildURL(path)
+
+	request := UpdateACLPolicyRequest{Policy: policyDocument}
+	resp, err := vc.commonRequest(&token, http.MethodPut, url, request)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to send Vault create policy request: %s", err.Error()))
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		vc.logger.Error(fmt.Sprintf("vault create policy request failed with status: %s", resp.Status))
+		return resp.StatusCode, err
+	}
+
+	vc.logger.Info(fmt.Sprintf("Created vault policy %s", policyName))
+	return resp.StatusCode, nil
+}
+
+func (vc *vaultClient) CreateToken(token string, parameters map[string]interface{}, response interface{}) (statusCode int, err error) {
+	url := vc.buildURL(CreateTokenAPI)
+
+	resp, err := vc.commonRequest(&token, http.MethodPost, url, parameters)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to send Vault create token request: %s", err.Error()))
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		vc.logger.Error(fmt.Sprintf("vault create token request failed with status: %s", resp.Status))
+		return resp.StatusCode, err
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to parse response body: %s", err.Error()))
+		return 0, err
+	}
+
+	tokenName, ok := parameters["display_name"].(string)
+	if !ok {
+		tokenName = "UNKNOWN DISPLAY_NAME"
+	}
+	vc.logger.Info(fmt.Sprintf("Created vault token %s", tokenName))
+	return resp.StatusCode, nil
+}
+
+func (vc *vaultClient) buildURL(path string) string {
+	return (&url.URL{
+		Scheme: vc.scheme,
+		Host:   vc.host,
+		Path:   path,
+	}).String()
+}
+
+func (vc *vaultClient) commonRequest(token *string, method string, url string, jsonBody interface{}) (*http.Response, error) {
+	body, err := json.Marshal(jsonBody)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to marshal request body: %s", err.Error()))
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to create request object: %s", err.Error()))
+		return nil, err
+	}
+
+	if token != nil {
+		req.Header.Set(VaultToken, *token)
+	}
+	req.Header.Set("Content-Type", JSONContentType)
+	return vc.client.Do(req)
+}

--- a/internal/security/secretstoreclient/vault_test.go
+++ b/internal/security/secretstoreclient/vault_test.go
@@ -1,0 +1,208 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+
+ *******************************************************************************/
+
+package secretstoreclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthCheck(t *testing.T) {
+	mockLogger := logger.MockLogger{}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.Method != "GET" {
+			t.Errorf("expected GET request, got %s instead", r.Method)
+		}
+
+		if r.URL.EscapedPath() != VaultHealthAPI {
+			t.Errorf("expected request to /%s, got %s instead", VaultHealthAPI, r.URL.EscapedPath())
+		}
+	}))
+	defer ts.Close()
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewSecretStoreClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+	code, _ := vc.HealthCheck()
+
+	if code != http.StatusOK {
+		t.Errorf("incorrect vault health check status.")
+	}
+}
+
+func TestInit(t *testing.T) {
+	mockLogger := logger.MockLogger{}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"keys": [
+			  "test-keys"
+			],
+			"keys_base64": [
+			  "test-keys-base64"
+			],
+			"root_token": "test-root-token"
+		}
+		`))
+		if r.Method != "POST" {
+			t.Errorf("expected POST request, got %s instead", r.Method)
+		}
+
+		if r.URL.EscapedPath() != VaultInitAPI {
+			t.Errorf("expected request to /%s, got %s instead", VaultInitAPI, r.URL.EscapedPath())
+		}
+	}))
+	defer ts.Close()
+
+	config := SecretServiceInfo{
+		TokenFolderPath: "testdata",
+		TokenFile:       "test-resp-init.json",
+	}
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewSecretStoreClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+	tokenFile, err := os.OpenFile(filepath.Join(config.TokenFolderPath, config.TokenFile), os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		t.Errorf("failed to open token file %s", err.Error())
+	}
+	defer tokenFile.Close()
+	code, _ := vc.Init(config, tokenFile)
+	if code != http.StatusOK {
+		t.Errorf("incorrect vault init status. The returned code is %d", code)
+	}
+}
+
+func TestUnseal(t *testing.T) {
+	mockLogger := logger.MockLogger{}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"sealed": false, "t": 1, "n": 1, "progress": 100}`))
+		if r.Method != "POST" {
+			t.Errorf("expected POST request, got %s instead", r.Method)
+		}
+
+		if r.URL.EscapedPath() != VaultUnsealAPI {
+			t.Errorf("expected request to /%s, got %s instead", VaultUnsealAPI, r.URL.EscapedPath())
+		}
+	}))
+	defer ts.Close()
+
+	config := SecretServiceInfo{
+		TokenFolderPath:   "testdata",
+		TokenFile:         "test-resp-init.json",
+		VaultSecretShares: 1,
+	}
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewSecretStoreClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+	tokenFile, err := fileioperformer.NewDefaultFileIoPerformer().OpenFileReader(filepath.Join(config.TokenFolderPath, config.TokenFile), os.O_RDONLY, 0400)
+	if err != nil {
+		t.Errorf("failed to open token file %s", err.Error())
+	}
+	code, err := vc.Unseal(config, tokenFile)
+	if code != http.StatusOK {
+		t.Errorf("incorrect vault unseal status. The returned code is %d, %s", code, err.Error())
+	}
+}
+
+func TestInstallPolicy(t *testing.T) {
+	// Arrange
+	assert := assert.New(t)
+	mockLogger := logger.MockLogger{}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("PUT", r.Method)
+		assert.Equal("/v1/sys/policies/acl/policy-name", r.URL.EscapedPath())
+		assert.Equal("fake-token", r.Header.Get("X-Vault-Token"))
+
+		// Make sure the policy doc was base64 encoded in the json response object
+		body := make(map[string]interface{})
+		err := json.NewDecoder(r.Body).Decode(&body)
+		assert.Nil(err)
+		assert.Equal("policydoc", body["policy"].(string))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewSecretStoreClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+
+	// Act
+	policyDoc := "policydoc"
+	code, err := vc.InstallPolicy("fake-token", "policy-name", policyDoc)
+
+	// Assert
+	assert.Nil(err)
+	assert.Equal(http.StatusNoContent, code)
+}
+
+func TestCreateToken(t *testing.T) {
+	// Arrange
+	assert := assert.New(t)
+	mockLogger := logger.MockLogger{}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("POST", r.Method)
+		assert.Equal(CreateTokenAPI, r.URL.EscapedPath())
+		assert.Equal("fake-token", r.Header.Get("X-Vault-Token"))
+
+		body := make(map[string]interface{})
+		err := json.NewDecoder(r.Body).Decode(&body)
+		assert.Nil(err)
+
+		assert.Equal("sample-value", body["sample_parameter"])
+
+		w.WriteHeader(http.StatusOK)
+
+		response := struct {
+			RequestID string `json:"request_id"`
+		}{
+			RequestID: "f00341c1-fad5-f6e6-13fd-235617f858a1",
+		}
+		err = json.NewEncoder(w).Encode(response)
+		assert.Nil(err)
+
+	}))
+	defer ts.Close()
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewSecretStoreClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+
+	// Act
+	parameters := make(map[string]interface{})
+	parameters["sample_parameter"] = "sample-value"
+	response := make(map[string]interface{})
+	code, err := vc.CreateToken("fake-token", parameters, &response)
+
+	// Assert
+	assert.Nil(err)
+	assert.Equal(http.StatusOK, code)
+	assert.Equal("f00341c1-fad5-f6e6-13fd-235617f858a1", response["request_id"].(string))
+}


### PR DESCRIPTION
This is a refactoring of the Vault client originally
found in security-secretstore-setup with re-use and
unit-testability in mind.

The original init and unseal flows have been modified
to remove dependencies on global variables and
hard dependencies on operating system file I/O. 
Additonal methods have been added to create Vault
policies and service tokens.

This is part 3 of 6 merges to resolve #1677

Testing instructions: Run "go test" to run init tests.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>