### PR TITLE
Revert 1847

### DIFF
--- a/internal/system/agent/executor/executor-stub.go
+++ b/internal/system/agent/executor/executor-stub.go
@@ -40,7 +40,7 @@ func NewStub(results []stubCall) Stub {
 
 // CommandExecutor provides the common callout to the configuration-defined executor.  This is a stub implementation of
 // the CommandExecutor interface.
-func (m *Stub) CommandExecutor(executorPath, serviceName, operation string, parameters []string) (string, error) {
+func (m *Stub) CommandExecutor(executorPath, serviceName, operation string) (string, error) {
 	m.Called++
 	m.capturedArgs = append(m.capturedArgs, []string{executorPath, serviceName, operation})
 	return m.perCallResults[m.Called-1].outString, m.perCallResults[m.Called-1].outError

--- a/internal/system/agent/executor/executor.go
+++ b/internal/system/agent/executor/executor.go
@@ -17,7 +17,7 @@ package executor
 import "os/exec"
 
 // CommandExecutor provides the common callout to the configuration-defined executor.
-func CommandExecutor(executorPath, serviceName, operation string, parameters []string) (string, error) {
-	bytes, err := exec.Command(executorPath, append([]string{serviceName, operation}, parameters...)...).CombinedOutput()
+func CommandExecutor(executorPath, serviceName, operation string) (string, error) {
+	bytes, err := exec.Command(executorPath, serviceName, operation).CombinedOutput()
 	return string(bytes), err
 }

--- a/internal/system/agent/executor/metrics.go
+++ b/internal/system/agent/executor/metrics.go
@@ -44,7 +44,7 @@ func NewMetrics(executor interfaces.CommandExecutor, loggingClient logger.Loggin
 func (e metrics) Get(services []string, ctx context.Context) interface{} {
 	var result []interface{}
 	for _, serviceName := range services {
-		r, err := e.executor(e.executorPath, serviceName, system.Metrics, []string{})
+		r, err := e.executor(e.executorPath, serviceName, system.Metrics)
 		if err != nil {
 			result = append(result, system.Failure(serviceName, system.Metrics, UnknownExecutorType, err.Error()))
 			continue

--- a/internal/system/agent/executor/operation.go
+++ b/internal/system/agent/executor/operation.go
@@ -43,10 +43,10 @@ func NewOperations(
 }
 
 // operationViaExecutor delegates a start/stop/restart operation request to the configuration-defined executor.
-func (e operations) Do(services []string, operation string, parameters []string) interface{} {
+func (e operations) Do(services []string, operation string) interface{} {
 	var result []interface{}
 	for _, serviceName := range services {
-		r, err := e.executor(e.executorPath, serviceName, operation, parameters)
+		r, err := e.executor(e.executorPath, serviceName, operation)
 		if err != nil {
 			result = append(result, system.Failure(serviceName, operation, UnknownExecutorType, err.Error()))
 			continue

--- a/internal/system/agent/executor/operation_test.go
+++ b/internal/system/agent/executor/operation_test.go
@@ -30,7 +30,7 @@ func TestOperationDoWithNoServices(t *testing.T) {
 	executor := NewStub([]stubCall{})
 	sut := NewOperations(executor.CommandExecutor, logger.NewMockClient(), "executorPathDoesNotMatter")
 
-	result := sut.Do([]string{}, "operationDoesNotMatter", []string{})
+	result := sut.Do([]string{}, "operationDoesNotMatter")
 
 	var emptyResult []interface{}
 	assert.Equal(t, result, emptyResult)
@@ -122,7 +122,7 @@ func TestOperationDoWithServices(t *testing.T) {
 			executor := NewStub(test.executorCalls)
 			sut := NewOperations(executor.CommandExecutor, loggingClient, executorPath)
 
-			result := sut.Do(test.services, operation, []string{})
+			result := sut.Do(test.services, operation)
 
 			if assert.Equal(t, len(test.executorCalls), executor.Called) {
 				for key, executorCall := range test.executorCalls {

--- a/internal/system/agent/interfaces/executor.go
+++ b/internal/system/agent/interfaces/executor.go
@@ -14,4 +14,4 @@
 
 package interfaces
 
-type CommandExecutor func(executorPath, serviceName, operation string, parameters []string) (string, error)
+type CommandExecutor func(executorPath, serviceName, operation string) (string, error)

--- a/internal/system/agent/interfaces/operations.go
+++ b/internal/system/agent/interfaces/operations.go
@@ -16,5 +16,5 @@ package interfaces
 
 // Operations defines an operation execution abstraction.
 type Operations interface {
-	Do(services []string, operation string, parameters []string) interface{}
+	Do(services []string, operation string) interface{}
 }

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -113,7 +113,7 @@ func operationHandler(
 		return
 	}
 
-	pkg.Encode(operationsImpl.Do(o.Services, o.Action, o.Parameters), w, loggingClient)
+	pkg.Encode(operationsImpl.Do(o.Services, o.Action), w, loggingClient)
 }
 
 // getConfigHandler implements a controller to execute a get configuration request.

--- a/internal/system/executor/README.md
+++ b/internal/system/executor/README.md
@@ -4,7 +4,7 @@
 This README.md is geared toward a developer interested in creating their own executor. It includes related information 
     that ties in with the System Management Agent (aka SMA). The main points are:
 
-- How the SMA passes service name, action, and optional parameters on the command line.
+- How the SMA passes service name, and action on the command line.
 - Current proxy-like behavior for stop/start/restart operations -- the SMA passes parameters received to executor as-is.
 - The Metrics Result Contract (and its support for embedding executor-specific results).
 - Expected format of operation result (based upon the existing Docker executor implementation).
@@ -12,14 +12,13 @@ This README.md is geared toward a developer interested in creating their own exe
 # Passing Parameters to SMA on Command Line #
 
 #### Usage ####
-./sys-mgmt-executor [service-name] [operation] {[optional-parameter]...}
+./sys-mgmt-executor [service-name] [operation]
 
 Where:
 - "service-name" is the name of the service to apply the operation to.
 - "operation" can be one of [start, stop, restart]
-- "optional-parameter" can be zero or more parameters that are executor-specific, have no meaning to the system 
-    management agent, and are no validated by the system management agent.  **An executor implementation is responsible
-    for validating and/or ignoring any optional-parameters passed to it.**
+
+**Note**: neither operation, nor service-name are verified by the SMA before passing to the executor, the executor is responsible for ensuring invalid service names and operations are handled gracefully.
 
 #### Examples of Usage (and Sample Responses) ####
 - ./sys-mgmt-executor edgex-support-notifications stop


### PR DESCRIPTION
This reverts commit 82e87b26c3ad337de0a3e78cb0efff640788bae8.

See https://github.com/edgexfoundry/edgex-go/issues/1851#issuecomment-543806893


Note that while there is an equivalent PR reverting the go-mod-core-contracts change (see https://github.com/edgexfoundry/go-mod-core-contracts/pull/178), this PR does not depend on that PR since without that revert, we just end up ignoring the Parameters field here. Regardless, we should still remove the Parameters field there too until there's consensus on how to proceed for this feature.

This and https://github.com/edgexfoundry/go-mod-core-contracts/pull/178 will close https://github.com/edgexfoundry/edgex-go/issues/1851