### PR TITLE
Add git rev to snap version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -343,7 +343,10 @@ parts:
     # since it changes rarely and therefore will not trigger a new pull
     source: snap/local/build-helpers
     override-pull: |
-      snapcraftctl set-version $(cat $SNAPCRAFT_PROJECT_DIR/VERSION)-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
+      cd $SNAPCRAFT_PROJECT_DIR
+      PROJECT_VERSION=$(cat VERSION)
+      GIT_REVISION=$(git rev-parse --short HEAD)
+      snapcraftctl set-version ${PROJECT_VERSION}-$(date +%Y%m%d)+${GIT_REVISION}}
   curl:
     plugin: nil
     # the default source for a part that doesn't specify one is ".", which

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -346,7 +346,7 @@ parts:
       cd $SNAPCRAFT_PROJECT_DIR
       PROJECT_VERSION=$(cat VERSION)
       GIT_REVISION=$(git rev-parse --short HEAD)
-      snapcraftctl set-version ${PROJECT_VERSION}-$(date +%Y%m%d)+${GIT_REVISION}}
+      snapcraftctl set-version ${PROJECT_VERSION}-$(date +%Y%m%d)+${GIT_REVISION}
   curl:
     plugin: nil
     # the default source for a part that doesn't specify one is ".", which


### PR DESCRIPTION
Change to project dir root before getting the git rev so that set-version can include the git rev.