### PR TITLE
security-secretstore-setup Credential Creation

### DIFF
--- a/cmd/config-seed/Attribution.txt
+++ b/cmd/config-seed/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/core-data/Attribution.txt
+++ b/cmd/core-data/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/export-client/Attribution.txt
+++ b/cmd/export-client/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/export-distro/Attribution.txt
+++ b/cmd/export-distro/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/security-proxy-setup/Attribution.txt
+++ b/cmd/security-proxy-setup/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/security-secrets-setup/Attribution.txt
+++ b/cmd/security-secrets-setup/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/security-secretstore-setup/Attribution.txt
+++ b/cmd/security-secretstore-setup/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -165,6 +165,7 @@ func main() {
 
 	// credential creation
 	gk := secretstore.NewGokeyGenerator(absPath)
+	secretstore.LoggingClient.Warn("WARNING: The gokey generator is a reference implementation for credential generation and the underlying libraries not been reviewed for cryptographic security. The user is encouraged to perform their own security investigation before deployment.")
 	cred := secretstore.NewCred(req, absPath, gk)
 	for dbname, info := range secretstore.Configuration.Databases {
 		service := info.Service

--- a/cmd/security-secretstore-setup/res/configuration.toml
+++ b/cmd/security-secretstore-setup/res/configuration.toml
@@ -38,3 +38,48 @@ vaultsecretthreshold = 3
 [Startup]
 Duration = 30
 Interval = 1
+
+[Databases]
+  [Databases.admin]
+  Username = "admin"
+
+  [Databases.authorization]
+  Username = "admin"
+
+  [Databases.config]
+  Username = "admin"
+
+  [Databases.local]
+  Username = "admin"
+
+  [Databases.metadata]
+  Service = "metadata"
+  Username = "meta"
+
+  [Databases.coredata]
+  Service = "coredata"
+  Username = "core"
+
+  [Databases.rulesengine]
+  Service = "rulesengine"
+  Username = "rulesengine"
+
+  [Databases.notifications]
+  Service = "notifications"
+  Username = "notifications"
+
+  [Databases.scheduler]
+  Service = "scheduler"
+  Username = "scheduler"
+
+  [Databases.logging]
+  Service = "logging"
+  Username = "logging"
+
+  [Databases.exportclient]
+  Service = "exportclient"
+  Username = "exportclient"
+
+  [Databases.application-service]
+  Service = "appservice"
+  Username = "appservice"

--- a/cmd/security-secretstore-setup/res/docker/configuration.toml
+++ b/cmd/security-secretstore-setup/res/docker/configuration.toml
@@ -38,3 +38,48 @@ vaultsecretthreshold = 3
 [Startup]
 Duration = 30
 Interval = 1
+
+[Databases]
+  [Databases.admin]
+  Username = "admin"
+
+  [Databases.authorization]
+  Username = "admin"
+
+  [Databases.config]
+  Username = "admin"
+
+  [Databases.local]
+  Username = "admin"
+
+  [Databases.metadata]
+  Service = "metadata"
+  Username = "meta"
+
+  [Databases.coredata]
+  Service = "coredata"
+  Username = "core"
+
+  [Databases.rulesengine]
+  Service = "rulesengine"
+  Username = "rulesengine"
+
+  [Databases.notifications]
+  Service = "notifications"
+  Username = "notifications"
+
+  [Databases.scheduler]
+  Service = "scheduler"
+  Username = "scheduler"
+
+  [Databases.logging]
+  Service = "logging"
+  Username = "logging"
+
+  [Databases.exportclient]
+  Service = "exportclient"
+  Username = "exportclient"
+
+  [Databases.application-service]
+  Service = "appservice"
+  Username = "appservice"

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/sys-mgmt-executor/Attribution.txt
+++ b/cmd/sys-mgmt-executor/Attribution.txt
@@ -143,3 +143,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.5
+	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.1.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.28

--- a/internal/security/secretstore/config.go
+++ b/internal/security/secretstore/config.go
@@ -24,9 +24,15 @@ type ConfigurationStruct struct {
 	Writable      WritableInfo
 	Logging       config.LoggingInfo
 	SecretService secretstoreclient.SecretServiceInfo
+	Databases     map[string]Database
 }
 
 type WritableInfo struct {
 	LogLevel string
 	Title    string
+}
+
+type Database struct {
+	Username string
+	Service  string
 }

--- a/internal/security/secretstore/password.go
+++ b/internal/security/secretstore/password.go
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package secretstore
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/cloudflare/gokey"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+)
+
+// CredentialGenerator returns a credential generated with random algorithm for secret store
+type CredentialGenerator interface {
+	Generate() (string, error)
+}
+
+type CredCollect struct {
+	Pair UserPasswordPair `json:"data"`
+}
+
+type UserPasswordPair struct {
+	User     string `json:"user,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+type Cred struct {
+	client    internal.HttpCaller
+	tokenPath string
+}
+
+func NewCred(caller internal.HttpCaller, tpath string) Cred {
+	return Cred{client: caller, tokenPath: tpath}
+}
+
+func (cr *Cred) AlreadyInStore(path string) (bool, error) {
+	pair, err := cr.getUserPasswordPair(path)
+	if err != nil {
+		if err == errNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	if len(pair.User) > 0 && len(pair.Password) > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (cr *Cred) getUserPasswordPair(path string) (*UserPasswordPair, error) {
+	t, err := GetAccessToken(cr.tokenPath)
+	if err != nil {
+		return nil, err
+	}
+	pair, err := cr.retrieve(t, path)
+	if err != nil {
+		return nil, err
+	}
+	return pair, nil
+}
+
+func (cr *Cred) retrieve(t string, path string) (*UserPasswordPair, error) {
+	credUrl, err := cr.credPathURL(path)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, credUrl, nil)
+	if err != nil {
+		e := fmt.Errorf("error creating http request: %v", err.Error())
+		LoggingClient.Error(e.Error())
+		return nil, e
+	}
+
+	req.Header.Set(VaultToken, t)
+	resp, err := cr.client.Do(req)
+	if err != nil {
+		e := fmt.Errorf("failed to retrieve the credential pair on path %s with error %s", path, err.Error())
+		LoggingClient.Error(e.Error())
+		return nil, e
+	}
+	defer resp.Body.Close()
+
+	cred := CredCollect{}
+
+	if resp.StatusCode == http.StatusNotFound {
+		LoggingClient.Info(fmt.Sprintf("credential pair NOT found in secret store @/%s, status: %s", path, resp.Status))
+		return nil, errNotFound
+	} else if resp.StatusCode != http.StatusOK {
+		e := fmt.Errorf("failed to retrieve the credential pair on path %s with error code %d", path, resp.StatusCode)
+		LoggingClient.Error(e.Error())
+		return nil, e
+	}
+
+	if err = json.NewDecoder(resp.Body).Decode(&cred); err != nil {
+		e := fmt.Errorf("error decoding json response when retrieving credential pair: %s", err.Error())
+		LoggingClient.Error(e.Error())
+		return nil, e
+	}
+
+	return &cred.Pair, nil
+}
+
+func (cr *Cred) credPathURL(path string) (string, error) {
+	baseURL, err := url.Parse(Configuration.SecretService.GetSecretSvcBaseURL())
+	if err != nil {
+		e := fmt.Errorf("error parsing secret-service url.  check server and port properties")
+		LoggingClient.Error(e.Error())
+		return "", err
+	}
+
+	p, err := url.Parse(path)
+	if err != nil {
+		e := fmt.Errorf("error parsing secret-service credpath.  check credpath property")
+		LoggingClient.Error(e.Error())
+		return "", err
+	}
+
+	fullURL := baseURL.ResolveReference(p)
+	return fullURL.String(), nil
+}
+
+func (cr *Cred) Generate(service string) (string, error) {
+	passSpec := &gokey.PasswordSpec{
+		Length:         16,
+		Upper:          3,
+		Lower:          3,
+		Digits:         2,
+		Special:        1,
+		AllowedSpecial: "",
+	}
+	t, err := GetAccessToken(cr.tokenPath)
+	if err != nil {
+		return "", err
+	}
+	return gokey.GetPass(t, service, nil, passSpec)
+}
+
+func (cr *Cred) UploadToStore(pair *UserPasswordPair, path string) error {
+	t, err := GetAccessToken(cr.tokenPath)
+	if err != nil {
+		return err
+	}
+
+	LoggingClient.Info("trying to upload the credential pair into secret store")
+	jsonBytes, err := json.Marshal(pair)
+	body := bytes.NewBuffer(jsonBytes)
+
+	credURL, err := cr.credPathURL(path)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, credURL, body)
+	if err != nil {
+		e := fmt.Errorf("error creating http request: %v", err.Error())
+		LoggingClient.Error(e.Error())
+		return e
+	}
+
+	req.Header.Set(VaultToken, t)
+	resp, err := cr.client.Do(req)
+	if err != nil {
+		e := fmt.Sprintf("failed to upload the credential pair on path %s: %s", path, err.Error())
+		LoggingClient.Error(e)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		e := fmt.Errorf("failed to load the credential pair to the secret store: %s %s", resp.Status, string(b))
+		LoggingClient.Error(e.Error())
+		return e
+	}
+
+	LoggingClient.Info("successfully uploaded the credential pair into secret store")
+	return nil
+}

--- a/internal/security/secretstore/password.go
+++ b/internal/security/secretstore/password.go
@@ -72,11 +72,11 @@ type UserPasswordPair struct {
 type Cred struct {
 	client    internal.HttpCaller
 	tokenPath string
-	g         CredentialGenerator
+	generator CredentialGenerator
 }
 
-func NewCred(caller internal.HttpCaller, tpath string, g CredentialGenerator) Cred {
-	return Cred{client: caller, tokenPath: tpath, g: g}
+func NewCred(caller internal.HttpCaller, tpath string, generator CredentialGenerator) Cred {
+	return Cred{client: caller, tokenPath: tpath, generator: generator}
 }
 
 func (cr *Cred) AlreadyInStore(path string) (bool, error) {
@@ -167,7 +167,7 @@ func (cr *Cred) credPathURL(path string) (string, error) {
 }
 
 func (cr *Cred) GeneratePassword(service string) (string, error) {
-	return cr.g.Generate(service)
+	return cr.generator.Generate(service)
 }
 
 func (cr *Cred) UploadToStore(pair *UserPasswordPair, path string) error {

--- a/internal/security/secretstore/password_test.go
+++ b/internal/security/secretstore/password_test.go
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package secretstore
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+)
+
+func TestGenerate(t *testing.T) {
+	LoggingClient = logger.MockLogger{}
+	tokenPath := "testdata/test-resp-init.json"
+	cr := NewCred(&http.Client{}, tokenPath)
+
+	realm1 := "service1"
+	realm2 := "service2"
+
+	p1, err := cr.Generate(realm1)
+	if err != nil {
+		t.Errorf("failed to create credential")
+		t.Errorf(err.Error())
+	}
+	p2, err := cr.Generate(realm2)
+	if err != nil {
+		t.Errorf("failed to create credential")
+		t.Errorf(err.Error())
+	}
+	if p1 == p2 {
+		t.Errorf("error: different master key and realm combination need to generate different passwords")
+	}
+}
+
+func TestRetrieveCred(t *testing.T) {
+	LoggingClient = logger.MockLogger{}
+
+	credPath := "testCredPath"
+	token := "token"
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data": {"user": "test-user", "password": "test-password"}}`))
+		if r.Method != "GET" {
+			t.Errorf("expected GET request, got %s instead", r.Method)
+		}
+
+		if r.URL.EscapedPath() != fmt.Sprintf("/%s", credPath) {
+			t.Errorf("expected request to /%s, got %s instead", credPath, r.URL.EscapedPath())
+		}
+
+		if r.Header.Get(VaultToken) != token {
+			t.Errorf("expected request header for %s is %s, got %s instead", VaultToken, token, r.Header.Get(VaultToken))
+		}
+	}))
+	defer ts.Close()
+
+	parsed, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Errorf("unable to parse test server URL %s", ts.URL)
+		return
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Errorf("parsed port number cannot be converted to int %s", parsed.Port())
+		return
+	}
+
+	oldConfig := Configuration
+	defer func() { Configuration = oldConfig }()
+
+	Configuration = &ConfigurationStruct{}
+	Configuration.SecretService = secretstoreclient.SecretServiceInfo{
+		Server: parsed.Hostname(),
+		Port:   port,
+		Scheme: "https",
+	}
+
+	cr := NewCred(NewRequester(true), "")
+	pair, err := cr.retrieve(token, credPath)
+	if err != nil {
+		t.Errorf("failed to retrieve credential pair")
+		t.Errorf(err.Error())
+	}
+	if pair.User != "test-user" || pair.Password != "test-password" {
+		t.Errorf("failed to parse credential pair")
+	}
+}

--- a/internal/security/secretstore/password_test.go
+++ b/internal/security/secretstore/password_test.go
@@ -31,17 +31,18 @@ import (
 func TestGenerate(t *testing.T) {
 	LoggingClient = logger.MockLogger{}
 	tokenPath := "testdata/test-resp-init.json"
-	cr := NewCred(&http.Client{}, tokenPath)
+	gk := NewGokeyGenerator(tokenPath)
+	cr := NewCred(&http.Client{}, tokenPath, gk)
 
 	realm1 := "service1"
 	realm2 := "service2"
 
-	p1, err := cr.Generate(realm1)
+	p1, err := cr.GeneratePassword(realm1)
 	if err != nil {
 		t.Errorf("failed to create credential")
 		t.Errorf(err.Error())
 	}
-	p2, err := cr.Generate(realm2)
+	p2, err := cr.GeneratePassword(realm2)
 	if err != nil {
 		t.Errorf("failed to create credential")
 		t.Errorf(err.Error())
@@ -94,7 +95,7 @@ func TestRetrieveCred(t *testing.T) {
 		Scheme: "https",
 	}
 
-	cr := NewCred(NewRequester(true), "")
+	cr := NewCred(NewRequester(true), "", NewGokeyGenerator(""))
 	pair, err := cr.retrieve(token, credPath)
 	if err != nil {
 		t.Errorf("failed to retrieve credential pair")


### PR DESCRIPTION
Fixes #1676 

This PR implements the functionality to create database/mongodb credentials and store them in Vault during security-secretstore-setup initialization.

There are a few subtleties around this process.

1. The databases to have credentials created are specified in a new section of the security-secretstore-setup config file (for now).  I know that @tingyuz and @michaelestrin have had discussions on other ways to implement this, but they're out of scope for Fuji.

2. For some databases (core-data, for example), a specific service needs access to the credentials as well as the mongo service.  For others (admin, authorization, config, local), only the mongo service needs access.   This separation is handled by having a "service" key in the config section of each database to specify if the credential should be added to a service-specific path (e.g., `secret/edgex/coredata/mongodb`).

3. The gokey library used to create credentials uses the vault token and the service name to generate durable (subsequent requests to generate passwords for the same token/service name will generate the same password), secure passwords.  As a result of this, the password for each service is generated, then vault is checked to see if it already contains credentials at the path, and if not they are stored at the path.  For the credentials that need to be stored in two paths, if for some reason they are found in just one (as a result of an interrupted initialization, for example), re-generating and storing in just the missing one will work fine.

## To test:
1. Inside `cmd/security-secretstore-setup/res/configuration.toml`, edit the `[SecretStore]` section for the following fields:
```
server = "localhost"
scheme = "http"
cafilepath = "/Users/jdharms/workspace/edgex-go/cmd/security-secretstore-setup/EdgeXFoundryCA.pem"
certfilepath = "/Users/jdharms/workspace/edgex-go/cmd/security-secretstore-setup/edgex-kong.pem"
keyfilepath = "/Users/jdharms/workspace/edgex-go/cmd/security-secretstore-setup/edgex-kong.priv.key"
tokenfolderpath = "/Users/jdharms/workspace/edgex-go/cmd/security-secretstore-setup"
```
2. Ensure the paths in the previous step point to files on your file system and not mine.  The contents of these files are not important right now; I just used the filenames.
3. Run vault with flag `-dev-kv-v1` to ensure the right version of the secrets engine (alternatively bring up the v1 kv some other way)
```
vault server -dev -dev-kv-v1
```
4. `VAULT_ADDR='http://127.0.0.1:8200' vault operator seal` will seal the local development server.
4. Create a resp-init.json file if it doesn't exist inside the tokenfolderpath above.  The contents should be:
```
{
  "keys": [
    "test-keys"
  ],
  "keys_base64": [
    "UsI8HbpFCt9zqVePbo4CvsijhlNaC7ckKiDnNiBt3F4="
  ],
  "root_token": "s.MRPe8MVhaSePWcfDdHQsMImy"
}
```
Where the `root_token` value is the root token for your dev mode vault instance and `keys_base64` is the Unseal Key.
5. Make build and executing the security-secretstore-setup with --init=true binary should succeed.
6. Check for existence of mongodb credentials in vault:
```
$ vault kv get secret/edgex/mongo/coredata
$ vault kv get secret/edgex/coredata/mongodb # should be the same
$ vault kv get secret/edgex/admin/mongodb # should not exist
$ vault kv get secret/edgex/mongo/admin # should exist