### PR TITLE
Makefile: rename security docker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,27 +171,29 @@ docker_sys_mgmt_agent:
 		.
 
 docker_security_secrets_setup:
+	# TODO: split this up and rename it when security-secrets-setup is a 
+	# different container
 	docker build \
 		-f cmd/security-secrets-setup/Dockerfile \
 		--label "git_sha=$(GIT_SHA)" \
-		-t edgexfoundry/docker-edgex-vault:$(GIT_SHA) \
-		-t edgexfoundry/docker-edgex-vault:$(DOCKER_TAG) \
+		-t edgexfoundry/docker-edgex-secret-store-go:$(GIT_SHA) \
+		-t edgexfoundry/docker-edgex-secret-store-go:$(DOCKER_TAG) \
 		.
 
 docker_security_proxy_setup:
 	docker build \
 		-f cmd/security-proxy-setup/Dockerfile \
 		--label "git_sha=$(GIT_SHA)" \
-		-t edgexfoundry/docker-edgex-proxy-go:$(GIT_SHA) \
-		-t edgexfoundry/docker-edgex-proxy-go:$(DOCKER_TAG) \
+		-t edgexfoundry/docker-edgex-security-proxy-setup-go:$(GIT_SHA) \
+		-t edgexfoundry/docker-edgex-security-proxy-setup-go:$(DOCKER_TAG) \
 		.
 
 docker_security_secretstore_setup:
 		docker build \
 		-f cmd/security-secretstore-setup/Dockerfile \
 		--label "git_sha=$(GIT_SHA)" \
-		-t edgexfoundry/docker-edgex-vault-worker-go:$(GIT_SHA) \
-		-t edgexfoundry/docker-edgex-vault-worker-go:$(DOCKER_TAG) \
+		-t edgexfoundry/docker-edgex-security-secretstore-setup-go:$(GIT_SHA) \
+		-t edgexfoundry/docker-edgex-security-secretstore-setup-go:$(DOCKER_TAG) \
 		.
 
 raml_verify:


### PR DESCRIPTION
Rename security docker containers:
* docker-edgex-vault -> docker-edgex-secret-store-go
* docker-edgex-proxy-go -> docker-edgex-security-proxy-setup-go
* docker-edgex-vault-worker-go -> docker-edgex-security-secretstore-setup-go

To test, just run `make docker` and observe that all the builds finish. Will require an update to the docker-compose for Fuji in developer-scripts

Fixes #1933 