### PR TITLE
Perform a consistent set of checks across core-services to ensure that the limit is not exceeded.

### DIFF
--- a/internal/core/data/device.go
+++ b/internal/core/data/device.go
@@ -15,7 +15,6 @@ package data
 
 import (
 	"context"
-	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
@@ -86,15 +85,6 @@ func updateDeviceServiceLastReportedConnected(device string) {
 	//Use of context.Background because this function is invoked asynchronously from a channel
 	msc.UpdateLastConnected(s.Id, t, context.Background())
 	msc.UpdateLastReported(s.Id, t, context.Background())
-}
-
-func checkMaxLimit(limit int) error {
-	if limit > Configuration.Service.MaxResultCount {
-		LoggingClient.Error(maxExceededString)
-		return errors.NewErrLimitExceeded(limit)
-	}
-
-	return nil
 }
 
 func checkDevice(device string, ctx context.Context) error {

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -299,7 +299,7 @@ func restGetProfileByModel(w http.ResponseWriter, r *http.Request) {
 	op := device_profile.NewGetModelExecutor(an, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.LimitExceeded, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -319,7 +319,7 @@ func restGetProfileWithLabel(w http.ResponseWriter, r *http.Request) {
 	op := device_profile.NewGetLabelExecutor(label, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.LimitExceeded, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -344,7 +344,7 @@ func restGetProfileByManufacturerModel(w http.ResponseWriter, r *http.Request) {
 	op := device_profile.NewGetManufacturerModelExecutor(man, mod, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.LimitExceeded, errorconcept.Default.InternalServerError)
 		return
 	}
 
@@ -363,7 +363,7 @@ func restGetProfileByManufacturer(w http.ResponseWriter, r *http.Request) {
 	op := device_profile.NewGetManufacturerExecutor(man, dbClient)
 	res, err := op.Execute()
 	if err != nil {
-		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
+		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.LimitExceeded, errorconcept.Default.InternalServerError)
 		return
 	}
 

--- a/internal/core/metadata/rest_devicereport.go
+++ b/internal/core/metadata/rest_devicereport.go
@@ -23,7 +23,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 )
 
 func restGetAllDeviceReports(w http.ResponseWriter, _ *http.Request) {
@@ -34,8 +33,7 @@ func restGetAllDeviceReports(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Check max limit
-	if len(res) > Configuration.Service.MaxResultCount {
-		err = errors.New("Max limit exceeded")
+	if err = checkMaxLimit(len(res)); err != nil {
 		httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 		return
 	}

--- a/internal/core/metadata/rest_provisionwatcher.go
+++ b/internal/core/metadata/rest_provisionwatcher.go
@@ -34,8 +34,8 @@ func restGetProvisionWatchers(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Check the length
-	if len(res) > Configuration.Service.MaxResultCount {
-		httpErrorHandler.Handle(w, errors.New("Max limit exceeded"), errorconcept.Default.RequestEntityTooLarge)
+	if err = checkMaxLimit(len(res)); err != nil {
+		httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 		return
 	}
 

--- a/internal/core/metadata/utils.go
+++ b/internal/core/metadata/utils.go
@@ -11,12 +11,16 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package data
+package metadata
 
 import (
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"io"
 	"io/ioutil"
+)
+
+const (
+	ExceededMaxResultCount = "error, exceeded the max limit as defined in config"
 )
 
 // Printing function purely for debugging purposes
@@ -34,7 +38,7 @@ func printBody(r io.ReadCloser) {
 
 func checkMaxLimit(limit int) error {
 	if limit > Configuration.Service.MaxResultCount {
-		LoggingClient.Error(maxExceededString)
+		LoggingClient.Error(ExceededMaxResultCount)
 		return errors.NewErrLimitExceeded(limit)
 	}
 

--- a/internal/support/logging/router.go
+++ b/internal/support/logging/router.go
@@ -66,13 +66,6 @@ func addLog(w http.ResponseWriter, r *http.Request) {
 	dbClient.add(l)
 }
 
-func checkMaxLimit(limit int) int {
-	if limit > Configuration.Service.MaxResultCount || limit == 0 {
-		return Configuration.Service.MaxResultCount
-	}
-	return limit
-}
-
 func getCriteria(w http.ResponseWriter, r *http.Request) *matchCriteria {
 	var criteria matchCriteria
 	vars := mux.Vars(r)
@@ -94,7 +87,7 @@ func getCriteria(w http.ResponseWriter, r *http.Request) *matchCriteria {
 		}
 	}
 	//In all cases, cap the # of entries returned at MaxResultCount
-	criteria.Limit = checkMaxLimit(criteria.Limit)
+	criteria.Limit = checkMaxLimitCount(criteria.Limit)
 
 	start := vars["start"]
 	if len(start) > 0 {

--- a/internal/support/logging/router_test.go
+++ b/internal/support/logging/router_test.go
@@ -223,7 +223,7 @@ func TestGetLogs(t *testing.T) {
 			// Only test that criteria is correctly parsed if request is valid
 			if tt.status == http.StatusOK {
 				//Apply rules for limit validation to original criteria
-				tt.criteria.Limit = checkMaxLimit(tt.criteria.Limit)
+				tt.criteria.Limit = checkMaxLimitCount(tt.criteria.Limit)
 				//Then compare against what was persisted during the test run
 				if !reflect.DeepEqual(dummy.criteria, tt.criteria) {
 					t.Errorf("Invalid criteria %v, should be %v", dummy.criteria, tt.criteria)

--- a/internal/support/logging/utils.go
+++ b/internal/support/logging/utils.go
@@ -1,0 +1,8 @@
+package logging
+
+func checkMaxLimitCount(limit int) int {
+	if limit > Configuration.Service.MaxResultCount || limit == 0 {
+		return Configuration.Service.MaxResultCount
+	}
+	return limit
+}

--- a/internal/support/notifications/rest_notification.go
+++ b/internal/support/notifications/rest_notification.go
@@ -223,9 +223,9 @@ func restGetNotificationsBySender(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if limitNum > Configuration.Service.MaxResultCount {
-		http.Error(w, "Exceeded max limit", http.StatusRequestEntityTooLarge)
-		LoggingClient.Error("Exceeded max limit")
+	// Check the length
+	if err = checkMaxLimit(limitNum); err != nil {
+		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
 
@@ -270,9 +270,9 @@ func restNotificationByStartEnd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if limitNum > Configuration.Service.MaxResultCount {
-		http.Error(w, "Exceeded max limit", http.StatusRequestEntityTooLarge)
-		LoggingClient.Error("Exceeded max limit")
+	// Check the length
+	if err = checkMaxLimit(limitNum); err != nil {
+		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
 
@@ -309,9 +309,9 @@ func restNotificationByStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if limitNum > Configuration.Service.MaxResultCount {
-		http.Error(w, "Exceeded max limit", http.StatusRequestEntityTooLarge)
-		LoggingClient.Error("Exceeded max limit")
+	// Check the length
+	if err = checkMaxLimit(limitNum); err != nil {
+		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
 
@@ -350,9 +350,9 @@ func restNotificationByEnd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if limitNum > Configuration.Service.MaxResultCount {
-		http.Error(w, "Exceeded max limit", http.StatusRequestEntityTooLarge)
-		LoggingClient.Error("Exceeded max limit")
+	// Check the length
+	if err = checkMaxLimit(limitNum); err != nil {
+		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
 
@@ -385,9 +385,9 @@ func restNotificationsByLabels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if limitNum > Configuration.Service.MaxResultCount {
-		http.Error(w, "Exceeded max limit", http.StatusRequestEntityTooLarge)
-		LoggingClient.Error("Exceeded max limit")
+	// Check the length
+	if err = checkMaxLimit(limitNum); err != nil {
+		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
 
@@ -422,9 +422,9 @@ func restNotificationsNew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if limitNum > Configuration.Service.MaxResultCount {
-		http.Error(w, "Exceeded max limit", http.StatusRequestEntityTooLarge)
-		LoggingClient.Error("Exceeded max limit")
+	// Check the length
+	if err = checkMaxLimit(limitNum); err != nil {
+		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
 

--- a/internal/support/notifications/utils.go
+++ b/internal/support/notifications/utils.go
@@ -18,11 +18,16 @@ package notifications
 
 import (
 	"fmt"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"io"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+const (
+	ExceededMaxResultCount string = "error, exceeded the max limit as defined in config"
 )
 
 // Printing function purely for debugging purposes
@@ -42,4 +47,13 @@ func printBody(r io.ReadCloser) {
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
+}
+
+func checkMaxLimit(limit int) error {
+	if limit > Configuration.Service.MaxResultCount {
+		LoggingClient.Error(ExceededMaxResultCount)
+		return errors.NewErrLimitExceeded(limit)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fix #1582 
- The work in this PR takes care of performing a consistent set of checks across core-services to ensure that the limit (`MaxResultCount`) is not exceeded.