### PR TITLE
Refactor to encapsulate common bootstrap handlers in own packages

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -21,8 +21,10 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/command"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/secret"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -46,7 +48,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := handlers.NewServerBootstrap(command.LoadRestRoutes())
+	httpServer := httpserver.NewBootstrap(command.LoadRestRoutes())
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -57,11 +59,11 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			handlers.SecretClientBootstrapHandler,
+			secret.BootstrapHandler,
 			database.NewDatabase(&httpServer, command.Configuration).BootstrapHandler,
 			command.BootstrapHandler,
 			telemetry.BootstrapHandler,
-			httpServer.Handler,
-			handlers.NewStartMessage(clients.CoreCommandServiceKey, edgex.Version).Handler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.CoreCommandServiceKey, edgex.Version).BootstrapHandler,
 		})
 }

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -21,8 +21,10 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/data"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/secret"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -47,7 +49,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := handlers.NewServerBootstrap(data.LoadRestRoutes())
+	httpServer := httpserver.NewBootstrap(data.LoadRestRoutes())
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -58,12 +60,12 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			handlers.SecretClientBootstrapHandler,
+			secret.BootstrapHandler,
 			database.NewDatabaseForCoreData(&httpServer, data.Configuration).BootstrapHandler,
 			data.BootstrapHandler,
 			telemetry.BootstrapHandler,
-			httpServer.Handler,
-			handlers.NewStartMessage(clients.CoreDataServiceKey, edgex.Version).Handler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.CoreDataServiceKey, edgex.Version).BootstrapHandler,
 		},
 	)
 }

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -20,8 +20,10 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/secret"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -46,7 +48,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := handlers.NewServerBootstrap(metadata.LoadRestRoutes())
+	httpServer := httpserver.NewBootstrap(metadata.LoadRestRoutes())
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -57,11 +59,11 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			handlers.SecretClientBootstrapHandler,
+			secret.BootstrapHandler,
 			database.NewDatabase(&httpServer, metadata.Configuration).BootstrapHandler,
 			metadata.BootstrapHandler,
 			telemetry.BootstrapHandler,
-			httpServer.Handler,
-			handlers.NewStartMessage(clients.CoreMetaDataServiceKey, edgex.Version).Handler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.CoreMetaDataServiceKey, edgex.Version).BootstrapHandler,
 		})
 }

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -15,8 +15,10 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/export/client"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/secret"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -41,7 +43,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := handlers.NewServerBootstrap(client.LoadRestRoutes())
+	httpServer := httpserver.NewBootstrap(client.LoadRestRoutes())
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -52,11 +54,11 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			handlers.SecretClientBootstrapHandler,
+			secret.BootstrapHandler,
 			database.NewDatabase(&httpServer, client.Configuration).BootstrapHandler,
 			client.BootstrapHandler,
 			telemetry.BootstrapHandler,
-			httpServer.Handler,
-			handlers.NewStartMessage(clients.ExportClientServiceKey, edgex.Version).Handler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.ExportClientServiceKey, edgex.Version).BootstrapHandler,
 		})
 }

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -16,7 +16,9 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/export/distro"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/secret"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -41,7 +43,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := handlers.NewServerBootstrap(distro.LoadRestRoutes())
+	httpServer := httpserver.NewBootstrap(distro.LoadRestRoutes())
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -52,10 +54,10 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			handlers.SecretClientBootstrapHandler,
+			secret.BootstrapHandler,
 			distro.BootstrapHandler,
 			telemetry.BootstrapHandler,
-			httpServer.Handler,
-			handlers.NewStartMessage(clients.ExportDistroServiceKey, edgex.Version).Handler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.ExportDistroServiceKey, edgex.Version).BootstrapHandler,
 		})
 }

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -14,7 +14,9 @@ import (
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/secret"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -40,7 +42,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := handlers.NewServerBootstrap(logging.LoadRestRoutes())
+	httpServer := httpserver.NewBootstrap(logging.LoadRestRoutes())
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -51,10 +53,10 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			handlers.SecretClientBootstrapHandler,
+			secret.BootstrapHandler,
 			logging.NewServiceInit(&httpServer).BootstrapHandler,
 			telemetry.BootstrapHandler,
-			httpServer.Handler,
-			handlers.NewStartMessage(clients.SupportLoggingServiceKey, edgex.Version).Handler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.SupportLoggingServiceKey, edgex.Version).BootstrapHandler,
 		})
 }

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -26,8 +26,10 @@ import (
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/secret"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -52,7 +54,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := handlers.NewServerBootstrap(notifications.LoadRestRoutes())
+	httpServer := httpserver.NewBootstrap(notifications.LoadRestRoutes())
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -63,11 +65,11 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			handlers.SecretClientBootstrapHandler,
+			secret.BootstrapHandler,
 			database.NewDatabase(&httpServer, notifications.Configuration).BootstrapHandler,
 			notifications.BootstrapHandler,
 			telemetry.BootstrapHandler,
-			httpServer.Handler,
-			handlers.NewStartMessage(clients.SupportNotificationsServiceKey, edgex.Version).Handler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.SupportNotificationsServiceKey, edgex.Version).BootstrapHandler,
 		})
 }

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -20,8 +20,10 @@ import (
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/secret"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -46,7 +48,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := handlers.NewServerBootstrap(scheduler.LoadRestRoutes())
+	httpServer := httpserver.NewBootstrap(scheduler.LoadRestRoutes())
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -57,11 +59,11 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			handlers.SecretClientBootstrapHandler,
+			secret.BootstrapHandler,
 			database.NewDatabase(&httpServer, scheduler.Configuration).BootstrapHandler,
 			scheduler.BootstrapHandler,
 			telemetry.BootstrapHandler,
-			httpServer.Handler,
-			handlers.NewStartMessage(clients.SupportSchedulerServiceKey, edgex.Version).Handler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.SupportSchedulerServiceKey, edgex.Version).BootstrapHandler,
 		})
 }

--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -20,7 +20,9 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
 	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/secret"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -56,7 +58,7 @@ func main() {
 			return get(container.ConfigurationName)
 		},
 	})
-	httpServer := handlers.NewServerBootstrap(agent.LoadRestRoutes(dic))
+	httpServer := httpserver.NewBootstrap(agent.LoadRestRoutes(dic))
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -67,9 +69,9 @@ func main() {
 		startupTimer,
 		dic,
 		[]interfaces.BootstrapHandler{
-			handlers.SecretClientBootstrapHandler,
+			secret.BootstrapHandler,
 			agent.BootstrapHandler,
-			httpServer.Handler,
-			handlers.NewStartMessage(clients.SystemManagementAgentServiceKey, edgex.Version).Handler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.SystemManagementAgentServiceKey, edgex.Version).BootstrapHandler,
 		})
 }

--- a/internal/pkg/bootstrap/handlers/message/message.go
+++ b/internal/pkg/bootstrap/handlers/message/message.go
@@ -12,7 +12,7 @@
  * the License.
  *******************************************************************************/
 
-package handlers
+package message
 
 import (
 	"context"
@@ -30,17 +30,17 @@ type StartMessage struct {
 	version    string
 }
 
-// NewStartMessage is a factory method that returns an initialized StartMessage receiver struct.
-func NewStartMessage(serviceKey, version string) StartMessage {
+// NewBootstrap is a factory method that returns an initialized StartMessage receiver struct.
+func NewBootstrap(serviceKey, version string) StartMessage {
 	return StartMessage{
 		serviceKey: serviceKey,
 		version:    version,
 	}
 }
 
-// Handler fulfills the BootstrapHandler contract.  It creates no go routines.  It logs a "standard" set of messages
-// when the service first starts up successfully.
-func (h StartMessage) Handler(
+// BootstrapHandler fulfills the BootstrapHandler contract.  It creates no go routines.  It logs a "standard" set of
+// messages when the service first starts up successfully.
+func (h StartMessage) BootstrapHandler(
 	wg *sync.WaitGroup,
 	context context.Context,
 	startupTimer startup.Timer,

--- a/internal/pkg/bootstrap/handlers/secret/secret.go
+++ b/internal/pkg/bootstrap/handlers/secret/secret.go
@@ -12,7 +12,7 @@
  * the License.
  *******************************************************************************/
 
-package handlers
+package secret
 
 import (
 	"context"
@@ -31,7 +31,7 @@ import (
 // NOTE: This BootstrapHandler is responsible for creating a utility that will most likely be used by other
 // BootstrapHandlers to obtain sensitive data, such as database credentials. This BootstrapHandler should be processed
 // before other BootstrapHandlers, possibly even first since it has not other dependencies.
-func SecretClientBootstrapHandler(
+func BootstrapHandler(
 	wg *sync.WaitGroup,
 	context context.Context,
 	startupTimer startup.Timer,


### PR DESCRIPTION
Affects secret, server, and start_message implementations at
internal/pkg/bootstrap/handlers.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1880
Signed-off-by: Michael Estrin <m.estrin@dell.com>