### PR TITLE
Fixes #1814 (nil panic while logging missing res/configuration.toml)

### DIFF
--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -69,6 +69,10 @@ func main() {
 		BootTimeout: internal.BootTimeoutDefault,
 	}
 	startup.Bootstrap(params, secretstore.Retry, logBeforeInit)
+	if secretstore.Configuration == nil {
+		// secretstore.LoggingClient wasn't initialized either
+		os.Exit(1)
+	}
 
 	//step 1: boot up secretstore general steps same as other EdgeX microservice
 

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -14,17 +14,18 @@
 package internal
 
 const (
-	BootTimeoutDefault             = BootTimeoutSecondsDefault * 1000
-	BootTimeoutSecondsDefault      = 30
-	BootRetrySecondsDefault        = 1
-	ClientMonitorDefault           = 15000
-	ConfigFileName                 = "configuration.toml"
-	ConfigRegistryStemCore         = "edgex/core/"
-	ConfigRegistryStemSecurity     = "edgex/security/"
-	ConfigMajorVersion             = "1.0/"
-	LogDurationKey                 = "duration"
-	SecuritySecretsSetupServiceKey = "edgex-security-secrets-setup"
-	SecurityProxySetupServiceKey   = "edgex-security-proxy-setup"
+	BootTimeoutDefault                 = BootTimeoutSecondsDefault * 1000
+	BootTimeoutSecondsDefault          = 30
+	BootRetrySecondsDefault            = 1
+	ClientMonitorDefault               = 15000
+	ConfigFileName                     = "configuration.toml"
+	ConfigRegistryStemCore             = "edgex/core/"
+	ConfigRegistryStemSecurity         = "edgex/security/"
+	ConfigMajorVersion                 = "1.0/"
+	LogDurationKey                     = "duration"
+	SecuritySecretStoreSetupServiceKey = "edgex-security-secretstore-setup"
+	SecuritySecretsSetupServiceKey     = "edgex-security-secrets-setup"
+	SecurityProxySetupServiceKey       = "edgex-security-proxy-setup"
 )
 
 const (

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 // Global variables
@@ -34,6 +35,11 @@ func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sy
 		var err error
 		// When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
+			// Next two lines are workaround for issue #1814 (nil panic while logging)
+			// where config.LoadFromFile depends on a global LoggingClient that isn't set anywhere
+			// Remove this workaround once this tool is migrated to common bootstrap.
+			lc := logger.NewClient(internal.SecuritySecretStoreSetupServiceKey, false, "", models.InfoLog)
+			config.LoggingClient = lc
 			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err
@@ -46,7 +52,7 @@ func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sy
 			} else {
 				// Setup Logging
 				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(internal.SecurityProxySetupServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
+				LoggingClient = logger.NewClient(internal.SecuritySecretStoreSetupServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
 			}
 		}
 		// This seems a bit artificial here due to lack of additional service requirements


### PR DESCRIPTION
security-secretsstore-setup is not migrating to common bootstrap
in this release. The config module can panic() while calling
deprecated methods to load the configuration while attempting
to log that configuration.toml cannot be found.

This patch sets the global variable before attempting to call
the deprecated configuration loading functions and then forces
the utility to exit if configuration cannot be loaded.
This is a temporary workaround until the utility can be
migrated to use the common bootstrap.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>