### PR TITLE
Integrate simple dependency injection container into common bootstrap

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 
@@ -53,6 +54,7 @@ func main() {
 		clients.CoreCommandServiceKey,
 		command.Configuration,
 		startupTimer,
+		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
 			command.NewServiceInit(&httpServer).BootstrapHandler,

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 
@@ -54,6 +55,7 @@ func main() {
 		clients.CoreDataServiceKey,
 		data.Configuration,
 		startupTimer,
+		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
 			data.NewServiceInit(&httpServer).BootstrapHandler,

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 
@@ -53,6 +54,7 @@ func main() {
 		clients.CoreMetaDataServiceKey,
 		metadata.Configuration,
 		startupTimer,
+		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
 			metadata.NewServiceInit(&httpServer).BootstrapHandler,

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"flag"
+
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/export/client"
@@ -17,6 +18,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 
@@ -47,6 +49,7 @@ func main() {
 		clients.ExportClientServiceKey,
 		client.Configuration,
 		startupTimer,
+		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
 			client.NewServiceInit(&httpServer).BootstrapHandler,

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 
@@ -49,6 +50,7 @@ func main() {
 		clients.ExportDistroServiceKey,
 		distro.Configuration,
 		startupTimer,
+		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
 			distro.BootstrapHandler,

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/logging"
@@ -48,6 +49,7 @@ func main() {
 		clients.SupportLoggingServiceKey,
 		logging.Configuration,
 		startupTimer,
+		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
 			logging.NewServiceInit(&httpServer).BootstrapHandler,

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications"
@@ -59,6 +60,7 @@ func main() {
 		clients.SupportNotificationsServiceKey,
 		notifications.Configuration,
 		startupTimer,
+		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
 			notifications.NewServiceInit(&httpServer).BootstrapHandler,

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler"
@@ -53,6 +54,7 @@ func main() {
 		clients.SupportSchedulerServiceKey,
 		scheduler.Configuration,
 		startupTimer,
+		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
 			scheduler.NewServiceInit(&httpServer).BootstrapHandler,

--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -14,59 +14,23 @@
 package main
 
 import (
-	"context"
 	"flag"
-	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
+	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent/direct"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent/executor"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent/getconfig"
-	agentInterfaces "github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent/setconfig"
+	agentConfig "github.com/edgexfoundry/edgex-go/internal/system/agent/config"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/container"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
-	"github.com/edgexfoundry/go-mod-registry/registry"
 )
-
-func httpServerBootstrapHandler(
-	wg *sync.WaitGroup,
-	ctx context.Context,
-	startupTimer startup.Timer,
-	config interfaces.Configuration,
-	logging logger.LoggingClient,
-	registry registry.Client) bool {
-
-	var metricsImpl agentInterfaces.Metrics
-	switch agent.Configuration.MetricsMechanism {
-	case direct.MetricsMechanism:
-		metricsImpl = direct.NewMetrics(logging, agent.GenClients, registry, agent.Configuration.Service.Protocol)
-	case executor.MetricsMechanism:
-		metricsImpl = executor.NewMetrics(executor.CommandExecutor, logging, agent.Configuration.ExecutorPath)
-	default:
-		logging.Error("the requested metrics mechanism is not supported")
-		return false
-	}
-
-	httpServer := handlers.NewServerBootstrap(
-		agent.LoadRestRoutes(
-			metricsImpl,
-			executor.NewOperations(executor.CommandExecutor, logging, agent.Configuration.ExecutorPath),
-			getconfig.New(
-				getconfig.NewExecutor(agent.GenClients, registry, logging, agent.Configuration.Service.Protocol),
-				logging),
-			setconfig.New(setconfig.NewExecutor(logging, agent.Configuration))))
-	return httpServer.Handler(wg, ctx, startupTimer, config, logging, registry)
-}
 
 func main() {
 	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
@@ -83,18 +47,29 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
+	configuration := &agentConfig.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
+			return get(container.ConfigurationName)
+		},
+	})
+	httpServer := handlers.NewServerBootstrap(agent.LoadRestRoutes(dic))
 	bootstrap.Run(
 		configDir,
 		profileDir,
 		internal.ConfigFileName,
 		useRegistry,
 		clients.SystemManagementAgentServiceKey,
-		agent.Configuration,
+		configuration,
 		startupTimer,
+		dic,
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
 			agent.BootstrapHandler,
-			httpServerBootstrapHandler,
+			httpServer.Handler,
 			handlers.NewStartMessage(clients.SystemManagementAgentServiceKey, edgex.Version).Handler,
 		})
 }

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -21,11 +21,12 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/command/interfaces"
-	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 
@@ -68,16 +69,15 @@ func (s ServiceInit) BootstrapHandler(
 	wg *sync.WaitGroup,
 	ctx context.Context,
 	startupTimer startup.Timer,
-	config bootstrap.Configuration,
-	logging logger.LoggingClient,
-	registry registry.Client) bool {
+	dic *di.Container) bool {
 
 	// update global variables.
-	LoggingClient = logging
-	httpErrorHandler = errorconcept.NewErrorHandler(logging)
+	LoggingClient = container.LoggingClientFrom(dic.Get)
+	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
 
 	// initialize clients required by service.
-	s.initializeClients(registry)
+	registryClient := container.RegistryFrom(dic.Get)
+	s.initializeClients(registryClient)
 
 	// initialize database.
 	for startupTimer.HasNotElapsed() {

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -21,11 +21,12 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
-	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 
@@ -140,16 +141,15 @@ func (s ServiceInit) BootstrapHandler(
 	wg *sync.WaitGroup,
 	ctx context.Context,
 	startupTimer startup.Timer,
-	config bootstrap.Configuration,
-	logging logger.LoggingClient,
-	registry registry.Client) bool {
+	dic *di.Container) bool {
 
 	// update global variables.
-	LoggingClient = logging
-	httpErrorHandler = errorconcept.NewErrorHandler(logging)
+	LoggingClient = container.LoggingClientFrom(dic.Get)
+	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
 
 	// initialize clients required by service.
-	s.initializeClients(registry != nil, registry)
+	registryClient := container.RegistryFrom(dic.Get)
+	s.initializeClients(registryClient != nil, registryClient)
 
 	// initialize database.
 	for startupTimer.HasNotElapsed() {

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -21,11 +21,12 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
-	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
@@ -115,16 +116,15 @@ func (s ServiceInit) BootstrapHandler(
 	wg *sync.WaitGroup,
 	ctx context.Context,
 	startupTimer startup.Timer,
-	config bootstrap.Configuration,
-	logging logger.LoggingClient,
-	registry registry.Client) bool {
+	dic *di.Container) bool {
 
 	// update global variables.
-	LoggingClient = logging
-	httpErrorHandler = errorconcept.NewErrorHandler(logging)
+	LoggingClient = container.LoggingClientFrom(dic.Get)
+	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
 
 	// initialize clients required by service.
-	s.initializeClients(registry != nil, registry)
+	registryClient := container.RegistryFrom(dic.Get)
+	s.initializeClients(registryClient != nil, registryClient)
 
 	// initialize database.
 	for startupTimer.HasNotElapsed() {

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -14,11 +14,12 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/export"
-	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
@@ -94,15 +95,14 @@ func (s ServiceInit) BootstrapHandler(
 	wg *sync.WaitGroup,
 	ctx context.Context,
 	startupTimer startup.Timer,
-	config bootstrap.Configuration,
-	logging logger.LoggingClient,
-	registry registry.Client) bool {
+	dic *di.Container) bool {
 
 	// update global variables.
-	LoggingClient = logging
+	LoggingClient = container.LoggingClientFrom(dic.Get)
 
 	// initialize clients required by service.
-	s.initializeClients(registry != nil, registry)
+	registryClient := container.RegistryFrom(dic.Get)
+	s.initializeClients(registryClient != nil, registryClient)
 
 	// initialize database.
 	for startupTimer.HasNotElapsed() {

--- a/internal/pkg/bootstrap/container/configuration.go
+++ b/internal/pkg/bootstrap/container/configuration.go
@@ -12,20 +12,17 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// ConfigurationInterfaceName contains the name of the interfaces.Configuration implementation in the DIC.
+var ConfigurationInterfaceName = di.TypeInstanceToName((*interfaces.Configuration)(nil))
+
+// ConfigurationFrom helper function queries the DIC and returns the interfaces.Configuration implementation.
+func ConfigurationFrom(get di.Get) interfaces.Configuration {
+	return get(ConfigurationInterfaceName).(interfaces.Configuration)
+}

--- a/internal/pkg/bootstrap/container/logging.go
+++ b/internal/pkg/bootstrap/container/logging.go
@@ -12,20 +12,17 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// LoggingClientInterfaceName contains the name of the logger.LoggingClient implementation in the DIC.
+var LoggingClientInterfaceName = di.TypeInstanceToName((*logger.LoggingClient)(nil))
+
+// LoggingClientFrom helper function queries the DIC and returns the logger.loggingClient implementation.
+func LoggingClientFrom(get di.Get) logger.LoggingClient {
+	return get(LoggingClientInterfaceName).(logger.LoggingClient)
+}

--- a/internal/pkg/bootstrap/container/registry.go
+++ b/internal/pkg/bootstrap/container/registry.go
@@ -12,20 +12,21 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// RegistryClientInterfaceName contains the name of the registry.Client implementation in the DIC.
+var RegistryClientInterfaceName = di.TypeInstanceToName((*registry.Client)(nil))
+
+// RegistryFrom helper function queries the DIC and returns the registry.Client implementation.
+func RegistryFrom(get di.Get) registry.Client {
+	registryClient := get(RegistryClientInterfaceName)
+	if registryClient != nil {
+		return registryClient.(registry.Client)
+	}
+	return (registry.Client)(nil)
+}

--- a/internal/pkg/bootstrap/container/secret.go
+++ b/internal/pkg/bootstrap/container/secret.go
@@ -12,20 +12,17 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/go-mod-secrets/pkg"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// SecretClientName contains the name of the registry.Client implementation in the DIC.
+var SecretClientName = di.TypeInstanceToName(pkg.SecretClient{})
+
+// SecretClientFrom helper function queries the DIC and returns the pkg.SecretClient implementation.
+func SecretClientFrom(get di.Get) *pkg.SecretClient {
+	return get(SecretClientName).(*pkg.SecretClient)
+}

--- a/internal/pkg/bootstrap/handlers/server.go
+++ b/internal/pkg/bootstrap/handlers/server.go
@@ -21,12 +21,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
-	"github.com/edgexfoundry/go-mod-registry/registry"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 
 	"github.com/gorilla/mux"
 )
@@ -59,11 +56,9 @@ func (h *Server) Handler(
 	wg *sync.WaitGroup,
 	ctx context.Context,
 	startupTimer startup.Timer,
-	config interfaces.Configuration,
-	loggingClient logger.LoggingClient,
-	registryClient registry.Client) bool {
+	dic *di.Container) bool {
 
-	bootstrapConfig := config.GetBootstrap()
+	bootstrapConfig := container.ConfigurationFrom(dic.Get).GetBootstrap()
 	addr := bootstrapConfig.Service.Host + ":" + strconv.Itoa(bootstrapConfig.Service.Port)
 	timeout := time.Millisecond * time.Duration(bootstrapConfig.Service.Timeout)
 	server := &http.Server{
@@ -73,6 +68,7 @@ func (h *Server) Handler(
 		ReadTimeout:  timeout,
 	}
 
+	loggingClient := container.LoggingClientFrom(dic.Get)
 	loggingClient.Info("Web server starting (" + addr + ")")
 
 	wg.Add(1)

--- a/internal/pkg/bootstrap/handlers/start_message.go
+++ b/internal/pkg/bootstrap/handlers/start_message.go
@@ -19,11 +19,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-registry/registry"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 )
 
 // StartMessage contains references to dependencies required by the start message handler.
@@ -46,14 +44,13 @@ func (h StartMessage) Handler(
 	wg *sync.WaitGroup,
 	context context.Context,
 	startupTimer startup.Timer,
-	config interfaces.Configuration,
-	loggingClient logger.LoggingClient,
-	registryClient registry.Client) bool {
+	dic *di.Container) bool {
 
+	loggingClient := container.LoggingClientFrom(dic.Get)
 	loggingClient.Info("Service dependencies resolved...")
 	loggingClient.Info(fmt.Sprintf("Starting %s %s ", h.serviceKey, h.version))
 
-	bootstrapConfig := config.GetBootstrap()
+	bootstrapConfig := container.ConfigurationFrom(dic.Get).GetBootstrap()
 	if len(bootstrapConfig.Service.StartupMsg) > 0 {
 		loggingClient.Info(bootstrapConfig.Service.StartupMsg)
 	}

--- a/internal/pkg/di/container.go
+++ b/internal/pkg/di/container.go
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// di implements a simple generic dependency injection container.
+//
+// Sample usage:
+//
+//		package main
+//
+//		import (
+//			"fmt"
+//			"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+//		)
+//
+//		type foo struct {
+//			FooMessage string
+//		}
+//
+//		func NewFoo(m string) *foo {
+//			return &foo{
+//				FooMessage: m,
+//			}
+//		}
+//
+//		type bar struct {
+//			BarMessage string
+//			Foo        *foo
+//		}
+//
+//		func NewBar(m string, foo *foo) *bar {
+//			return &bar{
+//				BarMessage: m,
+//				Foo:        foo,
+//			}
+//		}
+//
+//		func main() {
+//			container := di.NewContainer(
+//				di.ServiceConstructorMap{
+//					"foo": func(get di.Get) interface{} {
+//						return NewFoo("fooMessage")
+//					},
+//					"bar": func(get di.Get) interface{} {
+//						return NewBar("barMessage", get("foo").(*foo))
+//					},
+//				})
+//
+//			b := container.Get("bar").(*bar)
+//			fmt.Println(b.BarMessage)
+//			fmt.Println(b.Foo.FooMessage)
+//		}
+//
+package di
+
+import "sync"
+
+type Get func(serviceName string) interface{}
+
+// ServiceConstructor defines the contract for a function/closure to create a service.
+type ServiceConstructor func(get Get) interface{}
+
+// ServiceConstructorMap maps a service name to a function/closure to create that service.
+type ServiceConstructorMap map[string]ServiceConstructor
+
+// service is an internal structure used to track a specific service's constructor and constructed instance.
+type service struct {
+	constructor ServiceConstructor
+	instance    interface{}
+}
+
+// Container is a receiver that maintains a list of services, their constructors, and their constructed instances in a
+// thread-safe manner.
+type Container struct {
+	serviceMap map[string]service
+	mutex      sync.RWMutex
+}
+
+// NewContainer is a factory method that returns an initialized Container receiver struct.
+func NewContainer(serviceConstructors ServiceConstructorMap) *Container {
+	c := Container{
+		serviceMap: map[string]service{},
+		mutex:      sync.RWMutex{},
+	}
+	c.Update(serviceConstructors)
+	return &c
+}
+
+// Set updates its internal serviceMap with the contents of the provided ServiceConstructorMap.
+func (c *Container) Update(serviceConstructors ServiceConstructorMap) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	for serviceName, constructor := range serviceConstructors {
+		c.serviceMap[serviceName] = service{
+			constructor: constructor,
+			instance:    nil,
+		}
+	}
+}
+
+// get looks up the requested serviceName and, if it exists, returns a constructed instance.  If the requested service
+// does not exist, it panics.  Get wraps instance construction in a singleton; the implementation assumes an instance,
+// once constructed, will be reused and returned for all subsequent get(serviceName) calls.
+func (c *Container) get(serviceName string) interface{} {
+	service, ok := c.serviceMap[serviceName]
+	if !ok {
+		panic("attempt to get unknown service \"" + serviceName + "\"")
+	}
+	if service.instance == nil {
+		service.instance = service.constructor(c.get)
+		c.serviceMap[serviceName] = service
+	}
+	return service.instance
+}
+
+// Get wraps get to make it thread-safe.
+func (c *Container) Get(serviceName string) interface{} {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.get(serviceName)
+}

--- a/internal/pkg/di/container_test.go
+++ b/internal/pkg/di/container_test.go
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package di
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const serviceName = "serviceName"
+
+func TestGetUnknownServicePanics(t *testing.T) {
+	sut := NewContainer(ServiceConstructorMap{})
+
+	assert.Panics(t, func() { sut.Get("unknownService") })
+}
+
+func TestGetKnownServiceReturnsExpectedConstructorResult(t *testing.T) {
+	type serviceType struct{}
+	var service serviceType
+	var serviceConstructor = func(get Get) interface{} { return service }
+	sut := NewContainer(ServiceConstructorMap{serviceName: serviceConstructor})
+
+	result := sut.Get(serviceName)
+
+	assert.Equal(t, service, result)
+}
+
+func TestGetKnownServiceImplementsSingleton(t *testing.T) {
+	type serviceType struct {
+		value int
+	}
+	instanceCount := 0
+	var serviceConstructor = func(get Get) interface{} {
+		instanceCount += 1
+		return serviceType{value: instanceCount}
+	}
+	sut := NewContainer(ServiceConstructorMap{serviceName: serviceConstructor})
+
+	first := sut.Get(serviceName)
+	second := sut.Get(serviceName)
+
+	assert.Equal(t, first.(serviceType).value, second.(serviceType).value)
+}
+
+func TestUpdateOfNonExistentServiceAdds(t *testing.T) {
+	type serviceType struct{}
+	var service serviceType
+	var serviceConstructor = func(get Get) interface{} { return service }
+	sut := NewContainer(ServiceConstructorMap{})
+	sut.Update(ServiceConstructorMap{serviceName: serviceConstructor})
+
+	result := sut.Get(serviceName)
+
+	assert.Equal(t, service, result)
+}
+
+func TestUpdateOfExistingServiceReplaces(t *testing.T) {
+	const original = "original"
+	const replacement = "replacement"
+	type serviceType struct{ value string }
+	var originalConstructor = func(get Get) interface{} { return serviceType{value: original} }
+	sut := NewContainer(ServiceConstructorMap{serviceName: originalConstructor})
+	var replacementConstructor = func(get Get) interface{} { return serviceType{value: replacement} }
+	sut.Update(ServiceConstructorMap{serviceName: replacementConstructor})
+
+	result := sut.Get(serviceName)
+
+	assert.Equal(t, replacement, result.(serviceType).value)
+}
+
+func TestGetInsideGetReturnsAsExpected(t *testing.T) {
+	const fooName = "foo"
+	type foo struct {
+		FooMessage string
+	}
+
+	const barName = "bar"
+	type bar struct {
+		BarMessage string
+		Foo        *foo
+	}
+
+	sut := NewContainer(ServiceConstructorMap{
+		fooName: func(get Get) interface{} { return &foo{FooMessage: fooName} },
+		barName: func(get Get) interface{} { return &bar{BarMessage: barName, Foo: get(fooName).(*foo)} },
+	})
+
+	result := sut.Get(barName).(*bar)
+
+	assert.Equal(t, barName, result.BarMessage)
+	assert.NotNil(t, result.Foo)
+	assert.Equal(t, fooName, result.Foo.FooMessage)
+}

--- a/internal/pkg/di/type.go
+++ b/internal/pkg/di/type.go
@@ -12,20 +12,20 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package di
 
-import (
-	"context"
-	"sync"
+import "reflect"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
-)
+// TypeInstanceToName converts an instance of a type to a unique name.
+func TypeInstanceToName(v interface{}) string {
+	t := reflect.TypeOf(v)
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+	if name := t.Name(); name != "" {
+		// non-interface types
+		return t.PkgPath() + "." + name
+	}
+
+	// interface types
+	e := t.Elem()
+	return e.PkgPath() + "." + e.Name()
+}

--- a/internal/pkg/di/type_test.go
+++ b/internal/pkg/di/type_test.go
@@ -12,20 +12,16 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package di
 
 import (
-	"context"
-	"sync"
+	"testing"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/stretchr/testify/assert"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+type foo struct{}
+
+func TestTypeInstanceToNameReturnsExpectedPackagePlusTypeName(t *testing.T) {
+	assert.Equal(t, "github.com/edgexfoundry/edgex-go/internal/pkg/di.foo", TypeInstanceToName(foo{}))
+}

--- a/internal/pkg/telemetry/telemetry.go
+++ b/internal/pkg/telemetry/telemetry.go
@@ -20,12 +20,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
-	"github.com/edgexfoundry/go-mod-registry/registry"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 )
 
 type SystemUsage struct {
@@ -98,10 +95,9 @@ func BootstrapHandler(
 	wg *sync.WaitGroup,
 	ctx context.Context,
 	startupTimer startup.Timer,
-	config interfaces.Configuration,
-	loggingClient logger.LoggingClient,
-	registryClient registry.Client) bool {
+	dic *di.Container) bool {
 
+	loggingClient := container.LoggingClientFrom(dic.Get)
 	loggingClient.Info("Telemetry starting")
 
 	wg.Add(1)

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -14,12 +14,11 @@ import (
 	"sync"
 	"time"
 
-	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
-	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 var Configuration = &ConfigurationStruct{}
@@ -60,12 +59,16 @@ func (s ServiceInit) BootstrapHandler(
 	wg *sync.WaitGroup,
 	ctx context.Context,
 	startupTimer startup.Timer,
-	config bootstrap.Configuration,
-	logging logger.LoggingClient,
-	registry registry.Client) bool {
+	dic *di.Container) bool {
+
+	dic.Update(di.ServiceConstructorMap{
+		container.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return newPrivateLogger()
+		},
+	})
 
 	// update global variables.
-	LoggingClient = newPrivateLogger()
+	LoggingClient = container.LoggingClientFrom(dic.Get)
 
 	// initialize database.
 	for startupTimer.HasNotElapsed() {

--- a/internal/support/notifications/init.go
+++ b/internal/support/notifications/init.go
@@ -23,15 +23,15 @@ import (
 	"sync"
 	"time"
 
-	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications/interfaces"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
@@ -80,12 +80,10 @@ func (s ServiceInit) BootstrapHandler(
 	wg *sync.WaitGroup,
 	ctx context.Context,
 	startupTimer startup.Timer,
-	config bootstrap.Configuration,
-	logging logger.LoggingClient,
-	registry registry.Client) bool {
+	dic *di.Container) bool {
 
 	// update global variables.
-	LoggingClient = logging
+	LoggingClient = container.LoggingClientFrom(dic.Get)
 
 	// initialize database.
 	for startupTimer.HasNotElapsed() {

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -21,15 +21,15 @@ import (
 	"sync"
 	"time"
 
-	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-registry/registry"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/interfaces"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
 var Configuration = &ConfigurationStruct{}
@@ -80,12 +80,10 @@ func (s ServiceInit) BootstrapHandler(
 	wg *sync.WaitGroup,
 	ctx context.Context,
 	startupTimer startup.Timer,
-	config bootstrap.Configuration,
-	logging logger.LoggingClient,
-	registry registry.Client) bool {
+	dic *di.Container) bool {
 
 	// update global variables.
-	LoggingClient = logging
+	LoggingClient = container.LoggingClientFrom(dic.Get)
 
 	// initialize database.
 	for startupTimer.HasNotElapsed() {
@@ -124,7 +122,7 @@ func (s ServiceInit) BootstrapHandler(
 
 	// Initialize the ticker time
 	if err := LoadScheduler(); err != nil {
-		logging.Error(fmt.Sprintf("Failed to load schedules and events %s", err.Error()))
+		LoggingClient.Error(fmt.Sprintf("Failed to load schedules and events %s", err.Error()))
 		return false
 	}
 

--- a/internal/system/agent/container/config.go
+++ b/internal/system/agent/container/config.go
@@ -12,20 +12,17 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/config"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// ConfigurationName contains the name of the interfaces.GetConfig implementation in the DIC.
+var ConfigurationName = di.TypeInstanceToName(config.ConfigurationStruct{})
+
+// ConfigurationFrom helper function queries the DIC and returns the interfaces.GetConfig implementation.
+func ConfigurationFrom(get di.Get) *config.ConfigurationStruct {
+	return get(ConfigurationName).(*config.ConfigurationStruct)
+}

--- a/internal/system/agent/container/general.go
+++ b/internal/system/agent/container/general.go
@@ -12,20 +12,17 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/clients"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// GeneralClientsName contains the name of the clients.Clients implementation in the DIC.
+var GeneralClientsName = di.TypeInstanceToName((*clients.General)(nil))
+
+// GeneralClientsFrom helper function queries the DIC and returns the clients.General implementation.
+func GeneralClientsFrom(get di.Get) *clients.General {
+	return get(GeneralClientsName).(*clients.General)
+}

--- a/internal/system/agent/container/getconfig.go
+++ b/internal/system/agent/container/getconfig.go
@@ -12,20 +12,17 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// GetConfigInterfaceName contains the name of the interfaces.GetConfig implementation in the DIC.
+var GetConfigInterfaceName = di.TypeInstanceToName((*interfaces.GetConfig)(nil))
+
+// GetConfigFrom helper function queries the DIC and returns the interfaces.GetConfig implementation.
+func GetConfigFrom(get di.Get) interfaces.GetConfig {
+	return get(GetConfigInterfaceName).(interfaces.GetConfig)
+}

--- a/internal/system/agent/container/metrics.go
+++ b/internal/system/agent/container/metrics.go
@@ -12,20 +12,17 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// MetricsInterfaceName contains the name of the interfaces.Metrics implementation in the DIC.
+var MetricsInterfaceName = di.TypeInstanceToName((*interfaces.Metrics)(nil))
+
+// MetricsFrom helper function queries the DIC and returns the interfaces.Metrics implementation.
+func MetricsFrom(get di.Get) interfaces.Metrics {
+	return get(MetricsInterfaceName).(interfaces.Metrics)
+}

--- a/internal/system/agent/container/operations.go
+++ b/internal/system/agent/container/operations.go
@@ -12,20 +12,17 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// OperationsInterfaceName contains the name of the interfaces.Operations implementation in the DIC.
+var OperationsInterfaceName = di.TypeInstanceToName((*interfaces.Operations)(nil))
+
+// OperationsFrom helper function queries the DIC and returns the interfaces.Operations implementation.
+func OperationsFrom(get di.Get) interfaces.Operations {
+	return get(OperationsInterfaceName).(interfaces.Operations)
+}

--- a/internal/system/agent/container/setconfig.go
+++ b/internal/system/agent/container/setconfig.go
@@ -12,20 +12,17 @@
  * the License.
  *******************************************************************************/
 
-package interfaces
+package container
 
 import (
-	"context"
-	"sync"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
 )
 
-// BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
-// handler completed successfully, false if it did not.
-type BootstrapHandler func(
-	wg *sync.WaitGroup,
-	context context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) (success bool)
+// SetConfigInterfaceName contains the name of the interfaces.SetConfig implementation in the DIC.
+var SetConfigInterfaceName = di.TypeInstanceToName((*interfaces.SetConfig)(nil))
+
+// SetConfigFrom helper function queries the DIC and returns the interfaces.SetConfig implementation.
+func SetConfigFrom(get di.Get) interfaces.SetConfig {
+	return get(SetConfigInterfaceName).(interfaces.SetConfig)
+}


### PR DESCRIPTION
Provides a path to replace a service's global variables with instances managed by the DIC which are injected into controller methods.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1837