### PR TITLE
Core-Command: List all cmds should return empty slice

### DIFF
--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -134,7 +134,7 @@ func getCommands(ctx context.Context) (int, []contract.CommandResponse, error) {
 			return http.StatusInternalServerError, nil, err
 		}
 	}
-	var cr []contract.CommandResponse
+	cr := []contract.CommandResponse{}
 	for _, d := range devices {
 		commands, err := dbClient.GetCommandsByDeviceId(d.Id)
 		if err != nil {


### PR DESCRIPTION
Fix #1964

* If there are no devices provisioned, Core-Command should return an
  empty slice when asked to return all commands in the database. It is
  currently returning "null"

Signed-off-by: Trevor Conn <trevor_conn@dell.com>