### PR TITLE
log resp-init.json file creation error

### DIFF
--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -96,7 +96,7 @@ func main() {
 		func() {
 			tokenFile, err := os.OpenFile(absPath, os.O_CREATE|os.O_RDWR, 0600)
 			if err != nil {
-				secretstore.LoggingClient.Error(fmt.Sprintf("unable to open token file at %s", absPath))
+				secretstore.LoggingClient.Error(fmt.Sprintf("unable to open token file at %s with error: %s", absPath, err.Error()))
 				os.Exit(1)
 			}
 			defer tokenFile.Close()


### PR DESCRIPTION
Add detailed log entry when error of creating resp-init.json file happens.

Signed-off-by: Tingyu Zeng <tingyu.zeng@rsa.com>