### PR TITLE
Core-Data/AddEvent - ErrServiceClient no longer a pointer

### DIFF
--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -234,7 +234,7 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), http.StatusNotFound)
 			case *errors.ErrValueDescriptorInvalid:
 				http.Error(w, err.Error(), http.StatusBadRequest)
-			case *types.ErrServiceClient:
+			case types.ErrServiceClient:
 				http.Error(w, e.Error(), e.StatusCode)
 			default:
 				http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Fix #1816

Please see the issue for detailed repro steps. Using this PR, you can
go through the same steps and you will receive a 400 http status
instead of a 500.

The ErrServiceClient constructor in go-mod-core-contracts was changed
recently to not return a pointer. It appears all references to this
type in edgex-go were corrected accordingly except for this one.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>