### PR TITLE
Remove 'LoggingClient' global usage in core-data

### DIFF
--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"flag"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/data"
@@ -30,8 +32,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 )
 
 func main() {
@@ -49,7 +49,8 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := httpserver.NewBootstrap(data.LoadRestRoutes())
+	dic := di.NewContainer(di.ServiceConstructorMap{})
+	httpServer := httpserver.NewBootstrap(data.LoadRestRoutes(dic))
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -58,7 +59,7 @@ func main() {
 		clients.CoreDataServiceKey,
 		data.Configuration,
 		startupTimer,
-		di.NewContainer(di.ServiceConstructorMap{}),
+		dic,
 		[]interfaces.BootstrapHandler{
 			secret.NewSecret().BootstrapHandler,
 			database.NewDatabaseForCoreData(&httpServer, data.Configuration).BootstrapHandler,

--- a/internal/core/data/device.go
+++ b/internal/core/data/device.go
@@ -15,26 +15,29 @@ package data
 
 import (
 	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
 // Update when the device was last reported connected
-func updateDeviceLastReportedConnected(device string) {
+func updateDeviceLastReportedConnected(device string, loggingClient logger.LoggingClient) {
 	// Config set to skip update last reported
 	if !Configuration.Writable.DeviceUpdateLastConnected {
-		LoggingClient.Debug("Skipping update of device connected/reported times for:  " + device)
+		loggingClient.Debug("Skipping update of device connected/reported times for:  " + device)
 		return
 	}
 
 	d, err := mdc.CheckForDevice(device, context.Background())
 	if err != nil {
-		LoggingClient.Error("Error getting device " + device + ": " + err.Error())
+		loggingClient.Error("Error getting device " + device + ": " + err.Error())
 		return
 	}
 
 	// Couldn't find device
 	if len(d.Name) == 0 {
-		LoggingClient.Error("Error updating device connected/reported times.  Unknown device with identifier of:  " + device)
+		loggingClient.Error("Error updating device connected/reported times.  Unknown device with identifier of:  " + device)
 		return
 	}
 
@@ -43,20 +46,20 @@ func updateDeviceLastReportedConnected(device string) {
 	//Use of context.Background because this function is invoked asynchronously from a channel
 	err = mdc.UpdateLastConnectedByName(d.Name, t, context.Background())
 	if err != nil {
-		LoggingClient.Error("Problems updating last connected value for device: " + d.Name)
+		loggingClient.Error("Problems updating last connected value for device: " + d.Name)
 		return
 	}
 	err = mdc.UpdateLastReportedByName(d.Name, t, context.Background())
 	if err != nil {
-		LoggingClient.Error("Problems updating last reported value for device: " + d.Name)
+		loggingClient.Error("Problems updating last reported value for device: " + d.Name)
 	}
 	return
 }
 
 // Update when the device service was last reported connected
-func updateDeviceServiceLastReportedConnected(device string) {
+func updateDeviceServiceLastReportedConnected(device string, loggingClient logger.LoggingClient) {
 	if !Configuration.Writable.ServiceUpdateLastConnected {
-		LoggingClient.Debug("Skipping update of device service connected/reported times for:  " + device)
+		loggingClient.Debug("Skipping update of device service connected/reported times for:  " + device)
 		return
 	}
 
@@ -65,20 +68,20 @@ func updateDeviceServiceLastReportedConnected(device string) {
 	// Get the device
 	d, err := mdc.CheckForDevice(device, context.Background())
 	if err != nil {
-		LoggingClient.Error("Error getting device " + device + ": " + err.Error())
+		loggingClient.Error("Error getting device " + device + ": " + err.Error())
 		return
 	}
 
 	// Couldn't find device
 	if len(d.Name) == 0 {
-		LoggingClient.Error("Error updating device connected/reported times.  Unknown device with identifier of:  " + device)
+		loggingClient.Error("Error updating device connected/reported times.  Unknown device with identifier of:  " + device)
 		return
 	}
 
 	// Get the device service
 	s := d.Service
 	if &s == nil {
-		LoggingClient.Error("Error updating device service connected/reported times.  Unknown device service in device:  " + d.Name)
+		loggingClient.Error("Error updating device service connected/reported times.  Unknown device service in device:  " + d.Name)
 		return
 	}
 

--- a/internal/core/data/domain_events.go
+++ b/internal/core/data/domain_events.go
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package data
 
+import "github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
 // An event indicating that a given device has just reported some data
 type DeviceLastReported struct {
 	DeviceName string
@@ -23,7 +25,7 @@ type DeviceServiceLastReported struct {
 	DeviceName string
 }
 
-func initEventHandlers() {
+func initEventHandlers(loggingClient logger.LoggingClient) {
 	go func() {
 		for {
 			select {
@@ -32,11 +34,11 @@ func initEventHandlers() {
 					switch e.(type) {
 					case DeviceLastReported:
 						dlr := e.(DeviceLastReported)
-						updateDeviceLastReportedConnected(dlr.DeviceName)
+						updateDeviceLastReportedConnected(dlr.DeviceName, loggingClient)
 						break
 					case DeviceServiceLastReported:
 						dslr := e.(DeviceServiceLastReported)
-						updateDeviceServiceLastReportedConnected(dslr.DeviceName)
+						updateDeviceServiceLastReportedConnected(dslr.DeviceName, loggingClient)
 						break
 					}
 				} else {

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -27,7 +27,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 
@@ -38,7 +37,6 @@ import (
 // Global variables
 var Configuration = &ConfigurationStruct{}
 var dbClient interfaces.DBClient
-var LoggingClient logger.LoggingClient
 
 // TODO: Refactor names in separate PR: See comments on PR #1133
 var chEvents chan interface{} // A channel for "domain events" sourced from event operations
@@ -51,10 +49,10 @@ var httpErrorHandler errorconcept.ErrorHandler
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
 func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
-	LoggingClient = container.LoggingClientFrom(dic.Get)
+	loggingClient := container.LoggingClientFrom(dic.Get)
 	dbClient = container.DBClientFrom(dic.Get)
 
-	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
+	httpErrorHandler = errorconcept.NewErrorHandler(loggingClient)
 
 	// initialize clients required by service.
 	registryClient := container.RegistryFrom(dic.Get)
@@ -90,12 +88,12 @@ func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer star
 		})
 
 	if err != nil {
-		LoggingClient.Error(fmt.Sprintf("failed to create messaging client: %s", err.Error()))
+		loggingClient.Error(fmt.Sprintf("failed to create messaging client: %s", err.Error()))
 	}
 
 	// initialize event handlers
 	chEvents = make(chan interface{}, 100)
-	initEventHandlers()
+	initEventHandlers(loggingClient)
 
 	return true
 }

--- a/internal/core/data/reading_test.go
+++ b/internal/core/data/reading_test.go
@@ -6,6 +6,8 @@ import (
 	"math"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
 	dbMock "github.com/edgexfoundry/edgex-go/internal/core/data/interfaces/mocks"
@@ -30,7 +32,7 @@ func TestGetAllReadings(t *testing.T) {
 
 	dbClient = newReadingsMockDB()
 
-	_, err := getAllReadings()
+	_, err := getAllReadings(logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error thrown getting all readings: %s", err.Error())
@@ -43,7 +45,7 @@ func TestGetAllReadingsOverLimit(t *testing.T) {
 
 	dbClient = newReadingsMockDB()
 
-	_, err := getAllReadings()
+	_, err := getAllReadings(logger.NewMockClient())
 
 	if err != nil {
 		switch err.(type) {
@@ -68,7 +70,7 @@ func TestGetAllReadingsError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getAllReadings()
+	_, err := getAllReadings(logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting all readings")
@@ -83,7 +85,7 @@ func TestAddReading(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := addReading(models.Reading{Name: "valid"})
+	_, err := addReading(models.Reading{Name: "valid"}, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error adding reading")
@@ -98,7 +100,7 @@ func TestAddReadingError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := addReading(models.Reading{})
+	_, err := addReading(models.Reading{}, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error adding reading")
@@ -113,7 +115,7 @@ func TestGetReadingById(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingById("valid")
+	_, err := getReadingById("valid", logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting reading by ID")
@@ -128,7 +130,7 @@ func TestGetReadingByIdNotFound(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingById("404")
+	_, err := getReadingById("404", logger.NewMockClient())
 
 	if err != nil {
 		switch err.(type) {
@@ -152,7 +154,7 @@ func TestGetReadingByIdError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingById("error")
+	_, err := getReadingById("error", logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting reading by ID with some error")
@@ -167,7 +169,7 @@ func TestDeleteReadingById(t *testing.T) {
 
 	dbClient = myMock
 
-	err := deleteReadingById("valid")
+	err := deleteReadingById("valid", logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error deleting reading by ID")
@@ -184,7 +186,7 @@ func TestDeleteReadingByIdError(t *testing.T) {
 
 	dbClient = myMock
 
-	err := deleteReadingById("invalid")
+	err := deleteReadingById("invalid", logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error deleting reading by ID")
@@ -201,7 +203,7 @@ func TestCountReadings(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := countReadings()
+	_, err := countReadings(logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error in CountReadings")
@@ -216,7 +218,7 @@ func TestCountReadingsError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := countReadings()
+	_, err := countReadings(logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error in CountReadings")
@@ -231,7 +233,7 @@ func TestGetReadingsByDevice(t *testing.T) {
 
 	dbClient = myMock
 
-	expectedReadings, err := getReadingsByDevice("valid", 0, context.Background())
+	expectedReadings, err := getReadingsByDevice("valid", 0, context.Background(), logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error in getReadingsByDevice")
@@ -250,7 +252,7 @@ func TestGetReadingsByDeviceError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingsByDevice("error", 0, context.Background())
+	_, err := getReadingsByDevice("error", 0, context.Background(), logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error in getReadingsByDevice")
@@ -265,7 +267,7 @@ func TestGetReadingsByValueDescriptor(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingsByValueDescriptor("valid", 0)
+	_, err := getReadingsByValueDescriptor("valid", 0, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting readings by value descriptor")
@@ -276,7 +278,7 @@ func TestGetReadingsByValueDescriptorOverLimit(t *testing.T) {
 	reset()
 	dbClient = nil
 
-	_, err := getReadingsByValueDescriptor("", math.MaxInt32)
+	_, err := getReadingsByValueDescriptor("", math.MaxInt32, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting readings by value descriptor")
@@ -291,7 +293,7 @@ func TestGetReadingsByValueDescriptorError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingsByValueDescriptor("error", 0)
+	_, err := getReadingsByValueDescriptor("error", 0, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error in getting readings by value descriptor")
@@ -306,7 +308,7 @@ func TestGetReadingsByValueDescriptorNames(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingsByValueDescriptorNames([]string{"valid"}, 0)
+	_, err := getReadingsByValueDescriptorNames([]string{"valid"}, 0, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting readings by value descriptor names")
@@ -321,7 +323,7 @@ func TestGetReadingsByValueDescriptorNamesError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingsByValueDescriptorNames([]string{"error"}, 0)
+	_, err := getReadingsByValueDescriptorNames([]string{"error"}, 0, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error in getting readings by value descriptor names")
@@ -336,7 +338,7 @@ func TestGetReadingsByCreationTime(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingsByCreationTime(0xBEEF, 0, 0)
+	_, err := getReadingsByCreationTime(0xBEEF, 0, 0, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting readings by creation time")
@@ -351,7 +353,7 @@ func TestGetReadingsByCreationTimeError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingsByCreationTime(0xDEADBEEF, 0, 0)
+	_, err := getReadingsByCreationTime(0xDEADBEEF, 0, 0, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error in getting readings by creation time")
@@ -366,7 +368,7 @@ func TestGetReadingsByDeviceAndValueDescriptor(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingsByDeviceAndValueDescriptor("valid", "valid", 0)
+	_, err := getReadingsByDeviceAndValueDescriptor("valid", "valid", 0, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting readings by device and value descriptor")
@@ -381,7 +383,7 @@ func TestGetReadingsByDeviceAndValueDescriptorError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getReadingsByDeviceAndValueDescriptor("error", "error", 0)
+	_, err := getReadingsByDeviceAndValueDescriptor("error", "error", 0, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error in getting readings by device and value descriptor")

--- a/internal/core/data/utils.go
+++ b/internal/core/data/utils.go
@@ -14,6 +14,8 @@
 package data
 
 import (
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"io"
 	"io/ioutil"
@@ -21,20 +23,20 @@ import (
 
 // Printing function purely for debugging purposes
 // Print the body of a request to the console
-func printBody(r io.ReadCloser) {
+func printBody(r io.ReadCloser, loggingClient logger.LoggingClient) {
 	body, err := ioutil.ReadAll(r)
 	bodyString := string(body)
 
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 	}
 
-	LoggingClient.Info(bodyString)
+	loggingClient.Info(bodyString)
 }
 
-func checkMaxLimit(limit int) error {
+func checkMaxLimit(limit int, loggingClient logger.LoggingClient) error {
 	if limit > Configuration.Service.MaxResultCount {
-		LoggingClient.Error(maxExceededString)
+		loggingClient.Error(maxExceededString)
 		return errors.NewErrLimitExceeded(limit)
 	}
 

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -20,9 +20,11 @@ import (
 	"io"
 	"regexp"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 const (
@@ -31,7 +33,7 @@ const (
 )
 
 // Check if the value descriptor matches the format string regular expression
-func validateFormatString(v contract.ValueDescriptor) error {
+func validateFormatString(v contract.ValueDescriptor, loggingClient logger.LoggingClient) error {
 	// No formatting specified
 	if v.Formatting == "" {
 		return nil
@@ -40,23 +42,23 @@ func validateFormatString(v contract.ValueDescriptor) error {
 	match, err := regexp.MatchString(formatSpecifier, v.Formatting)
 
 	if err != nil {
-		LoggingClient.Error("Error checking for format string for value descriptor " + v.Name)
+		loggingClient.Error("Error checking for format string for value descriptor " + v.Name)
 		return err
 	}
 	if !match {
 		err = fmt.Errorf("format is not a valid printf format")
-		LoggingClient.Error(fmt.Sprintf("Error posting value descriptor. %s", err.Error()))
+		loggingClient.Error(fmt.Sprintf("Error posting value descriptor. %s", err.Error()))
 		return errors.NewErrValueDescriptorInvalid(v.Name, err)
 	}
 
 	return nil
 }
 
-func getValueDescriptorByName(name string) (vd contract.ValueDescriptor, err error) {
+func getValueDescriptorByName(name string, loggingClient logger.LoggingClient) (vd contract.ValueDescriptor, err error) {
 	vd, err = dbClient.ValueDescriptorByName(name)
 
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
 			return contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else {
@@ -67,11 +69,11 @@ func getValueDescriptorByName(name string) (vd contract.ValueDescriptor, err err
 	return vd, nil
 }
 
-func getValueDescriptorById(id string) (vd contract.ValueDescriptor, err error) {
+func getValueDescriptorById(id string, loggingClient logger.LoggingClient) (vd contract.ValueDescriptor, err error) {
 	vd, err = dbClient.ValueDescriptorById(id)
 
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
 			return contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else if err == db.ErrInvalidObjectId {
@@ -84,11 +86,11 @@ func getValueDescriptorById(id string) (vd contract.ValueDescriptor, err error) 
 	return vd, nil
 }
 
-func getValueDescriptorsByUomLabel(uomLabel string) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByUomLabel(uomLabel string, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
 	vdList, err = dbClient.ValueDescriptorsByUomLabel(uomLabel)
 
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
 			return []contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else {
@@ -99,11 +101,11 @@ func getValueDescriptorsByUomLabel(uomLabel string) (vdList []contract.ValueDesc
 	return vdList, nil
 }
 
-func getValueDescriptorsByLabel(label string) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByLabel(label string, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
 	vdList, err = dbClient.ValueDescriptorsByLabel(label)
 
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
 			return []contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else {
@@ -114,11 +116,11 @@ func getValueDescriptorsByLabel(label string) (vdList []contract.ValueDescriptor
 	return vdList, nil
 }
 
-func getValueDescriptorsByType(typ string) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByType(typ string, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
 	vdList, err = dbClient.ValueDescriptorsByType(typ)
 
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
 			return []contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else {
@@ -129,7 +131,7 @@ func getValueDescriptorsByType(typ string) (vdList []contract.ValueDescriptor, e
 	return vdList, nil
 }
 
-func getValueDescriptorsByDevice(device contract.Device) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByDevice(device contract.Device, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
 	// Get the names of the value descriptors
 	vdNames := []string{}
 	device.AllAssociatedValueDescriptors(&vdNames)
@@ -137,7 +139,7 @@ func getValueDescriptorsByDevice(device contract.Device) (vdList []contract.Valu
 	// Get the value descriptors
 	vdList = []contract.ValueDescriptor{}
 	for _, name := range vdNames {
-		vd, err := getValueDescriptorByName(name)
+		vd, err := getValueDescriptorByName(name, loggingClient)
 
 		// Not an error if not found
 		if err != nil {
@@ -155,49 +157,49 @@ func getValueDescriptorsByDevice(device contract.Device) (vdList []contract.Valu
 	return vdList, nil
 }
 
-func getValueDescriptorsByDeviceName(name string, ctx context.Context) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByDeviceName(name string, ctx context.Context, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
 	// Get the device
 	device, err := mdc.DeviceForName(name, ctx)
 	if err != nil {
-		LoggingClient.Error("Problem getting device from metadata: " + err.Error())
+		loggingClient.Error("Problem getting device from metadata: " + err.Error())
 		return []contract.ValueDescriptor{}, err
 	}
 
-	return getValueDescriptorsByDevice(device)
+	return getValueDescriptorsByDevice(device, loggingClient)
 }
 
-func getValueDescriptorsByDeviceId(id string, ctx context.Context) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByDeviceId(id string, ctx context.Context, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
 	// Get the device
 	device, err := mdc.Device(id, ctx)
 	if err != nil {
-		LoggingClient.Error("Problem getting device from metadata: " + err.Error())
+		loggingClient.Error("Problem getting device from metadata: " + err.Error())
 		return []contract.ValueDescriptor{}, err
 	}
 
-	return getValueDescriptorsByDevice(device)
+	return getValueDescriptorsByDevice(device, loggingClient)
 }
 
-func getAllValueDescriptors() (vd []contract.ValueDescriptor, err error) {
+func getAllValueDescriptors(loggingClient logger.LoggingClient) (vd []contract.ValueDescriptor, err error) {
 	vd, err = dbClient.ValueDescriptors()
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		return nil, err
 	}
 
 	return vd, nil
 }
 
-func decodeValueDescriptor(reader io.ReadCloser) (vd contract.ValueDescriptor, err error) {
+func decodeValueDescriptor(reader io.ReadCloser, loggingClient logger.LoggingClient) (vd contract.ValueDescriptor, err error) {
 	v := contract.ValueDescriptor{}
 	err = json.NewDecoder(reader).Decode(&v)
 	// Problems decoding
 	if err != nil {
-		LoggingClient.Error("Error decoding the value descriptor: " + err.Error())
+		loggingClient.Error("Error decoding the value descriptor: " + err.Error())
 		return contract.ValueDescriptor{}, errors.NewErrJsonDecoding(v.Name)
 	}
 
 	// Check the formatting
-	err = validateFormatString(v)
+	err = validateFormatString(v, loggingClient)
 	if err != nil {
 		return contract.ValueDescriptor{}, err
 	}
@@ -205,10 +207,10 @@ func decodeValueDescriptor(reader io.ReadCloser) (vd contract.ValueDescriptor, e
 	return v, nil
 }
 
-func addValueDescriptor(vd contract.ValueDescriptor) (id string, err error) {
+func addValueDescriptor(vd contract.ValueDescriptor, loggingClient logger.LoggingClient) (id string, err error) {
 	id, err = dbClient.AddValueDescriptor(vd)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotUnique {
 			return "", errors.NewErrDuplicateValueDescriptorName(vd.Name)
 		} else {
@@ -219,8 +221,8 @@ func addValueDescriptor(vd contract.ValueDescriptor) (id string, err error) {
 	return id, nil
 }
 
-func updateValueDescriptor(from contract.ValueDescriptor) error {
-	to, err := getValueDescriptorById(from.Id)
+func updateValueDescriptor(from contract.ValueDescriptor, loggingClient logger.LoggingClient) error {
+	to, err := getValueDescriptorById(from.Id, loggingClient)
 	if err != nil {
 		return err
 	}
@@ -235,11 +237,11 @@ func updateValueDescriptor(from contract.ValueDescriptor) error {
 	if from.Formatting != "" {
 		match, err := regexp.MatchString(formatSpecifier, from.Formatting)
 		if err != nil {
-			LoggingClient.Error("Error checking formatting for updated value descriptor")
+			loggingClient.Error("Error checking formatting for updated value descriptor")
 			return err
 		}
 		if !match {
-			LoggingClient.Error("value descriptor's format string doesn't fit the required pattern: " + formatSpecifier)
+			loggingClient.Error("value descriptor's format string doesn't fit the required pattern: " + formatSpecifier)
 			return errors.NewErrValueDescriptorInvalid(from.Name, err)
 		}
 		to.Formatting = from.Formatting
@@ -257,14 +259,14 @@ func updateValueDescriptor(from contract.ValueDescriptor) error {
 	if from.Name != "" {
 		// Check if value descriptor is still in use by readings if the name changes
 		if from.Name != to.Name {
-			r, err := getReadingsByValueDescriptor(to.Name, 10) // Arbitrary limit, we're just checking if there are any readings
+			r, err := getReadingsByValueDescriptor(to.Name, 10, loggingClient) // Arbitrary limit, we're just checking if there are any readings
 			if err != nil {
-				LoggingClient.Error("Error checking the readings for the value descriptor: " + err.Error())
+				loggingClient.Error("Error checking the readings for the value descriptor: " + err.Error())
 				return err
 			}
 			// Value descriptor is still in use
 			if len(r) != 0 {
-				LoggingClient.Error("Data integrity issue.  Value Descriptor with name:  " + from.Name + " is still referenced by existing readings.")
+				loggingClient.Error("Data integrity issue.  Value Descriptor with name:  " + from.Name + " is still referenced by existing readings.")
 				return errors.NewErrValueDescriptorInUse(from.Name)
 			}
 		}
@@ -284,10 +286,10 @@ func updateValueDescriptor(from contract.ValueDescriptor) error {
 	err = dbClient.UpdateValueDescriptor(to)
 	if err != nil {
 		if err == db.ErrNotUnique {
-			LoggingClient.Error("Value descriptor name is not unique")
+			loggingClient.Error("Value descriptor name is not unique")
 			return errors.NewErrDuplicateValueDescriptorName(to.Name)
 		} else {
-			LoggingClient.Error(err.Error())
+			loggingClient.Error(err.Error())
 			return err
 		}
 	}
@@ -295,49 +297,49 @@ func updateValueDescriptor(from contract.ValueDescriptor) error {
 	return nil
 }
 
-func deleteValueDescriptor(vd contract.ValueDescriptor) error {
+func deleteValueDescriptor(vd contract.ValueDescriptor, loggingClient logger.LoggingClient) error {
 	// Check if the value descriptor is still in use by readings
 	readings, err := dbClient.ReadingsByValueDescriptor(vd.Name, 10)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		return err
 	}
 	if len(readings) > 0 {
-		LoggingClient.Error("Data integrity issue.  Value Descriptor is still referenced by existing readings.")
+		loggingClient.Error("Data integrity issue.  Value Descriptor is still referenced by existing readings.")
 		return errors.NewErrValueDescriptorInUse(vd.Name)
 	}
 
 	// Delete the value descriptor
 	if err = dbClient.DeleteValueDescriptorById(vd.Id); err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		return err
 	}
 
 	return nil
 }
 
-func deleteValueDescriptorByName(name string) error {
+func deleteValueDescriptorByName(name string, loggingClient logger.LoggingClient) error {
 	// Check if the value descriptor exists
-	vd, err := getValueDescriptorByName(name)
+	vd, err := getValueDescriptorByName(name, loggingClient)
 	if err != nil {
 		return err
 	}
 
-	if err = deleteValueDescriptor(vd); err != nil {
+	if err = deleteValueDescriptor(vd, loggingClient); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func deleteValueDescriptorById(id string) error {
+func deleteValueDescriptorById(id string, loggingClient logger.LoggingClient) error {
 	// Check if the value descriptor exists
-	vd, err := getValueDescriptorById(id)
+	vd, err := getValueDescriptorById(id, loggingClient)
 	if err != nil {
 		return err
 	}
 
-	if err = deleteValueDescriptor(vd); err != nil {
+	if err = deleteValueDescriptor(vd, loggingClient); err != nil {
 		return err
 	}
 

--- a/internal/core/data/valuedescriptor_test.go
+++ b/internal/core/data/valuedescriptor_test.go
@@ -7,17 +7,19 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
 
 	"github.com/stretchr/testify/mock"
 )
 
 func TestValidateFormatString(t *testing.T) {
-	err := validateFormatString(models.ValueDescriptor{Formatting: "%s"})
+	err := validateFormatString(models.ValueDescriptor{Formatting: "%s"}, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Should match format specifier")
@@ -25,7 +27,7 @@ func TestValidateFormatString(t *testing.T) {
 }
 
 func TestValidateFormatStringEmpty(t *testing.T) {
-	err := validateFormatString(models.ValueDescriptor{Formatting: ""})
+	err := validateFormatString(models.ValueDescriptor{Formatting: ""}, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Should match format specifier")
@@ -33,7 +35,7 @@ func TestValidateFormatStringEmpty(t *testing.T) {
 }
 
 func TestValidateFormatStringInvalid(t *testing.T) {
-	err := validateFormatString(models.ValueDescriptor{Formatting: "error"})
+	err := validateFormatString(models.ValueDescriptor{Formatting: "error"}, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error on invalid format string")
@@ -48,7 +50,7 @@ func TestGetValueDescriptorByName(t *testing.T) {
 
 	dbClient = myMock
 
-	valueDescriptor, err := getValueDescriptorByName("valid")
+	valueDescriptor, err := getValueDescriptorByName("valid", logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by name")
@@ -67,7 +69,7 @@ func TestGetValueDescriptorByNameNotFound(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorByName("404")
+	_, err := getValueDescriptorByName("404", logger.NewMockClient())
 
 	if err != nil {
 		switch err.(type) {
@@ -91,7 +93,7 @@ func TestGetValueDescriptorByNameError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorByName("error")
+	_, err := getValueDescriptorByName("error", logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by name with some error")
@@ -106,7 +108,7 @@ func TestGetValueDescriptorById(t *testing.T) {
 
 	dbClient = myMock
 
-	valueDescriptor, err := getValueDescriptorById("valid")
+	valueDescriptor, err := getValueDescriptorById("valid", logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by ID")
@@ -125,7 +127,7 @@ func TestGetValueDescriptorByIdNotFound(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorById("404")
+	_, err := getValueDescriptorById("404", logger.NewMockClient())
 
 	if err != nil {
 		switch err.(type) {
@@ -149,7 +151,7 @@ func TestGetValueDescriptorByIdError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorById("error")
+	_, err := getValueDescriptorById("error", logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by ID with some error")
@@ -164,7 +166,7 @@ func TestGetValueDescriptorsByUomLabel(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorsByUomLabel("valid")
+	_, err := getValueDescriptorsByUomLabel("valid", logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by UOM label")
@@ -179,7 +181,7 @@ func TestGetValueDescriptorsByUomLabelNotFound(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorsByUomLabel("404")
+	_, err := getValueDescriptorsByUomLabel("404", logger.NewMockClient())
 
 	if err != nil {
 		switch err.(type) {
@@ -203,7 +205,7 @@ func TestGetValueDescriptorsByUomLabelError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorsByUomLabel("error")
+	_, err := getValueDescriptorsByUomLabel("error", logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by UOM label with some error")
@@ -220,7 +222,7 @@ func TestGetValueDescriptorsByLabel(t *testing.T) {
 
 	dbClient = myMock
 
-	valueDescriptor, err := getValueDescriptorsByLabel(testUUIDString)
+	valueDescriptor, err := getValueDescriptorsByLabel(testUUIDString, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by label")
@@ -239,7 +241,7 @@ func TestGetValueDescriptorsByLabelNotFound(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorsByLabel("404")
+	_, err := getValueDescriptorsByLabel("404", logger.NewMockClient())
 
 	if err != nil {
 		switch err.(type) {
@@ -263,7 +265,7 @@ func TestGetValueDescriptorsByLabelError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorsByLabel("error")
+	_, err := getValueDescriptorsByLabel("error", logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by label with some error")
@@ -278,7 +280,7 @@ func TestGetValueDescriptorsByType(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorsByType("valid")
+	_, err := getValueDescriptorsByType("valid", logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by type")
@@ -293,7 +295,7 @@ func TestGetValueDescriptorsByTypeNotFound(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getValueDescriptorsByType("404")
+	_, err := getValueDescriptorsByType("404", logger.NewMockClient())
 
 	if err != nil {
 		switch err.(type) {
@@ -316,8 +318,9 @@ func TestGetValueDescriptorsByTypeError(t *testing.T) {
 	myMock.On("ValueDescriptorsByType", mock.Anything).Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
 
 	dbClient = myMock
+	mdc = newMockDeviceClient()
 
-	_, err := getValueDescriptorsByType("R")
+	_, err := getValueDescriptorsByType("R", logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by type with some error")
@@ -328,7 +331,7 @@ func TestGetValueDescriptorsByDeviceName(t *testing.T) {
 	reset()
 	dbClient = nil
 
-	_, err := getValueDescriptorsByDeviceName(testDeviceName, context.Background())
+	_, err := getValueDescriptorsByDeviceName(testDeviceName, context.Background(), logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by device name")
@@ -339,7 +342,7 @@ func TestGetValueDescriptorsByDeviceNameNotFound(t *testing.T) {
 	reset()
 	dbClient = nil
 
-	_, err := getValueDescriptorsByDeviceName("404", context.Background())
+	_, err := getValueDescriptorsByDeviceName("404", context.Background(), logger.NewMockClient())
 
 	if err != nil {
 		switch err := err.(type) {
@@ -362,7 +365,7 @@ func TestGetValueDescriptorsByDeviceNameError(t *testing.T) {
 	reset()
 	dbClient = nil
 
-	_, err := getValueDescriptorsByDeviceName("error", context.Background())
+	_, err := getValueDescriptorsByDeviceName("error", context.Background(), logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by device name with some error")
@@ -373,7 +376,7 @@ func TestGetValueDescriptorsByDeviceId(t *testing.T) {
 	reset()
 	dbClient = nil
 
-	_, err := getValueDescriptorsByDeviceId("valid", context.Background())
+	_, err := getValueDescriptorsByDeviceId("valid", context.Background(), logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by device id")
@@ -384,7 +387,7 @@ func TestGetValueDescriptorsByDeviceIdNotFound(t *testing.T) {
 	reset()
 	dbClient = nil
 
-	_, err := getValueDescriptorsByDeviceId("404", context.Background())
+	_, err := getValueDescriptorsByDeviceId("404", context.Background(), logger.NewMockClient())
 
 	if err != nil {
 		switch err := err.(type) {
@@ -407,7 +410,7 @@ func TestGetValueDescriptorsByDeviceIdError(t *testing.T) {
 	reset()
 	dbClient = nil
 
-	_, err := getValueDescriptorsByDeviceId("error", context.Background())
+	_, err := getValueDescriptorsByDeviceId("error", context.Background(), logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by device id with some error")
@@ -426,7 +429,7 @@ func TestGetAllValueDescriptors(t *testing.T) {
 	myMock.On("ValueDescriptors").Return(vds, nil)
 	dbClient = myMock
 
-	_, err := getAllValueDescriptors()
+	_, err := getAllValueDescriptors(logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error getting all value descriptors")
@@ -441,7 +444,7 @@ func TestGetAllValueDescriptorsError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := getAllValueDescriptors()
+	_, err := getAllValueDescriptors(logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error getting all value descriptors some error")
@@ -456,7 +459,7 @@ func TestAddValueDescriptor(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := addValueDescriptor(models.ValueDescriptor{Name: "valid"})
+	_, err := addValueDescriptor(models.ValueDescriptor{Name: "valid"}, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error adding value descriptor")
@@ -471,7 +474,7 @@ func TestAddDuplicateValueDescriptor(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := addValueDescriptor(models.ValueDescriptor{Name: "409"})
+	_, err := addValueDescriptor(models.ValueDescriptor{Name: "409"}, logger.NewMockClient())
 
 	if err != nil {
 		switch err.(type) {
@@ -495,7 +498,7 @@ func TestAddValueDescriptorError(t *testing.T) {
 
 	dbClient = myMock
 
-	_, err := addValueDescriptor(models.ValueDescriptor{})
+	_, err := addValueDescriptor(models.ValueDescriptor{}, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error adding value descriptor some error")
@@ -511,7 +514,7 @@ func TestDeleteValueDescriptor(t *testing.T) {
 
 	dbClient = myMock
 
-	err := deleteValueDescriptor(models.ValueDescriptor{Name: "valid", Id: testBsonString})
+	err := deleteValueDescriptor(models.ValueDescriptor{Name: "valid", Id: testBsonString}, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpected error deleting value descriptor")
@@ -526,7 +529,7 @@ func TestDeleteValueDescriptorInUse(t *testing.T) {
 
 	dbClient = myMock
 
-	err := deleteValueDescriptor(models.ValueDescriptor{Name: "409"})
+	err := deleteValueDescriptor(models.ValueDescriptor{Name: "409"}, logger.NewMockClient())
 
 	if err != nil {
 		switch err.(type) {
@@ -550,7 +553,7 @@ func TestDeleteValueDescriptorErrorReadingsLookup(t *testing.T) {
 
 	dbClient = myMock
 
-	err := deleteValueDescriptor(models.ValueDescriptor{})
+	err := deleteValueDescriptor(models.ValueDescriptor{}, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error deleting value descriptor some error looking up readings")
@@ -566,7 +569,7 @@ func TestDeleteValueDescriptorError(t *testing.T) {
 
 	dbClient = myMock
 
-	err := deleteValueDescriptor(models.ValueDescriptor{Name: "validErrorTest"})
+	err := deleteValueDescriptor(models.ValueDescriptor{Name: "validErrorTest"}, logger.NewMockClient())
 
 	if err == nil {
 		t.Errorf("Expected error deleting value descriptor some error")


### PR DESCRIPTION
Fix #2024

Update core-data to leverage the dependency injection container(DIC)
during bootstrap and pass a 'LoggingClient' instance down the call stack
to eliminate the need for the 'LoggingClient' global variable.

Update tests to use a DIC when loading REST routes as they will need the
DIC to obtain a reference of the 'LoggingClient'. Also, update any
references to methods/functions which have updated signatures to accept
a 'LoggingClient' as part of changes to the production code.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>