### PR TITLE
Fix core-command configuration for secrets

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -45,7 +45,8 @@ File = './logs/edgex-core-command.log'
 [SecretStore]
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/corecommand/'
+# Use the core-meta data secrets due to core-command using core-meta-data's database for persistance.
+Path = '/v1/secret/edgex/metadata/'
 Protocol = 'https'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'

--- a/cmd/core-command/res/docker/configuration.toml
+++ b/cmd/core-command/res/docker/configuration.toml
@@ -45,7 +45,8 @@ File = '/edgex/logs/edgex-core-command.log'
 [SecretStore]
 Host = 'edgex-vault'
 Port = 8200
-Path = '/v1/secret/edgex/corecommand/'
+# Use the core-meta data secrets due to core-command using core-meta-data's database for persistance.
+Path = '/v1/secret/edgex/metadata/'
 Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'

--- a/cmd/security-secretstore-setup/res/configuration.toml
+++ b/cmd/security-secretstore-setup/res/configuration.toml
@@ -60,10 +60,6 @@ Interval = 1
   Service = "coredata"
   Username = "core"
 
-  [Databases.corecommand]
-  Service = "corecommand"
-  Username = "core"
-
   [Databases.rulesengine]
   Service = "rulesengine"
   Username = "rulesengine"

--- a/cmd/security-secretstore-setup/res/docker/configuration.toml
+++ b/cmd/security-secretstore-setup/res/docker/configuration.toml
@@ -60,10 +60,6 @@ Interval = 1
   Service = "coredata"
   Username = "core"
 
-  [Databases.corecommand]
-  Service = "corecommand"
-  Username = "core"
-
   [Databases.rulesengine]
   Service = "rulesengine"
   Username = "rulesengine"


### PR DESCRIPTION
Update core-commands' TOML files to use core-metadata's secrets since
core-command uses core-metadata's database for persistence.

Revert changes to security-secretstore-setup which included creating
secrets for core-command. These are not needed since core-command uses
core-metadata's database.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>