### PR TITLE
System Management Cyclical References

### DIFF
--- a/cmd/sys-mgmt-agent/toml_test.go
+++ b/cmd/sys-mgmt-agent/toml_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent"
+	agentConfig "github.com/edgexfoundry/edgex-go/internal/system/agent/config"
 )
 
 func TestToml(t *testing.T) {
-	configuration := &agent.ConfigurationStruct{}
+	configuration := &agentConfig.ConfigurationStruct{}
 	if err := config.VerifyTomlFiles(configuration); err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/internal/system/agent/clients/general.go
+++ b/internal/system/agent/clients/general.go
@@ -12,7 +12,7 @@
  * the License.
  *******************************************************************************/
 
-package agent
+package clients
 
 import (
 	"sync"
@@ -20,33 +20,36 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
 )
 
-// clientMap defines internal map structure to track multiple instances of general.GeneralClient.
-type clientMap map[string]general.GeneralClient
+// GeneralType is an alias for general.GeneralClient and hides implementation detail.
+type GeneralType general.GeneralClient
 
-// GeneralClients contains implementation structures for tracking multiple instances of general.GeneralClient.
-type GeneralClients struct {
+// clientMap defines internal map structure to track multiple instances of general.GeneralClient.
+type clientMap map[string]GeneralType
+
+// General contains implementation structures for tracking multiple instances of GeneralType.
+type General struct {
 	clients clientMap
 	mutex   sync.RWMutex
 }
 
-// NewGeneralClients is a factory function that returns an initialized GeneralClients receiver struct.
-func NewGeneralClients() *GeneralClients {
-	return &GeneralClients{
+// NewGeneral is a factory function that returns an initialized General receiver struct.
+func NewGeneral() *General {
+	return &General{
 		clients: make(clientMap),
 		mutex:   sync.RWMutex{},
 	}
 }
 
-// Get returns the general.GeneralClient and ok = true for the requested client name if it exists, otherwise ok = false.
-func (c *GeneralClients) Get(clientName string) (client general.GeneralClient, ok bool) {
+// Get returns the GeneralType and ok = true for the requested client name if it exists, otherwise ok = false.
+func (c *General) Get(clientName string) (client GeneralType, ok bool) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	client, ok = c.clients[clientName]
 	return
 }
 
-// Set updates the list of clients to ensure the provided clientName key contains the provided general.GeneralClient value.
-func (c *GeneralClients) Set(clientName string, value general.GeneralClient) {
+// Set updates the list of clients to ensure the provided clientName key contains the provided GeneralType value.
+func (c *General) Set(clientName string, value GeneralType) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	c.clients[clientName] = value

--- a/internal/system/agent/clients/general_test.go
+++ b/internal/system/agent/clients/general_test.go
@@ -12,7 +12,7 @@
  * the License.
  *******************************************************************************/
 
-package agent
+package clients
 
 import (
 	"testing"
@@ -26,7 +26,7 @@ import (
 )
 
 func TestEmptyGetReturnsExpectedValues(t *testing.T) {
-	sut := NewGeneralClients()
+	sut := NewGeneral()
 
 	result, ok := sut.Get("nonExistentKey")
 
@@ -37,7 +37,7 @@ func TestEmptyGetReturnsExpectedValues(t *testing.T) {
 func TestGetForKnownReturnsExpectedValues(t *testing.T) {
 	const clientName = "clientName"
 
-	sut := NewGeneralClients()
+	sut := NewGeneral()
 	client := general.NewGeneralClient(types.EndpointParams{}, endpoint.Endpoint{RegistryClient: nil})
 	sut.Set(clientName, client)
 

--- a/internal/system/agent/config/config.go
+++ b/internal/system/agent/config/config.go
@@ -12,7 +12,7 @@
  * the License.
  *******************************************************************************/
 
-package agent
+package config
 
 import (
 	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"

--- a/internal/system/agent/direct/metrics.go
+++ b/internal/system/agent/direct/metrics.go
@@ -25,7 +25,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/system"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent"
+	agentClients "github.com/edgexfoundry/edgex-go/internal/system/agent/clients"
 	"github.com/edgexfoundry/edgex-go/internal/system/executor"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
@@ -39,7 +39,7 @@ import (
 // metrics contains references to dependencies required to handle the metrics via direct service use case.
 type metrics struct {
 	loggingClient   logger.LoggingClient
-	genClients      *agent.GeneralClients
+	genClients      *agentClients.General
 	registryClient  registry.Client
 	serviceProtocol string
 }
@@ -47,7 +47,7 @@ type metrics struct {
 // NewMetrics is a factory function that returns an initialized metrics receiver struct.
 func NewMetrics(
 	loggingClient logger.LoggingClient,
-	genClients *agent.GeneralClients,
+	genClients *agentClients.General,
 	registryClient registry.Client,
 	serviceProtocol string) *metrics {
 

--- a/internal/system/agent/getconfig/executor.go
+++ b/internal/system/agent/getconfig/executor.go
@@ -21,7 +21,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent"
+	agentClients "github.com/edgexfoundry/edgex-go/internal/system/agent/clients"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
@@ -33,7 +33,7 @@ import (
 
 // executor contains references to dependencies required to execute a get configuration request.
 type executor struct {
-	genClients      *agent.GeneralClients
+	genClients      *agentClients.General
 	registryClient  registry.Client
 	loggingClient   logger.LoggingClient
 	serviceProtocol string
@@ -41,7 +41,7 @@ type executor struct {
 
 // NewExecutor is a factory function that returns an initialized executor struct.
 func NewExecutor(
-	genClients *agent.GeneralClients,
+	genClients *agentClients.General,
 	registryClient registry.Client,
 	loggingClient logger.LoggingClient,
 	serviceProtocol string) *executor {

--- a/internal/system/agent/setconfig/executor.go
+++ b/internal/system/agent/setconfig/executor.go
@@ -19,8 +19,7 @@ import (
 	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent"
-
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	requests "github.com/edgexfoundry/go-mod-core-contracts/requests/configuration"
 	responses "github.com/edgexfoundry/go-mod-core-contracts/responses/configuration"
@@ -32,11 +31,11 @@ import (
 // executor contains references to dependencies required to execute a set configuration request.
 type executor struct {
 	loggingClient logger.LoggingClient
-	configuration *agent.ConfigurationStruct
+	configuration *config.ConfigurationStruct
 }
 
 // NewExecutor is a factory function that returns an initialized executor struct.
-func NewExecutor(loggingClient logger.LoggingClient, configuration *agent.ConfigurationStruct) *executor {
+func NewExecutor(loggingClient logger.LoggingClient, configuration *config.ConfigurationStruct) *executor {
 	return &executor{
 		loggingClient: loggingClient,
 		configuration: configuration,


### PR DESCRIPTION
Refactored to remove cyclical references that occur when factory of
metricsImpl is moved from main.go into internal/system/agent.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1858
Signed-off-by: Michael Estrin <m.estrin@dell.com>