### PR TITLE
SMA should support disable/enable parameters for stop/start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.27
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.28
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8

--- a/internal/system/agent/executor/executor-stub.go
+++ b/internal/system/agent/executor/executor-stub.go
@@ -40,7 +40,7 @@ func NewStub(results []stubCall) Stub {
 
 // CommandExecutor provides the common callout to the configuration-defined executor.  This is a stub implementation of
 // the CommandExecutor interface.
-func (m *Stub) CommandExecutor(executorPath, serviceName, operation string) (string, error) {
+func (m *Stub) CommandExecutor(executorPath, serviceName, operation string, parameters []string) (string, error) {
 	m.Called++
 	m.capturedArgs = append(m.capturedArgs, []string{executorPath, serviceName, operation})
 	return m.perCallResults[m.Called-1].outString, m.perCallResults[m.Called-1].outError

--- a/internal/system/agent/executor/executor.go
+++ b/internal/system/agent/executor/executor.go
@@ -17,7 +17,7 @@ package executor
 import "os/exec"
 
 // CommandExecutor provides the common callout to the configuration-defined executor.
-func CommandExecutor(executorPath, serviceName, operation string) (string, error) {
-	bytes, err := exec.Command(executorPath, serviceName, operation).CombinedOutput()
+func CommandExecutor(executorPath, serviceName, operation string, parameters []string) (string, error) {
+	bytes, err := exec.Command(executorPath, append([]string{serviceName, operation}, parameters...)...).CombinedOutput()
 	return string(bytes), err
 }

--- a/internal/system/agent/executor/metrics.go
+++ b/internal/system/agent/executor/metrics.go
@@ -44,7 +44,7 @@ func NewMetrics(executor interfaces.CommandExecutor, loggingClient logger.Loggin
 func (e metrics) Get(services []string, ctx context.Context) interface{} {
 	var result []interface{}
 	for _, serviceName := range services {
-		r, err := e.executor(e.executorPath, serviceName, system.Metrics)
+		r, err := e.executor(e.executorPath, serviceName, system.Metrics, []string{})
 		if err != nil {
 			result = append(result, system.Failure(serviceName, system.Metrics, UnknownExecutorType, err.Error()))
 			continue

--- a/internal/system/agent/executor/operation.go
+++ b/internal/system/agent/executor/operation.go
@@ -43,10 +43,10 @@ func NewOperations(
 }
 
 // operationViaExecutor delegates a start/stop/restart operation request to the configuration-defined executor.
-func (e operations) Do(services []string, operation string) interface{} {
+func (e operations) Do(services []string, operation string, parameters []string) interface{} {
 	var result []interface{}
 	for _, serviceName := range services {
-		r, err := e.executor(e.executorPath, serviceName, operation)
+		r, err := e.executor(e.executorPath, serviceName, operation, parameters)
 		if err != nil {
 			result = append(result, system.Failure(serviceName, operation, UnknownExecutorType, err.Error()))
 			continue

--- a/internal/system/agent/executor/operation_test.go
+++ b/internal/system/agent/executor/operation_test.go
@@ -30,7 +30,7 @@ func TestOperationDoWithNoServices(t *testing.T) {
 	executor := NewStub([]stubCall{})
 	sut := NewOperations(executor.CommandExecutor, logger.NewMockClient(), "executorPathDoesNotMatter")
 
-	result := sut.Do([]string{}, "operationDoesNotMatter")
+	result := sut.Do([]string{}, "operationDoesNotMatter", []string{})
 
 	var emptyResult []interface{}
 	assert.Equal(t, result, emptyResult)
@@ -122,7 +122,7 @@ func TestOperationDoWithServices(t *testing.T) {
 			executor := NewStub(test.executorCalls)
 			sut := NewOperations(executor.CommandExecutor, loggingClient, executorPath)
 
-			result := sut.Do(test.services, operation)
+			result := sut.Do(test.services, operation, []string{})
 
 			if assert.Equal(t, len(test.executorCalls), executor.Called) {
 				for key, executorCall := range test.executorCalls {

--- a/internal/system/agent/interfaces/executor.go
+++ b/internal/system/agent/interfaces/executor.go
@@ -14,4 +14,4 @@
 
 package interfaces
 
-type CommandExecutor func(executorPath, serviceName, operation string) (string, error)
+type CommandExecutor func(executorPath, serviceName, operation string, parameters []string) (string, error)

--- a/internal/system/agent/interfaces/operations.go
+++ b/internal/system/agent/interfaces/operations.go
@@ -16,5 +16,5 @@ package interfaces
 
 // Operations defines an operation execution abstraction.
 type Operations interface {
-	Do(services []string, operation string) interface{}
+	Do(services []string, operation string, parameters []string) interface{}
 }

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -86,7 +86,7 @@ func operationHandler(w http.ResponseWriter, r *http.Request, operationsImpl int
 		return
 	}
 
-	pkg.Encode(operationsImpl.Do(o.Services, o.Action), w, LoggingClient)
+	pkg.Encode(operationsImpl.Do(o.Services, o.Action, o.Parameters), w, LoggingClient)
 }
 
 func getConfigHandler(w http.ResponseWriter, r *http.Request, getConfigImpl interfaces.GetConfig) {


### PR DESCRIPTION
Adds support for optional parameters on /api/v1/operations endpoint
to be passed along as-is to binary executor implementation.

Depends upon https://github.com/edgexfoundry/go-mod-core-contracts/pull/160.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/770

Signed-off-by: Michael Estrin <m.estrin@dell.com>