### PR TITLE
Service Bootstrap Timeout Not Being Honored

### DIFF
--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -153,6 +153,7 @@ func (s ServiceInit) BootstrapHandler(
 		if err == nil {
 			break
 		}
+		dbClient = nil
 		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
 		startupTimer.SleepForInterval()
 	}

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -128,6 +128,7 @@ func (s ServiceInit) BootstrapHandler(
 		if err == nil {
 			break
 		}
+		dbClient = nil
 		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
 		startupTimer.SleepForInterval()
 	}


### PR DESCRIPTION
Corrects issue when database doesn't connect (but abstraction returns
a non-nil dbClient) for core-data and core-metadata implementations.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1827

Signed-off-by: Michael Estrin <m.estrin@dell.com>