### PR TITLE
SMA Get Configuration Endpoint Without Registry Flag No Longer Returns Configuration

### DIFF
--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -50,7 +50,6 @@ func httpServerBootstrapHandler(
 		metricsImpl = direct.NewMetrics(
 			agent.LoggingClient,
 			agent.GenClients,
-			agent.Configuration.Clients,
 			agent.RegistryClient,
 			agent.Configuration.Service.Protocol)
 	case executor.MetricsMechanism:

--- a/internal/system/agent/direct/metrics.go
+++ b/internal/system/agent/direct/metrics.go
@@ -40,7 +40,6 @@ import (
 type metrics struct {
 	loggingClient   logger.LoggingClient
 	genClients      *agent.GeneralClients
-	configClients   agent.ConfigurationClients
 	registryClient  registry.Client
 	serviceProtocol string
 }
@@ -49,14 +48,12 @@ type metrics struct {
 func NewMetrics(
 	loggingClient logger.LoggingClient,
 	genClients *agent.GeneralClients,
-	configClients agent.ConfigurationClients,
 	registryClient registry.Client,
 	serviceProtocol string) *metrics {
 
 	return &metrics{
 		loggingClient:   loggingClient,
 		genClients:      genClients,
-		configClients:   configClients,
 		registryClient:  registryClient,
 		serviceProtocol: serviceProtocol,
 	}

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
@@ -37,13 +38,7 @@ var RegistryClient registry.Client
 
 func initializeClients(useRegistry bool) {
 	GenClients = NewGeneralClients()
-	if useRegistry {
-		// if we're using the registry, we'll create new general clients as we need them.
-		return
-	}
-
-	// if the registry is not being used, load clients from configurations; assume configuration key is service name
-	for serviceKey := range Configuration.Clients {
+	for serviceKey, serviceName := range config.ListDefaultServices() {
 		GenClients.Set(
 			serviceKey,
 			general.NewGeneralClient(
@@ -51,7 +46,7 @@ func initializeClients(useRegistry bool) {
 					ServiceKey:  serviceKey,
 					Path:        "/",
 					UseRegistry: useRegistry,
-					Url:         Configuration.Clients[serviceKey].Url(),
+					Url:         Configuration.Clients[serviceName].Url(),
 					Interval:    internal.ClientMonitorDefault,
 				},
 				endpoint.Endpoint{RegistryClient: &RegistryClient}))

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -103,7 +103,6 @@ func configHandler(w http.ResponseWriter, r *http.Request) {
 		ctx,
 		LoggingClient,
 		GenClients,
-		Configuration.Clients,
 		RegistryClient,
 		Configuration.Service.Protocol)
 	if err != nil {

--- a/internal/system/agent/services.go
+++ b/internal/system/agent/services.go
@@ -37,7 +37,6 @@ func getConfig(
 	ctx context.Context,
 	loggingClient logger.LoggingClient,
 	genClients *GeneralClients,
-	configClients ConfigurationClients,
 	registryClient registry.Client,
 	serviceProtocol string) (interface{}, error) {
 
@@ -77,12 +76,7 @@ func getConfig(
 				continue
 			}
 
-			// This code will evolve to take into account a manifest-like functionality in future. So
-			// rather than assume that the runtime bool flag useRegistry has been initialized to true,
-			// given that the flow has reached this point, having already called functions on the Registry,
-			// such as RegistryClient.IsServiceAvailable(service), we test for its truthiness. I expect
-			// this code to be refactored as we evolve toward a manifest-like functionality in future.
-			configClients[e.ServiceId] = config.ClientInfo{
+			configClient := config.ClientInfo{
 				Protocol: serviceProtocol,
 				Host:     e.Host,
 				Port:     e.Port,
@@ -92,7 +86,7 @@ func getConfig(
 				ServiceKey:  e.ServiceId,
 				Path:        "/",
 				UseRegistry: registryClient != nil,
-				Url:         configClients[e.ServiceId].Url() + clients.ApiConfigRoute,
+				Url:         configClient.Url() + clients.ApiConfigRoute,
 				Interval:    internal.ClientMonitorDefault,
 			}
 			// Add the service key to the map where the value is the respective GeneralClient


### PR DESCRIPTION
Restores backwards compatibility.

Restores prior behavior of mapping service keys to service names in
configuration to get endpoint data for connecting to external services
to obtain configuration (and health, metrics, etc.).

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1780

Signed-off-by: Michael Estrin <m.estrin@dell.com>