### PR TITLE
Fix "logTarget cannot be blank" every time on startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.32
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
 	github.com/edgexfoundry/go-mod-secrets v0.0.7

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.32
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.33
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
 	github.com/edgexfoundry/go-mod-secrets v0.0.7

--- a/internal/pkg/bootstrap/logging/factory.go
+++ b/internal/pkg/bootstrap/logging/factory.go
@@ -24,7 +24,7 @@ import (
 
 // FactoryToStdout returns a logger.LoggingClient that outputs to stdout.
 func FactoryToStdout(serviceKey string) logger.LoggingClient {
-	return logger.NewClient(serviceKey, false, "", models.DebugLog)
+	return logger.NewClientStdOut(serviceKey, false, models.DebugLog)
 }
 
 // FactoryFromConfiguration returns a logger.LoggingClient based on configuration settings.


### PR DESCRIPTION
Fixes #1989.

Requires edgexfoundry/go-mod-core-contracts/pull/182 and a release to be cut. Will be taken out of draft status after that happens.

Signed-off-by: Brandon Forster <brandonforster@gmail.com>