### PR TITLE
Convert export-client to use common bootstrap package

### DIFF
--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -10,26 +10,22 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"os"
-	"os/signal"
-	"strconv"
-	"time"
-
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/export/client"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 func main() {
-	start := time.Now()
+	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+
 	var useRegistry bool
 	var configDir, profileDir string
 
@@ -38,53 +34,23 @@ func main() {
 	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
 	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
 	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{
-		UseRegistry: useRegistry,
-		ConfigDir:   configDir,
-		ProfileDir:  profileDir,
-		BootTimeout: internal.BootTimeoutDefault,
-	}
-	startup.Bootstrap(params, client.Retry, logBeforeInit)
-
-	ok := client.Init(useRegistry)
-	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed", clients.ExportClientServiceKey))
-		os.Exit(1)
-	}
-
-	client.LoggingClient.Info("Service dependencies resolved...")
-	client.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.ExportClientServiceKey, edgex.Version))
-
-	client.LoggingClient.Info(client.Configuration.Service.StartupMsg)
-
-	errs := make(chan error, 2)
-	listenForInterrupt(errs)
-	url := client.Configuration.Service.Host + ":" + strconv.Itoa(client.Configuration.Service.Port)
-	startup.StartHTTPServer(client.LoggingClient, client.Configuration.Service.Timeout, client.LoadRestRoutes(), url, errs)
-
-	// Time it took to start service
-	client.LoggingClient.Info("Service started in: " + time.Since(start).String())
-	client.LoggingClient.Info("Listening on port: " + strconv.Itoa(client.Configuration.Service.Port))
-	c := <-errs
-	client.Destruct()
-	client.LoggingClient.Warn(fmt.Sprintf("terminating: %v", c))
-
-	os.Exit(0)
-}
-
-func logBeforeInit(err error) {
-	l := logger.NewClient(clients.ExportClientServiceKey, false, "", models.InfoLog)
-	l.Error(err.Error())
-}
-
-func listenForInterrupt(errChan chan error) {
-	go func() {
-		correlation.LoggingClient = client.LoggingClient
-		c := make(chan os.Signal)
-		signal.Notify(c, os.Interrupt)
-		errChan <- fmt.Errorf("%s", <-c)
-	}()
+	httpServer := handlers.NewServerBootstrap(client.LoadRestRoutes())
+	bootstrap.Run(
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.ExportClientServiceKey,
+		client.Configuration,
+		startupTimer,
+		[]interfaces.BootstrapHandler{
+			client.NewServiceInit(&httpServer).BootstrapHandler,
+			telemetry.BootstrapHandler,
+			httpServer.Handler,
+			handlers.NewStartMessage(clients.ExportClientServiceKey, edgex.Version).Handler,
+		})
 }

--- a/internal/export/client/config.go
+++ b/internal/export/client/config.go
@@ -13,7 +13,10 @@
  *******************************************************************************/
 package client
 
-import "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+)
 
 type ConfigurationStruct struct {
 	Writable  WritableInfo
@@ -26,4 +29,58 @@ type ConfigurationStruct struct {
 
 type WritableInfo struct {
 	LogLevel string
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		// Check that information was successfully read from Registry
+		if configuration.Service.Port == 0 {
+			return false
+		}
+		c = configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Clients:  c.Clients,
+		Service:  c.Service,
+		Registry: c.Registry,
+		Logging:  c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
+	c.Registry = registryInfo
 }

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -8,127 +8,61 @@
 package client
 
 import (
-	"errors"
+	"context"
 	"fmt"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/export"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/export/distro"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
 var dbClient export.DBClient
 var LoggingClient logger.LoggingClient
-var Configuration *ConfigurationStruct
+var Configuration = &ConfigurationStruct{}
 var dc distro.DistroClient
-var registryClient registry.Client
-var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
-var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
-		var err error
-		//When looping, only handle configuration if it hasn't already been set.
-		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
-			if err != nil {
-				ch <- err
-				if !useRegistry {
-					//Error occurred when attempting to read from local filesystem. Fail fast.
-					close(ch)
-					wait.Done()
-					return
-				}
-			} else {
-				// Setup Logging
-				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(clients.ExportClientServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
-
-				//Initialize service clients
-				initializeClients(useRegistry)
-			}
-		}
-
-		//Only attempt to connect to database if configuration has been populated
-		if Configuration != nil {
-			err := connectToDatabase()
-			if err != nil {
-				ch <- err
-			} else {
-				break
-			}
-		}
-		time.Sleep(time.Second * time.Duration(1))
-	}
-	close(ch)
-	wait.Done()
-
-	return
+type server interface {
+	IsRunning() bool
 }
 
-func Init(useRegistry bool) bool {
-	if Configuration == nil || dbClient == nil {
-		return false
-	}
-	if useRegistry {
-		registryErrors = make(chan error)
-		registryUpdates = make(chan interface{})
-		go listenForConfigChanges()
-	}
-
-	go telemetry.StartCpuUsageAverage()
-
-	return true
+type ServiceInit struct {
+	server server
 }
 
-func Destruct() {
-	if dbClient != nil {
-		dbClient.CloseSession()
-		dbClient = nil
-	}
-	if registryErrors != nil {
-		close(registryErrors)
-	}
-
-	if registryUpdates != nil {
-		close(registryUpdates)
+func NewServiceInit(server server) ServiceInit {
+	return ServiceInit{
+		server: server,
 	}
 }
 
-func connectToDatabase() error {
-	// Create a database client
-	var err error
-
-	dbClient, err = newDBClient(Configuration.Databases["Primary"].Type)
-	if err != nil {
-		dbClient = nil
-		return fmt.Errorf("couldn't create database client: %v", err.Error())
+func (s ServiceInit) initializeClients(useRegistry bool, registry registry.Client) {
+	// Create export-distro client
+	params := types.EndpointParams{
+		ServiceKey:  clients.ExportDistroServiceKey,
+		UseRegistry: useRegistry,
+		Url:         Configuration.Clients["Distro"].Url(),
+		Interval:    Configuration.Service.ClientMonitor,
 	}
 
-	return nil
+	dc = distro.NewDistroClient(params, endpoint.Endpoint{RegistryClient: &registry})
 }
 
 // Return the dbClient interface
-func newDBClient(dbType string) (export.DBClient, error) {
+func (s ServiceInit) newDBClient(dbType string) (export.DBClient, error) {
 	switch dbType {
 	case db.MongoDB:
 		dbConfig := db.Configuration{
@@ -145,130 +79,63 @@ func newDBClient(dbType string) (export.DBClient, error) {
 			Host: Configuration.Databases["Primary"].Host,
 			Port: Configuration.Databases["Primary"].Port,
 		}
-		return redis.NewClient(dbConfig, LoggingClient) //TODO: Verify this also connects to Redis
+		redisClient, err := redis.NewCoreDataClient(dbConfig, LoggingClient) // TODO: Verify this also connects to Redis
+		if err != nil {
+			return nil, err
+		}
+
+		return redisClient, nil
 	default:
 		return nil, db.ErrUnsupportedDatabase
 	}
 }
 
-func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
-	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
-	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(configDir, profileDir, configuration)
-	if err != nil {
-		return nil, err
-	}
-	configuration.Registry = config.OverrideFromEnvironment(configuration.Registry)
+func (s ServiceInit) BootstrapHandler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config bootstrap.Configuration,
+	logging logger.LoggingClient,
+	registry registry.Client) bool {
 
-	if useRegistry {
-		err = connectToRegistry(configuration)
-		if err != nil {
-			return nil, err
+	// update global variables.
+	LoggingClient = logging
+
+	// initialize clients required by service.
+	s.initializeClients(registry != nil, registry)
+
+	// initialize database.
+	for startupTimer.HasNotElapsed() {
+		var err error
+		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
+		if err == nil {
+			break
 		}
-
-		rawConfig, err := registryClient.GetConfiguration(configuration)
-		if err != nil {
-			return nil, fmt.Errorf("could not get configuration from Registry: %v", err.Error())
-		}
-
-		actual, ok := rawConfig.(*ConfigurationStruct)
-		if !ok {
-			return nil, fmt.Errorf("configuration from Registry failed type check")
-		}
-
-		configuration = actual
-
-		// Check that information was successfully read from Registry
-		if configuration.Service.Port == 0 {
-			return nil, errors.New("error reading configuration from Registry")
-		}
+		dbClient = nil
+		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
+		startupTimer.SleepForInterval()
 	}
 
-	return configuration, nil
-}
-
-func initializeClients(useRegistry bool) {
-	// Create export-distro client
-	params := types.EndpointParams{
-		ServiceKey:  clients.ExportDistroServiceKey,
-		UseRegistry: useRegistry,
-		Url:         Configuration.Clients["Distro"].Url(),
-		Interval:    Configuration.Service.ClientMonitor,
+	if dbClient == nil {
+		return false
 	}
 
-	dc = distro.NewDistroClient(params, endpoint.Endpoint{RegistryClient: &registryClient})
-}
+	LoggingClient.Info("Database connected")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 
-func connectToRegistry(conf *ConfigurationStruct) error {
-	var err error
-	registryConfig := registryTypes.Config{
-		Host:            conf.Registry.Host,
-		Port:            conf.Registry.Port,
-		Type:            conf.Registry.Type,
-		ServiceKey:      clients.ExportClientServiceKey,
-		ServiceHost:     conf.Service.Host,
-		ServicePort:     conf.Service.Port,
-		ServiceProtocol: conf.Service.Protocol,
-		CheckInterval:   conf.Service.CheckInterval,
-		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
-	}
-
-	registryClient, err = registry.NewRegistryClient(registryConfig)
-	if err != nil {
-		return fmt.Errorf("connection to Registry could not be made: %v", err.Error())
-	}
-
-	// Check if registry service is running
-	if !registryClient.IsAlive() {
-		return fmt.Errorf("registry is not available")
-	}
-
-	// Register the service with Registry
-	err = registryClient.Register()
-	if err != nil {
-		return fmt.Errorf("could not register service with Registry: %v", err.Error())
-	}
-	return nil
-}
-
-func listenForConfigChanges() {
-	if registryClient == nil {
-		LoggingClient.Error("listenForConfigChanges() registry client not set")
-		return
-	}
-
-	registryClient.WatchForChanges(registryUpdates, registryErrors, &WritableInfo{}, internal.WritableKey)
-
-	signals := make(chan os.Signal)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-signals:
-			// Quietly and gracefully stop when SIGINT/SIGTERM received
-			return
-		case raw, ok := <-registryUpdates:
-			if ok {
-				actual, ok := raw.(*WritableInfo)
-				if !ok {
-					LoggingClient.Error("listenForConfigChanges() type check failed")
-				}
-
-				Configuration.Writable = *actual
-
-				LoggingClient.Info("Writeable configuration has been updated from the Registry")
-				LoggingClient.SetLogLevel(Configuration.Writable.LogLevel)
-			} else {
-				return
+		<-ctx.Done()
+		for {
+			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
+			if s.server.IsRunning() == false {
+				dbClient.CloseSession()
+				break
 			}
+			time.Sleep(time.Second)
 		}
-	}
-}
+		LoggingClient.Info("Database disconnected")
+	}()
 
-func setLoggingTarget() string {
-	if Configuration.Logging.EnableRemote {
-		return Configuration.Clients["Logging"].Url() + clients.ApiLoggingRoute
-	}
-	return Configuration.Logging.File
+	return true
 }


### PR DESCRIPTION
Converts export-client to use the common bootstrap package.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1803

Signed-off-by: Michael Estrin <m.estrin@dell.com>