### PR TITLE
Update support notifications to use common boostrap logic.

### DIFF
--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -16,29 +16,29 @@
  * @author: Jim White, Dell Technologies
  * @version: 0.5.0
  *******************************************************************************/
+
+// main is the central entry point for the application and calls all the startup logic.
 package main
 
 import (
 	"flag"
-	"fmt"
-	"os"
-	"os/signal"
-	"strconv"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 func main() {
-	start := time.Now()
+	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+
 	var useRegistry bool
 	var configDir, profileDir string
 
@@ -50,49 +50,19 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	params := startup.BootParams{
-		UseRegistry: useRegistry,
-		ConfigDir:   configDir,
-		ProfileDir:  profileDir,
-		BootTimeout: internal.BootTimeoutDefault,
-	}
-	startup.Bootstrap(params, notifications.Retry, logBeforeInit)
-
-	ok := notifications.Init(useRegistry)
-	if !ok {
-		logBeforeInit(fmt.Errorf("%s: Service bootstrap failed!", clients.SupportNotificationsServiceKey))
-		os.Exit(1)
-	}
-
-	notifications.LoggingClient.Info("Service dependencies resolved...")
-	notifications.LoggingClient.Info(fmt.Sprintf("Starting %s %s ", clients.SupportNotificationsServiceKey, edgex.Version))
-
-	notifications.LoggingClient.Info(notifications.Configuration.Service.StartupMsg)
-
-	errs := make(chan error, 2)
-	listenForInterrupt(errs)
-	url := notifications.Configuration.Service.Host + ":" + strconv.Itoa(notifications.Configuration.Service.Port)
-	startup.StartHTTPServer(notifications.LoggingClient, notifications.Configuration.Service.Timeout, notifications.LoadRestRoutes(), url, errs)
-
-	// Time it took to start service
-	notifications.LoggingClient.Info("Service started in: " + time.Since(start).String())
-	notifications.LoggingClient.Info("Listening on port: " + strconv.Itoa(notifications.Configuration.Service.Port))
-	c := <-errs
-	notifications.Destruct()
-	notifications.LoggingClient.Warn(fmt.Sprintf("terminating: %v", c))
-
-	os.Exit(0)
-}
-
-func logBeforeInit(err error) {
-	l := logger.NewClient(clients.SupportNotificationsServiceKey, false, "", models.InfoLog)
-	l.Error(err.Error())
-}
-
-func listenForInterrupt(errChan chan error) {
-	go func() {
-		c := make(chan os.Signal)
-		signal.Notify(c, os.Interrupt)
-		errChan <- fmt.Errorf("%s", <-c)
-	}()
+	httpServer := handlers.NewServerBootstrap(notifications.LoadRestRoutes())
+	bootstrap.Run(
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SupportNotificationsServiceKey,
+		notifications.Configuration,
+		startupTimer,
+		[]interfaces.BootstrapHandler{
+			notifications.NewServiceInit(&httpServer).BootstrapHandler,
+			telemetry.BootstrapHandler,
+			httpServer.Handler,
+			handlers.NewStartMessage(clients.SupportNotificationsServiceKey, edgex.Version).Handler,
+		})
 }

--- a/internal/support/notifications/config.go
+++ b/internal/support/notifications/config.go
@@ -12,9 +12,13 @@
  * the License.
  *
  *******************************************************************************/
+
 package notifications
 
-import "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+)
 
 type ConfigurationStruct struct {
 	Writable  WritableInfo
@@ -49,4 +53,58 @@ func (s SmtpInfo) CheckUsername() string {
 		return s.Username
 	}
 	return s.Sender
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		// Check that information was successfully read from Registry
+		if configuration.Service.Port == 0 {
+			return false
+		}
+		c = configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Clients:  c.Clients,
+		Service:  c.Service,
+		Registry: c.Registry,
+		Logging:  c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
+	c.Registry = registryInfo
 }

--- a/internal/support/notifications/init.go
+++ b/internal/support/notifications/init.go
@@ -18,116 +18,42 @@
 package notifications
 
 import (
-	"errors"
+	"context"
 	"fmt"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications/interfaces"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
-var Configuration *ConfigurationStruct
+var Configuration = &ConfigurationStruct{}
 var dbClient interfaces.DBClient
 var LoggingClient logger.LoggingClient
-var registryClient registry.Client
-var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
-var registerUpdates chan interface{} //A channel for "config updates" sourced from Registry
 
-func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
-		var err error
-		//When looping, only handle configuration if it hasn't already been set.
-		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
-			if err != nil {
-				ch <- err
-				if !useRegistry {
-					//Error occurred when attempting to read from local filesystem. Fail fast.
-					close(ch)
-					wait.Done()
-					return
-				}
-			} else {
-				// Setup Logging
-				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(clients.SupportNotificationsServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
-			}
-		}
-
-		//Only attempt to connect to database if configuration has been populated
-		if Configuration != nil {
-			err := connectToDatabase()
-			if err != nil {
-				ch <- err
-			} else {
-				break
-			}
-		}
-		time.Sleep(time.Second * time.Duration(1))
-	}
-	close(ch)
-	wait.Done()
-
-	return
+type server interface {
+	IsRunning() bool
 }
 
-func Init(useRegistry bool) bool {
-	if Configuration == nil || dbClient == nil {
-		return false
-	}
-	if useRegistry {
-		registryErrors = make(chan error)
-		registerUpdates = make(chan interface{})
-		go listenForConfigChanges()
-	}
-
-	go telemetry.StartCpuUsageAverage()
-
-	return true
+type ServiceInit struct {
+	server server
 }
 
-func Destruct() {
-	if dbClient != nil {
-		dbClient.CloseSession()
-		dbClient = nil
-	}
-	if registryErrors != nil {
-		close(registryErrors)
-	}
-
-	if registerUpdates != nil {
-		close(registerUpdates)
+func NewServiceInit(server server) ServiceInit {
+	return ServiceInit{
+		server: server,
 	}
 }
 
-func connectToDatabase() error {
-	// Create a database client
-	var err error
-	dbClient, err = newDBClient(Configuration.Databases["Primary"].Type)
-	if err != nil {
-		return fmt.Errorf("couldn't create database client: %v", err.Error())
-	}
-
-	return err
-}
-
-// Return the dbClient interface
-func newDBClient(dbType string) (interfaces.DBClient, error) {
+func (s ServiceInit) newDBClient(dbType string) (interfaces.DBClient, error) {
 	switch dbType {
 	case db.MongoDB:
 		dbConfig := db.Configuration{
@@ -150,110 +76,49 @@ func newDBClient(dbType string) (interfaces.DBClient, error) {
 	}
 }
 
-func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
-	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
-	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(configDir, profileDir, configuration)
-	if err != nil {
-		return nil, err
-	}
-	configuration.Registry = config.OverrideFromEnvironment(configuration.Registry)
+func (s ServiceInit) BootstrapHandler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config bootstrap.Configuration,
+	logging logger.LoggingClient,
+	registry registry.Client) bool {
 
-	if useRegistry {
-		err = connectToRegistry(configuration)
-		if err != nil {
-			return nil, err
+	// update global variables.
+	LoggingClient = logging
+
+	// initialize database.
+	for startupTimer.HasNotElapsed() {
+		var err error
+		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
+		if err == nil {
+			break
 		}
-
-		rawConfig, err := registryClient.GetConfiguration(configuration)
-		if err != nil {
-			return nil, fmt.Errorf("could not get configuration from Registry: %v", err.Error())
-		}
-
-		actual, ok := rawConfig.(*ConfigurationStruct)
-		if !ok {
-			return nil, fmt.Errorf("configuration from Registry failed type check")
-		}
-
-		configuration = actual
-
-		// Check that information was successfully read from Registry
-		if configuration.Service.Port == 0 {
-			return nil, errors.New("error reading configuration from Registry")
-		}
-	}
-	return configuration, nil
-}
-
-func connectToRegistry(conf *ConfigurationStruct) error {
-	var err error
-	registryConfig := registryTypes.Config{
-		Host:            conf.Registry.Host,
-		Port:            conf.Registry.Port,
-		Type:            conf.Registry.Type,
-		ServiceKey:      clients.SupportNotificationsServiceKey,
-		ServiceHost:     conf.Service.Host,
-		ServicePort:     conf.Service.Port,
-		ServiceProtocol: conf.Service.Protocol,
-		CheckInterval:   conf.Service.CheckInterval,
-		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
+		dbClient = nil
+		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
+		startupTimer.SleepForInterval()
 	}
 
-	registryClient, err = registry.NewRegistryClient(registryConfig)
-	if err != nil {
-		return fmt.Errorf("connection to Registry could not be made: %v", err.Error())
+	if dbClient == nil {
+		return false
 	}
 
-	// Check if registry service is running
-	if !registryClient.IsAlive() {
-		return fmt.Errorf("registry is not available")
-	}
+	LoggingClient.Info("Database connected")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 
-	// Register the service with Registry
-	err = registryClient.Register()
-	if err != nil {
-		return fmt.Errorf("could not register service with Registry: %v", err.Error())
-	}
-	return nil
-}
-
-func listenForConfigChanges() {
-	if registryClient == nil {
-		LoggingClient.Error("listenForConfigChanges() registry client not set")
-		return
-	}
-
-	registryClient.WatchForChanges(registerUpdates, registryErrors, &WritableInfo{}, internal.WritableKey)
-
-	signals := make(chan os.Signal)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-signals:
-			// Quietly and gracefully stop when SIGINT/SIGTERM received
-			return
-		case raw, ok := <-registerUpdates:
-			if ok {
-				actual, ok := raw.(*WritableInfo)
-				if !ok {
-					LoggingClient.Error("listenForConfigChanges() type check failed")
-				}
-
-				Configuration.Writable = *actual
-
-				LoggingClient.Info("Writeable configuration has been updated from the Registry")
-				LoggingClient.SetLogLevel(Configuration.Writable.LogLevel)
-			} else {
-				return
+		<-ctx.Done()
+		for {
+			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
+			if s.server.IsRunning() == false {
+				dbClient.CloseSession()
+				break
 			}
+			time.Sleep(time.Second)
 		}
-	}
-}
-func setLoggingTarget() string {
-	if Configuration.Logging.EnableRemote {
-		return Configuration.Clients["Logging"].Url() + clients.ApiLoggingRoute
-	}
-	return Configuration.Logging.File
+		LoggingClient.Info("Database disconnected")
+	}()
+
+	return true
 }


### PR DESCRIPTION
Update main.go and init.go to leverage the common bootstrapping functionality available to all services and remove redundant code.

Signed-off-by: Brandon Forster <brandonforster@gmail.com>