### PR TITLE
Business logic for security-file-token-provider (part 5 of 6 merges for #1677)

### DIFF
--- a/internal/security/fileprovider/config.go
+++ b/internal/security/fileprovider/config.go
@@ -1,0 +1,93 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+)
+
+var Configuration = &ConfigurationStruct{}
+
+type ConfigurationStruct struct {
+	Writable          WritableInfo
+	Logging           config.LoggingInfo
+	SecretService     secretstoreclient.SecretServiceInfo
+	TokenFileProvider TokenFileProviderInfo
+	Clients           map[string]config.ClientInfo
+	Registry          config.RegistryInfo
+	Service           config.ServiceInfo
+}
+
+type WritableInfo struct {
+	LogLevel string
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		// Check that information was successfully read from Registry
+		if configuration.SecretService.Server == "" {
+			return false
+		}
+		c = configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Clients:  c.Clients,
+		Service:  c.Service,
+		Registry: c.Registry,
+		Logging:  c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
+	c.Registry = registryInfo
+}

--- a/internal/security/fileprovider/defaults.go
+++ b/internal/security/fileprovider/defaults.go
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+func makeDefaultTokenPolicy(serviceName string) map[string]interface{} {
+	protectedPath := "secret/edgex/" + serviceName + "/*"
+	capabilities := []string{"create", "update", "delete", "list", "read"}
+	acl := map[string]interface{}{"capabilities": capabilities}
+	pathObject := map[string]interface{}{protectedPath: acl}
+	retval := map[string]interface{}{"path": pathObject}
+	return retval
+
+	/*
+		{
+			"path": {
+			  "secret/edgex/service-name/*": {
+				"capabilities": [ "create", "update", "delete", "list", "read" ]
+			  }
+			}
+		  }
+	*/
+}
+
+func makeDefaultTokenParameters(serviceName string) map[string]interface{} {
+	return map[string]interface{}{
+		"display_name": serviceName,
+		"no_parent":    true,
+		"policies":     []string{"edgex-service-" + serviceName},
+	}
+}

--- a/internal/security/fileprovider/defaults_test.go
+++ b/internal/security/fileprovider/defaults_test.go
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package fileprovider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultTokenPolicy(t *testing.T) {
+	// Arrange
+
+	// Act
+	policies := makeDefaultTokenPolicy("service-name")
+
+	// Assert
+	bytes, err := json.Marshal(policies)
+	assert.NoError(t, err)
+
+	expected := `{"path":{"secret/edgex/service-name/*":{"capabilities":["create","update","delete","list","read"]}}}`
+	actual := string(bytes)
+	assert.Equal(t, expected, actual)
+}
+
+func TestDefaultTokenParameters(t *testing.T) {
+	// Arrange
+
+	// Act
+	parameters := makeDefaultTokenParameters("service-name")
+
+	// Assert
+	bytes, err := json.Marshal(parameters)
+	assert.NoError(t, err)
+
+	expected := `{"display_name":"service-name","no_parent":true,"policies":["edgex-service-service-name"]}`
+	actual := string(bytes)
+	assert.Equal(t, expected, actual)
+}

--- a/internal/security/fileprovider/interface.go
+++ b/internal/security/fileprovider/interface.go
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+)
+
+// TokenProvider is the interface that the main program expects
+// for implemeneting token generation
+type TokenProvider interface {
+	// Set configuration
+	SetConfiguration(secretConfig secretstoreclient.SecretServiceInfo, tokenConfig TokenFileProviderInfo)
+	// Generate tokens
+	Run() error
+}

--- a/internal/security/fileprovider/mocks/mock.go
+++ b/internal/security/fileprovider/mocks/mock.go
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockTokenProvider struct {
+	mock.Mock
+}
+
+// Run see interface.go
+func (p *MockTokenProvider) Run() error {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := p.Called()
+	return arguments.Error(0)
+}
+
+func (p *MockTokenProvider) SetConfiguration(secretConfig secretstoreclient.SecretServiceInfo, tokenConfig TokenFileProviderInfo) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	p.Called(secretConfig, tokenConfig)
+}

--- a/internal/security/fileprovider/mocks/mock_test.go
+++ b/internal/security/fileprovider/mocks/mock_test.go
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package mocks
+
+import (
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockInterfaceType(t *testing.T) {
+	// Typecast will fail if doesn't implement interface properly
+	var iface TokenProvider = &MockTokenProvider{}
+	assert.NotNil(t, iface)
+}
+
+func TestMockRun(t *testing.T) {
+	p := &MockTokenProvider{}
+	p.On("Run").Return(nil)
+
+	err := p.Run()
+
+	assert.Nil(t, err)
+	p.AssertExpectations(t)
+}
+
+func TestMockSetConfiguration(t *testing.T) {
+	p := &MockTokenProvider{}
+	p.On("SetConfiguration", secretstoreclient.SecretServiceInfo{}, TokenFileProviderInfo{})
+
+	p.SetConfiguration(secretstoreclient.SecretServiceInfo{}, TokenFileProviderInfo{})
+
+	p.AssertExpectations(t)
+}

--- a/internal/security/fileprovider/provider.go
+++ b/internal/security/fileprovider/provider.go
@@ -1,0 +1,155 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenloader"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// fileTokenProvider stores instance data
+type fileTokenProvider struct {
+	logger        logger.LoggingClient
+	fileOpener    fileioperformer.FileIoPerformer
+	tokenProvider authtokenloader.AuthTokenLoader
+	vaultClient   secretstoreclient.SecretStoreClient
+	secretConfig  secretstoreclient.SecretServiceInfo
+	tokenConfig   TokenFileProviderInfo
+}
+
+// NewTokenProvider creates a new TokenProvider
+func NewTokenProvider(logger logger.LoggingClient,
+	fileOpener fileioperformer.FileIoPerformer,
+	tokenProvider authtokenloader.AuthTokenLoader,
+	vaultClient secretstoreclient.SecretStoreClient) TokenProvider {
+	return &fileTokenProvider{
+		logger:        logger,
+		fileOpener:    fileOpener,
+		tokenProvider: tokenProvider,
+		vaultClient:   vaultClient,
+	}
+}
+
+// Set configuration
+func (p *fileTokenProvider) SetConfiguration(secretConfig secretstoreclient.SecretServiceInfo, tokenConfig TokenFileProviderInfo) {
+	p.secretConfig = secretConfig
+	p.tokenConfig = tokenConfig
+}
+
+// Do whatever is needed
+func (p *fileTokenProvider) Run() error {
+	p.logger.Info("Generating Vault tokens")
+
+	privilegedToken, err := p.tokenProvider.Load(p.tokenConfig.PrivilegedTokenPath)
+	if err != nil {
+		p.logger.Error(fmt.Sprintf("failed to read privileged access token: %s", err.Error()))
+		return err
+	}
+
+	var tokenConf TokenConfFile
+	if err := LoadTokenConfig(p.fileOpener, p.tokenConfig.ConfigFile, &tokenConf); err != nil {
+		p.logger.Error(fmt.Sprintf("failed to read token configuration file %s: %s", p.tokenConfig.ConfigFile, err.Error()))
+		return err
+	}
+
+	for serviceName, serviceConfig := range tokenConf {
+
+		p.logger.Info(fmt.Sprintf("generating policy/token defaults for service %s", serviceName))
+
+		servicePolicy := make(map[string]interface{})
+		createTokenParameters := make(map[string]interface{})
+
+		if serviceConfig.UseDefaults {
+			p.logger.Info(fmt.Sprintf("using policy/token defaults for service %s", serviceName))
+			servicePolicy = makeDefaultTokenPolicy(serviceName)
+			createTokenParameters = makeDefaultTokenParameters(serviceName)
+		}
+
+		if serviceConfig.CustomPolicy != nil {
+			customPolicy := serviceConfig.CustomPolicy
+			if customPolicy["path"] != nil {
+				customPaths := customPolicy["path"].(map[string]interface{})
+				if servicePolicy["path"] == nil {
+					servicePolicy["path"] = make(map[string]interface{})
+				}
+				for k, v := range customPaths {
+					(servicePolicy["path"]).(map[string]interface{})[k] = v
+				}
+			}
+		}
+
+		if serviceConfig.CustomTokenParameters != nil {
+			// Custom token parameters override the defaults
+			createTokenParameters = mergeMaps(createTokenParameters, serviceConfig.CustomTokenParameters)
+		}
+
+		// Set a meta property that consuming serices can use to automatically scope secret queries
+		createTokenParameters["meta"] = map[string]interface{}{
+			"edgex-service-name": serviceName,
+		}
+
+		// Always create a policy with this name
+		policyName := "edgex-service-" + serviceName
+
+		policyBytes, err := json.Marshal(servicePolicy)
+		if err != nil {
+			p.logger.Error(fmt.Sprintf("failed encode service policy for %s: %s", serviceName, err.Error()))
+			return err
+		}
+
+		if _, err := p.vaultClient.InstallPolicy(privilegedToken, policyName, string(policyBytes)); err != nil {
+			p.logger.Error(fmt.Sprintf("failed to install policy %s: %s", policyName, err.Error()))
+			return err
+		}
+
+		var createTokenResponse interface{}
+
+		if _, err = p.vaultClient.CreateToken(privilegedToken, createTokenParameters, &createTokenResponse); err != nil {
+			p.logger.Error(fmt.Sprintf("failed to create vault token for service %s: %s", serviceName, err.Error()))
+			return err
+		}
+
+		outputTokenDir := filepath.Join(p.tokenConfig.OutputDir, serviceName)
+		outputTokenFilename := filepath.Join(outputTokenDir, p.tokenConfig.OutputFilename)
+		if err := p.fileOpener.MkdirAll(outputTokenDir, os.FileMode(0700)); err != nil {
+			p.logger.Error(fmt.Sprintf("failed to create base directory path(s) %s: %s", outputTokenDir, err.Error()))
+			return err
+		}
+		writeCloser, err := p.fileOpener.OpenFileWriter(outputTokenFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600))
+		if err != nil {
+			p.logger.Error(fmt.Sprintf("failed open token file for writing %s: %s", outputTokenFilename, err.Error()))
+			return err
+		}
+		defer writeCloser.Close()
+
+		json.NewEncoder(writeCloser).Encode(createTokenResponse) // Write resulting token
+
+		if err := writeCloser.Close(); err != nil {
+			p.logger.Error(fmt.Sprintf("failed to close %s: %s", outputTokenFilename, err.Error()))
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/security/fileprovider/provider_test.go
+++ b/internal/security/fileprovider/provider_test.go
@@ -1,0 +1,360 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package fileprovider
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/authtokenloader/mocks"
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileioperformer/mocks"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	. "github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient/mocks"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+/*
+Test cases:
+
+1. Create multiple service tokens with no defaults
+2. Create a service with no defaults and custom policy
+3. Create a service with no defaults and custom token parameters
+4. Create a service with defaults for policy and token parameters
+*/
+
+// TestMultipleTokensWithNoDefaults
+func TestMultipleTokensWithNoDefaults(t *testing.T) {
+	// Arrange
+	privilegedTokenPath := "/dummy/privileged/token.json"
+	configFile := "token-config.json"
+	outputDir := "/outputdir"
+	outputFilename := "secrets-token.json"
+
+	mockLogger := logger.MockLogger{}
+
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	expectedService1Dir := filepath.Join(outputDir, "service1")
+	expectedService1File := filepath.Join(expectedService1Dir, outputFilename)
+	service1Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService1Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileReader", configFile, os.O_RDONLY, os.FileMode(0400)).Return(strings.NewReader(`{"service1":{},"service2":{}}`), nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService1File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service1Buffer}, nil)
+	expectedService2Dir := filepath.Join(outputDir, "service2")
+	expectedService2File := filepath.Join(expectedService2Dir, outputFilename)
+	service2Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService2Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService2File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service2Buffer}, nil)
+
+	mockAuthTokenLoader := &MockAuthTokenLoader{}
+	mockAuthTokenLoader.On("Load", privilegedTokenPath).Return("fake-priv-token", nil)
+
+	expectedService1Policy := "{}"
+	expectedService2Policy := "{}"
+	expectedService1Parameters := makeMetaServiceName("service1")
+	expectedService2Parameters := makeMetaServiceName("service2")
+	mockSecretStoreClient := &MockSecretStoreClient{}
+	mockSecretStoreClient.On("InstallPolicy", "fake-priv-token", "edgex-service-service1", expectedService1Policy).Return(http.StatusNoContent, nil)
+	mockSecretStoreClient.On("InstallPolicy", "fake-priv-token", "edgex-service-service2", expectedService2Policy).Return(http.StatusNoContent, nil)
+	mockSecretStoreClient.On("CreateToken", "fake-priv-token", expectedService1Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("service1", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+	mockSecretStoreClient.On("CreateToken", "fake-priv-token", expectedService2Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("service2", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenLoader, mockSecretStoreClient)
+	p.SetConfiguration(secretstoreclient.SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: privilegedTokenPath,
+		ConfigFile:          configFile,
+		OutputDir:           outputDir,
+		OutputFilename:      outputFilename,
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	// - {OutputDir}/service1/{OutputFilename} w/proper contents
+	// - {OutputDir}/service2/{OutputFilename} w/proper contents
+	// - Correct policy for service1
+	// - Correct policy for service2
+	// - All other expectations met
+	assert.NoError(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenLoader.AssertExpectations(t)
+	mockSecretStoreClient.AssertExpectations(t)
+	assert.Equal(t, expectedTokenFile("service1"), service1Buffer.Bytes())
+	assert.Equal(t, expectedTokenFile("service2"), service2Buffer.Bytes())
+}
+
+func setCreateTokenResponse(serviceName string, retval *interface{}) {
+	t := make(map[string]interface{})
+	t["request_id"] = "f00341c1-fad5-f6e6-13fd-235617f858a1"
+	t["auth"] = make(map[string]interface{})
+	t["auth"].(map[string]interface{})["client_token"] = "s.wOrq9dO9kzOcuvB06CMviJhZ"
+	t["auth"].(map[string]interface{})["accessor"] = "B6oixijqmeR4bsLOJH88Ska9"
+	(*retval) = t
+}
+
+func makeMetaServiceName(serviceName string) map[string]interface{} {
+	createTokenParameters := make(map[string]interface{})
+	meta := make(map[string]interface{})
+	meta["edgex-service-name"] = serviceName
+	createTokenParameters["meta"] = meta
+	return createTokenParameters
+}
+
+func expectedTokenFile(serviceName string) []byte {
+	var tokenResponse interface{}
+	setCreateTokenResponse(serviceName, &tokenResponse)
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(tokenResponse)
+	// Debugging note: take care to not write out the buffer or it will disturb the read pointer
+	return b.Bytes()
+}
+
+// TestNoDefaultsCustomPolicy
+func TestNoDefaultsCustomPolicy(t *testing.T) {
+	// Arrange
+	privilegedTokenPath := "/dummy/privileged/token.json"
+	configFile := "token-config.json"
+	outputDir := "/outputdir"
+	outputFilename := "secrets-token.json"
+
+	mockLogger := logger.MockLogger{}
+
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	expectedService1Dir := filepath.Join(outputDir, "myservice")
+	expectedService1File := filepath.Join(expectedService1Dir, outputFilename)
+	service1Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService1Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileReader", configFile, os.O_RDONLY, os.FileMode(0400)).Return(strings.NewReader(`{"myservice":{"custom_policy":{"path":{"secret/non/standard/location/*":{"capabilities":["list","read"]}}}}}`), nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService1File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service1Buffer}, nil)
+
+	mockAuthTokenLoader := &MockAuthTokenLoader{}
+	mockAuthTokenLoader.On("Load", privilegedTokenPath).Return("fake-priv-token", nil)
+
+	expectedService1Policy := `{"path":{"secret/non/standard/location/*":{"capabilities":["list","read"]}}}`
+	expectedService1Parameters := makeMetaServiceName("myservice")
+	mockSecretStoreClient := &MockSecretStoreClient{}
+	mockSecretStoreClient.On("InstallPolicy", "fake-priv-token", "edgex-service-myservice", expectedService1Policy).Return(http.StatusNoContent, nil)
+	mockSecretStoreClient.On("CreateToken", "fake-priv-token", expectedService1Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("myservice", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenLoader, mockSecretStoreClient)
+	p.SetConfiguration(secretstoreclient.SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: privilegedTokenPath,
+		ConfigFile:          configFile,
+		OutputDir:           outputDir,
+		OutputFilename:      outputFilename,
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	// - {OutputDir}/myservice/{OutputFilename} w/proper contents
+	// - Correct policy for myservice
+	// - All other expectations met
+	assert.NoError(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenLoader.AssertExpectations(t)
+	mockSecretStoreClient.AssertExpectations(t)
+	assert.Equal(t, expectedTokenFile("myservice"), service1Buffer.Bytes())
+}
+
+// TestNoDefaultsCustomTokenParameters
+func TestNoDefaultsCustomTokenParameters(t *testing.T) {
+	// Arrange
+	privilegedTokenPath := "/dummy/privileged/token.json"
+	configFile := "token-config.json"
+	outputDir := "/outputdir"
+	outputFilename := "secrets-token.json"
+
+	mockLogger := logger.MockLogger{}
+
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	expectedService1Dir := filepath.Join(outputDir, "myservice")
+	expectedService1File := filepath.Join(expectedService1Dir, outputFilename)
+	service1Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService1Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileReader", configFile, os.O_RDONLY, os.FileMode(0400)).Return(strings.NewReader(`{"myservice":{"custom_token_parameters":{"key1":"value1"}}}`), nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService1File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service1Buffer}, nil)
+
+	mockAuthTokenLoader := &MockAuthTokenLoader{}
+	mockAuthTokenLoader.On("Load", privilegedTokenPath).Return("fake-priv-token", nil)
+
+	expectedService1Policy := "{}"
+	expectedService1Parameters := make(map[string]interface{})
+	expectedService1Parameters["key1"] = "value1"
+	expectedService1Parameters["meta"] = makeMetaServiceName("myservice")["meta"]
+	mockSecretStoreClient := &MockSecretStoreClient{}
+	mockSecretStoreClient.On("InstallPolicy", "fake-priv-token", "edgex-service-myservice", expectedService1Policy).Return(http.StatusNoContent, nil)
+	mockSecretStoreClient.On("CreateToken", "fake-priv-token", expectedService1Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("myservice", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenLoader, mockSecretStoreClient)
+	p.SetConfiguration(secretstoreclient.SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: privilegedTokenPath,
+		ConfigFile:          configFile,
+		OutputDir:           outputDir,
+		OutputFilename:      outputFilename,
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	// - {OutputDir}/myservice/{OutputFilename} w/proper contents
+	// - Correct token parameters for myservice
+	// - All other expectations met
+	assert.NoError(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenLoader.AssertExpectations(t)
+	mockSecretStoreClient.AssertExpectations(t)
+	assert.Equal(t, expectedTokenFile("myservice"), service1Buffer.Bytes())
+}
+
+// TestTokenUsingDefaults
+func TestTokenUsingDefaults(t *testing.T) {
+	// Arrange
+	privilegedTokenPath := "/dummy/privileged/token.json"
+	configFile := "token-config.json"
+	outputDir := "/outputdir"
+	outputFilename := "secrets-token.json"
+
+	mockLogger := logger.MockLogger{}
+
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	expectedService1Dir := filepath.Join(outputDir, "myservice")
+	expectedService1File := filepath.Join(expectedService1Dir, outputFilename)
+	service1Buffer := new(bytes.Buffer)
+	mockFileIoPerformer.On("MkdirAll", expectedService1Dir, os.FileMode(0700)).Return(nil)
+	mockFileIoPerformer.On("OpenFileReader", configFile, os.O_RDONLY, os.FileMode(0400)).Return(strings.NewReader(`{"myservice":{"edgex_use_defaults":true}}`), nil)
+	mockFileIoPerformer.On("OpenFileWriter", expectedService1File, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&writeCloserBuffer{service1Buffer}, nil)
+
+	mockAuthTokenLoader := &MockAuthTokenLoader{}
+	mockAuthTokenLoader.On("Load", privilegedTokenPath).Return("fake-priv-token", nil)
+
+	expectedService1Policy := `{"path":{"secret/edgex/myservice/*":{"capabilities":["create","update","delete","list","read"]}}}`
+	expectedService1Parameters := makeDefaultTokenParameters("myservice")
+	expectedService1Parameters["meta"] = makeMetaServiceName("myservice")["meta"]
+	mockSecretStoreClient := &MockSecretStoreClient{}
+	mockSecretStoreClient.On("InstallPolicy", "fake-priv-token", "edgex-service-myservice", expectedService1Policy).Return(http.StatusNoContent, nil)
+	mockSecretStoreClient.On("CreateToken", "fake-priv-token", expectedService1Parameters, mock.Anything).
+		Run(func(args mock.Arguments) {
+			setCreateTokenResponse("myservice", args.Get(2).(*interface{}))
+		}).
+		Return(http.StatusOK, nil)
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenLoader, mockSecretStoreClient)
+	p.SetConfiguration(secretstoreclient.SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: privilegedTokenPath,
+		ConfigFile:          configFile,
+		OutputDir:           outputDir,
+		OutputFilename:      outputFilename,
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	// - {OutputDir}/myservice/{OutputFilename} w/proper contents
+	// - Correct token parameters for myservice
+	// - All other expectations met
+	assert.NoError(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenLoader.AssertExpectations(t)
+	mockSecretStoreClient.AssertExpectations(t)
+	assert.Equal(t, expectedTokenFile("myservice"), service1Buffer.Bytes())
+}
+
+func TestErrorLoading1(t *testing.T) {
+	// Arrange
+	mockLogger := logger.MockLogger{}
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockAuthTokenLoader := &MockAuthTokenLoader{}
+	mockAuthTokenLoader.On("Load", "tokenpath").Return("atoken", errors.New("an error"))
+	mockSecretStoreClient := &MockSecretStoreClient{}
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenLoader, mockSecretStoreClient)
+	p.SetConfiguration(secretstoreclient.SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: "tokenpath",
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	assert.Error(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenLoader.AssertExpectations(t)
+	mockSecretStoreClient.AssertExpectations(t)
+}
+
+func TestErrorLoading2(t *testing.T) {
+	// Arrange
+	mockLogger := logger.MockLogger{}
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "", os.O_RDONLY, os.FileMode(0400)).Return(strings.NewReader(""), errors.New("an error"))
+	mockAuthTokenLoader := &MockAuthTokenLoader{}
+	mockAuthTokenLoader.On("Load", "tokenpath").Return("atoken", nil)
+	mockSecretStoreClient := &MockSecretStoreClient{}
+
+	p := NewTokenProvider(mockLogger, mockFileIoPerformer, mockAuthTokenLoader, mockSecretStoreClient)
+	p.SetConfiguration(secretstoreclient.SecretServiceInfo{}, TokenFileProviderInfo{
+		PrivilegedTokenPath: "tokenpath",
+	})
+
+	// Act
+	err := p.Run()
+
+	// Assert
+	assert.Error(t, err)
+	mockFileIoPerformer.AssertExpectations(t)
+	mockAuthTokenLoader.AssertExpectations(t)
+	mockSecretStoreClient.AssertExpectations(t)
+}
+
+//
+// mocks
+//
+
+type writeCloserBuffer struct {
+	*bytes.Buffer
+}
+
+func (wcb *writeCloserBuffer) Close() error {
+	return nil
+}

--- a/internal/security/fileprovider/res/edgex-privileged-token-creator.hcl
+++ b/internal/security/fileprovider/res/edgex-privileged-token-creator.hcl
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+//
+// This file is taken from
+// https://raw.githubusercontent.com/edgexfoundry/edgex-docs/master/security/token-file-provider.1.rst
+//
+// This is a reference copy of the policy that security-file-token-provider requires
+// in order to run and create policies for other services.
+//
+
+path "auth/token/create" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "auth/token/create-orphan" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "auth/token/create/*" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "sys/policies/acl/edgex-service-*"
+{
+  capabilities = ["create", "read", "update", "delete" ]
+}
+
+path "sys/policies/acl"
+{
+  capabilities = ["list"]
+}

--- a/internal/security/fileprovider/tokenconfig.go
+++ b/internal/security/fileprovider/tokenconfig.go
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+/*
+
+Example config file
+
+{
+  "service-name": {
+    "edgex_use_defaults": true,
+    "custom_policy": [
+      {
+        "path": {
+          "secret/non/standard/location/*": {
+            "capabilities": [ "list", "read" ]
+          }
+        }
+      }
+    ],
+    "custom_token_parameters": { }
+  }
+}
+
+*/
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+)
+
+type TokenConfFile map[string]ServiceKey
+
+type ServiceKey struct {
+	UseDefaults           bool                   `json:"edgex_use_defaults"`
+	CustomPolicy          map[string]interface{} `json:"custom_policy"` // JSON serialization of HCL
+	CustomTokenParameters map[string]interface{} `json:"custom_token_parameters"`
+}
+
+func LoadTokenConfig(fileOpener fileioperformer.FileIoPerformer, path string, tokenConf *TokenConfFile) error {
+	reader, err := fileOpener.OpenFileReader(path, os.O_RDONLY, 0400)
+	if err != nil {
+		return err
+	}
+	readCloser := fileioperformer.MakeReadCloser(reader)
+	defer readCloser.Close()
+
+	err = json.NewDecoder(readCloser).Decode(tokenConf)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/security/fileprovider/tokenconfig_test.go
+++ b/internal/security/fileprovider/tokenconfig_test.go
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package fileprovider
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileioperformer/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sampleJSON = `{
+	"service-name": {
+	  "edgex_use_defaults": true,
+	  "custom_policy": {
+		"path": {
+		  "secret/non/standard/location/*": {
+		    "capabilities": [ "list", "read" ]
+		  }
+		}
+	  },
+	  "custom_token_parameters": { "custom_option": "custom_vaule" }
+	}
+  }`
+
+func TestLoadTokenConfig(t *testing.T) {
+	stringReader := strings.NewReader(sampleJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "dummy-file", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	var tokenConf TokenConfFile
+	err := LoadTokenConfig(mockFileIoPerformer, "dummy-file", &tokenConf)
+	assert.NoError(t, err)
+
+	aService := tokenConf["service-name"]
+	assert.NotNil(t, aService)
+	assert.Equal(t, true, aService.UseDefaults)
+	assert.Contains(t, aService.CustomPolicy, "path")
+	var path = aService.CustomPolicy["path"].(map[string]interface{})
+	assert.Contains(t, path, "secret/non/standard/location/*")
+	// Don't need to go further down the type assertion rabbit hole to prove that this is working
+	assert.Contains(t, aService.CustomTokenParameters, "custom_option")
+}
+
+func TestLoadTokenConfigError1(t *testing.T) {
+	stringReader := strings.NewReader(sampleJSON)
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "dummy-file", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, errors.New("an error"))
+
+	var tokenConf TokenConfFile
+	err := LoadTokenConfig(mockFileIoPerformer, "dummy-file", &tokenConf)
+	assert.Error(t, err)
+}
+
+func TestLoadTokenConfigError2(t *testing.T) {
+	stringReader := strings.NewReader("in{valid")
+	mockFileIoPerformer := &MockFileIoPerformer{}
+	mockFileIoPerformer.On("OpenFileReader", "dummy-file", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+
+	var tokenConf TokenConfFile
+	err := LoadTokenConfig(mockFileIoPerformer, "dummy-file", &tokenConf)
+	assert.Error(t, err)
+}

--- a/internal/security/fileprovider/types.go
+++ b/internal/security/fileprovider/types.go
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+type TokenFileProviderInfo struct {
+	// Path to Vault authorization token to be used by the service (default: /run/edgex/secrets/token-file-provider/secrets-token.json)
+	PrivilegedTokenPath string
+	// Configuration file used to control token creation (default: res/token-config.json)
+	ConfigFile string
+	// Base directory for token file output (default: /run/edgex/secrets)
+	OutputDir string
+	// File name for token file (default: secrets-token.json)
+	OutputFilename string
+}

--- a/internal/security/fileprovider/util.go
+++ b/internal/security/fileprovider/util.go
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+func mergeMaps(defaults map[string]interface{}, other map[string]interface{}) map[string]interface{} {
+	// Defaults are overridden
+	for key, value := range other {
+		defaults[key] = value
+	}
+	return defaults
+}

--- a/internal/security/fileprovider/util_test.go
+++ b/internal/security/fileprovider/util_test.go
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+package fileprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeMaps(t *testing.T) {
+	// Arrange
+	defaults := map[string]interface{}{"notoverridden": true, "overridden": false}
+	other := map[string]interface{}{"overridden": true, "newkey": true}
+
+	// Act
+	merged := mergeMaps(defaults, other)
+
+	// Assert
+	assert.True(t, merged["notoverridden"].(bool))
+	assert.True(t, merged["overridden"].(bool))
+	assert.True(t, merged["newkey"].(bool))
+}


### PR DESCRIPTION
This is the main business logic for
security-file-token-provider as documented in
edgex-docs/security/token-file-provider.1.rst

This component is responsible for looping through
the configuration file and creating Vault policies
and security tokens to enable retrieval of
service-specific secrets.

This is part 5 of 6 merges to resolve issue 1677

Testing instructions: Run "go test" to run init tests.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>