### PR TITLE
Correct usage of MarshalJSON methods in test code

### DIFF
--- a/internal/core/metadata/rest_deviceprofile_test.go
+++ b/internal/core/metadata/rest_deviceprofile_test.go
@@ -1089,7 +1089,7 @@ func createDeviceProfileRequestWithFile(fileContents []byte) *http.Request {
 }
 
 func createRequestWithBody(method string, d contract.DeviceProfile) *http.Request {
-	body, err := d.MarshalJSON()
+	body, err := json.Marshal(d)
 	if err != nil {
 		panic("Failed to create test JSON:" + err.Error())
 	}
@@ -1285,7 +1285,7 @@ func createTestDeviceProfile() contract.DeviceProfile {
 // createValidatedTestDeviceProfile creates an object by deserializing it from JSON
 // so that its unexported field isValidated will be true.
 func createValidatedTestDeviceProfile() contract.DeviceProfile {
-	bytes, _ := TestDeviceProfile.MarshalJSON()
+	bytes, _ := json.Marshal(TestDeviceProfile)
 	var dp contract.DeviceProfile
 	_ = json.Unmarshal(bytes, &dp)
 


### PR DESCRIPTION
Corrects two unit tests explicitly using DeviceProfile.MarshalJSON()
method instead of using json.Marshal(dp)

MarshalJSON() is the method that needs to be implemented for a type to satisfy the "Marshaler" interface in the json standard library package.  Passing the Marshaler to json.Marshal() insulates us from changes around whether or not the MarshalJSON() method gets overridden in the future.

This change is required for edgexfoundry/go-mod-core-contracts#143 to be resolved, but won't break anything in the meantime.

Signed-off-by: Daniel Harms <jdharms@gmail.com>