### PR TITLE
Uses adopt-info with new 'version' part.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,8 +1,6 @@
 name: edgexfoundry
 base: core18
-version: "replace-me"
-version-script: |
-  echo $(cat VERSION)-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
+adopt-info: version
 summary: Open-source framework for IoT edge computing
 description: |
   EdgeX Foundry is a vendor-neutral open source project hosted by The Linux 
@@ -339,6 +337,13 @@ apps:
       - network-bind
 
 parts:
+  version:
+    plugin: nil
+    # as with curl plugin, the source dir is unrelated to this part and is used
+    # since it changes rarely and therefore will not trigger a new pull
+    source: snap/local/build-helpers
+    override-pull: |
+      snapcraftctl set-version $(cat $SNAPCRAFT_PROJECT_DIR/VERSION)-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
   curl:
     plugin: nil
     # the default source for a part that doesn't specify one is ".", which


### PR DESCRIPTION
Executing snapcraft sets snap version for generated snap.
The version is read from VERSION file in root of source tree.
The date and git info is appended to version as previously.