### PR TITLE
Add handling for the POST of invalid data to /api/v1/operation.

### DIFF
--- a/internal/system/agent/executor/operation.go
+++ b/internal/system/agent/executor/operation.go
@@ -18,7 +18,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/system"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/response"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -26,6 +26,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/container"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 
@@ -110,6 +111,13 @@ func operationHandler(
 	if err = o.UnmarshalJSON(b); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		loggingClient.Error("error during decoding: %s", err.Error())
+		return
+	}
+
+	if len(o.Services) == 0 || len(o.Action) == 0 {
+		const errorMessage = "incorrect or malformed body was passed in with the request"
+		http.Error(w, errorMessage, http.StatusBadRequest)
+		loggingClient.Error(errorMessage)
 		return
 	}
 


### PR DESCRIPTION
Fix #1866 
Fix #1856 
- As part of DEV testing, I supplied, in turn, the following incorrect and empty body each in with the request:
1. {"fake":"key"}
2. {}
- As expected, got the expected error message back with the response:
```
"incorrect or malformed body was passed in with request"
```