### PR TITLE
Fix marshaling of secretstore.UserPasswordPair

### DIFF
--- a/internal/security/secretstore/password.go
+++ b/internal/security/secretstore/password.go
@@ -65,7 +65,7 @@ type CredCollect struct {
 }
 
 type UserPasswordPair struct {
-	User     string `json:"user,omitempty"`
+	User     string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
 }
 

--- a/internal/security/secretstore/password_test.go
+++ b/internal/security/secretstore/password_test.go
@@ -59,7 +59,7 @@ func TestRetrieveCred(t *testing.T) {
 	token := "token"
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"data": {"user": "test-user", "password": "test-password"}}`))
+		w.Write([]byte(`{"data": {"username": "test-user", "password": "test-password"}}`))
 		if r.Method != "GET" {
 			t.Errorf("expected GET request, got %s instead", r.Method)
 		}


### PR DESCRIPTION
Fixes #1981

UserPasswordPair should be marshaled into json as
{username, password} instead of {user, password}.

Signed-off-by: Daniel Harms <jdharms@gmail.com>