### PR TITLE
Add [cache] subcommand from merging pki-init option cache into security-secrets-setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,10 @@ cmd/core-data/core-data
 cmd/core-metadata/core-metadata
 cmd/export-client/export-client
 cmd/export-distro/export-distro
-cmd/security-secrets-setup/security-secrets-setup
-cmd/security-secrets-setup/config/*
-cmd/security-secretstore-setup/security-secretstore-setup
 cmd/security-proxy-setup/security-proxy-setup
+cmd/security-secrets-setup/config/*
+cmd/security-secrets-setup/security-secrets-setup
+cmd/security-secretstore-setup/security-secretstore-setup
 cmd/support-logging/support-logging
 cmd/support-notifications/support-notifications
 cmd/support-scheduler/support-scheduler

--- a/cmd/security-secrets-setup/main.go
+++ b/cmd/security-secrets-setup/main.go
@@ -45,6 +45,7 @@ var dispatcherInstance = newOptionDispatcher()
 var subcommands = map[string]*flag.FlagSet{
 	"legacy":   flag.NewFlagSet("legacy", flag.ExitOnError),
 	"generate": flag.NewFlagSet("generate", flag.ExitOnError),
+	"cache":    flag.NewFlagSet("cache", flag.ExitOnError),
 }
 var configFile string
 
@@ -107,7 +108,7 @@ func main() {
 			return
 		}
 
-	case "generate":
+	case "generate", "cache":
 		// no arguments expected
 		if len(subcmd.Args()) > 0 {
 			setup.LoggingClient.Error(fmt.Sprintf("subcommand %s doesn't use any args", subcmdName))
@@ -137,14 +138,17 @@ func newOptionDispatcher() optionDispatcher {
 }
 
 func setupPkiInitOption(subcommand string) (executor option.OptionsExecutor, status int, err error) {
-	generateOpt := false
+	var generateOpt, cacheOpt bool
 	switch subcommand {
 	case "generate":
 		generateOpt = true
+	case "cache":
+		cacheOpt = true
 	}
 
 	opts := option.PkiInitOption{
 		GenerateOpt: generateOpt,
+		CacheOpt:    cacheOpt,
 	}
 	return option.NewPkiInitOption(opts)
 }

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -48,6 +48,7 @@ Server Options:
 
 Server Subcommand:	
 	generate                        Generate PKI afresh every time and deployed. Typically, this will be whenever the framework is started.
+	cache                           Generate PKI exactly once and then copied to a designated cache location for future use.  The PKI is then deployed from the cached location.
 	legacy                          [Will be deprecated] Legacy mode to generate PKI
 	  -c, --config <name>           Provide absolute path to JSON configuration file
 

--- a/internal/security/setup/option/cache.go
+++ b/internal/security/setup/option/cache.go
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package option
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/setup"
+)
+
+// Cache option....
+func Cache() func(*PkiInitOption) (exitCode, error) {
+	return func(pkiInitOpton *PkiInitOption) (exitCode, error) {
+
+		if isCacheNoOp(pkiInitOpton) {
+			return normal, nil
+		}
+
+		return cachePkis()
+	}
+}
+
+func isCacheNoOp(pkiInitOption *PkiInitOption) bool {
+	// nop: if the flag is missing or not on
+	return pkiInitOption == nil || !pkiInitOption.CacheOpt
+}
+
+func cachePkis() (statusCode exitCode, err error) {
+	// generate a new one if pkicache dir is empty
+	pkiCacheDir := getPkiCacheDirEnv()
+	cachedCAPrivateKeyFile := filepath.Join(pkiCacheDir, caServiceName, tlsSecretFileName)
+	if empty, err := isDirEmpty(pkiCacheDir); err != nil {
+		return exitWithError, err
+	} else if empty {
+		setup.LoggingClient.Info(fmt.Sprintf("cache dir %s is empty, generating PKI into it...", pkiCacheDir))
+		// perform generate func
+		statusCode, err = generatePkis()
+		if err != nil {
+			return statusCode, err
+		}
+
+		generatedDirPath := filepath.Join(os.Getenv(envXdgRuntimeDir), pkiInitGeneratedDir)
+
+		// always shreds CA private key before cache
+		caPrivateKeyFile := filepath.Join(generatedDirPath, caServiceName, tlsSecretFileName)
+		if err := secureEraseFile(caPrivateKeyFile); err != nil {
+			return exitWithError, err
+		}
+
+		if err = doCache(generatedDirPath); err != nil {
+			return exitWithError, err
+		}
+	} else {
+		// cache dir is not empty: output error message if CA private key is present
+		// when cache is given
+		if checkIfFileExists(cachedCAPrivateKeyFile) {
+			return exitWithError, errCacheNotChangeAfter
+		}
+		setup.LoggingClient.Info(fmt.Sprintf("cached TLS assets from dir %s is present, using cached PKI", pkiCacheDir))
+	}
+
+	// to deploy
+	// copy stuff into dest dir from pkiCache
+	err = deploy(pkiCacheDir, pkiInitDeployDir)
+	if err != nil {
+		return exitWithError, err
+	}
+
+	return normal, nil
+}
+
+func doCache(fromDir string) error {
+	// destination
+	pkiCacheDir := getPkiCacheDirEnv()
+
+	// to cache
+	return copyDir(fromDir, pkiCacheDir)
+}

--- a/internal/security/setup/option/cache.go
+++ b/internal/security/setup/option/cache.go
@@ -24,7 +24,8 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/setup"
 )
 
-// Cache option....
+// Cache generates PKI exactly once and cached to a designated location for future use.
+// The PKI is then deployed from the cached location.
 func Cache() func(*PkiInitOption) (exitCode, error) {
 	return func(pkiInitOpton *PkiInitOption) (exitCode, error) {
 
@@ -44,7 +45,6 @@ func isCacheNoOp(pkiInitOption *PkiInitOption) bool {
 func cachePkis() (statusCode exitCode, err error) {
 	// generate a new one if pkicache dir is empty
 	pkiCacheDir := getPkiCacheDirEnv()
-	cachedCAPrivateKeyFile := filepath.Join(pkiCacheDir, caServiceName, tlsSecretFileName)
 	if empty, err := isDirEmpty(pkiCacheDir); err != nil {
 		return exitWithError, err
 	} else if empty {
@@ -69,6 +69,7 @@ func cachePkis() (statusCode exitCode, err error) {
 	} else {
 		// cache dir is not empty: output error message if CA private key is present
 		// when cache is given
+		cachedCAPrivateKeyFile := filepath.Join(pkiCacheDir, caServiceName, tlsSecretFileName)
 		if checkIfFileExists(cachedCAPrivateKeyFile) {
 			return exitWithError, errCacheNotChangeAfter
 		}

--- a/internal/security/setup/option/cache_test.go
+++ b/internal/security/setup/option/cache_test.go
@@ -29,13 +29,13 @@ func TestCacheOn(t *testing.T) {
 	vaultJSONPkiSetupExist = true
 	kongJSONPkiSetupExist = true
 	tearDown := setupCacheTest(t)
-	defer tearDown(t)
+	defer tearDown()
 
 	options := PkiInitOption{
 		CacheOpt: true,
 	}
 	cacheOn, _, _ := NewPkiInitOption(options)
-	cacheOn.(*PkiInitOption).executor = testExecutor
+	cacheOn.setExecutor(testExecutor)
 
 	var exitStatus exitCode
 	var err error
@@ -66,13 +66,13 @@ func TestCacheDirNotEmpty(t *testing.T) {
 	vaultJSONPkiSetupExist = true
 	kongJSONPkiSetupExist = true
 	tearDown := setupCacheTest(t)
-	defer tearDown(t)
+	defer tearDown()
 
 	options := PkiInitOption{
 		CacheOpt: true,
 	}
 	cacheOn, _, _ := NewPkiInitOption(options)
-	cacheOn.(*PkiInitOption).executor = testExecutor
+	cacheOn.setExecutor(testExecutor)
 
 	var exitStatus exitCode
 	var err error
@@ -110,13 +110,13 @@ func TestCacheOff(t *testing.T) {
 	vaultJSONPkiSetupExist = true
 	kongJSONPkiSetupExist = true
 	tearDown := setupCacheTest(t)
-	defer tearDown(t)
+	defer tearDown()
 
 	options := PkiInitOption{
 		CacheOpt: false,
 	}
 	cacheOff, _, _ := NewPkiInitOption(options)
-	cacheOff.(*PkiInitOption).executor = testExecutor
+	cacheOff.setExecutor(testExecutor)
 	exitCode, err := cacheOff.executeOptions(Cache())
 
 	assert := assert.New(t)
@@ -124,7 +124,7 @@ func TestCacheOff(t *testing.T) {
 	assert.Nil(err)
 }
 
-func setupCacheTest(t *testing.T) func(t *testing.T) {
+func setupCacheTest(t *testing.T) func() {
 	testExecutor = &mockOptionsExecutor{}
 	curDir, err := os.Getwd()
 	if err != nil {
@@ -189,7 +189,7 @@ func setupCacheTest(t *testing.T) func(t *testing.T) {
 	}
 	pkiInitDeployDir = tempDir
 
-	return func(t *testing.T) {
+	return func() {
 		// cleanup
 		os.Remove(jsonVaultFile)
 		os.Remove(jsonKongFile)

--- a/internal/security/setup/option/constant.go
+++ b/internal/security/setup/option/constant.go
@@ -17,6 +17,7 @@
 package option
 
 import (
+	"errors"
 	"path/filepath"
 )
 
@@ -31,6 +32,8 @@ const (
 	envXdgRuntimeDir              = "XDG_RUNTIME_DIR"
 	defaultXdgRuntimeDir          = "/tmp"
 	pkiInitBaseDir                = "/edgex/security-secrets-setup"
+	envPkiCache                   = "PKI_CACHE"
+	defaultPkiCacheDir            = "/etc/edgex/pki"
 	tmpfsRunDir                   = "/run"
 	tlsSecretFileName             = "server.key"
 	tlsCertFileName               = "server.crt"
@@ -44,7 +47,8 @@ const (
 )
 
 var (
-	pkiInitScratchDir   = filepath.Join(pkiInitBaseDir, "scratch")
-	pkiInitGeneratedDir = filepath.Join(pkiInitBaseDir, "generated")
-	pkiInitDeployDir    = filepath.Join(tmpfsRunDir, "edgex", "secrets")
+	pkiInitScratchDir      = filepath.Join(pkiInitBaseDir, "scratch")
+	pkiInitGeneratedDir    = filepath.Join(pkiInitBaseDir, "generated")
+	pkiInitDeployDir       = filepath.Join(tmpfsRunDir, "edgex", "secrets")
+	errCacheNotChangeAfter = errors.New("PKI cache cannot be changed after it was cached previously")
 )

--- a/internal/security/setup/option/generate.go
+++ b/internal/security/setup/option/generate.go
@@ -13,6 +13,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0'
 //
+
 package option
 
 import (

--- a/internal/security/setup/option/mock_OptionsExecutor_test.go
+++ b/internal/security/setup/option/mock_OptionsExecutor_test.go
@@ -72,3 +72,7 @@ func (_m *mockOptionsExecutor) executeOptions(_a0 ...func(*PkiInitOption) (exitC
 
 	return r0, r1
 }
+
+func (_m *mockOptionsExecutor) setExecutor(executor OptionsExecutor) {
+	// no-op
+}

--- a/internal/security/setup/option/optionHelpers.go
+++ b/internal/security/setup/option/optionHelpers.go
@@ -18,11 +18,9 @@ package option
 
 import (
 	"errors"
-
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -121,7 +119,7 @@ func copyDir(srcDir, destDir string) error {
 				return err
 			}
 		} else {
-			log.Printf("copying srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath)
+			setup.LoggingClient.Debug(fmt.Sprintf("copying srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath))
 			if _, copyErr := copyFile(srcFilePath, destFilePath); copyErr != nil {
 				return copyErr
 			}
@@ -222,6 +220,14 @@ func getXdgRuntimeDir() string {
 	}
 	// if $XDG_RUNTIME_DIR is undefined, default to /tmp
 	return defaultXdgRuntimeDir
+}
+
+func getPkiCacheDirEnv() string {
+	pkiCacheDir := os.Getenv(envPkiCache)
+	if pkiCacheDir == "" {
+		return defaultPkiCacheDir
+	}
+	return pkiCacheDir
 }
 
 // GenTLSAssets generates the TLS assets based on the JSON configuration file

--- a/internal/security/setup/option/pkiOption.go
+++ b/internal/security/setup/option/pkiOption.go
@@ -16,6 +16,10 @@
 
 package option
 
+import (
+	"errors"
+)
+
 // OptionsExecutor is an executor to process the input options
 type OptionsExecutor interface {
 	ProcessOptions() (int, error)
@@ -25,11 +29,17 @@ type OptionsExecutor interface {
 // PkiInitOption contains command line options for pki-init
 type PkiInitOption struct {
 	GenerateOpt bool
+	CacheOpt    bool
 	executor    OptionsExecutor
 }
 
 // NewPkiInitOption constructor to get options built for pki-init
 func NewPkiInitOption(opts PkiInitOption) (ex OptionsExecutor, statusCode int, err error) {
+	// cache option cannot used with -generate
+	if opts.CacheOpt && opts.GenerateOpt {
+		return ex, exitWithError.intValue(), errors.New("Cannot attempt cache option with other modes")
+	}
+
 	opts.executor = &opts
 
 	return &opts, normal.intValue(), nil
@@ -39,6 +49,7 @@ func NewPkiInitOption(opts PkiInitOption) (ex OptionsExecutor, statusCode int, e
 func (pkiInitOpt *PkiInitOption) ProcessOptions() (int, error) {
 	statusCode, err := pkiInitOpt.executor.executeOptions(
 		Generate(),
+		Cache(),
 	)
 
 	return statusCode.intValue(), err

--- a/internal/security/setup/option/pkiOption.go
+++ b/internal/security/setup/option/pkiOption.go
@@ -24,6 +24,7 @@ import (
 type OptionsExecutor interface {
 	ProcessOptions() (int, error)
 	executeOptions(...func(*PkiInitOption) (exitCode, error)) (exitCode, error)
+	setExecutor(executor OptionsExecutor)
 }
 
 // PkiInitOption contains command line options for pki-init
@@ -37,7 +38,7 @@ type PkiInitOption struct {
 func NewPkiInitOption(opts PkiInitOption) (ex OptionsExecutor, statusCode int, err error) {
 	// cache option cannot used with -generate
 	if opts.CacheOpt && opts.GenerateOpt {
-		return ex, exitWithError.intValue(), errors.New("Cannot attempt cache option with other modes")
+		return ex, exitWithError.intValue(), errors.New("Cannot execute cache option with generate option")
 	}
 
 	opts.executor = &opts
@@ -65,4 +66,8 @@ func (pkiInitOpt *PkiInitOption) executeOptions(executors ...func(*PkiInitOption
 		}
 	}
 	return statusCode, err
+}
+
+func (pkiInitOpt *PkiInitOption) setExecutor(executor OptionsExecutor) {
+	pkiInitOpt.executor = executor
 }

--- a/internal/security/setup/option/pkiOption_test.go
+++ b/internal/security/setup/option/pkiOption_test.go
@@ -87,7 +87,7 @@ func TestProcessOptionNormal(t *testing.T) {
 		GenerateOpt: true,
 	}
 	optsExecutor, _, _ := NewPkiInitOption(options)
-	optsExecutor.(*PkiInitOption).executor = testExecutor
+	optsExecutor.setExecutor(testExecutor)
 	exitCode, err := optsExecutor.ProcessOptions()
 	assert.Equal(normal.intValue(), exitCode)
 	assert.Nil(err)
@@ -108,7 +108,8 @@ func TestProcessOptionError(t *testing.T) {
 		GenerateOpt: true,
 	}
 	generateOn, _, _ := NewPkiInitOption(options)
-	generateOn.(*PkiInitOption).executor = testExecutor
+
+	generateOn.setExecutor(testExecutor)
 	exitCode, err := generateOn.ProcessOptions()
 	assert.Equal(exitWithError.intValue(), exitCode)
 	assert.Equal(generateErr, err)
@@ -124,14 +125,14 @@ func TestExecuteOption(t *testing.T) {
 		GenerateOpt: true,
 	}
 	generateOn, _, _ := NewPkiInitOption(options)
-	generateOn.(*PkiInitOption).executor = testExecutor
+	generateOn.setExecutor(testExecutor)
 	exitCode, err := generateOn.executeOptions(mockGenerate())
 	assert.Equal(normal, exitCode)
 	assert.Nil(err)
 
 	options.GenerateOpt = false
 	generateOff, _, _ := NewPkiInitOption(options)
-	generateOff.(*PkiInitOption).executor = testExecutor
+	generateOff.setExecutor(testExecutor)
 	exitCode, err = generateOff.executeOptions(mockGenerate())
 	assert.Equal(normal, exitCode)
 	assert.Nil(err)


### PR DESCRIPTION
- Cache directory is defined in environment variable $**PKI_CACHE**, and the default is `/etc/edgex/pki` if not defined
- If cache directory is empty, then TLS assets will be generated and then cached
- TLS assets will be deployed from cache directory into deploy directory which defaults to `run/edgex/secrets` tmpfs directory
- CA private key is always securely erased before cached

Example to run: ``` ./security-secrets-setup -confdir ./res cache ```

Related to: 
- Issue #1635
- Issue #1558 

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>