### PR TITLE
Revert "Add .git directory to .dockerignore file (#1974)"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,2 @@
 docs
 *.snap
-.git
-**/logs

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,7 @@ description: |
   services, as well as Consul, Kong, MongoDB, Vault, a JRE for the two 
   remaining Java services, and a set of basic device services. The packaging 
   for this snap can be found at: https://github.com/edgexfoundry/edgex-go
+
 icon: snap/local/assets/edgex-snap-icon.png
 
 # delhi is epoch 0, edinburgh epoch 1, etc.


### PR DESCRIPTION
This reverts commit b8067e79a59edeb59c32d43c4995926d047c226c.

Also manually add whitespace to the snapcraft.yaml folder to trigger the snap jobs in CI to confirm this unbreaks the snap builds.

We will eventually take up issue #1973 after Fuji is out, and we should also discuss in DevOps how to better address this sort of situation where a change outside of the snap/ dir affects the snap build.