### PR TITLE
Add .git directory to .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 docs
 *.snap
+.git
+**/logs


### PR DESCRIPTION
Fixes #1973

There's no reason to have the .git/ directory in our docker build context,
having it present slows down builds and bloats cached images.

Signed-off-by: Daniel Harms <jdharms@gmail.com>