### PR TITLE
Implement cmd/security-file-token-provider (part 6 of 6 merges for #1677)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOCGO=CGO_ENABLED=1 GO111MODULE=on go
 DOCKERS=docker_config_seed docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent docker_support_scheduler docker_security_secrets_setup docker_security_proxy_setup docker_security_secretstore_setup
 .PHONY: $(DOCKERS)
 
-MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup cmd/security-secretstore-setup/security-secretstore-setup
+MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup cmd/security-secretstore-setup/security-secretstore-setup cmd/security-file-token-provider/security-file-token-provider
 
 .PHONY: $(MICROSERVICES)
 
@@ -70,6 +70,8 @@ cmd/security-proxy-setup/security-proxy-setup:
 cmd/security-secretstore-setup/security-secretstore-setup:
 	$(GO) build $(GOFLAGS) -o ./cmd/security-secretstore-setup/security-secretstore-setup ./cmd/security-secretstore-setup
 
+cmd/security-file-token-provider/security-file-token-provider:
+	$(GO) build $(GOFLAGS) -o ./cmd/security-file-token-provider/security-file-token-provider ./cmd/security-file-token-provider
 
 clean:
 	rm -f $(MICROSERVICES)

--- a/cmd/security-file-token-provider/Attribution.txt
+++ b/cmd/security-file-token-provider/Attribution.txt
@@ -1,0 +1,146 @@
+The following open source projects are referenced by Security Secrets Setup:
+
+pkg/errors (BSD-2) https://github.com/pkg/errors
+https://github.com/pkg/errors/blob/master/LICENSE
+
+gorilla/mux (BSD-3) - https://github.com/gorilla/mux
+https://github.com/gorilla/mux/blob/master/LICENSE
+
+globalsign/mgo (unspecified) - https://github.com/globalsign/mgo
+https://github.com/globalsign/mgo/blob/master/LICENSE
+
+pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
+https://github.com/pebbe/zmq4/blob/master/LICENSE.txt
+
+go-kit/kit (MIT) github.com/go-kit/kit
+https://github.com/go-kit/kit/blob/master/LICENSE
+
+go-logfmt/logfmt (MIT) https://github.com/go-logfmt/logfmt
+https://github.com/go-logfmt/logfmt/blob/master/LICENSE
+
+robfig/cron (MIT) https://github.com/robfig/cron
+https://github.com/robfig/cron/blob/master/LICENSE
+
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
+google/uuid (BSD-3) https://github.com/google/uuid
+https://github.com/google/uuid/blob/master/LICENSE
+
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
+influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
+https://github.com/influxdata/influxdb/blob/master/LICENSE
+
+influxdata/platform (MIT) https://github.com/influxdata/platform
+https://github.com/influxdata/platform/blob/master/LICENSE
+
+eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
+https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
+
+mattn/go-xmpp (BSD-3) https://github.com/mattn/go-xmpp
+https://github.com/mattn/go-xmpp/blob/master/LICENSE
+
+BurntSushi/toml (MIT) https://github.com/BurntSushi/toml
+https://github.com/BurntSushi/toml/blob/master/COPYING
+
+mitchellh/consulstructure (MIT) https://github.com/mitchellh/consulstructure
+https://github.com/mitchellh/consulstructure/blob/master/LICENSE
+
+mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
+https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+mitchellh/copystructure (MIT) https://github.com/mitchellh/copystructure
+https://github.com/mitchellh/copystructure/blob/master/LICENSE
+
+mitchellh/reflectwalk (MIT) https://github.com/mitchellh/reflectwalk
+https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
+
+cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
+https://github.com/cenkalti/backoff/blob/master/LICENSE
+
+hashicorp/consul 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul
+https://github.com/hashicorp/consul/blob/master/LICENSE
+
+hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
+https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
+
+hashicorp/go-rootcerts (Mozilla Public License 2.0) https://github.com/hashicorp/go-rootcerts
+https://github.com/hashicorp/go-rootcerts/blob/master/LICENSE
+
+mitchellh/go-homedir (MIT) https://github.com/mitchellh/go-homedir
+https://github.com/mitchellh/go-homedir/blob/master/LICENSE
+
+mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
+https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+hashicorp/serf (Mozilla Public License 2.0) https://github.com/hashicorp/serf
+https://github.com/hashicorp/serf/blob/master/LICENSE
+
+armon/go-metrics (MIT) https://github.com/armon/go-metrics
+https://github.com/armon/go-metrics/blob/master/LICENSE
+
+hashicorp/go-immutable-radix (Mozilla Public License 2.0) https://github.com/hashicorp/go-immutable-radix
+https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
+
+hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
+https://github.com/hashicorp/golang-lru/blob/master/LICENSE
+
+gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
+https://github.com/gomodule/redigo/blob/master/LICENSE
+
+OneOfOne/xxhash (Apache 2.0) https://github.com/OneOfOne/xxhash
+https://github.com/OneOfOne/xxhash/blob/master/LICENSE
+
+imdario/mergo (BSD-3) github.com/imdario/mergo
+https://github.com/imdario/mergo/blob/master/LICENSE
+
+magiconair/properties (BSD-2) https://github.com/magiconair/properties
+https://github.com/magiconair/properties/blob/master/LICENSE
+
+gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
+https://github.com/eapache/queue/blob/v1.1.0/LICENSE
+
+bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
+https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
+https://github.com/hashicorp/consul/blob/master/LICENSE
+

--- a/cmd/security-file-token-provider/README.md
+++ b/cmd/security-file-token-provider/README.md
@@ -1,0 +1,57 @@
+# Integration testing instructions for security-file-token-provider
+
+## Build
+
+Use Makefile in the base directory of this repository to build the docker image of security-secretes-setup:
+
+```sh
+make -C ../.. cmd/security-file-token-provider/security-file-token-provider
+```
+
+It should create an executable named `security-file-token-provider` in the current directory.
+
+## Run
+
+Run the `integrationtest.sh` script.
+
+```sh
+./integrationtest.sh
+```
+
+Verify the resulting output for correctness.
+The script will automatically fail if a subcommand
+returns a nonzero exit status.
+
+Afterwards, shut down the docker composition
+
+```sh
+docker-compose down
+```
+
+## Details
+
+The integration test script first starts Vault and Consul via a docker-compose.yml script.
+The script copies out the CA certificate and root token JSON file to the current directory.
+It then overwrites `res/configuration.toml` with some values to allow the integration test to run.
+The script then dumps a list of all policies, and a list of current Vault tokens.
+
+Next, the script runs `security-file-token-provider`
+
+Afterwards, the script then dumps the policies, Vault tokens,
+the policy it just created, and calls the token lookup command
+on the newly-created Vault token.
+
+## Testing with TLS
+
+In order to test with TLS, it is necessary to edit `/etc/hosts` and add
+an alias for edgex-vault:
+
+```
+127.0.0.1 edgex-vault
+```
+
+Then edit `integrationtest.sh` and uncomment `CaFilePath`.
+
+Re-run `integrationtest.sh` and verify that it makes a TLS connection to Vault.
+
+_BE SURE TO REMOVE THE EDITS FROM `/etc/hosts` WHEN YOU ARE DONE!_

--- a/cmd/security-file-token-provider/main.go
+++ b/cmd/security-file-token-provider/main.go
@@ -1,0 +1,122 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
+	bootstrapinterface "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenloader"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// Constants
+
+// Dependencies
+
+var fileProvider fileprovider.TokenProvider
+
+func main() {
+	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+
+	var useRegistry bool
+	var profileDir, configDir string
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallback
+	flag.Parse()
+
+	bootstrap.Run(
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SupportLoggingServiceKey,
+		fileprovider.Configuration,
+		startupTimer,
+		di.NewContainer(di.ServiceConstructorMap{}),
+		[]bootstrapinterface.BootstrapHandler{
+			func(
+				wg *sync.WaitGroup,
+				ctx context.Context,
+				startupTimer startup.Timer,
+				dic *di.Container) bool {
+
+				logging := container.LoggingClientFrom(dic.Get)
+				return runTokenProvider(logging)
+			},
+		})
+}
+
+func runTokenProvider(logging logger.LoggingClient) bool {
+
+	cfg := fileprovider.Configuration
+
+	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
+	tokenProvider := authtokenloader.NewAuthTokenLoader(fileOpener)
+
+	var req internal.HttpCaller
+	if caFilePath := cfg.SecretService.CaFilePath; caFilePath != "" {
+		logging.Info("using certificate verification for secret store connection")
+		caReader, err := fileOpener.OpenFileReader(caFilePath, os.O_RDONLY, 0400)
+		if err != nil {
+			logging.Error(fmt.Sprintf("failed to load CA certificate: %s", err.Error()))
+			return false
+		}
+		req = secretstoreclient.NewRequestor(logging).WithTLS(caReader, cfg.SecretService.ServerName)
+	} else {
+		logging.Info("bypassing certificate verification for secret store connection")
+		req = secretstoreclient.NewRequestor(logging).Insecure()
+	}
+	vaultScheme := cfg.SecretService.Scheme
+	vaultHost := fmt.Sprintf("%s:%v", cfg.SecretService.Server, cfg.SecretService.Port)
+	vaultClient := secretstoreclient.NewSecretStoreClient(logging, req, vaultScheme, vaultHost)
+
+	if fileProvider == nil {
+		// main_test.go has injected a testing mock if fileProvider != nil
+		fileProvider = fileprovider.NewTokenProvider(logging, fileOpener, tokenProvider, vaultClient)
+	}
+
+	fileProvider.SetConfiguration(cfg.SecretService, cfg.TokenFileProvider)
+	err := fileProvider.Run()
+
+	if err != nil {
+		logging.Error(fmt.Sprintf("error occurred generating tokens: %s", err.Error()))
+	}
+
+	return false // Tell bootstrap.Run() to exit wait loop and terminate
+}

--- a/cmd/security-file-token-provider/main_test.go
+++ b/cmd/security-file-token-provider/main_test.go
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileprovider/mocks"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNoOption(t *testing.T) {
+	assert := assert.New(t)
+
+	mockLogger := logger.MockLogger{}
+	mockTokenProvider := &MockTokenProvider{}
+	mockTokenProvider.On("Run").Return(nil)
+	mockTokenProvider.On("SetConfiguration", mock.Anything, mock.Anything).Once()
+
+	fileProvider = mockTokenProvider // fileProvider is global in main.go
+	status := runTokenProvider(mockLogger)
+
+	assert.False(status)
+	mockTokenProvider.AssertExpectations(t)
+}
+
+func TestHandleError(t *testing.T) {
+	assert := assert.New(t)
+
+	mockLogger := logger.MockLogger{}
+	mockTokenProvider := &MockTokenProvider{}
+	mockTokenProvider.On("Run").Return(errors.New("an error occurred"))
+	mockTokenProvider.On("SetConfiguration", mock.Anything, mock.Anything).Once()
+
+	fileProvider = mockTokenProvider // fileProvider is global in main.go
+	status := runTokenProvider(mockLogger)
+
+	assert.False(status)
+	mockTokenProvider.AssertExpectations(t)
+}

--- a/cmd/security-file-token-provider/res/configuration.toml
+++ b/cmd/security-file-token-provider/res/configuration.toml
@@ -1,0 +1,18 @@
+[SecretService]
+Scheme = "https"
+Server = "localhost"
+Port = 8200
+# CaFilePath = "EdgeXFoundryCA.pem"
+
+[TokenFileProvider]
+PrivilegedTokenPath = "resp-init.json"
+ConfigFile = "res/token-config.json"
+OutputDir = "/tmp"
+OutputFilename = "secrets-token.json"
+
+[Writable]
+LogLevel = 'DEBUG'
+
+[Logging]
+EnableRemote = false
+File = './logs/security-file-token-provider.log'

--- a/cmd/security-file-token-provider/res/token-config.json
+++ b/cmd/security-file-token-provider/res/token-config.json
@@ -1,0 +1,13 @@
+{
+    "service-name": {
+      "edgex_use_defaults": true,
+      "custom_policy": {
+        "path": {
+          "secret/non/standard/location/*": {
+            "capabilities": [ "list", "read" ]
+          }
+        }
+      },
+      "custom_token_parameters": { }
+    }
+  }

--- a/cmd/security-file-token-provider/testdata/.gitignore
+++ b/cmd/security-file-token-provider/testdata/.gitignore
@@ -1,0 +1,2 @@
+EdgeXFoundryCA.pem
+resp-init.json

--- a/cmd/security-file-token-provider/testdata/docker-compose.yml
+++ b/cmd/security-file-token-provider/testdata/docker-compose.yml
@@ -1,0 +1,119 @@
+# /*******************************************************************************
+#  * Copyright 2018 Dell Inc.
+#  * Copyright 2019 Intel Corporation
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  * @author: Jim White, Dell
+#  * EdgeX Foundry, Delhi version, 0.7.1
+#  * added: Dec 10, 2018
+#  *******************************************************************************/
+
+version: '3'
+volumes:
+  db-data:
+  log-data:
+  consul-config:
+  consul-data:
+  vault-config:
+  vault-file:
+  vault-logs:
+
+services:
+  volume:
+    image: edgexfoundry/docker-edgex-volume:0.6.0
+    container_name: edgex-files
+    networks:
+      - edgex-network
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+      
+  consul:
+    image: consul:1.4.4
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:8600"
+    container_name: edgex-core-consul
+    hostname: edgex-core-consul
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-consul
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume  
+
+  config-seed:
+    image: edgexfoundry/docker-core-config-seed-go:0.7.1
+    container_name: edgex-config-seed
+    hostname: edgex-core-config-seed
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-config-seed
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume
+      - consul
+
+  vault:
+    image: edgexfoundry/docker-edgex-vault:1.0.0
+    container_name: edgex-vault
+    hostname: edgex-vault
+    networks:
+      - edgex-network
+    ports:
+      - "8200:8200"
+    cap_add:
+      - "IPC_LOCK"
+    command: "server -log-level=info"
+    environment:
+      - 'VAULT_ADDR=https://edgex-vault:8200'
+      - 'VAULT_CONFIG_DIR=/vault/config'
+      - 'VAULT_UI=true'
+    volumes:
+      - vault-config:/vault/config
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
+    depends_on:
+      - volume
+      - consul
+
+  vault-worker:
+    image: edgexfoundry/docker-edgex-vault-worker-go:1.0.0
+    container_name: edgex-vault-worker
+    hostname: edgex-vault-worker
+    command: ["--init=true", "--debug=false", "--wait=10", "--insureskipverify=false"]
+    networks:
+      - edgex-network
+    volumes:
+      - vault-config:/vault/config
+    depends_on:
+      - volume
+      - consul
+      - vault  
+
+networks:
+  edgex-network:
+    driver: "bridge"
+...

--- a/cmd/security-file-token-provider/testdata/integrationtest.sh
+++ b/cmd/security-file-token-provider/testdata/integrationtest.sh
@@ -1,0 +1,79 @@
+#!/bin/sh -e
+
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+# SPDX-License-Identifier: Apache-2.0'
+#
+
+make -C ../../.. cmd/security-file-token-provider/security-file-token-provider
+
+cp ../res/token-config.json res/
+
+docker-compose -f docker-compose.yml up -d
+
+echo 'Waiting for stack to come up...'
+sleep 5
+
+vaultid=`docker ps | grep 'edgexfoundry/docker-edgex-vault' | cut -d' ' -f1`
+echo "Vault container id $vaultid"
+
+docker exec $vaultid cat /vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem > EdgeXFoundryCA.pem
+docker exec $vaultid cat /vault/config/assets/resp-init.json > resp-init.json
+
+vault_token=`jq -r .root_token ./resp-init.json`
+echo "Vault root token is $vault_token"
+
+cat <<EOH > res/configuration.toml
+[SecretService]
+Scheme = "https"
+Server = "localhost"
+Port = 8200
+# CaFilePath = "EdgeXFoundryCA.pem"
+
+[TokenFileProvider]
+PrivilegedTokenPath = "resp-init.json"
+ConfigFile = "res/token-config.json"
+OutputDir = "/tmp"
+OutputFilename = "secrets-token.json"
+
+[Writable]
+LogLevel = 'DEBUG'
+
+[Logging]
+EnableRemote = false
+File = './logs/security-file-token-provider.log'
+EOH
+
+echo "---==[ BEFORE policies ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault policy list -tls-skip-verify
+
+echo "---==[ BEFORE tokens ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault list -tls-skip-verify auth/token/accessors
+
+../security-file-token-provider
+
+echo "---==[ AFTER policies ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault policy list -tls-skip-verify
+
+echo "---==[ AFTER policy (dump edgex-service-service-name) ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault policy read -tls-skip-verify edgex-service-service-name
+
+echo "---==[ AFTER tokens ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$vault_token" $vaultid vault list -tls-skip-verify auth/token/accessors
+
+new_token=`jq -r .auth.client_token /tmp/service-name/secrets-token.json`
+
+echo "---==[ INFO on new token ]==---"
+docker exec -e "VAULT_ADDR=https://edgex-vault:8200" -e "VAULT_TOKEN=$new_token" $vaultid vault token lookup -tls-skip-verify
+

--- a/cmd/security-file-token-provider/testdata/res/.gitignore
+++ b/cmd/security-file-token-provider/testdata/res/.gitignore
@@ -1,0 +1,2 @@
+configuration.toml
+token-config.json

--- a/internal/security/secretstoreclient/types.go
+++ b/internal/security/secretstoreclient/types.go
@@ -23,6 +23,7 @@ import (
 type SecretServiceInfo struct {
 	Scheme               string
 	Server               string
+	ServerName           string
 	Port                 int
 	CertPath             string
 	CaFilePath           string


### PR DESCRIPTION
This is the main program for
cmd/security-file-token-provider as documented in
edgex-docs/security/token-file-provider.1.rst

The main program creates all of the needed
dependencies and invokes the business logic
to create per-service vault tokens.

This is part 6 of 6 merges to resolve #1677

Unit testing instructions:
  Run "go test" to run unit tests.

Integration testing instructions:
  See detailed instructions in README.md.

Preqrequisites:
  * https://github.com/edgexfoundry/edgex-go/pull/1788
  * https://github.com/edgexfoundry/edgex-go/pull/1789
  * https://github.com/edgexfoundry/edgex-go/pull/1790
  * https://github.com/edgexfoundry/edgex-go/pull/1791
  * https://github.com/edgexfoundry/edgex-go/pull/1792

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>