### PR TITLE
Fix error handling bug in SecretStoreClient.processResponse

### DIFF
--- a/internal/security/secretstoreclient/vault.go
+++ b/internal/security/secretstoreclient/vault.go
@@ -171,21 +171,22 @@ func (vc *vaultClient) commonRequest(token *string, method string, path string, 
 // delegate is a callback function called to handle the decoded response
 func (vc *vaultClient) processResponse(resp *http.Response, responseError error,
 	operationDescription string, expectedStatusCode int,
-	responseObject interface{}) (statusCode int, err error) {
+	responseObject interface{}) (int, error) {
 
 	if responseError != nil {
-		vc.logger.Error(fmt.Sprintf("unable to make request to %s failed: %s", operationDescription, err.Error()))
-		return 0, err
+		vc.logger.Error(fmt.Sprintf("unable to make request to %s failed: %s", operationDescription, responseError.Error()))
+		return 0, responseError
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != expectedStatusCode {
-		vc.logger.Error(fmt.Sprintf("request to %s failed with status: %s", operationDescription, resp.Status))
+		err := fmt.Errorf("request to %s failed with status: %s", operationDescription, resp.Status)
+		vc.logger.Error(err.Error())
 		return resp.StatusCode, err
 	}
 
 	if responseObject != nil {
-		err = json.NewDecoder(resp.Body).Decode(responseObject)
+		err := json.NewDecoder(resp.Body).Decode(responseObject)
 		if err != nil {
 			vc.logger.Error(fmt.Sprintf("failed to parse response body: %s", err.Error()))
 			return resp.StatusCode, err


### PR DESCRIPTION
The processResponse() internal method takes the response object
and eror object from the previous call to commonRequest().
While processing the error, the code formats an error using
the output error object as a source instead of the input
error object as a source, resulting in a nil access error.
A similar error is made when processing an unexpected response
code: this time a nil error object is always returned.

Unit tests have been added to check regressions.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>