### PR TITLE
Initialize and Unseal Vault in secretstore-setup init

### DIFF
--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -60,31 +60,31 @@ Common Options:
 var securityProxySetupUsageStr = `
 Usage: %s [options]
 Server Options:	
-    -p, --profile <name>            Indicate configuration profile other than default
-    -r, --registry                  Indicates service should use Registry
+    -p, --profile <name>              Indicate configuration profile other than default
+    -r, --registry                    Indicates service should use Registry
 	--insecureSkipVerify=true/false   Indicates if skipping the server side SSL cert verification, similar to -k of curl
-	--init=true/false               Indicates if security service should be initialized
-	--reset=true/false              Indicate if security service should be reset to initialization status
-	--useradd=<username>            Create an account and return JWT
-	--group=<groupname>             Group name the user belongs to
-	--userdel=<username>            Delete an account		
-	--configfile=<file.toml>        Use a different config file (default: res/configuration.toml)
+	--init=true/false                 Indicates if security service should be initialized
+	--reset=true/false                Indicate if security service should be reset to initialization status
+	--useradd=<username>              Create an account and return JWT
+	--group=<groupname>               Group name the user belongs to
+	--userdel=<username>              Delete an account
+	--configfile=<file.toml>          Use a different config file (default: res/configuration.toml)
 
 Common Options:
-	-h, --help                      Show this message
+	-h, --help                        Show this message
 `
 
 var securitySecretStoreSetupUsageStr = `
 Usage: %s [options]
 Server Options:
-	-p, --profile <name>            Indicate configuration profile other than default
-	-r, --registry                  Indicates service should use Registry
-	--insecureSkipVerify=true/false			Indicates if skipping the server side SSL cert verifcation, similar to -k of curl
-	--init=true/false				Indicates if security service should be initialized
-	--configfile=<file.toml>			Use a different config file (default: res/configuration.toml)
-	--wait=<time in seconds>		Indicates how long the program will pause between the vault initialization until it succeeds
+	-p, --profile <name>                Indicate configuration profile other than default
+	-r, --registry                      Indicates service should use Registry
+	--insecureSkipVerify=true/false     Indicates if skipping the server side SSL cert verifcation, similar to -k of curl
+	--init=true/false                   Indicates if security service should be initialized
+	--configfile=<file.toml>            Use a different config file (default: res/configuration.toml)
+	--vaultInterval=<seconds>           Indicates how long the program will pause between vault initialization attempts until it succeeds
 Common Options:
-	-h, --help					Show this message
+	-h, --help                          Show this message
 `
 
 // usage will print out the flag options for the server.

--- a/internal/security/secretstore/certs_test.go
+++ b/internal/security/secretstore/certs_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
 )
 
 func TestGetAccessToken(t *testing.T) {
@@ -78,7 +80,7 @@ func TestRetrieve(t *testing.T) {
 	defer func() { Configuration = oldConfig }()
 
 	Configuration = &ConfigurationStruct{}
-	Configuration.SecretService = SecretServiceInfo{
+	Configuration.SecretService = secretstoreclient.SecretServiceInfo{
 		Server: parsed.Hostname(),
 		Port:   port,
 		Scheme: "https",

--- a/internal/security/secretstore/config.go
+++ b/internal/security/secretstore/config.go
@@ -16,42 +16,17 @@
 package secretstore
 
 import (
-	"fmt"
-	"net/url"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
 )
 
 type ConfigurationStruct struct {
 	Writable      WritableInfo
 	Logging       config.LoggingInfo
-	SecretService SecretServiceInfo
+	SecretService secretstoreclient.SecretServiceInfo
 }
 
 type WritableInfo struct {
 	LogLevel string
 	Title    string
-}
-
-type SecretServiceInfo struct {
-	Scheme               string
-	Server               string
-	Port                 int
-	CertPath             string
-	CaFilePath           string
-	CertFilePath         string
-	KeyFilePath          string
-	TokenFolderPath      string
-	TokenFile            string
-	VaultSecretShares    int
-	VaultSecretThreshold int
-}
-
-func (s SecretServiceInfo) GetSecretSvcBaseURL() string {
-	url := &url.URL{
-		Scheme: s.Scheme,
-		Host:   fmt.Sprintf("%s:%v", s.Server, s.Port),
-		Path:   "/",
-	}
-	return url.String()
 }

--- a/internal/security/secretstoreclient/vault.go
+++ b/internal/security/secretstoreclient/vault.go
@@ -96,7 +96,8 @@ func (vc *vaultClient) Unseal(config SecretServiceInfo, vmkReader io.Reader) (st
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			vc.logger.Error(fmt.Sprintf("vault unseal request failed with status code: %s", resp.Status))
+			err := fmt.Errorf("vault unseal request failed with status code: %s", resp.Status)
+			vc.logger.Error(err.Error())
 			return resp.StatusCode, err
 		}
 


### PR DESCRIPTION
Adds logic to check to see if Vault is currently unsealed and
if not to unseal it.

## To test:
1. Inside `cmd/security-secretstore-setup/res/configuration.toml`, edit the `[SecretStore]` section for the following fields:
```
server = "localhost"
scheme = "http"
cafilepath = "/Users/jdharms/workspace/edgex-go/cmd/security-secretstore-setup/EdgeXFoundryCA.pem"
certfilepath = "/Users/jdharms/workspace/edgex-go/cmd/security-secretstore-setup/edgex-kong.pem"
keyfilepath = "/Users/jdharms/workspace/edgex-go/cmd/security-secretstore-setup/edgex-kong.priv.key"
tokenfolderpath = "/Users/jdharms/workspace/edgex-go/cmd/security-secretstore-setup"
```
2. Ensure the paths in the previous step point to files on your file system and not mine.  The contents of these files are not important right now; I just used the filenames.
3. Run vault with flag `-dev-kv-v1` to ensure the right version of the secrets engine (alternatively bring up the v1 kv some other way)
```
vault server -dev -dev-kv-v1
```
4. `VAULT_ADDR='http://127.0.0.1:8200' vault operator seal` will seal the local development server.
4. Create a resp-init.json file if it doesn't exist inside the tokenfolderpath above.  The contents should be:
```
{
  "keys": [
    "test-keys"
  ],
  "keys_base64": [
    "UsI8HbpFCt9zqVePbo4CvsijhlNaC7ckKiDnNiBt3F4="
  ],
  "root_token": "s.MRPe8MVhaSePWcfDdHQsMImy"
}
```
Where the `root_token` value is the root token for your dev mode vault instance and `keys_base64` is the Unseal Key.
5. Make build and executing the security-secretstore-setup with --init=true binary should succeed.

Signed-off-by: Daniel Harms <jdharms@gmail.com>