### PR TITLE
Add SecretStore configurations to TOML files

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -41,3 +41,12 @@ File = './logs/edgex-core-command.log'
   Username = ''
   Timeout = 5000
   Type = 'mongodb'
+
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secrets/edgex/core-command/'
+Protocol = 'http'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken = 'edgex'

--- a/cmd/core-command/res/docker/configuration.toml
+++ b/cmd/core-command/res/docker/configuration.toml
@@ -41,3 +41,14 @@ File = '/edgex/logs/edgex-core-command.log'
   Username = 'meta'
   Timeout = 5000
   Type = 'mongodb'
+
+[SecretStore]
+Host = 'edgex-vault'
+Port = 8200
+Path = '/v1/secrets/edgex/core-command/'
+Protocol = 'http'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'edgex-vault'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken= 'edgex'

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -54,3 +54,12 @@ Host = '*'
 Port = 5563
 Type = 'zero'
 Topic = 'events'
+
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secret/edgex/core-data/'
+Protocol = 'http'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken = 'edgex'

--- a/cmd/core-data/res/docker/configuration.toml
+++ b/cmd/core-data/res/docker/configuration.toml
@@ -53,3 +53,14 @@ Host = '*'
 Port = 5563
 Type = 'zero'
 Topic = 'events'
+
+[SecretStore]
+Host = 'edgex-vault'
+Port = 8200
+Path = '/v1/secrets/edgex/core-data/'
+Protocol = 'http'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'edgex-vault'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken= 'edgex'

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -55,3 +55,11 @@ Sender = 'core-metadata'
 Description = 'Metadata device notice'
 Label = 'metadata'
 
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secrets/edgex/core-metadata/'
+Protocol = 'http'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken = 'edgex'

--- a/cmd/core-metadata/res/docker/configuration.toml
+++ b/cmd/core-metadata/res/docker/configuration.toml
@@ -53,3 +53,14 @@ Content = 'Device update: '
 Sender = 'edgex-core-metadata'
 Description = 'Metadata device notice'
 Label = 'metadata'
+
+[SecretStore]
+Host = 'edgex-vault'
+Port = 8200
+Path = '/v1/secrets/edgex/core-metadata/'
+Protocol = 'http'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'edgex-vault'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken= 'edgex'

--- a/cmd/export-client/res/configuration.toml
+++ b/cmd/export-client/res/configuration.toml
@@ -42,3 +42,11 @@ File = './logs/edgex-export-client.log'
   Timeout = 5000
   Type = 'mongodb'
 
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secrets/edgex/export-client/'
+Protocol = 'http'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken = 'edgex'

--- a/cmd/export-client/res/docker/configuration.toml
+++ b/cmd/export-client/res/docker/configuration.toml
@@ -42,3 +42,13 @@ File = '/edgex/logs/edgex-export-client.log'
   Timeout = 5000
   Type = 'mongodb'
 
+[SecretStore]
+Host = 'edgex-vault'
+Port = 8200
+Path = '/v1/secrets/edgex/export-client/'
+Protocol = 'http'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'edgex-vault'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken= 'edgex'

--- a/cmd/export-distro/res/configuration.toml
+++ b/cmd/export-distro/res/configuration.toml
@@ -60,4 +60,11 @@ Host = '*'
 Port = 5566
 Type = 'zero'
 
-
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secrets/edgex/export-distro/'
+Protocol = 'http'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken = 'edgex'

--- a/cmd/export-distro/res/docker/configuration.toml
+++ b/cmd/export-distro/res/docker/configuration.toml
@@ -59,3 +59,14 @@ Protocol = 'tcp'
 Host = '*'
 Port = 5566
 Type = 'zero'
+
+[SecretStore]
+Host = 'edgex-vault'
+Port = 8200
+Path = '/v1/secrets/edgex/export-distro/'
+Protocol = 'http'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'edgex-vault'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken= 'edgex'

--- a/cmd/support-logging/res/configuration.toml
+++ b/cmd/support-logging/res/configuration.toml
@@ -30,3 +30,12 @@ File = './logs/edgex-support-logging.log'
   Username = ''
   Timeout = 5000
   Type = 'mongodb'
+
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secrets/edgex/support-logging/'
+Protocol = 'http'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken = 'edgex'

--- a/cmd/support-logging/res/docker/configuration.toml
+++ b/cmd/support-logging/res/docker/configuration.toml
@@ -30,3 +30,14 @@ File = '/edgex/logs/edgex-support-logging.log'
   Username = 'logging'
   Timeout = 5000
   Type = 'mongodb'
+
+[SecretStore]
+Host = 'edgex-vault'
+Port = 8200
+Path = '/v1/secrets/edgex/support-logging/'
+Protocol = 'http'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'edgex-vault'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken= 'edgex'

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -46,3 +46,12 @@ File = './logs/edgex-support-notifications.log'
   Sender = 'jdoe@gmail.com'
   EnableSelfSignedCert = false
   Subject = 'EdgeX Notification'
+
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secrets/edgex/support-notifications/'
+Protocol = 'http'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken = 'edgex'

--- a/cmd/support-notifications/res/docker/configuration.toml
+++ b/cmd/support-notifications/res/docker/configuration.toml
@@ -46,3 +46,14 @@ File = '/edgex/logs/edgex-support-notifications.log'
   Sender = 'jdoe@gmail.com'
   EnableSelfSignedCert = false
   Subject = 'EdgeX Notification'
+
+[SecretStore]
+Host = 'edgex-vault'
+Port = 8200
+Path = '/v1/secrets/edgex/support-notifications/'
+Protocol = 'http'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'edgex-vault'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken= 'edgex'

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -65,7 +65,11 @@ File = './logs/edgex-support-scheduler.log'
     Path = '/api/v1/event/removeold/age/604800000'
     Interval = 'midnight'
 
-
-
-
-
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secrets/edgex/support-scheduler/'
+Protocol = 'http'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken = 'edgex'

--- a/cmd/support-scheduler/res/docker/configuration.toml
+++ b/cmd/support-scheduler/res/docker/configuration.toml
@@ -64,3 +64,14 @@ File = '/edgex/logs/edgex-support-scheduler.log'
     Target = 'core-data'
     Path = '/api/v1/event/removeold/age/604800000'
     Interval = 'midnight'
+
+[SecretStore]
+Host = 'edgex-vault'
+Port = 8200
+Path = '/v1/secrets/edgex/support-scheduler/'
+Protocol = 'http'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'edgex-vault'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken= 'edgex'

--- a/cmd/sys-mgmt-agent/res/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/configuration.toml
@@ -76,3 +76,12 @@ File = './logs/edgex-sys-mgmt-agent.log'
   Protocol = 'http'
   Host = 'localhost'
   Port = 48070
+
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secrets/edgex/sys-mgmt-agent/'
+Protocol = 'http'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken = 'edgex'

--- a/cmd/sys-mgmt-agent/res/docker/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/docker/configuration.toml
@@ -76,3 +76,14 @@ File = '/edgex/logs/edgex-sys-mgmt-agent.log'
   Protocol = 'http'
   Host = 'edgex-export-distro'
   Port = 48070
+
+[SecretStore]
+Host = 'edgex-vault'
+Port = 8200
+Path = '/v1/secrets/edgex/sys-mgmt-agent/'
+Protocol = 'http'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'edgex-vault'
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+  AuthToken= 'edgex'

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.28
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
-	github.com/edgexfoundry/go-mod-secrets v0.0.6
+	github.com/edgexfoundry/go-mod-secrets v0.0.7
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/internal/pkg/bootstrap/container/secret.go
+++ b/internal/pkg/bootstrap/container/secret.go
@@ -20,9 +20,9 @@ import (
 )
 
 // SecretClientName contains the name of the registry.Client implementation in the DIC.
-var SecretClientName = di.TypeInstanceToName(pkg.SecretClient{})
+var SecretClientName = di.TypeInstanceToName((*pkg.SecretClient)(nil))
 
 // SecretClientFrom helper function queries the DIC and returns the pkg.SecretClient implementation.
-func SecretClientFrom(get di.Get) *pkg.SecretClient {
-	return get(SecretClientName).(*pkg.SecretClient)
+func SecretClientFrom(get di.Get) pkg.SecretClient {
+	return get(SecretClientName).(pkg.SecretClient)
 }

--- a/internal/pkg/bootstrap/handlers/secret/secret.go
+++ b/internal/pkg/bootstrap/handlers/secret/secret.go
@@ -38,7 +38,7 @@ func BootstrapHandler(
 	dic *di.Container) bool {
 
 	// check for environment variable that turns security off
-	if env := os.Getenv("EDGEX_SECURITY_SECRET_STORE"); env != "false" {
+	if env := os.Getenv("EDGEX_SECURITY_SECRET_STORE"); env == "false" {
 		dic.Update(di.ServiceConstructorMap{
 			container.SecretClientName: func(get di.Get) interface{} {
 				return nil


### PR DESCRIPTION
Fix #1825

Update configuration TOML files to include configurations for
SecretStore which is used to create a SecretClient.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>