### PR TITLE
snapcraft.yaml: update rulesengine jar file name (edinburgh)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -684,7 +684,7 @@ parts:
       # The logic following logic is all handled by DockerFile for
       # the EdgeX support-rulesengine docker image.
       install -d "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine"
-      mv "$SNAPCRAFT_PART_INSTALL"/jar/support-rulesengine-*-SNAPSHOT.jar \
+      mv "$SNAPCRAFT_PART_INSTALL"/jar/support-rulesengine.jar \
          "$SNAPCRAFT_PART_INSTALL"/jar/support-rulesengine/support-rulesengine.jar
 
       # FIXME:
@@ -693,8 +693,8 @@ parts:
       # to be staged or primed.
       install -DT "./Attribution.txt" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/java/doc/support-rulesengine/Attribution.txt"
-      install -DT "./LICENSE-2.0.txt" \
-         "$SNAPCRAFT_PART_INSTALL/usr/share/java/doc/support-rulesengine/LICENSE-2.0.txt"
+      install -DT "./LICENSE" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/java/doc/support-rulesengine/LICENSE"
       install -DT "./src/main/resources/rule-template.drl" \
          "$SNAPCRAFT_PART_INSTALL/jar/support-rulesengine/templates/rule-template.drl"
     prime:


### PR DESCRIPTION
Duplicate of https://github.com/edgexfoundry/edgex-go/pull/1956 for Edinburgh so we can unbreak the builds there.

This one was broken by https://github.com/edgexfoundry/support-rulesengine/pull/54