### PR TITLE
[DO NOT MERGE] Split customized vault into two docker images

### DIFF
--- a/cmd/security-secrets-setup/Dockerfile
+++ b/cmd/security-secrets-setup/Dockerfile
@@ -44,22 +44,18 @@ COPY . .
 
 RUN make cmd/security-secrets-setup/security-secrets-setup
 
-FROM vault:1.0.2
+FROM alpine:latest
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-      copyright='Copyright (c) 2019: Dell Technologies, Inc.'
+      copyright='Copyright (c) 2019: Dell Technologies, Inc.  Copyright (c) 2019 Intel Corporation'
 
 USER root
 
 # install necessary tools
-RUN apk update && apk add ca-certificates dumb-init jq \
+RUN apk update && apk add ca-certificates dumb-init \
     && rm -rf /var/cache/apk/* 
 
-ENV BASE_DIR=/vault
-
-# Vault Config File
-WORKDIR $BASE_DIR/config
-COPY --from=build-env /edgex-go/cmd/security-secrets-setup/res/local-tls.hcl ./local.hcl
+ENV BASE_DIR=/edgex/security-secrets-setup
 
 WORKDIR $BASE_DIR
 RUN mkdir res
@@ -80,13 +76,6 @@ COPY --from=build-env /edgex-go/cmd/security-secrets-setup/entrypoint.sh /usr/lo
 RUN chmod +x /usr/local/bin/entrypoint.sh \
     && ln -s /usr/local/bin/entrypoint.sh /
 
-# Create assets folder (needed for unseal key/s, root token and tmp)
-# Run CA/Vault and Kong PKI/TLS setups and peform housekeeping tasks
-RUN mkdir $BASE_DIR/config/assets && \
-    chown -R vault:vault $BASE_DIR && \
-    chmod 644 $BASE_DIR/config/local.hcl && \
-    chmod 744 security-secrets-setup
-
-VOLUME $BASE_DIR/config
+RUN chmod 755 security-secrets-setup
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/cmd/security-secrets-setup/edgex-stack-security.yml
+++ b/cmd/security-secrets-setup/edgex-stack-security.yml
@@ -1,0 +1,560 @@
+# /*******************************************************************************
+#  * Copyright 2019 Intel Corporation
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+#  * in compliance with the License. You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software distributed under the License
+#  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  * or implied. See the License for the specific language governing permissions and limitations under
+#  * the License.
+#  *
+#  * @author: Jim White, Dell
+#  * EdgeX Foundry, Edinburgh, version 1.0.1
+#  * added: July 26, 2019
+#  *******************************************************************************/
+
+version: '3'
+volumes:
+  db-data:
+  log-data:
+  consul-config:
+  consul-data:
+  portainer_data:
+  vault-config:
+  vault-file:
+  vault-logs:
+
+services:
+  volume:
+    image: edgexfoundry/docker-edgex-volume:1.0.0
+    container_name: edgex-files
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-files
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+
+  consul:
+    image: consul:1.3.1
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:8600"
+    container_name: edgex-core-consul
+    hostname: edgex-core-consul
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-consul
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume
+
+  config-seed:
+    image: edgexfoundry/docker-core-config-seed-go:1.0.0
+    container_name: edgex-config-seed
+    hostname: edgex-core-config-seed
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-config-seed
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume
+      - consul
+
+  vault:
+    image: vault:1.2.3
+    container_name: edgex-vault
+    hostname: edgex-vault
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-vault
+    ports:
+      - "8200:8200"
+    cap_add:
+      - "IPC_LOCK"
+    command: '/usr/bin/dumb-init -- /bin/sh -c "while test \! -f /run/edgex/secrets/edgex-vault/.security-secrets-setup.complete; do sleep 1; done; exec  /usr/local/bin/docker-entrypoint.sh server -log-level=info"'
+    environment:
+      - 'VAULT_ADDR=https://edgex-vault:8200'
+      - 'VAULT_LOCAL_CONFIG=listener "tcp" {   address = "edgex-vault:8200"   tls_disable = "0"   cluster_address = "edgex-vault:8201"  tls_min_version = "tls12"  tls_client_ca_file ="/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem"  tls_cert_file ="/run/edgex/secrets/edgex-vault/server.crt"  tls_key_file = "/run/edgex/secrets/edgex-vault/server.key"  tls_perfer_server_cipher_suites = true }  backend "consul" { path = "vault/" address = "edgex-core-consul:8500" scheme = "http" redirect_addr = "https://edgex-vault:8200" cluster_addr = "https://edgex-vault:8201" }  default_lease_ttl = "168h"  max_lease_ttl = "720h"'
+      - 'VAULT_CONFIG_DIR=/vault/config'
+      - 'VAULT_UI=true'
+    volumes:
+      - vault-file:/vault/file
+      - vault-logs:/vault/logs
+      - /run/edgex/secrets/edgex-vault:/run/edgex/secrets/edgex-vault:ro
+    depends_on:
+      - security-secrets-setup
+      - volume
+      - consul
+
+  security-secrets-setup:
+    image: edgexfoundry/docker-edgex-vault:1.1.0-dev
+    container_name: edgex-secrets-setup
+    hostname: edgex-secrets-setup
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-secrets-setup
+    tmpfs:
+      - /run
+    environment:
+      - 'VAULT_ADDR=https://edgex-vault:8200'
+      - 'VAULT_CONFIG_DIR=/vault/config'
+      - 'VAULT_UI=true'
+    volumes:
+      - /run/edgex/secrets/edgex-vault:/run/edgex/secrets/edgex-vault
+    depends_on:
+      - volume
+
+  vault-worker:
+    image: edgexfoundry/docker-edgex-vault-worker-go:1.0.0
+    container_name: edgex-vault-worker
+    hostname: edgex-vault-worker
+    command: ["--init=true", "--debug=false", "--wait=10", "--insureskipverify=false"]
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-vault-worker
+    volumes:
+      - vault-config:/vault/config
+    depends_on:
+      - volume
+      - consul
+      - vault
+
+# containers for reverse proxy
+  kong-db:
+    image: "postgres:9.6"
+    container_name: kong-db
+    hostname: kong-db
+    networks:
+      edgex-network:
+        aliases:
+            - kong-db
+    ports:
+        - "5432:5432"
+    environment:
+        - 'POSTGRES_DB=kong'
+        - 'POSTGRES_USER=kong'
+
+  kong-migrations:
+    image: "kong:1.0.3"
+    container_name: kong-migration
+    hostname: kong-migration
+    networks:
+      edgex-network:
+        aliases:
+            - kong-migration
+    environment:
+        - 'KONG_DATABASE=postgres'
+        - 'KONG_PG_HOST=kong-db'
+    command: "kong migrations bootstrap"
+
+  kong:
+    image: "kong:1.0.3"
+    container_name: kong
+    hostname: kong
+    networks:
+      edgex-network:
+        aliases:
+            - kong
+    ports:
+        - "8000:8000"
+        - "8001:8001"
+        - "8443:8443"
+        - "8444:8444"
+    environment:
+        - 'KONG_DATABASE=postgres'
+        - 'KONG_PG_HOST=kong-db'
+        - 'KONG_PROXY_ACCESS_LOG=/dev/stdout'
+        - 'KONG_ADMIN_ACCESS_LOG=/dev/stdout'
+        - 'KONG_PROXY_ERROR_LOG=/dev/stderr'
+        - 'KONG_ADMIN_ERROR_LOG=/dev/stderr'
+        - 'KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl'
+    depends_on:
+        - kong-db
+
+  edgex-proxy:
+    image: "edgexfoundry/docker-edgex-proxy-go:1.0.0"
+    container_name: edgex-proxy
+    hostname: edgex-proxy
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-proxy
+    volumes:
+        - vault-config:/vault/config
+    depends_on:
+        - vault
+        - kong-db
+        - kong
+
+# end of containers for reverse proxy
+
+  mongo:
+    image: edgexfoundry/docker-edgex-mongo:1.0.1
+    ports:
+      - "27017:27017"
+    container_name: edgex-mongo
+    hostname: edgex-mongo
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-mongo
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - volume
+
+  logging:
+    image: edgexfoundry/docker-support-logging-go:1.0.1
+    ports:
+      - "48061:48061"
+    container_name: edgex-support-logging
+    hostname: edgex-support-logging
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-support-logging
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - config-seed
+      - mongo
+      - volume
+
+  system:
+    image: edgexfoundry/docker-sys-mgmt-agent-go:1.0.1
+    ports:
+      - "48090:48090"
+    container_name: edgex-sys-mgmt-agent
+    hostname: edgex-sys-mgmt-agent
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-sys-mgmt-agent
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - logging
+
+  notifications:
+    image: edgexfoundry/docker-support-notifications-go:1.0.1
+    ports:
+      - "48060:48060"
+    container_name: edgex-support-notifications
+    hostname: edgex-support-notifications
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-support-notifications
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - logging
+
+  metadata:
+    image: edgexfoundry/docker-core-metadata-go:1.0.1
+    ports:
+      - "48081:48081"
+    container_name: edgex-core-metadata
+    hostname: edgex-core-metadata
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-metadata
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - logging
+
+  data:
+    image: edgexfoundry/docker-core-data-go:1.0.1
+    ports:
+      - "48080:48080"
+      - "5563:5563"
+    container_name: edgex-core-data
+    hostname: edgex-core-data
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-data
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - logging
+
+  command:
+    image: edgexfoundry/docker-core-command-go:1.0.1
+    ports:
+      - "48082:48082"
+    container_name: edgex-core-command
+    hostname: edgex-core-command
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-core-command
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - metadata
+
+  scheduler:
+    image: edgexfoundry/docker-support-scheduler-go:1.0.1
+    ports:
+      - "48085:48085"
+    container_name: edgex-support-scheduler
+    hostname: edgex-support-scheduler
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-support-scheduler
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - metadata
+
+  export-client:
+    image: edgexfoundry/docker-export-client-go:1.0.1
+    ports:
+      - "48071:48071"
+    container_name: edgex-export-client
+    hostname: edgex-export-client
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-export-client
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - data
+
+  export-distro:
+    image: edgexfoundry/docker-export-distro-go:1.0.1
+    ports:
+      - "48070:48070"
+      - "5566:5566"
+    container_name: edgex-export-distro
+    hostname: edgex-export-distro
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-export-distro
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - export-client
+    environment:
+      - EXPORT_DISTRO_CLIENT_HOST=export-client
+      - EXPORT_DISTRO_DATA_HOST=edgex-core-data
+      - EXPORT_DISTRO_CONSUL_HOST=edgex-config-seed
+      - EXPORT_DISTRO_MQTTS_CERT_FILE=none
+      - EXPORT_DISTRO_MQTTS_KEY_FILE=none
+
+  rulesengine:
+    image: edgexfoundry/docker-support-rulesengine:1.0.0
+    ports:
+      - "48075:48075"
+    container_name: edgex-support-rulesengine
+    hostname: edgex-support-rulesengine
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-support-rulesengine
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - export-client
+
+#################################################################
+# Device Services
+#################################################################
+
+  device-virtual:
+    image: edgexfoundry/docker-device-virtual-go:1.0.0
+    ports:
+    - "49990:49990"
+    container_name: edgex-device-virtual
+    hostname: edgex-device-virtual
+    networks:
+      edgex-network:
+        aliases:
+        - edgex-device-virtual
+    volumes:
+    - db-data:/data/db
+    - log-data:/edgex/logs
+    - consul-config:/consul/config
+    - consul-data:/consul/data
+    depends_on:
+    - data
+    - command
+
+  # device-random:
+  #   image: edgexfoundry/docker-device-random-go:1.0.0
+  #   ports:
+  #     - "49988:49988"
+  #   container_name: edgex-device-random
+  #   hostname: edgex-device-random
+  #   networks:
+  #     edgex-network:
+  #       aliases:
+  #           - edgex-device-random
+  #   volumes:
+  #     - db-data:/data/db
+  #     - log-data:/edgex/logs
+  #     - consul-config:/consul/config
+  #     - consul-data:/consul/data
+  #   depends_on:
+  #     - data
+  #     - command
+  #
+  # device-mqtt:
+  #   image: edgexfoundry/docker-device-mqtt-go:1.0.0
+  #   ports:
+  #     - "49982:49982"
+  #   container_name: edgex-device-mqtt
+  #   hostname: edgex-device-mqtt
+  #   networks:
+  #     edgex-network:
+  #       aliases:
+  #           - edgex-device-mqtt
+  #   volumes:
+  #     - db-data:/data/db
+  #     - log-data:/edgex/logs
+  #     - consul-config:/consul/config
+  #     - consul-data:/consul/data
+  #   depends_on:
+  #     - data
+  #     - command
+  #
+  # device-modbus:
+  #   image: edgexfoundry/docker-device-modbus-go:1.0.0
+  #   ports:
+  #     - "49991:49991"
+  #   container_name: edgex-device-modbus
+  #   hostname: edgex-device-modbus
+  #   networks:
+  #     edgex-network:
+  #       aliases:
+  #           - edgex-device-modbus
+  #   volumes:
+  #     - db-data:/data/db
+  #     - log-data:/edgex/logs
+  #     - consul-config:/consul/config
+  #     - consul-data:/consul/data
+  #   depends_on:
+  #     - data
+  #     - command
+  #
+  # device-snmp:
+  #   image: edgexfoundry/docker-device-snmp-go:1.0.0
+  #   ports:
+  #     - "49993:49993"
+  #   container_name: edgex-device-snmp
+  #   hostname: edgex-device-snmp
+  #   networks:
+  #     edgex-network:
+  #       aliases:
+  #           - edgex-device-snmp
+  #   volumes:
+  #     - db-data:/data/db
+  #     - log-data:/edgex/logs
+  #     - consul-config:/consul/config
+  #     - consul-data:/consul/data
+  #   depends_on:
+  #     - data
+  #     - command
+
+#################################################################
+# UIs
+#################################################################
+  ui:
+    image: edgexfoundry/docker-edgex-ui-go:1.0.0
+    ports:
+      - "4000:4000"
+    container_name: edgex-ui-go
+    hostname: edgex-ui-go
+    networks:
+      edgex-network:
+        aliases:
+            - edgex-ui-go
+    volumes:
+      - db-data:/data/db
+      - log-data:/edgex/logs
+      - consul-config:/consul/config
+      - consul-data:/consul/data
+    depends_on:
+      - data
+      - command
+
+#################################################################
+# Tooling
+#################################################################
+
+  portainer:
+    image:  portainer/portainer
+    ports:
+      - "9000:9000"
+    command: -H unix:///var/run/docker.sock
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    depends_on:
+      - volume
+
+networks:
+  edgex-network:
+    driver: "bridge"
+...


### PR DESCRIPTION
Still WIP but it is functioning now most of time.
 
TBD:
- cross mount volume so that we use docker-entry or shell script on the volume service to do the command so that the compose file won't contain very very long string.

- any other way using file instead of VAULT_LOCAL_CONFIG ? If using file, we can do the same trick as above bullet


Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>