### PR TITLE
Convert support-logging to use common bootstrap package

### DIFF
--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -10,25 +10,23 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"os"
-	"os/signal"
-	"strconv"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/logging"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 func main() {
-	start := time.Now()
+	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+
 	var useRegistry bool
 	var configDir, profileDir string
 
@@ -37,51 +35,23 @@ func main() {
 	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
 	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
 	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{
-		UseRegistry: useRegistry,
-		ConfigDir:   configDir,
-		ProfileDir:  profileDir,
-		BootTimeout: internal.BootTimeoutDefault,
-	}
-	startup.Bootstrap(params, logging.Retry, logBeforeInit)
-
-	ok := logging.Init(useRegistry)
-	if !ok {
-		time.Sleep(time.Millisecond * time.Duration(15))
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.SupportLoggingServiceKey))
-		os.Exit(1)
-	}
-	logging.LoggingClient.Info("Service dependencies resolved...")
-	logging.LoggingClient.Info(fmt.Sprintf("Starting %s %s", clients.SupportLoggingServiceKey, edgex.Version))
-
-	errs := make(chan error, 2)
-	listenForInterrupt(errs)
-
-	// Time it took to start service
-	logging.LoggingClient.Info("Service started in: " + time.Since(start).String())
-	logging.LoggingClient.Info("Listening on port: " + strconv.Itoa(logging.Configuration.Service.Port))
-	url := logging.Configuration.Service.Host + ":" + strconv.Itoa(logging.Configuration.Service.Port)
-	startup.StartHTTPServer(logging.LoggingClient, logging.Configuration.Service.Timeout, logging.LoadRestRoutes(), url, errs)
-
-	c := <-errs
-	logging.Destruct()
-	logging.LoggingClient.Warn(fmt.Sprintf("terminated %v", c))
-
-	os.Exit(0)
-}
-
-func logBeforeInit(err error) {
-	l := logger.NewClient(clients.SupportLoggingServiceKey, false, "", models.InfoLog)
-	l.Error(err.Error())
-}
-
-func listenForInterrupt(errChan chan error) {
-	go func() {
-		c := make(chan os.Signal)
-		signal.Notify(c, os.Interrupt)
-		errChan <- fmt.Errorf("%s", <-c)
-	}()
+	httpServer := handlers.NewServerBootstrap(logging.LoadRestRoutes())
+	bootstrap.Run(
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SupportLoggingServiceKey,
+		logging.Configuration,
+		startupTimer,
+		[]interfaces.BootstrapHandler{
+			logging.NewServiceInit(&httpServer).BootstrapHandler,
+			telemetry.BootstrapHandler,
+			httpServer.Handler,
+			handlers.NewStartMessage(clients.SupportLoggingServiceKey, edgex.Version).Handler,
+		})
 }

--- a/internal/support/logging/config.go
+++ b/internal/support/logging/config.go
@@ -13,7 +13,10 @@
  *******************************************************************************/
 package logging
 
-import "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+)
 
 type ConfigurationStruct struct {
 	Writable  WritableInfo
@@ -26,4 +29,58 @@ type ConfigurationStruct struct {
 type WritableInfo struct {
 	Persistence string
 	LogLevel    string
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		// Check that information was successfully read from Registry
+		if configuration.Service.Port == 0 {
+			return false
+		}
+		c = configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Clients:  map[string]config.ClientInfo{},
+		Service:  c.Service,
+		Registry: c.Registry,
+		Logging:  c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
+	c.Registry = registryInfo
 }

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -8,215 +8,96 @@
 package logging
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
-	"github.com/edgexfoundry/go-mod-registry/registry"
+	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 
-	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
-var Configuration *ConfigurationStruct
+var Configuration = &ConfigurationStruct{}
 var dbClient persistence
 var LoggingClient logger.LoggingClient
-var registryClient registry.Client
-var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
-var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	LoggingClient = newPrivateLogger()
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
-		var err error
-		//When looping, only handle configuration if it hasn't already been set.
-		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
-			if err != nil {
-				ch <- err
-				if !useRegistry {
-					//Error occurred when attempting to read from local filesystem. Fail fast.
-					close(ch)
-					wait.Done()
-					return
-				}
-			}
-		}
-
-		//Only attempt to connect to database if configuration has been populated
-		if Configuration != nil {
-			err = getPersistence()
-			if err != nil {
-				ch <- err
-			} else {
-				break
-			}
-		}
-		time.Sleep(time.Second * time.Duration(1))
-	}
-	close(ch)
-	wait.Done()
-
-	return
+type server interface {
+	IsRunning() bool
 }
 
-func Init(useRegistry bool) bool {
-	if Configuration == nil || dbClient == nil {
-		return false
-	}
-	if useRegistry {
-		registryErrors = make(chan error)
-		registryUpdates = make(chan interface{})
-		go listenForConfigChanges()
-	}
-
-	go telemetry.StartCpuUsageAverage()
-
-	return true
+type ServiceInit struct {
+	server server
 }
 
-func Destruct() {
-	if dbClient != nil {
-		dbClient.closeSession()
-		dbClient = nil
-	}
-
-	if registryErrors != nil {
-		close(registryErrors)
-	}
-
-	if registryUpdates != nil {
-		close(registryUpdates)
+func NewServiceInit(server server) ServiceInit {
+	return ServiceInit{
+		server: server,
 	}
 }
 
-func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
-	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
-	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(configDir, profileDir, configuration)
-	if err != nil {
-		return nil, err
-	}
-	configuration.Registry = config.OverrideFromEnvironment(configuration.Registry)
-
-	if useRegistry {
-		err = connectToRegistry(configuration)
-		if err != nil {
-			return nil, err
-		}
-
-		rawConfig, err := registryClient.GetConfiguration(configuration)
-		if err != nil {
-			return nil, fmt.Errorf("could not get configuration from Registry: %v", err.Error())
-		}
-
-		actual, ok := rawConfig.(*ConfigurationStruct)
-		if !ok {
-			return nil, fmt.Errorf("configuration from Registry failed type check")
-		}
-
-		configuration = actual
-
-		// Check that information was successfully read from Registry
-		if configuration.Service.Port == 0 {
-			return nil, errors.New("error reading configuration from Registry")
-		}
-	}
-	return configuration, nil
-}
-
-func connectToRegistry(conf *ConfigurationStruct) error {
-	var err error
-	registryConfig := registryTypes.Config{
-		Host:            conf.Registry.Host,
-		Port:            conf.Registry.Port,
-		Type:            conf.Registry.Type,
-		ServiceKey:      clients.SupportLoggingServiceKey,
-		ServiceHost:     conf.Service.Host,
-		ServicePort:     conf.Service.Port,
-		ServiceProtocol: conf.Service.Protocol,
-		CheckInterval:   conf.Service.CheckInterval,
-		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
-	}
-
-	registryClient, err = registry.NewRegistryClient(registryConfig)
-	if err != nil {
-		return fmt.Errorf("connection to Registry could not be made: %v", err.Error())
-	}
-
-	// Check if registry service is running
-	if !registryClient.IsAlive() {
-		return fmt.Errorf("registry is not available")
-	}
-
-	// Register the service with Registry
-	err = registryClient.Register()
-	if err != nil {
-		return fmt.Errorf("could not register service with Registry: %v", err.Error())
-	}
-	return nil
-}
-
-func listenForConfigChanges() {
-	if registryClient == nil {
-		LoggingClient.Error("listenForConfigChanges() registry client not set")
-		return
-	}
-
-	registryClient.WatchForChanges(registryUpdates, registryErrors, &WritableInfo{}, internal.WritableKey)
-
-	signals := make(chan os.Signal)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-signals:
-			// Quietly and gracefully stop when SIGINT/SIGTERM received
-			return
-		case ex := <-registryErrors:
-			LoggingClient.Error(ex.Error())
-		case raw, ok := <-registryUpdates:
-			if ok {
-				actual, ok := raw.(*WritableInfo)
-				if !ok {
-					LoggingClient.Error("listenForConfigChanges() type check failed")
-				}
-
-				Configuration.Writable = *actual
-
-				LoggingClient.Info("Writeable configuration has been updated from the Registry")
-				LoggingClient.SetLogLevel(Configuration.Writable.LogLevel)
-			} else {
-				return
-			}
-		}
-	}
-}
-
-func getPersistence() error {
+func getPersistence() (persistence, error) {
 	switch Configuration.Writable.Persistence {
 	case PersistenceFile:
-		dbClient = &fileLog{filename: Configuration.Logging.File}
+		return &fileLog{filename: Configuration.Logging.File}, nil
 	case PersistenceDB:
 		// TODO: Integrate db layer with internal/pkg/db/ types so we can support other databases
 		ms, err := connectToMongo()
 		if err != nil {
-			return err
-		} else {
-			dbClient = &mongoLog{session: ms}
+			return nil, err
 		}
+		return &mongoLog{session: ms}, nil
 	default:
-		return errors.New(fmt.Sprintf("unrecognized value Configuration.Persistence: %s", Configuration.Writable.Persistence))
+		return nil, errors.New(fmt.Sprintf("unrecognized value Configuration.Persistence: %s", Configuration.Writable.Persistence))
 	}
-	return nil
+}
+
+func (s ServiceInit) BootstrapHandler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config bootstrap.Configuration,
+	logging logger.LoggingClient,
+	registry registry.Client) bool {
+
+	// update global variables.
+	LoggingClient = newPrivateLogger()
+
+	// initialize database.
+	for startupTimer.HasNotElapsed() {
+		var err error
+		dbClient, err = getPersistence()
+		if err == nil {
+			break
+		}
+		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
+		startupTimer.SleepForInterval()
+	}
+
+	if dbClient == nil {
+		return false
+	}
+
+	LoggingClient.Info("Database connected")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		<-ctx.Done()
+		for {
+			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
+			if s.server.IsRunning() == false {
+				LoggingClient.Info("Database disconnecting")
+				dbClient.closeSession()
+				break
+			}
+			time.Sleep(time.Second)
+		}
+	}()
+
+	return true
 }


### PR DESCRIPTION
Converts support-logging to use the common bootstrap package.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1807

Signed-off-by: Michael Estrin <m.estrin@dell.com>