### PR TITLE
Convert sys-mgmt-agent to use common bootstrap package

### DIFF
--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -14,29 +14,59 @@
 package main
 
 import (
+	"context"
 	"flag"
-	"fmt"
-	"os"
-	"os/signal"
-	"strconv"
-	"time"
+	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/direct"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/executor"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
+	agentInterfaces "github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
+func httpServerBootstrapHandler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config interfaces.Configuration,
+	logging logger.LoggingClient,
+	registry registry.Client) bool {
+
+	var metricsImpl agentInterfaces.Metrics
+	switch agent.Configuration.MetricsMechanism {
+	case direct.MetricsMechanism:
+		metricsImpl = direct.NewMetrics(
+			agent.LoggingClient,
+			agent.GenClients,
+			agent.Configuration.Clients,
+			agent.RegistryClient,
+			agent.Configuration.Service.Protocol)
+	case executor.MetricsMechanism:
+		metricsImpl = executor.NewMetrics(executor.CommandExecutor, agent.LoggingClient, agent.Configuration.ExecutorPath)
+	default:
+		agent.LoggingClient.Error("the requested metrics mechanism is not supported")
+		return false
+	}
+
+	httpServer := handlers.NewServerBootstrap(agent.LoadRestRoutes(metricsImpl))
+	return httpServer.Handler(wg, ctx, startupTimer, config, logging, registry)
+}
+
 func main() {
-	start := time.Now()
+	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+
 	var useRegistry bool
 	var configDir, profileDir string
 
@@ -45,80 +75,21 @@ func main() {
 	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
 	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
 	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	instance := agent.NewInstance()
-	params := startup.BootParams{
-		UseRegistry: useRegistry,
-		ConfigDir:   configDir,
-		ProfileDir:  profileDir,
-		BootTimeout: internal.BootTimeoutDefault,
-	}
-	startup.Bootstrap(params, instance.Retry, logBeforeInit)
-
-	ok := instance.Init(useRegistry)
-	if !ok {
-		logBeforeInit(fmt.Errorf("%s: service bootstrap failed", clients.SystemManagementAgentServiceKey))
-		os.Exit(1)
-	}
-
-	instance.LoggingClient.Info("Service dependencies resolved...")
-	instance.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.SystemManagementAgentServiceKey, edgex.Version))
-
-	instance.LoggingClient.Info(instance.Configuration.Service.StartupMsg)
-
-	errs := make(chan error, 2)
-	listenForInterrupt(errs)
-	startup.StartHTTPServer(
-		instance.LoggingClient,
-		instance.Configuration.Service.Timeout,
-		agent.LoadRestRoutes(instance, getMetricsImplementation(instance)),
-		instance.Configuration.Service.Host+":"+strconv.Itoa(instance.Configuration.Service.Port),
-		errs)
-
-	// Time it took to start service
-	instance.LoggingClient.Info("Service started in: " + time.Since(start).String())
-	instance.LoggingClient.Info("Listening on port: " + strconv.Itoa(instance.Configuration.Service.Port))
-	c := <-errs
-	instance.Destruct()
-	instance.LoggingClient.Warn(fmt.Sprintf("terminating: %v", c))
-
-	os.Exit(0)
-}
-
-// getMetricsImplementation creates and returns an interfaces.Metrics implementation based on configuration settings.
-func getMetricsImplementation(instance *agent.Instance) interfaces.Metrics {
-	var result interfaces.Metrics
-	switch instance.Configuration.MetricsMechanism {
-	case direct.MetricsMechanism:
-		result = direct.NewMetrics(
-			instance.LoggingClient,
-			instance.GenClients,
-			instance.Configuration.Clients,
-			instance.RegistryClient,
-			instance.Configuration.Service.Protocol)
-	case executor.MetricsMechanism:
-		result = executor.NewMetrics(
-			executor.CommandExecutor,
-			instance.LoggingClient,
-			instance.Configuration.ExecutorPath)
-	default:
-		instance.LoggingClient.Error("the requested metrics mechanism is not supported")
-		os.Exit(1)
-	}
-	return result
-}
-
-func logBeforeInit(err error) {
-	l := logger.NewClient(clients.SystemManagementAgentServiceKey, false, "", models.InfoLog)
-	l.Error(err.Error())
-}
-
-func listenForInterrupt(errChan chan error) {
-	go func() {
-		c := make(chan os.Signal)
-		signal.Notify(c, os.Interrupt)
-		errChan <- fmt.Errorf("%s", <-c)
-	}()
+	bootstrap.Run(
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SystemManagementAgentServiceKey,
+		agent.Configuration,
+		startupTimer,
+		[]interfaces.BootstrapHandler{
+			agent.BootstrapHandler,
+			httpServerBootstrapHandler,
+			handlers.NewStartMessage(clients.SystemManagementAgentServiceKey, edgex.Version).Handler,
+		})
 }

--- a/internal/system/agent/config.go
+++ b/internal/system/agent/config.go
@@ -14,7 +14,10 @@
 
 package agent
 
-import "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+)
 
 type ConfigurationClients map[string]config.ClientInfo
 
@@ -32,4 +35,58 @@ type ConfigurationStruct struct {
 type WritableInfo struct {
 	ResendLimit int
 	LogLevel    string
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		// Check that information was successfully read from Registry
+		if configuration.Service.Port == 0 {
+			return false
+		}
+		c = configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Clients:  c.Clients,
+		Service:  c.Service,
+		Registry: c.Registry,
+		Logging:  c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
+	c.Registry = registryInfo
 }

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -15,243 +15,63 @@
 package agent
 
 import (
-	"errors"
-	"fmt"
-	"os"
-	"os/signal"
+	"context"
 	"sync"
-	"syscall"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
-// Instance contains what were global variables.
-type Instance struct {
-	Configuration  *ConfigurationStruct
-	GenClients     *GeneralClients
-	LoggingClient  logger.LoggingClient
-	RegistryClient registry.Client
-	chErrors       chan error       //A channel for "config wait error" sourced from Registry
-	chUpdates      chan interface{} //A channel for "config updates" sourced from Registry
-}
+var Configuration = &ConfigurationStruct{}
+var GenClients *GeneralClients
+var LoggingClient logger.LoggingClient
+var RegistryClient registry.Client
 
-// NewInstance returns an empty Instance struct that is subsequently populated by a call to the Retry method.
-func NewInstance() *Instance {
-	return &Instance{}
-}
-
-func (instance *Instance) Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
-		var err error
-		// When looping, only handle configuration if it hasn't already been set.
-		// Note, too, that the SMA-managed services are bootstrapped by the SMA.
-		// Read in those setting, too, which specifies details for those services
-		// (Those setting were _previously_ to be found in a now-defunct TOML manifest file).
-		if instance.Configuration == nil {
-			instance.Configuration, err = instance.initializeConfiguration(useRegistry, configDir, profileDir)
-			if err != nil {
-				ch <- err
-				if !useRegistry {
-					//Error occurred when attempting to read from local filesystem. Fail fast.
-					close(ch)
-					wait.Done()
-					return
-				}
-			} else {
-				// Setup Logging
-				logTarget := instance.setLoggingTarget()
-				instance.LoggingClient = logger.NewClient(clients.SystemManagementAgentServiceKey, instance.Configuration.Logging.EnableRemote, logTarget, instance.Configuration.Writable.LogLevel)
-
-				//Initialize service clients
-				instance.initializeClients(useRegistry)
-			}
-		}
-
-		// Exit the loop if the dependencies have been satisfied.
-		if instance.Configuration != nil {
-			break
-		}
-		time.Sleep(time.Second * time.Duration(1))
-	}
-	close(ch)
-	wait.Done()
-
-	return
-}
-
-func (instance *Instance) Init(useRegistry bool) bool {
-	if instance.Configuration == nil {
-		return false
-	}
-
-	if useRegistry && instance.RegistryClient != nil {
-		instance.chErrors = make(chan error)
-		instance.chUpdates = make(chan interface{})
-		go instance.listenForConfigChanges()
-	}
-
-	return true
-}
-
-func (instance *Instance) Destruct() {
-
-	if instance.chErrors != nil {
-		close(instance.chErrors)
-	}
-
-	if instance.chUpdates != nil {
-		close(instance.chUpdates)
-	}
-}
-
-func (instance *Instance) initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
-	//We currently have to load configuration from filesystem first in order to obtain Registry Host/Port
-	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(configDir, profileDir, configuration)
-	if err != nil {
-		return nil, err
-	}
-	configuration.Registry = config.OverrideFromEnvironment(configuration.Registry)
-
-	if useRegistry {
-		err = instance.connectToRegistry(configuration)
-		if err != nil {
-			return nil, err
-		}
-
-		rawConfig, err := instance.RegistryClient.GetConfiguration(configuration)
-		if err != nil {
-			return nil, fmt.Errorf("could not get configuration from Registry: %v", err.Error())
-		}
-
-		actual, ok := rawConfig.(*ConfigurationStruct)
-		if !ok {
-			return nil, fmt.Errorf("configuration from Registry failed type check")
-		}
-
-		configuration = actual
-
-		// Check that information was successfully read from Registry
-		if configuration.Service.Port == 0 {
-			return nil, errors.New("error reading configuration from Registry")
-		}
-	}
-
-	return configuration, nil
-}
-
-func (instance *Instance) connectToRegistry(conf *ConfigurationStruct) error {
-	var err error
-	registryConfig := registryTypes.Config{
-		Host:            conf.Registry.Host,
-		Port:            conf.Registry.Port,
-		Type:            conf.Registry.Type,
-		ServiceKey:      clients.SystemManagementAgentServiceKey,
-		ServiceHost:     conf.Service.Host,
-		ServicePort:     conf.Service.Port,
-		ServiceProtocol: conf.Service.Protocol,
-		CheckInterval:   conf.Service.CheckInterval,
-		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
-	}
-
-	instance.RegistryClient, err = registry.NewRegistryClient(registryConfig)
-	if err != nil {
-		return fmt.Errorf("connection to Registry could not be made: %v", err.Error())
-	}
-
-	// Check if registry service is running
-	if !instance.RegistryClient.IsAlive() {
-		return fmt.Errorf("registry is not available")
-	}
-
-	// Register the service with Registry
-	err = instance.RegistryClient.Register()
-	if err != nil {
-		return fmt.Errorf("could not register service with Registry: %v", err.Error())
-	}
-
-	return nil
-}
-
-func (instance *Instance) listenForConfigChanges() {
-	if instance.RegistryClient == nil {
-		instance.LoggingClient.Error("listenForConfigChanges() registry client not set")
-		return
-	}
-
-	instance.RegistryClient.WatchForChanges(instance.chUpdates, instance.chErrors, &WritableInfo{}, internal.WritableKey)
-
-	// TODO: Refactor names in separate PR: See comments on PR #1133
-	chSignals := make(chan os.Signal)
-	signal.Notify(chSignals, os.Interrupt, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-chSignals:
-			// Quietly and gracefully stop when SIGINT/SIGTERM received
-			return
-
-		case ex := <-instance.chErrors:
-			instance.LoggingClient.Error(ex.Error())
-
-		case raw, ok := <-instance.chUpdates:
-			if !ok {
-				return
-			}
-
-			actual, ok := raw.(*WritableInfo)
-			if !ok {
-				instance.LoggingClient.Error("listenForConfigChanges() type check failed")
-				return
-			}
-
-			instance.Configuration.Writable = *actual
-
-			instance.LoggingClient.Info("Writeable configuration has been updated from the Registry")
-			instance.LoggingClient.SetLogLevel(instance.Configuration.Writable.LogLevel)
-		}
-	}
-}
-
-func (instance *Instance) initializeClients(useRegistry bool) {
-	instance.GenClients = NewGeneralClients()
+func initializeClients(useRegistry bool) {
+	GenClients = NewGeneralClients()
 	if useRegistry {
 		// if we're using the registry, we'll create new general clients as we need them.
 		return
 	}
 
 	// if the registry is not being used, load clients from configurations; assume configuration key is service name
-	for serviceKey := range instance.Configuration.Clients {
-		instance.GenClients.Set(
+	for serviceKey := range Configuration.Clients {
+		GenClients.Set(
 			serviceKey,
 			general.NewGeneralClient(
 				types.EndpointParams{
 					ServiceKey:  serviceKey,
 					Path:        "/",
 					UseRegistry: useRegistry,
-					Url:         instance.Configuration.Clients[serviceKey].Url(),
+					Url:         Configuration.Clients[serviceKey].Url(),
 					Interval:    internal.ClientMonitorDefault,
 				},
-				endpoint.Endpoint{RegistryClient: &instance.RegistryClient}))
+				endpoint.Endpoint{RegistryClient: &RegistryClient}))
 	}
 }
 
-func (instance *Instance) setLoggingTarget() string {
-	if instance.Configuration.Logging.EnableRemote {
-		return instance.Configuration.Clients["Logging"].Url() + clients.ApiLoggingRoute
-	}
-	return instance.Configuration.Logging.File
+func BootstrapHandler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config bootstrap.Configuration,
+	logging logger.LoggingClient,
+	registry registry.Client) bool {
+
+	// update global variables.
+	LoggingClient = logging
+	RegistryClient = registry
+
+	// initialize clients required by service.
+	initializeClients(registry != nil)
+
+	return true
 }

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -31,14 +31,14 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func LoadRestRoutes(instance *Instance, metricsImpl interfaces.Metrics) *mux.Router {
+func LoadRestRoutes(metricsImpl interfaces.Metrics) *mux.Router {
 	r := mux.NewRouter()
 
 	b := r.PathPrefix("/api/v1").Subrouter()
-	b.HandleFunc("/operation", func(w http.ResponseWriter, r *http.Request) { operationHandler(w, r, instance) }).Methods(http.MethodPost)
-	b.HandleFunc("/config/{services}", func(w http.ResponseWriter, r *http.Request) { configHandler(w, r, instance) }).Methods(http.MethodGet)
-	b.HandleFunc("/metrics/{services}", func(w http.ResponseWriter, r *http.Request) { metricsHandler(w, r, instance, metricsImpl) }).Methods(http.MethodGet)
-	b.HandleFunc("/health/{services}", func(w http.ResponseWriter, r *http.Request) { healthHandler(w, r, instance) }).Methods(http.MethodGet)
+	b.HandleFunc("/operation", operationHandler).Methods(http.MethodPost)
+	b.HandleFunc("/config/{services}", configHandler).Methods(http.MethodGet)
+	b.HandleFunc("/metrics/{services}", func(w http.ResponseWriter, r *http.Request) { metricsHandler(w, r, metricsImpl) }).Methods(http.MethodGet)
+	b.HandleFunc("/health/{services}", healthHandler).Methods(http.MethodGet)
 	b.HandleFunc("/ping", pingHandler).Methods(http.MethodGet)
 
 	r.HandleFunc(clients.ApiVersionRoute, pkg.VersionHandler).Methods(http.MethodGet)
@@ -57,41 +57,41 @@ func pingHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 // metricsHandler implements a controller to execute a metrics request.
-func metricsHandler(w http.ResponseWriter, r *http.Request, instance *Instance, metricsImpl interfaces.Metrics) {
-	instance.LoggingClient.Debug("retrieved service names")
+func metricsHandler(w http.ResponseWriter, r *http.Request, metricsImpl interfaces.Metrics) {
+	LoggingClient.Debug("retrieved service names")
 
 	vars := mux.Vars(r)
-	pkg.Encode(metricsImpl.Get(strings.Split(vars["services"], ","), r.Context()), w, instance.LoggingClient)
+	pkg.Encode(metricsImpl.Get(strings.Split(vars["services"], ","), r.Context()), w, LoggingClient)
 }
 
 // operationHandler implements a controller to execute a start/stop/restart operation request.
-func operationHandler(w http.ResponseWriter, r *http.Request, instance *Instance) {
+func operationHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		instance.LoggingClient.Error(err.Error())
+		LoggingClient.Error(err.Error())
 		return
 	}
 
 	o := models.Operation{}
 	if err = o.UnmarshalJSON(b); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		instance.LoggingClient.Error("error during decoding: %s", err.Error())
+		LoggingClient.Error("error during decoding: %s", err.Error())
 		return
 	}
 
 	operation := executor.NewOperations(
 		executor.CommandExecutor,
-		instance.LoggingClient,
-		instance.Configuration.ExecutorPath)
-	pkg.Encode(operation.Do(o.Services, o.Action), w, instance.LoggingClient)
+		LoggingClient,
+		Configuration.ExecutorPath)
+	pkg.Encode(operation.Do(o.Services, o.Action), w, LoggingClient)
 }
 
-func configHandler(w http.ResponseWriter, r *http.Request, instance *Instance) {
+func configHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	instance.LoggingClient.Debug("retrieved service names")
+	LoggingClient.Debug("retrieved service names")
 
 	list := vars["services"]
 	var services []string
@@ -101,32 +101,32 @@ func configHandler(w http.ResponseWriter, r *http.Request, instance *Instance) {
 	send, err := getConfig(
 		services,
 		ctx,
-		instance.LoggingClient,
-		instance.GenClients,
-		instance.Configuration.Clients,
-		instance.RegistryClient,
-		instance.Configuration.Service.Protocol)
+		LoggingClient,
+		GenClients,
+		Configuration.Clients,
+		RegistryClient,
+		Configuration.Service.Protocol)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		instance.LoggingClient.Error(err.Error())
+		LoggingClient.Error(err.Error())
 		return
 	}
-	pkg.Encode(send, w, instance.LoggingClient)
+	pkg.Encode(send, w, LoggingClient)
 }
 
-func healthHandler(w http.ResponseWriter, r *http.Request, instance *Instance) {
+func healthHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	instance.LoggingClient.Debug("health status data requested")
+	LoggingClient.Debug("health status data requested")
 
 	list := vars["services"]
 	var services []string
 	services = strings.Split(list, ",")
 
-	send, err := getHealth(services, instance.RegistryClient)
+	send, err := getHealth(services, RegistryClient)
 	if err != nil {
-		instance.LoggingClient.Error(err.Error())
+		LoggingClient.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	pkg.Encode(send, w, instance.LoggingClient)
+	pkg.Encode(send, w, LoggingClient)
 }


### PR DESCRIPTION
Converts system management agent to use the common bootstrap package.

Intentionally reverts global variables eliminated by https://github.com/edgexfoundry/edgex-go/issues/1486
to be consistent with other core service implementations to simplify
intended post-conversion activity to remove global variables from
all core services.

Fixes https://github.com/edgexfoundry/edgex-go/issues/1810

Signed-off-by: Michael Estrin <m.estrin@dell.com>