### PR TITLE
Update to obtain DB credentials from secret store

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -59,7 +59,7 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			secret.BootstrapHandler,
+			secret.NewSecret().BootstrapHandler,
 			database.NewDatabase(&httpServer, command.Configuration).BootstrapHandler,
 			command.BootstrapHandler,
 			telemetry.BootstrapHandler,

--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -45,7 +45,7 @@ File = './logs/edgex-core-command.log'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secrets/edgex/core-command/'
+Path = '/v1/secret/edgex/corecommand/'
 Protocol = 'http'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/core-command/res/docker/configuration.toml
+++ b/cmd/core-command/res/docker/configuration.toml
@@ -45,7 +45,7 @@ File = '/edgex/logs/edgex-core-command.log'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secrets/edgex/core-command/'
+Path = '/v1/secret/edgex/corecommand/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -60,7 +60,7 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			secret.BootstrapHandler,
+			secret.NewSecret().BootstrapHandler,
 			database.NewDatabaseForCoreData(&httpServer, data.Configuration).BootstrapHandler,
 			data.BootstrapHandler,
 			telemetry.BootstrapHandler,

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -58,7 +58,7 @@ Topic = 'events'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/core-data/'
+Path = '/v1/secret/edgex/coredata/'
 Protocol = 'http'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/core-data/res/docker/configuration.toml
+++ b/cmd/core-data/res/docker/configuration.toml
@@ -57,7 +57,7 @@ Topic = 'events'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secrets/edgex/core-data/'
+Path = '/v1/secret/edgex/coredata/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -59,7 +59,7 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			secret.BootstrapHandler,
+			secret.NewSecret().BootstrapHandler,
 			database.NewDatabase(&httpServer, metadata.Configuration).BootstrapHandler,
 			metadata.BootstrapHandler,
 			telemetry.BootstrapHandler,

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -58,7 +58,7 @@ Label = 'metadata'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secrets/edgex/core-metadata/'
+Path = '/v1/secret/edgex/coremetadata/'
 Protocol = 'http'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/core-metadata/res/docker/configuration.toml
+++ b/cmd/core-metadata/res/docker/configuration.toml
@@ -57,7 +57,7 @@ Label = 'metadata'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secrets/edgex/core-metadata/'
+Path = '/v1/secret/edgex/coremetadata/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/cmd/export-client/main.go
+++ b/cmd/export-client/main.go
@@ -54,7 +54,7 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			secret.BootstrapHandler,
+			secret.NewSecret().BootstrapHandler,
 			database.NewDatabase(&httpServer, client.Configuration).BootstrapHandler,
 			client.BootstrapHandler,
 			telemetry.BootstrapHandler,

--- a/cmd/export-client/res/configuration.toml
+++ b/cmd/export-client/res/configuration.toml
@@ -45,7 +45,7 @@ File = './logs/edgex-export-client.log'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secrets/edgex/export-client/'
+Path = '/v1/secret/edgex/exportclient/'
 Protocol = 'http'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/export-client/res/docker/configuration.toml
+++ b/cmd/export-client/res/docker/configuration.toml
@@ -45,7 +45,7 @@ File = '/edgex/logs/edgex-export-client.log'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secrets/edgex/export-client/'
+Path = '/v1/secret/edgex/exportclient/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/cmd/export-distro/main.go
+++ b/cmd/export-distro/main.go
@@ -54,7 +54,7 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			secret.BootstrapHandler,
+			secret.NewSecret().BootstrapHandler,
 			distro.BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,

--- a/cmd/export-distro/res/configuration.toml
+++ b/cmd/export-distro/res/configuration.toml
@@ -63,7 +63,7 @@ Type = 'zero'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secrets/edgex/export-distro/'
+Path = '/v1/secret/edgex/exportdistro/'
 Protocol = 'http'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/export-distro/res/docker/configuration.toml
+++ b/cmd/export-distro/res/docker/configuration.toml
@@ -63,7 +63,7 @@ Type = 'zero'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secrets/edgex/export-distro/'
+Path = '/v1/secret/edgex/exportdistro/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -53,7 +53,7 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			secret.BootstrapHandler,
+			secret.NewSecret().BootstrapHandler,
 			logging.NewServiceInit(&httpServer).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,

--- a/cmd/support-logging/res/configuration.toml
+++ b/cmd/support-logging/res/configuration.toml
@@ -34,7 +34,7 @@ File = './logs/edgex-support-logging.log'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secrets/edgex/support-logging/'
+Path = '/v1/secret/edgex/supportlogging/'
 Protocol = 'http'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/support-logging/res/docker/configuration.toml
+++ b/cmd/support-logging/res/docker/configuration.toml
@@ -34,7 +34,7 @@ File = '/edgex/logs/edgex-support-logging.log'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secrets/edgex/support-logging/'
+Path = '/v1/secret/edgex/supportlogging/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -65,7 +65,7 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			secret.BootstrapHandler,
+			secret.NewSecret().BootstrapHandler,
 			database.NewDatabase(&httpServer, notifications.Configuration).BootstrapHandler,
 			notifications.BootstrapHandler,
 			telemetry.BootstrapHandler,

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -50,7 +50,7 @@ File = './logs/edgex-support-notifications.log'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secrets/edgex/support-notifications/'
+Path = '/v1/secret/edgex/supportnotifications/'
 Protocol = 'http'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/support-notifications/res/docker/configuration.toml
+++ b/cmd/support-notifications/res/docker/configuration.toml
@@ -50,7 +50,7 @@ File = '/edgex/logs/edgex-support-notifications.log'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secrets/edgex/support-notifications/'
+Path = '/v1/secret/edgex/supportnotifications/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -59,7 +59,7 @@ func main() {
 		startupTimer,
 		di.NewContainer(di.ServiceConstructorMap{}),
 		[]interfaces.BootstrapHandler{
-			secret.BootstrapHandler,
+			secret.NewSecret().BootstrapHandler,
 			database.NewDatabase(&httpServer, scheduler.Configuration).BootstrapHandler,
 			scheduler.BootstrapHandler,
 			telemetry.BootstrapHandler,

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -68,7 +68,7 @@ File = './logs/edgex-support-scheduler.log'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secrets/edgex/support-scheduler/'
+Path = '/v1/secret/edgex/supportscheduler/'
 Protocol = 'http'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/support-scheduler/res/docker/configuration.toml
+++ b/cmd/support-scheduler/res/docker/configuration.toml
@@ -68,7 +68,7 @@ File = '/edgex/logs/edgex-support-scheduler.log'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secrets/edgex/support-scheduler/'
+Path = '/v1/secret/edgex/supportscheduler/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -69,7 +69,7 @@ func main() {
 		startupTimer,
 		dic,
 		[]interfaces.BootstrapHandler{
-			secret.BootstrapHandler,
+			secret.NewSecret().BootstrapHandler,
 			agent.BootstrapHandler,
 			httpServer.BootstrapHandler,
 			message.NewBootstrap(clients.SystemManagementAgentServiceKey, edgex.Version).BootstrapHandler,

--- a/cmd/sys-mgmt-agent/res/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/configuration.toml
@@ -80,7 +80,7 @@ File = './logs/edgex-sys-mgmt-agent.log'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secrets/edgex/sys-mgmt-agent/'
+Path = '/v1/secret/edgex/sysmgmtagent/'
 Protocol = 'http'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/sys-mgmt-agent/res/docker/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/docker/configuration.toml
@@ -80,7 +80,7 @@ File = '/edgex/logs/edgex-sys-mgmt-agent.log'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secrets/edgex/sys-mgmt-agent/'
+Path = '/v1/secret/edgex/sysmgmtagent/'
 Protocol = 'http'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/internal/pkg/bootstrap/container/credentials.go
+++ b/internal/pkg/bootstrap/container/credentials.go
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright 2019 Dell Inc.
+/********************************************************************************
+ *  Copyright 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,15 +15,15 @@
 package container
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg"
-
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 )
 
-// SecretClientName contains the name of the registry.Client implementation in the DIC.
-var SecretClientName = di.TypeInstanceToName((*pkg.SecretClient)(nil))
+// CredentialsProviderName contains the name of the interfaces.CredentialsProvider implementation in the DIC.
+var CredentialsProviderName = di.TypeInstanceToName((*interfaces.CredentialsProvider)(nil))
 
-// SecretClientFrom helper function queries the DIC and returns the pkg.SecretClient implementation.
-func SecretClientFrom(get di.Get) pkg.SecretClient {
-	return get(SecretClientName).(pkg.SecretClient)
+// CredentialsProviderFrom helper function queries the DIC and returns the interfaces.CredentialsProviderName
+// implementation.
+func CredentialsProviderFrom(get di.Get) interfaces.CredentialsProvider {
+	return get(CredentialsProviderName).(interfaces.CredentialsProvider)
 }

--- a/internal/pkg/bootstrap/handlers/secret/credentials.go
+++ b/internal/pkg/bootstrap/handlers/secret/credentials.go
@@ -1,0 +1,43 @@
+/********************************************************************************
+ *  Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package secret
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+)
+
+func (s *SecretProvider) GetDatabaseCredentials(database config.Database) (config.Credentials, error) {
+	// If security is disabled or the database is Redis then we are to use the credentials supplied by the
+	// configuration. The reason we do this for Redis is because Redis does not have an authentication nor an
+	// authorization mechanism.
+	if !s.isSecurityEnabled() || database.Type == db.RedisDB {
+		return config.Credentials{
+			Username: database.Username,
+			Password: database.Password,
+		}, nil
+	}
+
+	secrets, err := s.secretClient.GetSecrets(database.Type, "username", "password")
+	if err != nil {
+		return config.Credentials{}, err
+	}
+
+	return config.Credentials{
+		Username: secrets["username"],
+		Password: secrets["password"],
+	}, nil
+
+}

--- a/internal/pkg/bootstrap/interfaces/database.go
+++ b/internal/pkg/bootstrap/interfaces/database.go
@@ -21,3 +21,9 @@ type Database interface {
 	// GetDatabaseInfo returns a database information map.
 	GetDatabaseInfo() config.DatabaseInfo
 }
+
+// CredentialsProvider interface provides an abstraction for obtaining credentials.
+type CredentialsProvider interface {
+	// GetDatabaseCredentials retrieves database credentials.
+	GetDatabaseCredentials(database config.Database) (config.Credentials, error)
+}

--- a/internal/pkg/config/types.go
+++ b/internal/pkg/config/types.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
 )
@@ -111,15 +112,7 @@ func (m MessageQueueInfo) Uri() string {
 }
 
 // DatabaseInfo defines the parameters necessary for connecting to the desired persistence layer.
-type DatabaseInfo map[string]struct {
-	Type     string
-	Timeout  int
-	Host     string
-	Port     int
-	Username string
-	Password string
-	Name     string
-}
+type DatabaseInfo map[string]Database
 
 type IntervalInfo struct {
 	// Name of the schedule must be unique?
@@ -193,4 +186,19 @@ type SecretStoreInfo struct {
 	vault.SecretConfig
 	// TokenFile provides a location to a token file.
 	TokenFile string
+}
+
+type Database struct {
+	Credentials
+	Type    string
+	Timeout int
+	Host    string
+	Port    int
+	Name    string
+}
+
+// Credentials encapsulates username-password attributes.
+type Credentials struct {
+	Username string
+	Password string
 }

--- a/internal/support/logging/mongo.go
+++ b/internal/support/logging/mongo.go
@@ -11,8 +11,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 
 	mgo "github.com/globalsign/mgo"
 	bson "github.com/globalsign/mgo/bson"
@@ -22,13 +24,13 @@ type mongoLog struct {
 	session *mgo.Session // Mongo database session
 }
 
-func connectToMongo() (*mgo.Session, error) {
+func connectToMongo(credentials config.Credentials) (*mgo.Session, error) {
 	mongoDBDialInfo := &mgo.DialInfo{
 		Addrs:    []string{Configuration.Databases["Primary"].Host + ":" + strconv.Itoa(Configuration.Databases["Primary"].Port)},
 		Timeout:  time.Duration(Configuration.Databases["Primary"].Timeout) * time.Millisecond,
 		Database: Configuration.Databases["Primary"].Name,
-		Username: Configuration.Databases["Primary"].Username,
-		Password: Configuration.Databases["Primary"].Password,
+		Username: credentials.Username,
+		Password: credentials.Password,
 	}
 
 	ms, err := mgo.DialWithInfo(mongoDBDialInfo)


### PR DESCRIPTION
Fix #1341

Update database.BootstrapHandler and support-logging's init.go to use
the SecretClient to obtain database credentials when security features
have been enabled.

Create helper functions for determining if security is enabled and
another for obtaining database credentials.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>