### PR TITLE
Convert security-secretstore-setup to use common bootstrap package

### DIFF
--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -21,33 +21,27 @@ package main
 
 import (
 	"flag"
-	"os"
-	"path/filepath"
-
 	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"os"
 )
 
 func main() {
+	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+
 	if len(os.Args) < 2 {
 		usage.HelpCallbackSecuritySecretStore()
 	}
 
-	var initNeeded bool
 	var insecureSkipVerify bool
-	var configFileLocation string
-	var waitInterval int
 	var configDir, profileDir string
 	var useRegistry bool
 
-	flag.BoolVar(&initNeeded, "init", false, "run init procedure for security service.")
 	flag.BoolVar(&insecureSkipVerify, "insecureSkipVerify", false, "skip server side SSL verification, mainly for self-signed cert")
-	flag.StringVar(&configFileLocation, "configfile", "res/configuration.toml", "configuration file")
-	flag.IntVar(&waitInterval, "wait", 30, "time to wait between checking Vault status in seconds.")
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
 	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
@@ -57,61 +51,15 @@ func main() {
 	flag.Usage = usage.HelpCallbackSecuritySecretStore
 	flag.Parse()
 
-	params := startup.BootParams{
-		UseRegistry: useRegistry,
-		ConfigDir:   configDir,
-		ProfileDir:  profileDir,
-		BootTimeout: internal.BootTimeoutDefault,
-	}
-	startup.Bootstrap(params, secretstore.Retry, logBeforeInit)
-
-	//step 1: boot up secretstore general steps same as other EdgeX microservice
-
-	//step 2: initialize the communications
-	req := secretstore.NewRequester(insecureSkipVerify)
-
-	//step 3: initialize and unseal Vault
-
-	//Step 4:
-	//TODO: create vault access token for different roles
-
-	//step 5 :
-	//TODO: implement credential creation
-
-	absTokenPath := filepath.Join(secretstore.Configuration.SecretService.TokenFolderPath, secretstore.Configuration.SecretService.TokenFile)
-	cert := secretstore.NewCerts(req, secretstore.Configuration.SecretService.CertPath, absTokenPath)
-	existing, err := cert.AlreadyinStore()
-	if err != nil {
-		secretstore.LoggingClient.Error(err.Error())
-		os.Exit(1)
-	}
-
-	if existing == true {
-		secretstore.LoggingClient.Info("proxy certificate pair are in the secret store already, skip uploading")
-		os.Exit(0)
-	}
-
-	secretstore.LoggingClient.Info("proxy certificate pair are not in the secret store yet, uploading them")
-	cp, err := cert.ReadFrom(secretstore.Configuration.SecretService.CertFilePath, secretstore.Configuration.SecretService.KeyFilePath)
-	if err != nil {
-		secretstore.LoggingClient.Error("failed to get certificate pair from volume")
-		os.Exit(1)
-	}
-
-	secretstore.LoggingClient.Info("proxy certificate pair are loaded from volume successfully, will upload to secret store")
-
-	err = cert.UploadToStore(cp)
-	if err != nil {
-		secretstore.LoggingClient.Error("failed to upload the proxy cert pair into the secret store")
-		secretstore.LoggingClient.Error(err.Error())
-		os.Exit(1)
-	}
-
-	secretstore.LoggingClient.Info("proxy certificate pair are uploaded to secret store successfully, Vault init done successfully")
-	os.Exit(0)
-}
-
-func logBeforeInit(err error) {
-	l := logger.NewClient("security-secretstore-setup", false, "", models.InfoLog)
-	l.Error(err.Error())
+	bootstrap.Run(
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		internal.SecurityProxySetupServiceKey,
+		secretstore.Configuration,
+		startupTimer,
+		[]interfaces.BootstrapHandler{
+			secretstore.NewHandler(insecureSkipVerify).BootstrapHandler,
+		})
 }

--- a/cmd/security-secretstore-setup/res/configuration.toml
+++ b/cmd/security-secretstore-setup/res/configuration.toml
@@ -18,9 +18,27 @@
 [Writable]
 LogLevel = 'DEBUG'
 
+[Service]
+CheckInterval = '10s'
+Host = 'localhost'
+Port = 48080
+Protocol = 'http'
+Timeout = 5000
+
+[Registry]
+Host = 'localhost'
+Port = 8500
+Type = 'consul'
+
 [Logging]
 EnableRemote = false
 File = './logs/security-secretstore-setup.log'
+
+[Clients]
+  [Clients.Logging]
+  Protocol = 'http'
+  Host = 'localhost'
+  Port = 48061
 
 [SecretService]
 scheme = "https"

--- a/cmd/security-secretstore-setup/res/docker/configuration.toml
+++ b/cmd/security-secretstore-setup/res/docker/configuration.toml
@@ -18,9 +18,28 @@
 [Writable]
 LogLevel = 'DEBUG'
 
+[Service]
+CheckInterval = '10s'
+Host = 'localhost'
+Port = 48080
+Protocol = 'http'
+Timeout = 5000
+
+[Registry]
+Host = 'edgex-core-consul'
+Port = 8500
+Type = 'consul'
+
+
 [Logging]
 EnableRemote = false
 File = './logs/security-secretstore-setup.log'
+
+[Clients]
+  [Clients.Logging]
+  Protocol = 'http'
+  Host = 'edgex-support-logging'
+  Port = 48061
 
 [SecretService]
 scheme = "https"

--- a/internal/security/secretstore/config.go
+++ b/internal/security/secretstore/config.go
@@ -17,6 +17,7 @@ package secretstore
 
 import (
 	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"net/url"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
@@ -24,7 +25,10 @@ import (
 
 type ConfigurationStruct struct {
 	Writable      WritableInfo
+	Clients       map[string]config.ClientInfo
 	Logging       config.LoggingInfo
+	Registry      config.RegistryInfo
+	Service       config.ServiceInfo
 	SecretService SecretServiceInfo
 }
 
@@ -54,4 +58,54 @@ func (s SecretServiceInfo) GetSecretSvcBaseURL() string {
 		Path:   "/",
 	}
 	return url.String()
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	if configuration, ok := rawConfig.(*ConfigurationStruct); ok {
+		c = configuration
+		return true
+	}
+	return false
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Clients:  c.Clients,
+		Service:  c.Service,
+		Registry: c.Registry,
+		Logging:  c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
+	c.Registry = registryInfo
 }

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -16,62 +16,85 @@
 package secretstore
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"sync"
-	"time"
 
-	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
-var Configuration *ConfigurationStruct
+var Configuration = &ConfigurationStruct{}
 var LoggingClient logger.LoggingClient
 
-func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
-		var err error
-		// When looping, only handle configuration if it hasn't already been set.
-		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
-			if err != nil {
-				ch <- err
-				if !useRegistry {
-					// Error occurred when attempting to read from local filesystem. Fail fast.
-					close(ch)
-					wait.Done()
-					return
-				}
-			} else {
-				// Setup Logging
-				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.SecurityProxySetupServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
-			}
-		}
-		// This seems a bit artificial here due to lack of additional service requirements
-		// but conforms to the pattern found in other edgex-go services.
-		if Configuration != nil {
-			break
-		}
-		time.Sleep(time.Second * time.Duration(1))
-	}
-	close(ch)
-	wait.Done()
-
-	return
+type Handler struct {
+	insecureSkipVerify bool
 }
 
-func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
-	// We currently have to load configuration from filesystem first in order to obtain Registry Host/Port
-	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(configDir, profileDir, configuration)
+func NewHandler(insecureSkipVerify bool) Handler {
+	return Handler{
+		insecureSkipVerify: insecureSkipVerify,
+	}
+}
+
+func (h Handler) BootstrapHandler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config bootstrap.Configuration,
+	logging logger.LoggingClient,
+	registry registry.Client) bool {
+
+	// update global variables.
+	LoggingClient = logging
+
+	//step 1: boot up secretstore general steps same as other EdgeX microservice
+
+	//step 2: initialize the communications
+	req := NewRequester(h.insecureSkipVerify)
+
+	//step 3: initialize and unseal Vault
+
+	//Step 4:
+	//TODO: create vault access token for different roles
+
+	//step 5 :
+	//TODO: implement credential creation
+
+	absTokenPath := filepath.Join(Configuration.SecretService.TokenFolderPath, Configuration.SecretService.TokenFile)
+	cert := NewCerts(req, Configuration.SecretService.CertPath, absTokenPath)
+	existing, err := cert.AlreadyinStore()
 	if err != nil {
-		return nil, err
+		LoggingClient.Error(err.Error())
+		return false
 	}
-	return configuration, nil
-}
 
-func setLoggingTarget() string {
-	return Configuration.Logging.File
+	if existing == true {
+		LoggingClient.Info("proxy certificate pair are in the secret store already, skip uploading")
+		os.Exit(0)
+	}
+
+	LoggingClient.Info("proxy certificate pair are not in the secret store yet, uploading them")
+	cp, err := cert.ReadFrom(Configuration.SecretService.CertFilePath, Configuration.SecretService.KeyFilePath)
+	if err != nil {
+		LoggingClient.Error("failed to get certificate pair from volume")
+		return false
+	}
+
+	LoggingClient.Info("proxy certificate pair are loaded from volume successfully, will upload to secret store")
+
+	err = cert.UploadToStore(cp)
+	if err != nil {
+		LoggingClient.Error("failed to upload the proxy cert pair into the secret store")
+		LoggingClient.Error(err.Error())
+		return false
+	}
+
+	LoggingClient.Info("proxy certificate pair are uploaded to secret store successfully, Vault init done successfully")
+	return false
 }


### PR DESCRIPTION
Converts security-secretstore-setup to use the common bootstrap package.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1806

Signed-off-by: Michael Estrin <m.estrin@dell.com>