### PR TITLE
Update secret BootstrapHandler to read token file

### DIFF
--- a/cmd/core-command/res/docker/configuration.toml
+++ b/cmd/core-command/res/docker/configuration.toml
@@ -49,9 +49,9 @@ Path = '/v1/secrets/edgex/core-command/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken= 'edgex'
 
 [Startup]
 Duration = 30

--- a/cmd/core-data/res/docker/configuration.toml
+++ b/cmd/core-data/res/docker/configuration.toml
@@ -61,9 +61,9 @@ Path = '/v1/secrets/edgex/core-data/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken= 'edgex'
 
 [Startup]
 Duration = 30

--- a/cmd/core-metadata/res/docker/configuration.toml
+++ b/cmd/core-metadata/res/docker/configuration.toml
@@ -61,9 +61,9 @@ Path = '/v1/secrets/edgex/core-metadata/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken= 'edgex'
 
 [Startup]
 Duration = 30

--- a/cmd/export-client/res/docker/configuration.toml
+++ b/cmd/export-client/res/docker/configuration.toml
@@ -49,9 +49,9 @@ Path = '/v1/secrets/edgex/export-client/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken= 'edgex'
 
 [Startup]
 Duration = 30

--- a/cmd/export-distro/res/docker/configuration.toml
+++ b/cmd/export-distro/res/docker/configuration.toml
@@ -67,9 +67,9 @@ Path = '/v1/secrets/edgex/export-distro/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken= 'edgex'
 
 [Startup]
 Duration = 30

--- a/cmd/support-logging/res/docker/configuration.toml
+++ b/cmd/support-logging/res/docker/configuration.toml
@@ -38,9 +38,9 @@ Path = '/v1/secrets/edgex/support-logging/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken= 'edgex'
 
 [Startup]
 Duration = 30

--- a/cmd/support-notifications/res/docker/configuration.toml
+++ b/cmd/support-notifications/res/docker/configuration.toml
@@ -54,9 +54,9 @@ Path = '/v1/secrets/edgex/support-notifications/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken= 'edgex'
 
 [Startup]
 Duration = 30

--- a/cmd/support-scheduler/res/docker/configuration.toml
+++ b/cmd/support-scheduler/res/docker/configuration.toml
@@ -72,9 +72,9 @@ Path = '/v1/secrets/edgex/support-scheduler/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken= 'edgex'
 
 [Startup]
 Duration = 30

--- a/cmd/sys-mgmt-agent/res/docker/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/docker/configuration.toml
@@ -84,9 +84,9 @@ Path = '/v1/secrets/edgex/sys-mgmt-agent/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
-  AuthToken= 'edgex'
 
 [Startup]
 Duration = 30

--- a/internal/core/command/config.go
+++ b/internal/core/command/config.go
@@ -14,8 +14,6 @@
 package command
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -28,7 +26,7 @@ type ConfigurationStruct struct {
 	Logging     config.LoggingInfo
 	Registry    config.RegistryInfo
 	Service     config.ServiceInfo
-	SecretStore vault.SecretConfig
+	SecretStore config.SecretStoreInfo
 	Startup     config.StartupInfo
 }
 

--- a/internal/core/data/config.go
+++ b/internal/core/data/config.go
@@ -14,8 +14,6 @@
 package data
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -28,7 +26,7 @@ type ConfigurationStruct struct {
 	Logging      config.LoggingInfo
 	Registry     config.RegistryInfo
 	Service      config.ServiceInfo
-	SecretStore  vault.SecretConfig
+	SecretStore  config.SecretStoreInfo
 	Startup      config.StartupInfo
 }
 

--- a/internal/core/metadata/config.go
+++ b/internal/core/metadata/config.go
@@ -14,8 +14,6 @@
 package metadata
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -29,7 +27,7 @@ type ConfigurationStruct struct {
 	Notifications config.NotificationInfo
 	Registry      config.RegistryInfo
 	Service       config.ServiceInfo
-	SecretStore   vault.SecretConfig
+	SecretStore   config.SecretStoreInfo
 	Startup       config.StartupInfo
 }
 

--- a/internal/export/client/config.go
+++ b/internal/export/client/config.go
@@ -14,8 +14,6 @@
 package client
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -27,7 +25,7 @@ type ConfigurationStruct struct {
 	Logging     config.LoggingInfo
 	Registry    config.RegistryInfo
 	Service     config.ServiceInfo
-	SecretStore vault.SecretConfig
+	SecretStore config.SecretStoreInfo
 	Startup     config.StartupInfo
 }
 

--- a/internal/export/distro/config.go
+++ b/internal/export/distro/config.go
@@ -14,8 +14,6 @@
 package distro
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -29,7 +27,7 @@ type ConfigurationStruct struct {
 	AnalyticsQueue config.MessageQueueInfo
 	Registry       config.RegistryInfo
 	Service        config.ServiceInfo
-	SecretStore    vault.SecretConfig
+	SecretStore    config.SecretStoreInfo
 	Startup        config.StartupInfo
 }
 

--- a/internal/pkg/bootstrap/interfaces/configuration.go
+++ b/internal/pkg/bootstrap/interfaces/configuration.go
@@ -15,8 +15,6 @@
 package interfaces
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
 
@@ -26,7 +24,7 @@ type BootstrapConfiguration struct {
 	Service     config.ServiceInfo
 	Registry    config.RegistryInfo
 	Logging     config.LoggingInfo
-	SecretStore vault.SecretConfig
+	SecretStore config.SecretStoreInfo
 	Startup     config.StartupInfo
 }
 

--- a/internal/pkg/config/types.go
+++ b/internal/pkg/config/types.go
@@ -16,6 +16,7 @@ package config
 import (
 	"fmt"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
 )
 
 func ListDefaultServices() map[string]string {
@@ -185,4 +186,11 @@ type NotificationInfo struct {
 	PostDeviceChanges bool
 	Sender            string
 	Slug              string
+}
+
+// SecretStoreInfo encapsulates configuration properties used to create a SecretClient.
+type SecretStoreInfo struct {
+	vault.SecretConfig
+	// TokenFile provides a location to a token file.
+	TokenFile string
 }

--- a/internal/support/logging/config.go
+++ b/internal/support/logging/config.go
@@ -14,8 +14,6 @@
 package logging
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -26,7 +24,7 @@ type ConfigurationStruct struct {
 	Logging     config.LoggingInfo
 	Registry    config.RegistryInfo
 	Service     config.ServiceInfo
-	SecretStore vault.SecretConfig
+	SecretStore config.SecretStoreInfo
 	Startup     config.StartupInfo
 }
 

--- a/internal/support/notifications/config.go
+++ b/internal/support/notifications/config.go
@@ -16,8 +16,6 @@
 package notifications
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -30,7 +28,7 @@ type ConfigurationStruct struct {
 	Registry    config.RegistryInfo
 	Service     config.ServiceInfo
 	Smtp        SmtpInfo
-	SecretStore vault.SecretConfig
+	SecretStore config.SecretStoreInfo
 	Startup     config.StartupInfo
 }
 

--- a/internal/support/scheduler/config.go
+++ b/internal/support/scheduler/config.go
@@ -15,8 +15,6 @@
 package scheduler
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -31,7 +29,7 @@ type ConfigurationStruct struct {
 	Service         config.ServiceInfo
 	Intervals       map[string]config.IntervalInfo
 	IntervalActions map[string]config.IntervalActionInfo
-	SecretStore     vault.SecretConfig
+	SecretStore     config.SecretStoreInfo
 	Startup         config.StartupInfo
 }
 

--- a/internal/system/agent/config/config.go
+++ b/internal/system/agent/config/config.go
@@ -15,8 +15,6 @@
 package config
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
@@ -32,7 +30,7 @@ type ConfigurationStruct struct {
 	Registry         config.RegistryInfo
 	Logging          config.LoggingInfo
 	FormatSpecifier  string
-	SecretStore      vault.SecretConfig
+	SecretStore      config.SecretStoreInfo
 	Startup          config.StartupInfo
 }
 


### PR DESCRIPTION
Fix #1876

Update secret.BootstrapHandler to read the Vault token from a file
specified in the configuration.

Create a new SecretStoreInfo type which encapsulates the SecretConfig
and adds a configuration property for tokenfile information.

Update service specific configurations to use the newly created
SecretStoreInfo rather than SecretConfig so the tokenfile information
can be captured in the struct.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>