### PR TITLE
Convert core-metadata to use common bootstrap package

### DIFF
--- a/internal/core/metadata/config.go
+++ b/internal/core/metadata/config.go
@@ -14,6 +14,7 @@
 package metadata
 
 import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
 
@@ -31,4 +32,58 @@ type ConfigurationStruct struct {
 type WritableInfo struct {
 	LogLevel                        string
 	EnableValueDescriptorManagement bool
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		// Check that information was successfully read from Registry
+		if configuration.Service.Port == 0 {
+			return false
+		}
+		c = configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Clients:  c.Clients,
+		Service:  c.Service,
+		Registry: c.Registry,
+		Logging:  c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
+	c.Registry = registryInfo
 }

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -15,226 +15,71 @@
 package metadata
 
 import (
-	"errors"
+	"context"
 	"fmt"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
-var Configuration *ConfigurationStruct
+var Configuration = &ConfigurationStruct{}
 var dbClient interfaces.DBClient
 var LoggingClient logger.LoggingClient
-var registryClient registry.Client
 var nc notifications.NotificationsClient
 var vdc coredata.ValueDescriptorClient
-var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
-var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry.
 
-func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
-		var err error
-		//When looping, only handle configuration if it hasn't already been set.
-		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
-			if err != nil {
-				ch <- err
-				if !useRegistry {
-					//Error occurred when attempting to read from local filesystem. Fail fast.
-					close(ch)
-					wait.Done()
-					return
-				}
-			} else {
-				// Initialize notificationsClient based on configuration
-				initializeClients(useRegistry)
-				// Setup Logging
-				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(clients.CoreMetaDataServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
-			}
-		}
-
-		//Only attempt to connect to database if configuration has been populated
-		if Configuration != nil {
-			err := connectToDatabase()
-			if err != nil {
-				ch <- err
-			} else {
-				break
-			}
-		}
-		time.Sleep(time.Second * time.Duration(1))
-	}
-	close(ch)
-	wait.Done()
-
-	return
+type server interface {
+	IsRunning() bool
 }
 
-func Init(useRegistry bool) bool {
-	if Configuration == nil || dbClient == nil {
-		return false
-	}
-	if useRegistry {
-		registryErrors = make(chan error)
-		registryUpdates = make(chan interface{})
-		go listenForConfigChanges()
-	}
-
-	go telemetry.StartCpuUsageAverage()
-
-	return true
+type ServiceInit struct {
+	server server
 }
 
-func Destruct() {
-	if dbClient != nil {
-		dbClient.CloseSession()
-		dbClient = nil
+func NewServiceInit(server server) ServiceInit {
+	return ServiceInit{
+		server: server,
 	}
 }
 
-func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
-	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
-	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(configDir, profileDir, configuration)
-	if err != nil {
-		return nil, err
+func (s ServiceInit) initializeClients(useRegistry bool, registryClient registry.Client) {
+	// Create notification client
+	nParams := types.EndpointParams{
+		ServiceKey:  clients.SupportNotificationsServiceKey,
+		Path:        clients.ApiNotificationRoute,
+		UseRegistry: useRegistry,
+		Url:         Configuration.Clients["Notifications"].Url() + clients.ApiNotificationRoute,
+		Interval:    Configuration.Service.ClientMonitor,
 	}
-	configuration.Registry = config.OverrideFromEnvironment(configuration.Registry)
+	nc = notifications.NewNotificationsClient(nParams, endpoint.Endpoint{RegistryClient: &registryClient})
 
-	if useRegistry {
-		err = connectToRegistry(configuration)
-		if err != nil {
-			return nil, err
-		}
-
-		rawConfig, err := registryClient.GetConfiguration(configuration)
-		if err != nil {
-			return nil, fmt.Errorf("could not get configuration from Registry: %v", err.Error())
-		}
-
-		actual, ok := rawConfig.(*ConfigurationStruct)
-		if !ok {
-			return nil, fmt.Errorf("configuration from Registry failed type check")
-		}
-
-		configuration = actual
-
-		// Check that information was successfully read from Registry
-		if configuration.Service.Port == 0 {
-			return nil, errors.New("error reading configuration from Registry")
-		}
+	vParams := types.EndpointParams{
+		ServiceKey:  clients.CoreDataServiceKey,
+		Path:        clients.ApiValueDescriptorRoute,
+		UseRegistry: useRegistry,
+		Url:         Configuration.Clients["CoreData"].Url() + clients.ApiValueDescriptorRoute,
+		Interval:    Configuration.Service.ClientMonitor,
 	}
-	return configuration, nil
-}
-
-func connectToRegistry(conf *ConfigurationStruct) error {
-	var err error
-	registryConfig := registryTypes.Config{
-		Host:            conf.Registry.Host,
-		Port:            conf.Registry.Port,
-		Type:            conf.Registry.Type,
-		ServiceKey:      clients.CoreMetaDataServiceKey,
-		ServiceHost:     conf.Service.Host,
-		ServicePort:     conf.Service.Port,
-		ServiceProtocol: conf.Service.Protocol,
-		CheckInterval:   conf.Service.CheckInterval,
-		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
-	}
-
-	registryClient, err = registry.NewRegistryClient(registryConfig)
-	if err != nil {
-		return fmt.Errorf("connection to Registry could not be made: %v", err.Error())
-	}
-
-	// Check if registry service is running
-	if !registryClient.IsAlive() {
-		return fmt.Errorf("registry is not available")
-	}
-
-	// Register the service with Registry
-	err = registryClient.Register()
-	if err != nil {
-		return fmt.Errorf("could not register service with Registry: %v", err.Error())
-	}
-
-	return nil
-}
-
-func listenForConfigChanges() {
-	if registryClient == nil {
-		LoggingClient.Error("listenForConfigChanges() registry client not set")
-		return
-	}
-
-	registryClient.WatchForChanges(registryUpdates, registryErrors, &WritableInfo{}, internal.WritableKey)
-
-	signals := make(chan os.Signal)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-signals:
-			// Quietly and gracefully stop when SIGINT/SIGTERM received
-			return
-
-		case ex := <-registryErrors:
-			LoggingClient.Error(ex.Error())
-		case raw, ok := <-registryUpdates:
-			if ok {
-				actual, ok := raw.(*WritableInfo)
-				if !ok {
-					LoggingClient.Error("listenForConfigChanges() type check failed")
-				}
-
-				Configuration.Writable = *actual
-
-				LoggingClient.Info("Writeable configuration has been updated from the Registry")
-				LoggingClient.SetLogLevel(Configuration.Writable.LogLevel)
-			} else {
-				return
-			}
-		}
-	}
-}
-
-func connectToDatabase() error {
-	var err error
-
-	dbClient, err = newDBClient(Configuration.Databases["Primary"].Type)
-	if err != nil {
-		dbClient = nil
-		return fmt.Errorf("couldn't create database client: %v", err.Error())
-	}
-
-	return nil
+	vdc = coredata.NewValueDescriptorClient(vParams, endpoint.Endpoint{RegistryClient: &registryClient})
 }
 
 // Return the dbClient interface
-func newDBClient(dbType string) (interfaces.DBClient, error) {
+func (s ServiceInit) newDBClient(dbType string) (interfaces.DBClient, error) {
 	switch dbType {
 	case db.MongoDB:
 		dbConfig := db.Configuration{
@@ -251,37 +96,62 @@ func newDBClient(dbType string) (interfaces.DBClient, error) {
 			Host: Configuration.Databases["Primary"].Host,
 			Port: Configuration.Databases["Primary"].Port,
 		}
-		return redis.NewClient(dbConfig, LoggingClient) //TODO: Verify this also connects to Redis
+		redisClient, err := redis.NewCoreDataClient(dbConfig, LoggingClient) // TODO: Verify this also connects to Redis
+		if err != nil {
+			return nil, err
+		}
+
+		return redisClient, nil
 	default:
 		return nil, db.ErrUnsupportedDatabase
 	}
 }
 
-func initializeClients(useRegistry bool) {
-	// Create notification client
-	nParams := types.EndpointParams{
-		ServiceKey:  clients.SupportNotificationsServiceKey,
-		Path:        clients.ApiNotificationRoute,
-		UseRegistry: useRegistry,
-		Url:         Configuration.Clients["Notifications"].Url() + clients.ApiNotificationRoute,
-		Interval:    Configuration.Service.ClientMonitor,
+func (s ServiceInit) BootstrapHandler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config bootstrap.Configuration,
+	logging logger.LoggingClient,
+	registry registry.Client) bool {
+
+	// update global variables.
+	LoggingClient = logging
+
+	// initialize clients required by service.
+	s.initializeClients(registry != nil, registry)
+
+	// initialize database.
+	for startupTimer.HasNotElapsed() {
+		var err error
+		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
+		if err == nil {
+			break
+		}
+		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
+		startupTimer.SleepForInterval()
 	}
 
-	nc = notifications.NewNotificationsClient(nParams, endpoint.Endpoint{RegistryClient: &registryClient})
-
-	vParams := types.EndpointParams{
-		ServiceKey:  clients.CoreDataServiceKey,
-		Path:        clients.ApiValueDescriptorRoute,
-		UseRegistry: useRegistry,
-		Url:         Configuration.Clients["CoreData"].Url() + clients.ApiValueDescriptorRoute,
-		Interval:    Configuration.Service.ClientMonitor,
+	if dbClient == nil {
+		return false
 	}
-	vdc = coredata.NewValueDescriptorClient(vParams, endpoint.Endpoint{RegistryClient: &registryClient})
-}
 
-func setLoggingTarget() string {
-	if Configuration.Logging.EnableRemote {
-		return Configuration.Clients["Logging"].Url() + clients.ApiLoggingRoute
-	}
-	return Configuration.Logging.File
+	LoggingClient.Info("Database connected")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		<-ctx.Done()
+		for {
+			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
+			if s.server.IsRunning() == false {
+				dbClient.CloseSession()
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		LoggingClient.Info("Database disconnected")
+	}()
+
+	return true
 }


### PR DESCRIPTION
Converts core-metadata to use the common bootstrap package.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1802

Signed-off-by: Michael Estrin <m.estrin@dell.com>