### PR TITLE
Apply errorConcept pattern to core-command REST Handler

### DIFF
--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -111,8 +111,8 @@ func getCommands(ctx context.Context) ([]contract.CommandResponse, error) {
 		}
 		cr = append(cr, contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()))
 	}
-	return cr, err
 
+	return cr, nil
 }
 
 func getCommandsByDeviceID(did string, ctx context.Context) (contract.CommandResponse, error) {
@@ -126,7 +126,7 @@ func getCommandsByDeviceID(did string, ctx context.Context) (contract.CommandRes
 		return contract.CommandResponse{}, err
 	}
 
-	return contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()), err
+	return contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()), nil
 }
 
 func getCommandsByDeviceName(dn string, ctx context.Context) (contract.CommandResponse, error) {
@@ -140,5 +140,5 @@ func getCommandsByDeviceName(dn string, ctx context.Context) (contract.CommandRe
 		return contract.CommandResponse{}, err
 	}
 
-	return contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()), err
+	return contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()), nil
 }

--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+
 	"github.com/edgexfoundry/edgex-go/internal/core/command/errors"
 
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -92,7 +94,7 @@ func commandByDevice(device contract.Device, command contract.Command, body stri
 		return "", err
 	}
 	if responseCode != 200 {
-		return "", errors.NewErrUnexpectedResponseFromService(responseCode)
+		return "", types.NewErrServiceClient(responseCode, []byte(responseBody))
 	}
 
 	return responseBody, nil

--- a/internal/core/command/device_test.go
+++ b/internal/core/command/device_test.go
@@ -2,8 +2,9 @@ package command
 
 import (
 	"context"
-	"errors"
+	goErrors "errors"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
@@ -12,6 +13,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/command/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/interfaces/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
@@ -25,67 +27,69 @@ func TestExecuteGETCommandByDeviceIdAndCommandId(t *testing.T) {
 	dbClient = newCommandMock()
 
 	tests := []struct {
-		name           string
-		deviceId       string
-		commandId      string
-		expectedStatus int
+		name        string
+		deviceId    string
+		commandId   string
+		expectedErr error
 	}{
 		{
 			"Device-InvalidObjectId",
 			status400,
 			TestCommandId,
-			http.StatusBadRequest,
+			types.NewErrServiceClient(400, []byte("Invalid object ID")),
 		},
 		{
 			"Device-NotFound",
 			status404,
 			TestCommandId,
-			http.StatusNotFound,
+			types.NewErrServiceClient(http.StatusNotFound, []byte{}),
 		},
 		{
 			"Device-InternalServerErr",
 			status500,
 			TestCommandId,
-			http.StatusInternalServerError,
+			goErrors.New("unexpected error"),
 		},
 		{
 			"Device-Locked",
 			status423,
 			TestCommandId,
-			http.StatusLocked,
+			errors.NewErrDeviceLocked(""),
 		},
 		{
 			"Command-NotFound",
 			d200c404,
 			status400,
-			http.StatusNotFound,
+			db.ErrNotFound,
 		},
 		{
 			"Command-InternalServerErr",
 			d200c500,
 			status500,
-			http.StatusInternalServerError,
+			goErrors.New("unexpected error"),
 		},
 		{
 			"Command-NotBelongToDevice",
 			mismatch,
 			mismatch,
-			http.StatusNotFound,
+			errors.NewErrCommandNotAssociatedWithDevice(TestCommandId, mismatch),
 		},
 		{
 			"Command-500URLCannotBeParsed",
 			"d200c200",
 			"200",
-			http.StatusInternalServerError,
+			&url.Error{Op: "parse", URL: "://:0?", Err: goErrors.New("missing protocol scheme")},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, statusCode := commandByDeviceID(tt.deviceId, TestCommandId, "", "", false, context.Background())
-			if tt.expectedStatus != statusCode {
-				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, statusCode)
-				return
+			_, actualErr := commandByDeviceID(tt.deviceId, TestCommandId, "", "", false, context.Background())
+			if actualErr == nil {
+				t.Fatal("expected error")
+			}
+			if tt.expectedErr.Error() != actualErr.Error() {
+				t.Fatalf("error value mismatch -- expected %v got %v", tt.expectedErr, actualErr)
 			}
 		})
 	}
@@ -95,7 +99,7 @@ func newMockDeviceClient() *mdMocks.DeviceClient {
 	client := mdMocks.DeviceClient{}
 	client.On("Device", status404, context.Background()).Return(contract.Device{}, types.NewErrServiceClient(http.StatusNotFound, []byte{}))
 	client.On("Device", status400, context.Background()).Return(contract.Device{}, types.NewErrServiceClient(400, []byte("Invalid object ID")))
-	client.On("Device", status500, context.Background()).Return(contract.Device{}, errors.New("unexpected error"))
+	client.On("Device", status500, context.Background()).Return(contract.Device{}, goErrors.New("unexpected error"))
 	client.On("Device", status423, context.Background()).Return(contract.Device{AdminState: "LOCKED"}, nil)
 	client.On("Device", d200c404, context.Background()).Return(contract.Device{Id: status400}, nil)
 	client.On("Device", d200c500, context.Background()).Return(contract.Device{Id: status500}, nil)
@@ -108,7 +112,7 @@ func newMockDeviceClient() *mdMocks.DeviceClient {
 func newCommandMock() interfaces.DBClient {
 	dbMock := &mocks.DBClient{}
 	dbMock.On("GetCommandsByDeviceId", status400).Return(nil, db.ErrNotFound)
-	dbMock.On("GetCommandsByDeviceId", status500).Return(nil, errors.New("unexpected error"))
+	dbMock.On("GetCommandsByDeviceId", status500).Return(nil, goErrors.New("unexpected error"))
 	dbMock.On("GetCommandsByDeviceId", mismatch).Return([]models.Command{contract.Command{Id: "dummy"}}, nil)
 
 	dbMock.On("GetCommandsByDeviceId", TestDeviceId).Return([]models.Command{contract.Command{Id: TestCommandId}}, nil)

--- a/internal/core/command/errors/types.go
+++ b/internal/core/command/errors/types.go
@@ -13,3 +13,28 @@ func (e ErrDeviceLocked) Error() string {
 func NewErrDeviceLocked(name string) error {
 	return ErrDeviceLocked{device: name}
 }
+
+type ErrCommandNotAssociatedWithDevice struct {
+	commandID string
+	deviceID  string
+}
+
+func (e ErrCommandNotAssociatedWithDevice) Error() string {
+	return fmt.Sprintf("Command with id '%v' does not belong to device with id '%v'.", e.commandID, e.deviceID)
+}
+
+func NewErrCommandNotAssociatedWithDevice(commandID string, deviceID string) error {
+	return ErrCommandNotAssociatedWithDevice{commandID, deviceID}
+}
+
+type ErrUnexpectedResponseFromService struct {
+	statusCode int
+}
+
+func (e ErrUnexpectedResponseFromService) Error() string {
+	return fmt.Sprintf("Command response HTTP status code was %v, expected 200", e.statusCode)
+}
+
+func NewErrUnexpectedResponseFromService(statusCode int) error {
+	return ErrUnexpectedResponseFromService{statusCode}
+}

--- a/internal/core/command/errors/types.go
+++ b/internal/core/command/errors/types.go
@@ -26,15 +26,3 @@ func (e ErrCommandNotAssociatedWithDevice) Error() string {
 func NewErrCommandNotAssociatedWithDevice(commandID string, deviceID string) error {
 	return ErrCommandNotAssociatedWithDevice{commandID, deviceID}
 }
-
-type ErrUnexpectedResponseFromService struct {
-	statusCode int
-}
-
-func (e ErrUnexpectedResponseFromService) Error() string {
-	return fmt.Sprintf("Command response HTTP status code was %v, expected 200", e.statusCode)
-}
-
-func NewErrUnexpectedResponseFromService(statusCode int) error {
-	return ErrUnexpectedResponseFromService{statusCode}
-}

--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -64,8 +64,8 @@ func issueDeviceCommand(w http.ResponseWriter, r *http.Request, isPutCommand boo
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(body))
 }
 
@@ -109,8 +109,8 @@ func issueDeviceCommandByNames(w http.ResponseWriter, r *http.Request, isPutComm
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(body))
 }
 
@@ -132,8 +132,8 @@ func restGetCommandsByDeviceID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(&device)
 }
 
@@ -155,8 +155,8 @@ func restGetCommandsByDeviceName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(&devices)
 }
 
@@ -176,7 +176,7 @@ func restGetAllCommands(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(devices)
 }

--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -43,15 +43,17 @@ func issueDeviceCommand(w http.ResponseWriter, r *http.Request, isPutCommand boo
 	}
 
 	ctx := r.Context()
-	body, status := commandByDeviceID(did, cid, string(b), r.URL.RawQuery, isPutCommand, ctx)
-	if status != http.StatusOK {
+	body, err := commandByDeviceID(did, cid, string(b), r.URL.RawQuery, isPutCommand, ctx)
+	if err != nil {
 		http.Error(w, body, status)
-	} else {
-		if len(body) > 0 {
-			w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
-		}
-		w.Write([]byte(body))
+		return
 	}
+
+	if len(body) > 0 {
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	}
+	w.Write([]byte(body))
+
 }
 
 func restGetDeviceCommandByNames(w http.ResponseWriter, r *http.Request) {
@@ -76,31 +78,31 @@ func issueDeviceCommandByNames(w http.ResponseWriter, r *http.Request, isPutComm
 		LoggingClient.Error(err.Error())
 		return
 	}
-	body, status := commandByNames(dn, cn, string(b), r.URL.RawQuery, isPutCommand, ctx)
+	body, err := commandByNames(dn, cn, string(b), r.URL.RawQuery, isPutCommand, ctx)
 
-	if status != http.StatusOK {
+	if err != nil {
 		http.Error(w, body, status)
-	} else {
-		if len(body) > 0 {
-			w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
-		}
-		w.Write([]byte(body))
+		return
 	}
+
+	if len(body) > 0 {
+		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	}
+	w.Write([]byte(body))
+
 }
 
 func restGetCommandsByDeviceID(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	did := vars[ID]
 	ctx := r.Context()
-	status, device, err := getCommandsByDeviceID(did, ctx)
+	device, err := getCommandsByDeviceID(did, ctx)
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, "Device not found", http.StatusNotFound)
 		return
-	} else if status != http.StatusOK {
-		w.WriteHeader(status)
-		return
 	}
+
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(&device)
 }
@@ -109,29 +111,25 @@ func restGetCommandsByDeviceName(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	dn := vars[NAME]
 	ctx := r.Context()
-	status, devices, err := getCommandsByDeviceName(dn, ctx)
+	devices, err := getCommandsByDeviceName(dn, ctx)
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		http.Error(w, "Device not found", http.StatusNotFound)
 		return
-	} else if status != http.StatusOK {
-		w.WriteHeader(status)
-		return
 	}
+
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(&devices)
 }
 
 func restGetAllCommands(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	status, devices, err := getCommands(ctx)
+	devices, err := getCommands(ctx)
 	if err != nil {
 		LoggingClient.Error(err.Error())
 		w.WriteHeader(status)
-	} else if status != http.StatusOK {
-		w.WriteHeader(status)
-		return
 	}
+
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	json.NewEncoder(w).Encode(devices)
 }

--- a/internal/pkg/errorconcept/command.go
+++ b/internal/pkg/errorconcept/command.go
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package errorconcept
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/command/errors"
+)
+
+var Command commandErrorConcept
+
+// ValueDescriptorsErrorConcept represents the accessor for the value-descriptor-specific error concepts
+type commandErrorConcept struct {
+	NotAssociatedWithDevice commandNotAssociatedWithDevice
+}
+
+type commandNotAssociatedWithDevice struct{}
+
+func (r commandNotAssociatedWithDevice) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r commandNotAssociatedWithDevice) isA(err error) bool {
+	_, ok := err.(errors.ErrCommandNotAssociatedWithDevice)
+	return ok
+}
+
+func (r commandNotAssociatedWithDevice) message(err error) string {
+	return err.Error()
+}

--- a/internal/pkg/errorconcept/device.go
+++ b/internal/pkg/errorconcept/device.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	command "github.com/edgexfoundry/edgex-go/internal/core/command/errors"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
 var Device deviceErrorConcept
@@ -26,6 +27,7 @@ var Device deviceErrorConcept
 type deviceErrorConcept struct {
 	Locked         deviceLocked
 	NotFound       deviceNotFound
+	NotFoundInDB   deviceNotFoundInDB
 	NotifyError    deviceNotify
 	RequesterError deviceRequester
 }
@@ -59,10 +61,24 @@ func (r deviceNotFound) message(err error) string {
 	return err.Error()
 }
 
+type deviceNotFoundInDB struct{}
+
+func (r deviceNotFoundInDB) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r deviceNotFoundInDB) isA(err error) bool {
+	return err == db.ErrNotFound
+}
+
+func (r deviceNotFoundInDB) message(err error) string {
+	return "Device not found"
+}
+
 type deviceNotify struct{}
 
 func (r deviceNotify) httpErrorCode() int {
-	return http.StatusLocked
+	return http.StatusServiceUnavailable
 }
 
 func (r deviceNotify) isA(err error) bool {

--- a/internal/pkg/errorconcept/device.go
+++ b/internal/pkg/errorconcept/device.go
@@ -16,15 +16,33 @@ package errorconcept
 
 import (
 	"net/http"
+
+	command "github.com/edgexfoundry/edgex-go/internal/core/command/errors"
 )
 
 var Device deviceErrorConcept
 
 // DeviceErrorConcept represents the accessor for the device-specific error concepts
 type deviceErrorConcept struct {
+	Locked         deviceLocked
 	NotFound       deviceNotFound
 	NotifyError    deviceNotify
 	RequesterError deviceRequester
+}
+
+type deviceLocked struct{}
+
+func (r deviceLocked) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r deviceLocked) isA(err error) bool {
+	_, ok := err.(command.ErrDeviceLocked)
+	return ok
+}
+
+func (r deviceLocked) message(err error) string {
+	return err.Error()
 }
 
 type deviceNotFound struct{}
@@ -44,7 +62,7 @@ func (r deviceNotFound) message(err error) string {
 type deviceNotify struct{}
 
 func (r deviceNotify) httpErrorCode() int {
-	return http.StatusServiceUnavailable
+	return http.StatusLocked
 }
 
 func (r deviceNotify) isA(err error) bool {


### PR DESCRIPTION
Fixes #1860, supercedes #1890.

This PR contains a large refactor for core command. This PR's functionality should be verified as well as ensuring there are no regressions from the previous code.