### PR TITLE
Extract dbClient implementations into single common bootstrap handler

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/command"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -57,7 +58,8 @@ func main() {
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
-			command.NewServiceInit(&httpServer).BootstrapHandler,
+			database.NewDatabase(&httpServer, command.Configuration).BootstrapHandler,
+			command.BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.Handler,
 			handlers.NewStartMessage(clients.CoreCommandServiceKey, edgex.Version).Handler,

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/data"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -58,7 +59,8 @@ func main() {
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
-			data.NewServiceInit(&httpServer).BootstrapHandler,
+			database.NewDatabaseForCoreData(&httpServer, data.Configuration).BootstrapHandler,
+			data.BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.Handler,
 			handlers.NewStartMessage(clients.CoreDataServiceKey, edgex.Version).Handler,

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -57,7 +58,8 @@ func main() {
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
-			metadata.NewServiceInit(&httpServer).BootstrapHandler,
+			database.NewDatabase(&httpServer, metadata.Configuration).BootstrapHandler,
+			metadata.BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.Handler,
 			handlers.NewStartMessage(clients.CoreMetaDataServiceKey, edgex.Version).Handler,

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/export/client"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -52,7 +53,8 @@ func main() {
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
-			client.NewServiceInit(&httpServer).BootstrapHandler,
+			database.NewDatabase(&httpServer, client.Configuration).BootstrapHandler,
+			client.BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.Handler,
 			handlers.NewStartMessage(clients.ExportClientServiceKey, edgex.Version).Handler,

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -63,7 +64,8 @@ func main() {
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
-			notifications.NewServiceInit(&httpServer).BootstrapHandler,
+			database.NewDatabase(&httpServer, notifications.Configuration).BootstrapHandler,
+			notifications.BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.Handler,
 			handlers.NewStartMessage(clients.SupportNotificationsServiceKey, edgex.Version).Handler,

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -57,7 +58,8 @@ func main() {
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
 			handlers.SecretClientBootstrapHandler,
-			scheduler.NewServiceInit(&httpServer).BootstrapHandler,
+			database.NewDatabase(&httpServer, scheduler.Configuration).BootstrapHandler,
+			scheduler.BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.Handler,
 			handlers.NewStartMessage(clients.SupportSchedulerServiceKey, edgex.Version).Handler,

--- a/internal/core/command/config.go
+++ b/internal/core/command/config.go
@@ -24,7 +24,7 @@ import (
 type ConfigurationStruct struct {
 	Writable    WritableInfo
 	Clients     map[string]config.ClientInfo
-	Databases   map[string]config.DatabaseInfo
+	Databases   config.DatabaseInfo
 	Logging     config.LoggingInfo
 	Registry    config.RegistryInfo
 	Service     config.ServiceInfo
@@ -88,4 +88,9 @@ func (c *ConfigurationStruct) GetLogLevel() string {
 // SetRegistryInfo updates the registry info in the ConfigurationStruct.
 func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
 	c.Registry = registryInfo
+}
+
+// GetDatabaseInfo returns a database information map.
+func (c *ConfigurationStruct) GetDatabaseInfo() config.DatabaseInfo {
+	return c.Databases
 }

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -16,16 +16,11 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"sync"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/command/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
@@ -34,8 +29,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-
-	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
@@ -48,109 +41,24 @@ var dbClient interfaces.DBClient
 // Global ErrorConcept variables
 var httpErrorHandler errorconcept.ErrorHandler
 
-type server interface {
-	IsRunning() bool
-}
-
-// ServiceInit encapsulates information needed for the service to startup.
-type ServiceInit struct {
-	server server
-}
-
-// NewServiceInit creates a new ServiceInit
-func NewServiceInit(server server) ServiceInit {
-	return ServiceInit{
-		server: server,
-	}
-}
-
-// BootstrapHandler fulfills the BootstrapHandler contract and performs and startup actions needed by the service.
-func (s ServiceInit) BootstrapHandler(
-	wg *sync.WaitGroup,
-	ctx context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) bool {
-
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the command service.
+func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
 	LoggingClient = container.LoggingClientFrom(dic.Get)
 	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
+	dbClient = container.DBClientFrom(dic.Get)
 
 	// initialize clients required by service.
 	registryClient := container.RegistryFrom(dic.Get)
-	s.initializeClients(registryClient)
-
-	// initialize database.
-	for startupTimer.HasNotElapsed() {
-		var err error
-		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
-		if err == nil {
-			break
-		}
-		dbClient = nil
-		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %s", err.Error()))
-		startupTimer.SleepForInterval()
-	}
-
-	if dbClient == nil {
-		return false
-	}
-
-	LoggingClient.Info("Database connected")
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		<-ctx.Done()
-		for {
-			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
-			if s.server.IsRunning() == false {
-				dbClient.CloseSession()
-
-				break
-			}
-			time.Sleep(time.Second)
-		}
-		LoggingClient.Info("Database disconnected")
-	}()
+	mdc = metadata.NewDeviceClient(
+		types.EndpointParams{
+			ServiceKey:  clients.CoreMetaDataServiceKey,
+			Path:        clients.ApiDeviceRoute,
+			UseRegistry: registryClient != nil,
+			Url:         Configuration.Clients["Metadata"].Url() + clients.ApiDeviceRoute,
+			Interval:    Configuration.Service.ClientMonitor,
+		},
+		endpoint.Endpoint{RegistryClient: &registryClient})
 
 	return true
-}
-
-// initializeClients initializes the clients needed by the service.
-func (s ServiceInit) initializeClients(registry registry.Client) {
-	// Create metadata clients
-	params := types.EndpointParams{
-		ServiceKey:  clients.CoreMetaDataServiceKey,
-		Path:        clients.ApiDeviceRoute,
-		UseRegistry: registry != nil,
-		Url:         Configuration.Clients["Metadata"].Url() + clients.ApiDeviceRoute,
-		Interval:    Configuration.Service.ClientMonitor,
-	}
-
-	mdc = metadata.NewDeviceClient(params, endpoint.Endpoint{RegistryClient: &registry})
-}
-
-// newDBClient creates a DBClient based on the underlying database.
-func (s ServiceInit) newDBClient(dbType string) (interfaces.DBClient, error) {
-	switch dbType {
-	case db.MongoDB:
-		dbConfig := db.Configuration{
-			Host:         Configuration.Databases["Primary"].Host,
-			Port:         Configuration.Databases["Primary"].Port,
-			Timeout:      Configuration.Databases["Primary"].Timeout,
-			DatabaseName: Configuration.Databases["Primary"].Name,
-			Username:     Configuration.Databases["Primary"].Username,
-			Password:     Configuration.Databases["Primary"].Password,
-		}
-		return mongo.NewClient(dbConfig)
-	case db.RedisDB:
-		dbConfig := db.Configuration{
-			Host: Configuration.Databases["Primary"].Host,
-			Port: Configuration.Databases["Primary"].Port,
-		}
-		return redis.NewClient(dbConfig, LoggingClient)
-	default:
-		return nil, db.ErrUnsupportedDatabase
-	}
 }

--- a/internal/core/data/config.go
+++ b/internal/core/data/config.go
@@ -24,7 +24,7 @@ type ConfigurationStruct struct {
 	Writable     WritableInfo
 	MessageQueue config.MessageQueueInfo
 	Clients      map[string]config.ClientInfo
-	Databases    map[string]config.DatabaseInfo
+	Databases    config.DatabaseInfo
 	Logging      config.LoggingInfo
 	Registry     config.RegistryInfo
 	Service      config.ServiceInfo
@@ -94,4 +94,9 @@ func (c *ConfigurationStruct) GetLogLevel() string {
 // SetLogLevel updates the log level in the ConfigurationStruct.
 func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
 	c.Registry = registryInfo
+}
+
+// GetDatabaseInfo returns a database information map.
+func (c *ConfigurationStruct) GetDatabaseInfo() config.DatabaseInfo {
+	return c.Databases
 }

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -18,14 +18,10 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
@@ -37,8 +33,6 @@ import (
 
 	"github.com/edgexfoundry/go-mod-messaging/messaging"
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/pkg/types"
-
-	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
@@ -52,44 +46,36 @@ var msgClient messaging.MessageClient
 var mdc metadata.DeviceClient
 var msc metadata.DeviceServiceClient
 
-// Global ErrorConcept variables
 var httpErrorHandler errorconcept.ErrorHandler
 
-type server interface {
-	IsRunning() bool
-}
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
+func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+	// update global variables.
+	LoggingClient = container.LoggingClientFrom(dic.Get)
+	dbClient = container.DBClientFrom(dic.Get)
 
-type ServiceInit struct {
-	server server
-}
+	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
 
-func NewServiceInit(server server) ServiceInit {
-	return ServiceInit{
-		server: server,
-	}
-}
-
-func (s ServiceInit) initializeClients(useRegistry bool, registry registry.Client) {
-	// Create metadata clients
+	// initialize clients required by service.
+	registryClient := container.RegistryFrom(dic.Get)
 	mdc = metadata.NewDeviceClient(
 		types.EndpointParams{
 			ServiceKey:  clients.CoreMetaDataServiceKey,
 			Path:        clients.ApiDeviceRoute,
-			UseRegistry: useRegistry,
+			UseRegistry: registryClient != nil,
 			Url:         Configuration.Clients["Metadata"].Url() + clients.ApiDeviceRoute,
 			Interval:    Configuration.Service.ClientMonitor,
 		},
-		endpoint.Endpoint{RegistryClient: &registry})
-
+		endpoint.Endpoint{RegistryClient: &registryClient})
 	msc = metadata.NewDeviceServiceClient(
 		types.EndpointParams{
 			ServiceKey:  clients.CoreMetaDataServiceKey,
 			Path:        clients.ApiDeviceServiceRoute,
-			UseRegistry: useRegistry,
+			UseRegistry: registryClient != nil,
 			Url:         Configuration.Clients["Metadata"].Url() + clients.ApiDeviceRoute,
 			Interval:    Configuration.Service.ClientMonitor,
 		},
-		endpoint.Endpoint{RegistryClient: &registry})
+		endpoint.Endpoint{RegistryClient: &registryClient})
 
 	// Create the messaging client
 	var err error
@@ -106,83 +92,6 @@ func (s ServiceInit) initializeClients(useRegistry bool, registry registry.Clien
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("failed to create messaging client: %s", err.Error()))
 	}
-}
-
-// Return the dbClient interface
-func (s ServiceInit) newDBClient(dbType string) (interfaces.DBClient, error) {
-	switch dbType {
-	case db.MongoDB:
-		dbConfig := db.Configuration{
-			Host:         Configuration.Databases["Primary"].Host,
-			Port:         Configuration.Databases["Primary"].Port,
-			Timeout:      Configuration.Databases["Primary"].Timeout,
-			DatabaseName: Configuration.Databases["Primary"].Name,
-			Username:     Configuration.Databases["Primary"].Username,
-			Password:     Configuration.Databases["Primary"].Password,
-		}
-		return mongo.NewClient(dbConfig)
-	case db.RedisDB:
-		dbConfig := db.Configuration{
-			Host: Configuration.Databases["Primary"].Host,
-			Port: Configuration.Databases["Primary"].Port,
-		}
-		redisClient, err := redis.NewCoreDataClient(dbConfig, LoggingClient) // TODO: Verify this also connects to Redis
-		if err != nil {
-			return nil, err
-		}
-
-		return redisClient, nil
-	default:
-		return nil, db.ErrUnsupportedDatabase
-	}
-}
-
-func (s ServiceInit) BootstrapHandler(
-	wg *sync.WaitGroup,
-	ctx context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) bool {
-
-	// update global variables.
-	LoggingClient = container.LoggingClientFrom(dic.Get)
-	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
-
-	// initialize clients required by service.
-	registryClient := container.RegistryFrom(dic.Get)
-	s.initializeClients(registryClient != nil, registryClient)
-
-	// initialize database.
-	for startupTimer.HasNotElapsed() {
-		var err error
-		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
-		if err == nil {
-			break
-		}
-		dbClient = nil
-		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
-		startupTimer.SleepForInterval()
-	}
-
-	if dbClient == nil {
-		return false
-	}
-
-	LoggingClient.Info("Database connected")
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		<-ctx.Done()
-		for {
-			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
-			if s.server.IsRunning() == false {
-				dbClient.CloseSession()
-				break
-			}
-			time.Sleep(time.Second)
-		}
-		LoggingClient.Info("Database disconnected")
-	}()
 
 	// initialize event handlers
 	chEvents = make(chan interface{}, 100)

--- a/internal/core/metadata/config.go
+++ b/internal/core/metadata/config.go
@@ -24,7 +24,7 @@ import (
 type ConfigurationStruct struct {
 	Writable      WritableInfo
 	Clients       map[string]config.ClientInfo
-	Databases     map[string]config.DatabaseInfo
+	Databases     config.DatabaseInfo
 	Logging       config.LoggingInfo
 	Notifications config.NotificationInfo
 	Registry      config.RegistryInfo
@@ -90,4 +90,9 @@ func (c *ConfigurationStruct) GetLogLevel() string {
 // SetLogLevel updates the log level in the ConfigurationStruct.
 func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
 	c.Registry = registryInfo
+}
+
+// GetDatabaseInfo returns a database information map.
+func (c *ConfigurationStruct) GetDatabaseInfo() config.DatabaseInfo {
+	return c.Databases
 }

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -16,26 +16,20 @@ package metadata
 
 import (
 	"context"
-	"fmt"
 	"sync"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-
-	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
@@ -44,120 +38,36 @@ var dbClient interfaces.DBClient
 var LoggingClient logger.LoggingClient
 var nc notifications.NotificationsClient
 var vdc coredata.ValueDescriptorClient
-
-// Global ErrorConcept variables
 var httpErrorHandler errorconcept.ErrorHandler
 
-type server interface {
-	IsRunning() bool
-}
-
-type ServiceInit struct {
-	server server
-}
-
-func NewServiceInit(server server) ServiceInit {
-	return ServiceInit{
-		server: server,
-	}
-}
-
-func (s ServiceInit) initializeClients(useRegistry bool, registryClient registry.Client) {
-	// Create notification client
-	nParams := types.EndpointParams{
-		ServiceKey:  clients.SupportNotificationsServiceKey,
-		Path:        clients.ApiNotificationRoute,
-		UseRegistry: useRegistry,
-		Url:         Configuration.Clients["Notifications"].Url() + clients.ApiNotificationRoute,
-		Interval:    Configuration.Service.ClientMonitor,
-	}
-	nc = notifications.NewNotificationsClient(nParams, endpoint.Endpoint{RegistryClient: &registryClient})
-
-	vParams := types.EndpointParams{
-		ServiceKey:  clients.CoreDataServiceKey,
-		Path:        clients.ApiValueDescriptorRoute,
-		UseRegistry: useRegistry,
-		Url:         Configuration.Clients["CoreData"].Url() + clients.ApiValueDescriptorRoute,
-		Interval:    Configuration.Service.ClientMonitor,
-	}
-	vdc = coredata.NewValueDescriptorClient(vParams, endpoint.Endpoint{RegistryClient: &registryClient})
-}
-
-// Return the dbClient interface
-func (s ServiceInit) newDBClient(dbType string) (interfaces.DBClient, error) {
-	switch dbType {
-	case db.MongoDB:
-		dbConfig := db.Configuration{
-			Host:         Configuration.Databases["Primary"].Host,
-			Port:         Configuration.Databases["Primary"].Port,
-			Timeout:      Configuration.Databases["Primary"].Timeout,
-			DatabaseName: Configuration.Databases["Primary"].Name,
-			Username:     Configuration.Databases["Primary"].Username,
-			Password:     Configuration.Databases["Primary"].Password,
-		}
-		return mongo.NewClient(dbConfig)
-	case db.RedisDB:
-		dbConfig := db.Configuration{
-			Host: Configuration.Databases["Primary"].Host,
-			Port: Configuration.Databases["Primary"].Port,
-		}
-		redisClient, err := redis.NewCoreDataClient(dbConfig, LoggingClient) // TODO: Verify this also connects to Redis
-		if err != nil {
-			return nil, err
-		}
-
-		return redisClient, nil
-	default:
-		return nil, db.ErrUnsupportedDatabase
-	}
-}
-
-func (s ServiceInit) BootstrapHandler(
-	wg *sync.WaitGroup,
-	ctx context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) bool {
-
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the metadata service.
+func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
 	LoggingClient = container.LoggingClientFrom(dic.Get)
+	dbClient = container.DBClientFrom(dic.Get)
+
 	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
 
 	// initialize clients required by service.
 	registryClient := container.RegistryFrom(dic.Get)
-	s.initializeClients(registryClient != nil, registryClient)
-
-	// initialize database.
-	for startupTimer.HasNotElapsed() {
-		var err error
-		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
-		if err == nil {
-			break
-		}
-		dbClient = nil
-		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
-		startupTimer.SleepForInterval()
-	}
-
-	if dbClient == nil {
-		return false
-	}
-
-	LoggingClient.Info("Database connected")
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		<-ctx.Done()
-		for {
-			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
-			if s.server.IsRunning() == false {
-				dbClient.CloseSession()
-				break
-			}
-			time.Sleep(time.Second)
-		}
-		LoggingClient.Info("Database disconnected")
-	}()
+	nc = notifications.NewNotificationsClient(
+		types.EndpointParams{
+			ServiceKey:  clients.SupportNotificationsServiceKey,
+			Path:        clients.ApiNotificationRoute,
+			UseRegistry: registryClient != nil,
+			Url:         Configuration.Clients["Notifications"].Url() + clients.ApiNotificationRoute,
+			Interval:    Configuration.Service.ClientMonitor,
+		},
+		endpoint.Endpoint{RegistryClient: &registryClient})
+	vdc = coredata.NewValueDescriptorClient(
+		types.EndpointParams{
+			ServiceKey:  clients.CoreDataServiceKey,
+			Path:        clients.ApiValueDescriptorRoute,
+			UseRegistry: registryClient != nil,
+			Url:         Configuration.Clients["CoreData"].Url() + clients.ApiValueDescriptorRoute,
+			Interval:    Configuration.Service.ClientMonitor,
+		},
+		endpoint.Endpoint{RegistryClient: &registryClient})
 
 	return true
 }

--- a/internal/export/client/config.go
+++ b/internal/export/client/config.go
@@ -23,7 +23,7 @@ import (
 type ConfigurationStruct struct {
 	Writable    WritableInfo
 	Clients     map[string]config.ClientInfo
-	Databases   map[string]config.DatabaseInfo
+	Databases   config.DatabaseInfo
 	Logging     config.LoggingInfo
 	Registry    config.RegistryInfo
 	Service     config.ServiceInfo
@@ -87,4 +87,9 @@ func (c *ConfigurationStruct) GetLogLevel() string {
 // SetLogLevel updates the log level in the ConfigurationStruct.
 func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
 	c.Registry = registryInfo
+}
+
+// GetDatabaseInfo returns a database information map.
+func (c *ConfigurationStruct) GetDatabaseInfo() config.DatabaseInfo {
+	return c.Databases
 }

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -9,16 +9,11 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"sync"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/export"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
 
@@ -26,8 +21,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/export/distro"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-
-	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
@@ -36,106 +29,22 @@ var LoggingClient logger.LoggingClient
 var Configuration = &ConfigurationStruct{}
 var dc distro.DistroClient
 
-type server interface {
-	IsRunning() bool
-}
-
-type ServiceInit struct {
-	server server
-}
-
-func NewServiceInit(server server) ServiceInit {
-	return ServiceInit{
-		server: server,
-	}
-}
-
-func (s ServiceInit) initializeClients(useRegistry bool, registry registry.Client) {
-	// Create export-distro client
-	params := types.EndpointParams{
-		ServiceKey:  clients.ExportDistroServiceKey,
-		UseRegistry: useRegistry,
-		Url:         Configuration.Clients["Distro"].Url(),
-		Interval:    Configuration.Service.ClientMonitor,
-	}
-
-	dc = distro.NewDistroClient(params, endpoint.Endpoint{RegistryClient: &registry})
-}
-
-// Return the dbClient interface
-func (s ServiceInit) newDBClient(dbType string) (export.DBClient, error) {
-	switch dbType {
-	case db.MongoDB:
-		dbConfig := db.Configuration{
-			Host:         Configuration.Databases["Primary"].Host,
-			Port:         Configuration.Databases["Primary"].Port,
-			Timeout:      Configuration.Databases["Primary"].Timeout,
-			DatabaseName: Configuration.Databases["Primary"].Name,
-			Username:     Configuration.Databases["Primary"].Username,
-			Password:     Configuration.Databases["Primary"].Password,
-		}
-		return mongo.NewClient(dbConfig)
-	case db.RedisDB:
-		dbConfig := db.Configuration{
-			Host: Configuration.Databases["Primary"].Host,
-			Port: Configuration.Databases["Primary"].Port,
-		}
-		redisClient, err := redis.NewCoreDataClient(dbConfig, LoggingClient) // TODO: Verify this also connects to Redis
-		if err != nil {
-			return nil, err
-		}
-
-		return redisClient, nil
-	default:
-		return nil, db.ErrUnsupportedDatabase
-	}
-}
-
-func (s ServiceInit) BootstrapHandler(
-	wg *sync.WaitGroup,
-	ctx context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) bool {
-
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the export-client service.
+func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
 	LoggingClient = container.LoggingClientFrom(dic.Get)
+	dbClient = container.DBClientFrom(dic.Get)
 
 	// initialize clients required by service.
 	registryClient := container.RegistryFrom(dic.Get)
-	s.initializeClients(registryClient != nil, registryClient)
-
-	// initialize database.
-	for startupTimer.HasNotElapsed() {
-		var err error
-		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
-		if err == nil {
-			break
-		}
-		dbClient = nil
-		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
-		startupTimer.SleepForInterval()
-	}
-
-	if dbClient == nil {
-		return false
-	}
-
-	LoggingClient.Info("Database connected")
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		<-ctx.Done()
-		for {
-			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
-			if s.server.IsRunning() == false {
-				dbClient.CloseSession()
-				break
-			}
-			time.Sleep(time.Second)
-		}
-		LoggingClient.Info("Database disconnected")
-	}()
+	dc = distro.NewDistroClient(
+		types.EndpointParams{
+			ServiceKey:  clients.ExportDistroServiceKey,
+			UseRegistry: registryClient != nil,
+			Url:         Configuration.Clients["Distro"].Url(),
+			Interval:    Configuration.Service.ClientMonitor,
+		},
+		endpoint.Endpoint{RegistryClient: &registryClient})
 
 	return true
 }

--- a/internal/export/distro/init.go
+++ b/internal/export/distro/init.go
@@ -27,12 +27,14 @@ import (
 	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
+// Global variables
 var LoggingClient logger.LoggingClient
 var ec coredata.EventClient
 var Configuration = &ConfigurationStruct{}
 var messageErrors chan error
 var messageEnvelopes chan msgTypes.MessageEnvelope
 
+// initializeClients creates the clients required by the service.
 func initializeClients(useRegistry bool, registryClient registry.Client) (messaging.MessageClient, error) {
 	ec = coredata.NewEventClient(
 		types.EndpointParams{
@@ -56,12 +58,8 @@ func initializeClients(useRegistry bool, registryClient registry.Client) (messag
 		})
 }
 
-func BootstrapHandler(
-	wg *sync.WaitGroup,
-	ctx context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) bool {
-
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the export-distro service.
+func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
 	LoggingClient = container.LoggingClientFrom(dic.Get)
 

--- a/internal/pkg/bootstrap/container/database.go
+++ b/internal/pkg/bootstrap/container/database.go
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package container
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+)
+
+// DBClientInterfaceName contains the name of the interfaces.DBClient implementation in the DIC.
+var DBClientInterfaceName = di.TypeInstanceToName((*interfaces.DBClient)(nil))
+
+// DBClientFrom helper function queries the DIC and returns the interfaces.DBClient implementation.
+func DBClientFrom(get di.Get) interfaces.DBClient {
+	return get(DBClientInterfaceName).(interfaces.DBClient)
+}

--- a/internal/pkg/bootstrap/handlers/database/database.go
+++ b/internal/pkg/bootstrap/handlers/database/database.go
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	dbInterfaces "github.com/edgexfoundry/edgex-go/internal/pkg/db/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// httpServer defines the contract used to determine whether or not the http httpServer is running.
+type httpServer interface {
+	IsRunning() bool
+}
+
+// Database contains references to dependencies required by the database bootstrap implementation.
+type Database struct {
+	httpServer httpServer
+	database   interfaces.Database
+	isCoreData bool
+}
+
+// NewDatabase is a factory method that returns an initialized Database receiver struct.
+func NewDatabase(httpServer httpServer, database interfaces.Database) Database {
+	return Database{
+		httpServer: httpServer,
+		database:   database,
+		isCoreData: false,
+	}
+}
+
+// NewDatabaseForCoreData is a factory method that returns an initialized Database receiver struct.
+func NewDatabaseForCoreData(httpServer httpServer, database interfaces.Database) Database {
+	return Database{
+		httpServer: httpServer,
+		database:   database,
+		isCoreData: true,
+	}
+}
+
+// Return the dbClient interface
+func (d Database) newDBClient(loggingClient logger.LoggingClient) (dbInterfaces.DBClient, error) {
+	databaseInfo := d.database.GetDatabaseInfo()["Primary"]
+	switch databaseInfo.Type {
+	case db.MongoDB:
+		return mongo.NewClient(
+			db.Configuration{
+				Host:         databaseInfo.Host,
+				Port:         databaseInfo.Port,
+				Timeout:      databaseInfo.Timeout,
+				DatabaseName: databaseInfo.Name,
+				Username:     databaseInfo.Username,
+				Password:     databaseInfo.Password,
+			})
+	case db.RedisDB:
+		if d.isCoreData {
+			return redis.NewCoreDataClient(
+				db.Configuration{
+					Host: databaseInfo.Host,
+					Port: databaseInfo.Port,
+				},
+				loggingClient)
+		}
+		return redis.NewClient(db.Configuration{Host: databaseInfo.Host, Port: databaseInfo.Port}, loggingClient)
+	default:
+		return nil, db.ErrUnsupportedDatabase
+	}
+}
+
+// BootstrapHandler fulfills the BootstrapHandler contract and initializes the database.
+func (d Database) BootstrapHandler(
+	wg *sync.WaitGroup,
+	context context.Context,
+	startupTimer startup.Timer,
+	dic *di.Container) bool {
+
+	loggingClient := container.LoggingClientFrom(dic.Get)
+
+	// initialize database.
+	var dbClient dbInterfaces.DBClient
+	for startupTimer.HasNotElapsed() {
+		var err error
+		dbClient, err = d.newDBClient(loggingClient)
+		if err == nil {
+			break
+		}
+		dbClient = nil
+		loggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
+		startupTimer.SleepForInterval()
+	}
+
+	if dbClient == nil {
+		return false
+	}
+
+	dic.Update(di.ServiceConstructorMap{
+		container.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClient
+		},
+	})
+
+	loggingClient.Info("Database connected")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		<-context.Done()
+		for {
+			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
+			if d.httpServer.IsRunning() == false {
+				dbClient.CloseSession()
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		loggingClient.Info("Database disconnected")
+	}()
+
+	return true
+}

--- a/internal/pkg/bootstrap/interfaces/database.go
+++ b/internal/pkg/bootstrap/interfaces/database.go
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package interfaces
+
+import "github.com/edgexfoundry/edgex-go/internal/pkg/config"
+
+// Database interface provides an abstraction for obtaining the database configuration information.
+type Database interface {
+	// GetDatabaseInfo returns a database information map.
+	GetDatabaseInfo() config.DatabaseInfo
+}

--- a/internal/pkg/config/types.go
+++ b/internal/pkg/config/types.go
@@ -105,7 +105,7 @@ func (m MessageQueueInfo) Uri() string {
 }
 
 // DatabaseInfo defines the parameters necessary for connecting to the desired persistence layer.
-type DatabaseInfo struct {
+type DatabaseInfo map[string]struct {
 	Type     string
 	Timeout  int
 	Host     string

--- a/internal/pkg/db/interfaces/db.go
+++ b/internal/pkg/db/interfaces/db.go
@@ -1,0 +1,207 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package interfaces
+
+import (
+	correlation "github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+type DBClient interface {
+	CloseSession()
+
+	Events() ([]contract.Event, error)
+	EventsWithLimit(limit int) ([]contract.Event, error)
+	AddEvent(e correlation.Event) (string, error)
+	UpdateEvent(e correlation.Event) error
+	EventById(id string) (contract.Event, error)
+	EventsByChecksum(checksum string) ([]contract.Event, error)
+	EventCount() (int, error)
+	EventCountByDeviceId(id string) (int, error)
+	DeleteEventById(id string) error
+	DeleteEventsByDevice(deviceId string) (int, error)
+	EventsForDeviceLimit(id string, limit int) ([]contract.Event, error)
+	EventsForDevice(id string) ([]contract.Event, error)
+	EventsByCreationTime(startTime, endTime int64, limit int) ([]contract.Event, error)
+	EventsOlderThanAge(age int64) ([]contract.Event, error)
+	EventsPushed() ([]contract.Event, error)
+	ScrubAllEvents() error
+
+	Readings() ([]contract.Reading, error)
+	AddReading(r contract.Reading) (string, error)
+	UpdateReading(r contract.Reading) error
+	ReadingById(id string) (contract.Reading, error)
+	ReadingCount() (int, error)
+	DeleteReadingById(id string) error
+	DeleteReadingsByDevice(deviceId string) error
+	ReadingsByDevice(id string, limit int) ([]contract.Reading, error)
+	ReadingsByValueDescriptor(name string, limit int) ([]contract.Reading, error)
+	ReadingsByValueDescriptorNames(names []string, limit int) ([]contract.Reading, error)
+	ReadingsByCreationTime(start, end int64, limit int) ([]contract.Reading, error)
+	ReadingsByDeviceAndValueDescriptor(deviceId, valueDescriptor string, limit int) ([]contract.Reading, error)
+
+	ValueDescriptors() ([]contract.ValueDescriptor, error)
+	AddValueDescriptor(v contract.ValueDescriptor) (string, error)
+	UpdateValueDescriptor(cvd contract.ValueDescriptor) error
+	DeleteValueDescriptorById(id string) error
+	ValueDescriptorByName(name string) (contract.ValueDescriptor, error)
+	ValueDescriptorsByName(names []string) ([]contract.ValueDescriptor, error)
+	ValueDescriptorById(id string) (contract.ValueDescriptor, error)
+	ValueDescriptorsByUomLabel(uomLabel string) ([]contract.ValueDescriptor, error)
+	ValueDescriptorsByLabel(label string) ([]contract.ValueDescriptor, error)
+	ValueDescriptorsByType(t string) ([]contract.ValueDescriptor, error)
+	ScrubAllValueDescriptors() error
+
+	Registrations() ([]contract.Registration, error)
+	AddRegistration(r contract.Registration) (string, error)
+	UpdateRegistration(reg contract.Registration) error
+	RegistrationById(id string) (contract.Registration, error)
+	RegistrationByName(name string) (contract.Registration, error)
+	DeleteRegistrationById(id string) error
+	DeleteRegistrationByName(name string) error
+	ScrubAllRegistrations() error
+
+	GetAllDeviceReports() ([]contract.DeviceReport, error)
+	GetDeviceReportByName(n string) (contract.DeviceReport, error)
+	GetDeviceReportByDeviceName(n string) ([]contract.DeviceReport, error)
+	GetDeviceReportById(id string) (contract.DeviceReport, error)
+	GetDeviceReportsByAction(n string) ([]contract.DeviceReport, error)
+	AddDeviceReport(d contract.DeviceReport) (string, error)
+	UpdateDeviceReport(dr contract.DeviceReport) error
+	DeleteDeviceReportById(id string) error
+
+	GetAllDevices() ([]contract.Device, error)
+	AddDevice(d contract.Device, commands []contract.Command) (string, error)
+	UpdateDevice(d contract.Device) error
+	DeleteDeviceById(id string) error
+	GetDevicesByProfileId(id string) ([]contract.Device, error)
+	GetDeviceById(id string) (contract.Device, error)
+	GetDeviceByName(n string) (contract.Device, error)
+	GetDevicesByServiceId(id string) ([]contract.Device, error)
+	GetDevicesWithLabel(l string) ([]contract.Device, error)
+
+	GetAllDeviceProfiles() ([]contract.DeviceProfile, error)
+	GetDeviceProfileById(id string) (contract.DeviceProfile, error)
+	GetDeviceProfilesByModel(model string) ([]contract.DeviceProfile, error)
+	GetDeviceProfilesWithLabel(l string) ([]contract.DeviceProfile, error)
+	GetDeviceProfilesByManufacturerModel(man string, mod string) ([]contract.DeviceProfile, error)
+	GetDeviceProfilesByManufacturer(man string) ([]contract.DeviceProfile, error)
+	GetDeviceProfileByName(n string) (contract.DeviceProfile, error)
+	AddDeviceProfile(dp contract.DeviceProfile) (string, error)
+	UpdateDeviceProfile(dp contract.DeviceProfile) error
+	DeleteDeviceProfileById(id string) error
+
+	GetAddressables() ([]contract.Addressable, error)
+	UpdateAddressable(a contract.Addressable) error
+	GetAddressableById(id string) (contract.Addressable, error)
+	AddAddressable(a contract.Addressable) (string, error)
+	GetAddressableByName(n string) (contract.Addressable, error)
+	GetAddressablesByTopic(t string) ([]contract.Addressable, error)
+	GetAddressablesByPort(p int) ([]contract.Addressable, error)
+	GetAddressablesByPublisher(p string) ([]contract.Addressable, error)
+	GetAddressablesByAddress(add string) ([]contract.Addressable, error)
+	DeleteAddressableById(id string) error
+
+	GetDeviceServiceByName(n string) (contract.DeviceService, error)
+	GetDeviceServiceById(id string) (contract.DeviceService, error)
+	GetAllDeviceServices() ([]contract.DeviceService, error)
+	GetDeviceServicesByAddressableId(id string) ([]contract.DeviceService, error)
+	GetDeviceServicesWithLabel(l string) ([]contract.DeviceService, error)
+	AddDeviceService(ds contract.DeviceService) (string, error)
+	UpdateDeviceService(ds contract.DeviceService) error
+	DeleteDeviceServiceById(id string) error
+
+	GetAllProvisionWatchers() (pw []contract.ProvisionWatcher, err error)
+	GetProvisionWatcherByName(n string) (pw contract.ProvisionWatcher, err error)
+	GetProvisionWatchersByIdentifier(k string, v string) (pw []contract.ProvisionWatcher, err error)
+	GetProvisionWatchersByServiceId(id string) (pw []contract.ProvisionWatcher, err error)
+	GetProvisionWatchersByProfileId(id string) (pw []contract.ProvisionWatcher, err error)
+	GetProvisionWatcherById(id string) (pw contract.ProvisionWatcher, err error)
+	AddProvisionWatcher(pw contract.ProvisionWatcher) (string, error)
+	UpdateProvisionWatcher(pw contract.ProvisionWatcher) error
+	DeleteProvisionWatcherById(id string) error
+
+	GetAllCommands() ([]contract.Command, error)
+	GetCommandById(id string) (contract.Command, error)
+	GetCommandsByName(n string) ([]contract.Command, error)
+	GetCommandsByDeviceId(did string) ([]contract.Command, error)
+	GetCommandByNameAndDeviceId(cname string, did string) (contract.Command, error)
+
+	ScrubMetadata() error
+
+	GetNotifications() ([]contract.Notification, error)
+	GetNotificationById(id string) (contract.Notification, error)
+	GetNotificationBySlug(slug string) (contract.Notification, error)
+	GetNotificationBySender(sender string, limit int) ([]contract.Notification, error)
+	GetNotificationsByLabels(labels []string, limit int) ([]contract.Notification, error)
+	GetNotificationsByStartEnd(start int64, end int64, limit int) ([]contract.Notification, error)
+	GetNotificationsByStart(start int64, limit int) ([]contract.Notification, error)
+	GetNotificationsByEnd(end int64, limit int) ([]contract.Notification, error)
+	GetNewNotifications(limit int) ([]contract.Notification, error)
+	GetNewNormalNotifications(limit int) ([]contract.Notification, error)
+	AddNotification(n contract.Notification) (string, error)
+	UpdateNotification(n contract.Notification) error
+	MarkNotificationProcessed(n contract.Notification) error
+	DeleteNotificationById(id string) error
+	DeleteNotificationBySlug(slug string) error
+	DeleteNotificationsOld(age int) error
+
+	GetSubscriptionBySlug(slug string) (contract.Subscription, error)
+	GetSubscriptionByCategories(categories []string) ([]contract.Subscription, error)
+	GetSubscriptionByLabels(labels []string) ([]contract.Subscription, error)
+	GetSubscriptionByCategoriesLabels(categories []string, labels []string) ([]contract.Subscription, error)
+	GetSubscriptionByReceiver(receiver string) ([]contract.Subscription, error)
+	GetSubscriptionById(id string) (contract.Subscription, error)
+	DeleteSubscriptionById(id string) error
+	AddSubscription(sub contract.Subscription) (string, error)
+	UpdateSubscription(sub contract.Subscription) error
+	DeleteSubscriptionBySlug(slug string) error
+	GetSubscriptions() ([]contract.Subscription, error)
+
+	AddTransmission(t contract.Transmission) (string, error)
+	UpdateTransmission(t contract.Transmission) error
+	DeleteTransmission(age int64, status contract.TransmissionStatus) error
+	GetTransmissionById(id string) (contract.Transmission, error)
+	GetTransmissionsByNotificationSlug(slug string, limit int) ([]contract.Transmission, error)
+	GetTransmissionsByNotificationSlugAndStartEnd(slug string, start int64, end int64, limit int) ([]contract.Transmission, error)
+	GetTransmissionsByStartEnd(start int64, end int64, limit int) ([]contract.Transmission, error)
+	GetTransmissionsByStart(start int64, limit int) ([]contract.Transmission, error)
+	GetTransmissionsByEnd(end int64, limit int) ([]contract.Transmission, error)
+	GetTransmissionsByStatus(limit int, status contract.TransmissionStatus) ([]contract.Transmission, error)
+
+	Cleanup() error
+	CleanupOld(age int) error
+
+	Intervals() ([]contract.Interval, error)
+	IntervalsWithLimit(limit int) ([]contract.Interval, error)
+	IntervalByName(name string) (contract.Interval, error)
+	IntervalById(id string) (contract.Interval, error)
+	AddInterval(interval contract.Interval) (string, error)
+	UpdateInterval(interval contract.Interval) error
+	DeleteIntervalById(id string) error
+
+	IntervalActions() ([]contract.IntervalAction, error)
+	IntervalActionsWithLimit(limit int) ([]contract.IntervalAction, error)
+	IntervalActionsByIntervalName(name string) ([]contract.IntervalAction, error)
+	IntervalActionsByTarget(name string) ([]contract.IntervalAction, error)
+	IntervalActionById(id string) (contract.IntervalAction, error)
+	IntervalActionByName(name string) (contract.IntervalAction, error)
+	AddIntervalAction(action contract.IntervalAction) (string, error)
+	UpdateIntervalAction(action contract.IntervalAction) error
+	DeleteIntervalActionById(id string) error
+
+	ScrubAllIntervalActions() (int, error)
+	ScrubAllIntervals() (int, error)
+}

--- a/internal/pkg/telemetry/telemetry.go
+++ b/internal/pkg/telemetry/telemetry.go
@@ -91,12 +91,7 @@ func StartCpuUsageAverage() {
 // BootstrapHandler fulfills the BootstrapHandler contract.  It creates a go routine to periodically sample CPU usage
 // and is intended to supersede the existing StartCpuUsageAverage() function when the new bootstrap package is used
 // by all of the core services.
-func BootstrapHandler(
-	wg *sync.WaitGroup,
-	ctx context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) bool {
-
+func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	loggingClient := container.LoggingClientFrom(dic.Get)
 	loggingClient.Info("Telemetry starting")
 

--- a/internal/support/logging/config.go
+++ b/internal/support/logging/config.go
@@ -22,7 +22,7 @@ import (
 
 type ConfigurationStruct struct {
 	Writable    WritableInfo
-	Databases   map[string]config.DatabaseInfo
+	Databases   config.DatabaseInfo
 	Logging     config.LoggingInfo
 	Registry    config.RegistryInfo
 	Service     config.ServiceInfo
@@ -87,4 +87,9 @@ func (c *ConfigurationStruct) GetLogLevel() string {
 // SetLogLevel updates the log level in the ConfigurationStruct.
 func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
 	c.Registry = registryInfo
+}
+
+// GetDatabaseInfo returns a database information map.
+func (c *ConfigurationStruct) GetDatabaseInfo() config.DatabaseInfo {
+	return c.Databases
 }

--- a/internal/support/notifications/config.go
+++ b/internal/support/notifications/config.go
@@ -25,7 +25,7 @@ import (
 type ConfigurationStruct struct {
 	Writable    WritableInfo
 	Clients     map[string]config.ClientInfo
-	Databases   map[string]config.DatabaseInfo
+	Databases   config.DatabaseInfo
 	Logging     config.LoggingInfo
 	Registry    config.RegistryInfo
 	Service     config.ServiceInfo
@@ -111,4 +111,9 @@ func (c *ConfigurationStruct) GetLogLevel() string {
 // SetLogLevel updates the log level in the ConfigurationStruct.
 func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
 	c.Registry = registryInfo
+}
+
+// GetDatabaseInfo returns a database information map.
+func (c *ConfigurationStruct) GetDatabaseInfo() config.DatabaseInfo {
+	return c.Databases
 }

--- a/internal/support/notifications/init.go
+++ b/internal/support/notifications/init.go
@@ -19,15 +19,10 @@ package notifications
 
 import (
 	"context"
-	"fmt"
 	"sync"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications/interfaces"
 
@@ -39,84 +34,11 @@ var Configuration = &ConfigurationStruct{}
 var dbClient interfaces.DBClient
 var LoggingClient logger.LoggingClient
 
-type server interface {
-	IsRunning() bool
-}
-
-type ServiceInit struct {
-	server server
-}
-
-func NewServiceInit(server server) ServiceInit {
-	return ServiceInit{
-		server: server,
-	}
-}
-
-func (s ServiceInit) newDBClient(dbType string) (interfaces.DBClient, error) {
-	switch dbType {
-	case db.MongoDB:
-		dbConfig := db.Configuration{
-			Host:         Configuration.Databases["Primary"].Host,
-			Port:         Configuration.Databases["Primary"].Port,
-			Timeout:      Configuration.Databases["Primary"].Timeout,
-			DatabaseName: Configuration.Databases["Primary"].Name,
-			Username:     Configuration.Databases["Primary"].Username,
-			Password:     Configuration.Databases["Primary"].Password,
-		}
-		return mongo.NewClient(dbConfig)
-	case db.RedisDB:
-		dbConfig := db.Configuration{
-			Host: Configuration.Databases["Primary"].Host,
-			Port: Configuration.Databases["Primary"].Port,
-		}
-		return redis.NewClient(dbConfig, LoggingClient)
-	default:
-		return nil, db.ErrUnsupportedDatabase
-	}
-}
-
-func (s ServiceInit) BootstrapHandler(
-	wg *sync.WaitGroup,
-	ctx context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) bool {
-
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the notifications service.
+func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
 	LoggingClient = container.LoggingClientFrom(dic.Get)
-
-	// initialize database.
-	for startupTimer.HasNotElapsed() {
-		var err error
-		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
-		if err == nil {
-			break
-		}
-		dbClient = nil
-		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
-		startupTimer.SleepForInterval()
-	}
-
-	if dbClient == nil {
-		return false
-	}
-
-	LoggingClient.Info("Database connected")
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		<-ctx.Done()
-		for {
-			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
-			if s.server.IsRunning() == false {
-				dbClient.CloseSession()
-				break
-			}
-			time.Sleep(time.Second)
-		}
-		LoggingClient.Info("Database disconnected")
-	}()
+	dbClient = container.DBClientFrom(dic.Get)
 
 	return true
 }

--- a/internal/support/scheduler/config.go
+++ b/internal/support/scheduler/config.go
@@ -25,7 +25,7 @@ import (
 type ConfigurationStruct struct {
 	Writable        WritableInfo
 	Clients         map[string]config.ClientInfo
-	Databases       map[string]config.DatabaseInfo
+	Databases       config.DatabaseInfo
 	Logging         config.LoggingInfo
 	Registry        config.RegistryInfo
 	Service         config.ServiceInfo
@@ -92,4 +92,9 @@ func (c *ConfigurationStruct) GetLogLevel() string {
 // SetLogLevel updates the log level in the ConfigurationStruct.
 func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
 	c.Registry = registryInfo
+}
+
+// GetDatabaseInfo returns a database information map.
+func (c *ConfigurationStruct) GetDatabaseInfo() config.DatabaseInfo {
+	return c.Databases
 }

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -36,12 +36,7 @@ import (
 )
 
 // BootstrapHandler fulfills the BootstrapHandler contract.  It implements agent-specific initialization.
-func BootstrapHandler(
-	wg *sync.WaitGroup,
-	ctx context.Context,
-	startupTimer startup.Timer,
-	dic *di.Container) bool {
-
+func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	configuration := container.ConfigurationFrom(dic.Get)
 
 	// validate metrics implementation


### PR DESCRIPTION
Extracted dbClient creation from individual service-specific bootstrap
handlers into a common bootstrap handler.  Affected core-command,
core-data, core-metadata, export-client, support-logging,
support-notifications, and support-scheduler.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/1868

Signed-off-by: Michael Estrin <m.estrin@dell.com>