### PR TITLE
feat(config-seed): Change Config Seed rules engine properties for App-Service-Configurable

### DIFF
--- a/cmd/config-seed/res/properties/edgex-support-rulesengine/application.properties
+++ b/cmd/config-seed/res/properties/edgex-support-rulesengine/application.properties
@@ -28,7 +28,7 @@ server.port=48075
 #-----------------Export Service Config----------------------------------------
 #Turn on/off registration of rules engine as export distro client.  
 #Set to false to receive messages directly from core data
-export.client=true
+export.client=false
 expect.serializedjava=false
 export.client.registration.url=http://localhost:48071/api/v1
 #export.client.registration.url=http://edgex-export-client:48071/api/v1

--- a/cmd/config-seed/res/properties/edgex-support-rulesengine;docker/application.properties
+++ b/cmd/config-seed/res/properties/edgex-support-rulesengine;docker/application.properties
@@ -29,7 +29,7 @@ server.port=48075
 #-----------------Export Service Config----------------------------------------
 #Turn on/off registration of rules engine as export distro client.  
 #Set to false to receive messages directly from core data
-export.client=true
+export.client=false
 expect.serializedjava=false
 #export.client.registration.url=http://localhost:48071/api/v1
 export.client.registration.url=http://edgex-export-client:48071/api/v1
@@ -39,7 +39,7 @@ export.client.registration.name=EdgeXRulesEngine
 export.zeromq.port=5566
 #export.zeromq.port=5563
 #export.zeromq.host=tcp://localhost
-export.zeromq.host=tcp://edgex-export-distro
+export.zeromq.host=tcp://edgex-app-service-configurable-rules
 #how long to wait to retry registration
 export.client.registration.retry.time=10000
 #how many times to try registration before exiting


### PR DESCRIPTION
Rules Engine properties changed so the default is that it now receives messages from new App Service Configurable (rules-engine profile).

closes #1991