### PR TITLE
The new boot functionality immediate creates a startup parameter with…

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
 
 	var useRegistry bool
 	var configDir, profileDir string

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
 
 	var useRegistry bool
 	var profileDir, configDir string

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
 
 	var useRegistry bool
 	var configDir, profileDir string

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
 
 	var useRegistry bool
 	var configDir, profileDir string

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
 
 	var useRegistry bool
 	var configDir, profileDir string

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
 
 	var useRegistry bool
 	var configDir, profileDir string

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -37,7 +37,7 @@ import (
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
 
 	var useRegistry bool
 	var configDir, profileDir string

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
 	var useRegistry bool
 	var configDir, profileDir string
 

--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -69,7 +69,7 @@ func httpServerBootstrapHandler(
 }
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(1, internal.BootTimeoutDefault)
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
 
 	var useRegistry bool
 	var configDir, profileDir string

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -15,6 +15,8 @@ package internal
 
 const (
 	BootTimeoutDefault             = 30000
+	BootTimeoutSecondsDefault      = 30
+	BootRetrySecondsDefault        = 1
 	ClientMonitorDefault           = 15000
 	ConfigFileName                 = "configuration.toml"
 	ConfigRegistryStemCore         = "edgex/core/"

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -14,7 +14,7 @@
 package internal
 
 const (
-	BootTimeoutDefault             = 30000
+	BootTimeoutDefault             = BootTimeoutSecondsDefault * 1000
 	BootTimeoutSecondsDefault      = 30
 	BootRetrySecondsDefault        = 1
 	ClientMonitorDefault           = 15000

--- a/internal/pkg/bootstrap/startup/timer.go
+++ b/internal/pkg/bootstrap/startup/timer.go
@@ -27,8 +27,8 @@ type Timer struct {
 func NewStartUpTimer(retryIntervalInSeconds, maxWaitInSeconds int) Timer {
 	return Timer{
 		startTime: time.Now(),
-		duration:  time.Millisecond * time.Duration(maxWaitInSeconds),
-		interval:  time.Millisecond * time.Duration(retryIntervalInSeconds),
+		duration:  time.Second * time.Duration(maxWaitInSeconds),
+		interval:  time.Second * time.Duration(retryIntervalInSeconds),
 	}
 }
 


### PR DESCRIPTION
… the parameters '1' and 'internal.BootTimeoutDefault'

BootTimeoutDefault is from the original implementation, in milliseconds, but startup.NewStartupTimer expects seconds.  To fix without breaking the existing usages of internal.BootTimeoutDefault, created a BootTimeoutSecondsDefault and changed all instances of NewStartupTimer to use that.

I also added a BootRetrySecondsDefault for completeness and add it to the calls creating the new startup timer.

Fix #1886

Signed-off-by: Scott C Sosna <me@scottsosna.dev>