### PR TITLE
doc: Save to docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ They can be launched easily with **docker-compose**.
 The simplest way to get started is to fetch the latest docker-compose.yml and start the EdgeX containers:
 
 ```sh
-wget https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/edinburgh/compose-files/docker-compose-edinburgh-1.0.1.yml
+wget -O docker-compose.yml https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/edinburgh/compose-files/docker-compose-edinburgh-1.0.1.yml
 docker-compose up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ They can be launched easily with **docker-compose**.
 The simplest way to get started is to fetch the latest docker-compose.yml and start the EdgeX containers:
 
 ```sh
-wget -O docker-compose.yml https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/edinburgh/compose-files/docker-compose-edinburgh-1.0.1.yml
+wget -O docker-compose.yml \
+https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files/docker-compose-nexus.yml
 docker-compose up -d
 ```
 


### PR DESCRIPTION
Observed issue was:

```
docker-compose --version
docker-compose version 1.21.0, build unknown

ERROR:
        Can't find a suitable configuration file in this directory or any
        parent. Are you in the right directory?

        Supported filenames: docker-compose.yml, docker-compose.yaml
```

Change-Id: Ia750efa6da96509e2e095ae8f76f094b2b01bde6
Signed-off-by: Philippe Coval <p.coval@samsung.com>