### PR TITLE
snapcraft.yaml: update docker-edgex-mongo args, add env var to disable security

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -161,6 +161,11 @@ apps:
     after: [mongod]
     command: bin/edgex-mongo --config $SNAP_DATA/config/edgex-mongo/res/configuration.toml
     daemon: oneshot
+    environment:
+      # TODO: set this to true and make it configurable when docker-edgex-mongo
+      # is integrated with vault access for database access, etc. see
+      # https://github.com/edgexfoundry/edgex-go/issues/1840
+      EDGEX_SECURITY_SECRET_STORE: "false"
     start-timeout: 15m
     plugs: [network]
   core-data:
@@ -498,6 +503,8 @@ parts:
 
       install -d "$SNAPCRAFT_PART_INSTALL/config/edgex-mongo/res/"
 
+      # TODO: set CACertPath and TokenPath when docker-edgex-mongo is integrated
+      # with vault, see https://github.com/edgexfoundry/edgex-go/issues/1840
       cp "./cmd/res/configuration.toml" \
         "$SNAPCRAFT_PART_INSTALL/config/edgex-mongo/res/configuration.toml"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -156,7 +156,7 @@ apps:
     plugs:
       - network
       - network-bind
-  mongo-worker:
+  edgex-mongo:
     adapter: full
     after: [mongod]
     command: bin/edgex-mongo --config $SNAP_DATA/config/edgex-mongo/res/configuration.toml
@@ -167,7 +167,7 @@ apps:
     adapter: full
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/core-data -confdir $SNAP_DATA/config/core-data/res --registry
     daemon: simple
@@ -180,7 +180,7 @@ apps:
     adapter: none
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/core-metadata -confdir $SNAP_DATA/config/core-metadata/res --registry
     daemon: simple
@@ -190,7 +190,7 @@ apps:
     adapter: none
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/core-command -confdir $SNAP_DATA/config/core-command/res --registry
     daemon: simple
@@ -200,7 +200,7 @@ apps:
     adapter: none
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/support-logging -confdir $SNAP_DATA/config/support-logging/res --registry
     daemon: simple
@@ -210,7 +210,7 @@ apps:
     adapter: none
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/support-notifications -confdir $SNAP_DATA/config/support-notifications/res --registry
     daemon: simple
@@ -220,7 +220,7 @@ apps:
     adapter: none
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/support-scheduler -confdir $SNAP_DATA/config/support-scheduler/res --registry
     daemon: simple
@@ -231,7 +231,7 @@ apps:
     after:
       - export-client
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/support-rulesengine-wrapper.sh
     daemon: simple
@@ -240,7 +240,7 @@ apps:
     adapter: none
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/export-client -confdir $SNAP_DATA/config/export-client/res --registry
     daemon: simple
@@ -250,7 +250,7 @@ apps:
     adapter: full
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/export-distro -confdir $SNAP_DATA/config/export-distro/res --registry
     daemon: simple
@@ -260,7 +260,7 @@ apps:
     adapter: none
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
     command: bin/sys-mgmt-agent -confdir $SNAP_DATA/config/sys-mgmt-agent/res --registry
     daemon: simple
@@ -269,7 +269,7 @@ apps:
     adapter: none
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
       - core-data
       - core-metadata
@@ -283,7 +283,7 @@ apps:
     adapter: none
     after:
       - core-config-seed
-      - mongo-worker
+      - edgex-mongo
       - edgexproxy
       - core-data
       - core-metadata

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -159,7 +159,7 @@ apps:
   edgex-mongo:
     adapter: full
     after: [mongod]
-    command: bin/edgex-mongo --config $SNAP_DATA/config/edgex-mongo/res/configuration.toml
+    command: bin/edgex-mongo -confdir $SNAP_DATA/config/edgex-mongo/res
     daemon: oneshot
     environment:
       # TODO: set this to true and make it configurable when docker-edgex-mongo


### PR DESCRIPTION
Currently, integration within docker-edgex-mongo to access/setup vault isn't done, so we can't enable integration with vault yet for edgex-mongo, so explicitly turn it off (since if we don't specify it edgex-mongo defaults to trying to turn it on). This env var currently controls whether to use the `Credentials`  (with the env var set to `false` or the `SecretStore` section (with the env var missing or set to true) within the specified configuration.toml (we want Credentials which is just hard-coding the credentials inside the configuration.toml file).

This is a temporary measure until full integration is done. 

See also https://github.com/edgexfoundry/edgex-go/issues/1840

Also, the configuration options were changed to match the rest of EdgeX services, so update that too. 

See https://github.com/edgexfoundry/docker-edgex-mongo/pull/44 and https://github.com/edgexfoundry/docker-edgex-mongo/pull/40 for additional context on the design decisions for docker-edgex-mongo in this area.

To test, just build the snap and install it in devmode. You should see something like this in the logs for `edgex-mongo` service:

```
$ journalctl --no-hostname -ef -u snap.edgexfoundry.edgex-mongo.service 
-- Logs begin at Thu 2019-07-04 19:15:05 CDT. --
Sep 27 15:26:11 systemd[1]: Starting Service for snap application edgexfoundry.edgex-mongo...
Sep 27 15:26:11 edgexfoundry.edgex-mongo[119509]: level=ERROR ts=2019-09-27T20:26:11.856618158Z app=edgex-mongo source=logger.go:105 msg="logTarget cannot be blank, using stdout only"
Sep 27 15:26:11 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:11.861931256Z app=edgex-mongo source=main.go:32 msg="starting edgex-mongo process ..."
Sep 27 15:26:11 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:11.861952015Z app=edgex-mongo source=config.go:24 msg="loading the configuration ignoring the secret store"
Sep 27 15:26:11 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:11.861974608Z app=edgex-mongo source=init.go:47 msg="config file location: /var/snap/edgexfoundry/x1/config/edgex-mongo/res/configuration.toml"
Sep 27 15:26:11 edgexfoundry.edgex-mongo[119509]: level=ERROR ts=2019-09-27T20:26:11.862537701Z app=edgex-mongo source=logger.go:105 msg="logTarget cannot be blank, using stdout only"
Sep 27 15:26:11 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:11.890903083Z app=edgex-mongo source=client.go:46 msg="Settting up admin database"
Sep 27 15:26:11 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:11.931613734Z app=edgex-mongo source=client.go:46 msg="Settting up authorization database"
Sep 27 15:26:11 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:11.949751812Z app=edgex-mongo source=client.go:46 msg="Settting up rules_engine_db database"
Sep 27 15:26:11 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:11.963312154Z app=edgex-mongo source=client.go:46 msg="Settting up metadata database"
Sep 27 15:26:12 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:12.225132279Z app=edgex-mongo source=client.go:46 msg="Settting up notifications database"
Sep 27 15:26:12 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:12.316485162Z app=edgex-mongo source=client.go:46 msg="Settting up logging database"
Sep 27 15:26:12 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:12.355069815Z app=edgex-mongo source=client.go:46 msg="Settting up application-service database"
Sep 27 15:26:12 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:12.439380088Z app=edgex-mongo source=client.go:46 msg="Settting up coredata database"
Sep 27 15:26:12 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:12.541934281Z app=edgex-mongo source=client.go:46 msg="Settting up scheduler database"
Sep 27 15:26:12 edgexfoundry.edgex-mongo[119509]: level=INFO ts=2019-09-27T20:26:12.638751379Z app=edgex-mongo source=client.go:46 msg="Settting up exportclient database"
Sep 27 15:26:12 systemd[1]: snap.edgexfoundry.edgex-mongo.service: Succeeded.
Sep 27 15:26:12 systemd[1]: Started Service for snap application edgexfoundry.edgex-mongo.
```