### PR TITLE
Create component to read service token config file (part 4 of 6 merges for #1677)

### DIFF
--- a/internal/security/tokenconfig/interface.go
+++ b/internal/security/tokenconfig/interface.go
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package tokenconfig
+
+// TokenConfigParser returns authorization token for secret store
+type TokenConfigParser interface {
+	// Load loads authorization token
+	Load(path string) error
+	// Get service keys
+	ServiceKeys() []string
+	// Get configuration for a service
+	GetServiceConfig(serviceName string) ServiceKey
+}

--- a/internal/security/tokenconfig/methods.go
+++ b/internal/security/tokenconfig/methods.go
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package tokenconfig
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+)
+
+type tokenConfigParser struct {
+	fileOpener fileioperformer.FileIoPerformer
+	tokenConf  TokenConfFile
+}
+
+// NewTokenConfigParser creates a new TokenConfigParser
+func NewTokenConfigParser(opener fileioperformer.FileIoPerformer) TokenConfigParser {
+	return &tokenConfigParser{fileOpener: opener}
+}
+
+func (p *tokenConfigParser) Load(path string) error {
+	reader, err := p.fileOpener.OpenFileReader(path, os.O_RDONLY, 0400)
+	if err != nil {
+		return err
+	}
+	readCloser := fileioperformer.MakeReadCloser(reader)
+	fileContents, err := ioutil.ReadAll(readCloser)
+	if err != nil {
+		return err
+	}
+	defer readCloser.Close()
+
+	var parsedContents TokenConfFile
+	err = json.Unmarshal(fileContents, &parsedContents)
+	if err != nil {
+		return err
+	}
+
+	p.tokenConf = parsedContents
+	return nil
+}
+
+func (p *tokenConfigParser) ServiceKeys() []string {
+	serviceNames := make([]string, 0, len(p.tokenConf))
+	for serviceName := range p.tokenConf {
+		serviceNames = append(serviceNames, serviceName)
+	}
+	return serviceNames
+}
+
+func (p tokenConfigParser) GetServiceConfig(service string) ServiceKey {
+	return p.tokenConf[service]
+}

--- a/internal/security/tokenconfig/methods_test.go
+++ b/internal/security/tokenconfig/methods_test.go
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package tokenconfig
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileioperformer/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sampleJSON = `{
+	"service-name": {
+	  "edgex_use_defaults": true,
+	  "custom_policy": {
+		"path": {
+		  "secret/non/standard/location/*": {
+		    "capabilities": [ "list", "read" ]
+		  }
+		}
+	  },
+	  "custom_token_parameters": { "custom_option": "custom_vaule" }
+	}
+  }`
+
+func TestTokenConfigParser(t *testing.T) {
+	stringReader := strings.NewReader(sampleJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "dummy-file", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	p := NewTokenConfigParser(mockFileIoPerformer)
+
+	err := p.Load("dummy-file")
+	assert.Nil(t, err)
+
+	serviceKeys := p.ServiceKeys()
+	assert.Equal(t, []string{"service-name"}, serviceKeys)
+
+	aService := p.GetServiceConfig("service-name")
+
+	assert.Equal(t, true, aService.UseDefaults)
+	assert.Contains(t, aService.CustomPolicy, "path")
+	var path = aService.CustomPolicy["path"].(map[string]interface{})
+	assert.Contains(t, path, "secret/non/standard/location/*")
+	// Don't need to go further down the type assertion rabbit hole to prove that this is working
+	assert.Contains(t, aService.CustomTokenParameters, "custom_option")
+}

--- a/internal/security/tokenconfig/mocks/mock.go
+++ b/internal/security/tokenconfig/mocks/mock.go
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	. "github.com/edgexfoundry/edgex-go/internal/security/tokenconfig"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockTokenConfigParser struct {
+	mock.Mock
+}
+
+func (m *MockTokenConfigParser) Load(path string) error {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(path)
+	return arguments.Error(0)
+}
+
+func (m *MockTokenConfigParser) ServiceKeys() []string {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called()
+	return arguments.Get(0).([]string)
+}
+
+func (m *MockTokenConfigParser) GetServiceConfig(service string) ServiceKey {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(service)
+	return arguments.Get(0).(ServiceKey)
+}

--- a/internal/security/tokenconfig/mocks/mock_test.go
+++ b/internal/security/tokenconfig/mocks/mock_test.go
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/tokenconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface TokenConfigParser = &MockTokenConfigParser{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockLoad(t *testing.T) {
+	parser := &MockTokenConfigParser{}
+	parser.On("Load", "path").Return(nil)
+
+	err := parser.Load("path")
+
+	assert.Nil(t, err)
+	parser.AssertExpectations(t)
+}
+
+func TestMockServiceKeys(t *testing.T) {
+	parser := &MockTokenConfigParser{}
+	parser.On("ServiceKeys").Return([]string{"key1"})
+
+	keys := parser.ServiceKeys()
+
+	assert.Equal(t, "key1", keys[0])
+	parser.AssertExpectations(t)
+}
+
+func TestMockGetServiceConfig(t *testing.T) {
+	parser := &MockTokenConfigParser{}
+	parser.On("GetServiceConfig", "key1").Return(ServiceKey{UseDefaults: true})
+
+	sk := parser.GetServiceConfig("key1")
+
+	assert.True(t, sk.UseDefaults)
+	parser.AssertExpectations(t)
+}

--- a/internal/security/tokenconfig/types.go
+++ b/internal/security/tokenconfig/types.go
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package tokenconfig
+
+/*
+
+Example config file
+
+{
+  "service-name": {
+    "edgex_use_defaults": true,
+    "custom_policy": [
+      {
+        "path": {
+          "secret/non/standard/location/*": {
+            "capabilities": [ "list", "read" ]
+          }
+        }
+      }
+    ],
+    "custom_token_parameters": { }
+  }
+}
+
+*/
+type TokenConfFile map[string]ServiceKey
+
+type ServiceKey struct {
+	UseDefaults           bool                   `json:"edgex_use_defaults"` // BUG - change to underscores in man page
+	CustomPolicy          map[string]interface{} `json:"custom_policy"`      // JSON serialization of HCL
+	CustomTokenParameters map[string]interface{} `json:"custom_token_parameters"`
+}
+
+/* Note that above types must be exported in order to visible to JSON marshaller */


### PR DESCRIPTION
Create mockable component to read a service token
configuration file that will be used to create
per-service Vault tokens. This component handles
the loading and structure parsing of the file.

This is part 4 of 6 merges to resolve #1677

Testing instructions: Run "go test" to run init tests.

Preqrequisites:
  * https://github.com/edgexfoundry/edgex-go/pull/1788

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>