### PR TITLE
Remove 'LoggingClient' global usage in core-command

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -48,7 +48,8 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := httpserver.NewBootstrap(command.LoadRestRoutes())
+	dic := di.NewContainer(nil)
+	httpServer := httpserver.NewBootstrap(command.LoadRestRoutes(dic))
 	bootstrap.Run(
 		configDir,
 		profileDir,

--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -48,7 +48,7 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	dic := di.NewContainer(nil)
+	dic := di.NewContainer(di.ServiceConstructorMap{})
 	httpServer := httpserver.NewBootstrap(command.LoadRestRoutes(dic))
 	bootstrap.Run(
 		configDir,
@@ -58,7 +58,7 @@ func main() {
 		clients.CoreCommandServiceKey,
 		command.Configuration,
 		startupTimer,
-		di.NewContainer(di.ServiceConstructorMap{}),
+		dic,
 		[]interfaces.BootstrapHandler{
 			secret.NewSecret().BootstrapHandler,
 			database.NewDatabase(&httpServer, command.Configuration).BootstrapHandler,

--- a/internal/core/command/config.go
+++ b/internal/core/command/config.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (

--- a/internal/core/command/const.go
+++ b/internal/core/command/const.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 const (

--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -27,8 +27,14 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
-func commandByDeviceID(deviceID string, commandID string, body string, queryParams string, isPutCommand bool,
-	ctx context.Context, loggingClient logger.LoggingClient) (string, int) {
+func commandByDeviceID(
+	deviceID string,
+	commandID string,
+	body string,
+	queryParams string,
+	isPutCommand bool,
+	ctx context.Context,
+	loggingClient logger.LoggingClient) (string, int) {
 	d, err := mdc.Device(deviceID, ctx)
 	if err != nil {
 		loggingClient.Error(err.Error())
@@ -74,7 +80,13 @@ func commandByDeviceID(deviceID string, commandID string, body string, queryPara
 	return commandByDevice(d, c, body, queryParams, isPutCommand, ctx, loggingClient)
 }
 
-func commandByNames(dn string, cn string, body string, queryParams string, isPutCommand bool, ctx context.Context,
+func commandByNames(
+	dn string,
+	cn string,
+	body string,
+	queryParams string,
+	isPutCommand bool,
+	ctx context.Context,
 	loggingClient logger.LoggingClient) (string, int) {
 	d, err := mdc.DeviceForName(dn, ctx)
 	if err != nil {
@@ -105,8 +117,14 @@ func commandByNames(dn string, cn string, body string, queryParams string, isPut
 	return commandByDevice(d, command, body, queryParams, isPutCommand, ctx, loggingClient)
 }
 
-func commandByDevice(device contract.Device, command contract.Command, body string, queryParams string,
-	isPutCommand bool, ctx context.Context, loggingClient logger.LoggingClient) (string, int) {
+func commandByDevice(
+	device contract.Device,
+	command contract.Command,
+	body string,
+	queryParams string,
+	isPutCommand bool,
+	ctx context.Context,
+	loggingClient logger.LoggingClient) (string, int) {
 	var ex Executor
 	var err error
 	if isPutCommand {
@@ -156,8 +174,10 @@ func getCommands(ctx context.Context, loggingClient logger.LoggingClient) (int, 
 
 }
 
-func getCommandsByDeviceID(did string, ctx context.Context, loggingClient logger.LoggingClient) (int,
-	contract.CommandResponse, error) {
+func getCommandsByDeviceID(
+	did string,
+	ctx context.Context,
+	loggingClient logger.LoggingClient) (int, contract.CommandResponse, error) {
 	d, err := mdc.Device(did, ctx)
 	if err != nil {
 		chk, ok := err.(types.ErrServiceClient)
@@ -181,8 +201,10 @@ func getCommandsByDeviceID(did string, ctx context.Context, loggingClient logger
 	return http.StatusOK, contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()), err
 }
 
-func getCommandsByDeviceName(dn string, ctx context.Context, loggingClient logger.LoggingClient) (int,
-	contract.CommandResponse, error) {
+func getCommandsByDeviceName(
+	dn string,
+	ctx context.Context,
+	loggingClient logger.LoggingClient) (int, contract.CommandResponse, error) {
 	d, err := mdc.DeviceForName(dn, ctx)
 	if err != nil {
 		chk, ok := err.(types.ErrServiceClient)

--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (
@@ -18,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
@@ -25,10 +27,11 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
-func commandByDeviceID(deviceID string, commandID string, body string, queryParams string, isPutCommand bool, ctx context.Context) (string, int) {
+func commandByDeviceID(deviceID string, commandID string, body string, queryParams string, isPutCommand bool,
+	ctx context.Context, loggingClient logger.LoggingClient) (string, int) {
 	d, err := mdc.Device(deviceID, ctx)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 
 		chk, ok := err.(types.ErrServiceClient)
 		if ok {
@@ -39,14 +42,14 @@ func commandByDeviceID(deviceID string, commandID string, body string, queryPara
 	}
 
 	if d.AdminState == contract.Locked {
-		LoggingClient.Error(d.Name + " is in admin locked state")
+		loggingClient.Error(d.Name + " is in admin locked state")
 		return errors.NewErrDeviceLocked(d.Name).Error(), http.StatusLocked
 	}
 
 	//once command service have its own persistence layer this call will be changed.
 	commands, err := dbClient.GetCommandsByDeviceId(d.Id)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
 			return err.Error(), http.StatusNotFound
 		} else {
@@ -64,17 +67,18 @@ func commandByDeviceID(deviceID string, commandID string, body string, queryPara
 
 	if c.String() == (contract.Command{}).String() {
 		errMsg := fmt.Sprintf("Command with id '%v' does not belong to device with id '%v'.", commandID, deviceID)
-		LoggingClient.Error(errMsg)
+		loggingClient.Error(errMsg)
 		return errMsg, http.StatusNotFound
 	}
 
-	return commandByDevice(d, c, body, queryParams, isPutCommand, ctx)
+	return commandByDevice(d, c, body, queryParams, isPutCommand, ctx, loggingClient)
 }
 
-func commandByNames(dn string, cn string, body string, queryParams string, isPutCommand bool, ctx context.Context) (string, int) {
+func commandByNames(dn string, cn string, body string, queryParams string, isPutCommand bool, ctx context.Context,
+	loggingClient logger.LoggingClient) (string, int) {
 	d, err := mdc.DeviceForName(dn, ctx)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		chk, ok := err.(types.ErrServiceClient)
 		if ok {
 			return err.Error(), chk.StatusCode
@@ -84,13 +88,13 @@ func commandByNames(dn string, cn string, body string, queryParams string, isPut
 	}
 
 	if d.AdminState == contract.Locked {
-		LoggingClient.Error(d.Name + " is in admin locked state")
+		loggingClient.Error(d.Name + " is in admin locked state")
 		return errors.NewErrDeviceLocked(d.Name).Error(), http.StatusLocked
 	}
 
 	command, err := dbClient.GetCommandByNameAndDeviceId(cn, d.Id)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
 			return err.Error(), http.StatusNotFound
 		} else {
@@ -98,33 +102,34 @@ func commandByNames(dn string, cn string, body string, queryParams string, isPut
 		}
 	}
 
-	return commandByDevice(d, command, body, queryParams, isPutCommand, ctx)
+	return commandByDevice(d, command, body, queryParams, isPutCommand, ctx, loggingClient)
 }
 
-func commandByDevice(device contract.Device, command contract.Command, body string, queryParams string, isPutCommand bool, ctx context.Context) (string, int) {
+func commandByDevice(device contract.Device, command contract.Command, body string, queryParams string,
+	isPutCommand bool, ctx context.Context, loggingClient logger.LoggingClient) (string, int) {
 	var ex Executor
 	var err error
 	if isPutCommand {
-		ex, err = NewPutCommand(device, command, body, ctx, &http.Client{})
+		ex, err = NewPutCommand(device, command, body, ctx, &http.Client{}, loggingClient)
 	} else {
-		ex, err = NewGetCommand(device, command, queryParams, ctx, &http.Client{})
+		ex, err = NewGetCommand(device, command, queryParams, ctx, &http.Client{}, loggingClient)
 	}
 
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		return err.Error(), http.StatusInternalServerError
 	}
 
 	responseBody, responseCode, err := ex.Execute()
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		return err.Error(), http.StatusInternalServerError
 	}
 
 	return responseBody, responseCode
 }
 
-func getCommands(ctx context.Context) (int, []contract.CommandResponse, error) {
+func getCommands(ctx context.Context, loggingClient logger.LoggingClient) (int, []contract.CommandResponse, error) {
 	devices, err := mdc.Devices(ctx)
 	if err != nil {
 		chk, ok := err.(types.ErrServiceClient)
@@ -138,7 +143,7 @@ func getCommands(ctx context.Context) (int, []contract.CommandResponse, error) {
 	for _, d := range devices {
 		commands, err := dbClient.GetCommandsByDeviceId(d.Id)
 		if err != nil {
-			LoggingClient.Error(err.Error())
+			loggingClient.Error(err.Error())
 			if err == db.ErrNotFound {
 				return http.StatusNotFound, nil, err
 			} else {
@@ -151,7 +156,8 @@ func getCommands(ctx context.Context) (int, []contract.CommandResponse, error) {
 
 }
 
-func getCommandsByDeviceID(did string, ctx context.Context) (int, contract.CommandResponse, error) {
+func getCommandsByDeviceID(did string, ctx context.Context, loggingClient logger.LoggingClient) (int,
+	contract.CommandResponse, error) {
 	d, err := mdc.Device(did, ctx)
 	if err != nil {
 		chk, ok := err.(types.ErrServiceClient)
@@ -164,7 +170,7 @@ func getCommandsByDeviceID(did string, ctx context.Context) (int, contract.Comma
 
 	commands, err := dbClient.GetCommandsByDeviceId(d.Id)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
 			return http.StatusNotFound, contract.CommandResponse{}, err
 		} else {
@@ -175,7 +181,8 @@ func getCommandsByDeviceID(did string, ctx context.Context) (int, contract.Comma
 	return http.StatusOK, contract.CommandResponseFromDevice(d, commands, Configuration.Service.Url()), err
 }
 
-func getCommandsByDeviceName(dn string, ctx context.Context) (int, contract.CommandResponse, error) {
+func getCommandsByDeviceName(dn string, ctx context.Context, loggingClient logger.LoggingClient) (int,
+	contract.CommandResponse, error) {
 	d, err := mdc.DeviceForName(dn, ctx)
 	if err != nil {
 		chk, ok := err.(types.ErrServiceClient)
@@ -188,7 +195,7 @@ func getCommandsByDeviceName(dn string, ctx context.Context) (int, contract.Comm
 
 	commands, err := dbClient.GetCommandsByDeviceId(d.Id)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		if err == db.ErrNotFound {
 			return http.StatusNotFound, contract.CommandResponse{}, err
 		} else {

--- a/internal/core/command/device_test.go
+++ b/internal/core/command/device_test.go
@@ -1,3 +1,17 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
 package command
 
 import (
@@ -17,9 +31,20 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
-var mockLoggingClient = logger.NewMockClient()
+var (
+	status400 = "400"
+	status404 = "404"
+	status500 = "500"
+	status423 = "423"
 
-//commandByDeviceID
+	mismatch = "d200-c200-mismatch"
+	d200c404 = "d200-c404"
+	d200c500 = "d200-c500"
+
+	TestCommandId = "TestCommandID"
+)
+
+// commandByDeviceID
 func TestExecuteGETCommandByDeviceIdAndCommandId(t *testing.T) {
 	mdc = newMockDeviceClient()
 	dbClient = newCommandMock()
@@ -83,7 +108,7 @@ func TestExecuteGETCommandByDeviceIdAndCommandId(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, statusCode := commandByDeviceID(tt.deviceId, TestCommandId, "", "", false, context.Background(),
-				mockLoggingClient)
+				logger.NewMockClient())
 			if tt.expectedStatus != statusCode {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, statusCode)
 				return
@@ -116,16 +141,3 @@ func newCommandMock() interfaces.DBClient {
 
 	return dbMock
 }
-
-var (
-	status400 = "400"
-	status404 = "404"
-	status500 = "500"
-	status423 = "423"
-
-	mismatch = "d200-c200-mismatch"
-	d200c404 = "d200-c404"
-	d200c500 = "d200-c500"
-
-	TestCommandId = "TestCommandID"
-)

--- a/internal/core/command/device_test.go
+++ b/internal/core/command/device_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
+var mockLoggingClient = logger.NewMockClient()
+
 //commandByDeviceID
 func TestExecuteGETCommandByDeviceIdAndCommandId(t *testing.T) {
-
-	LoggingClient = logger.NewMockClient()
 	mdc = newMockDeviceClient()
 	dbClient = newCommandMock()
 
@@ -82,7 +82,8 @@ func TestExecuteGETCommandByDeviceIdAndCommandId(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, statusCode := commandByDeviceID(tt.deviceId, TestCommandId, "", "", false, context.Background())
+			_, statusCode := commandByDeviceID(tt.deviceId, TestCommandId, "", "", false, context.Background(),
+				mockLoggingClient)
 			if tt.expectedStatus != statusCode {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, statusCode)
 				return

--- a/internal/core/command/get.go
+++ b/internal/core/command/get.go
@@ -27,8 +27,13 @@ import (
 )
 
 // NewGetCommand creates and Executor which can be used to execute the GET related command.
-func NewGetCommand(device contract.Device, command contract.Command, queryParams string, context context.Context,
-	httpCaller internal.HttpCaller, loggingClient logger.LoggingClient) (Executor, error) {
+func NewGetCommand(
+	device contract.Device,
+	command contract.Command,
+	queryParams string,
+	context context.Context,
+	httpCaller internal.HttpCaller,
+	loggingClient logger.LoggingClient) (Executor, error) {
 	urlResult := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1) + "?" + queryParams
 	validURL, err := url.ParseRequestURI(urlResult)
 	if err != nil {
@@ -44,5 +49,5 @@ func NewGetCommand(device contract.Device, command contract.Command, queryParams
 		request.Header.Set(clients.CorrelationHeader, correlationID.(string))
 	}
 
-	return NewServiceCommand(device, httpCaller, request, loggingClient), nil
+	return newServiceCommand(device, httpCaller, request, loggingClient), nil
 }

--- a/internal/core/command/get.go
+++ b/internal/core/command/get.go
@@ -21,19 +21,21 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 // NewGetCommand creates and Executor which can be used to execute the GET related command.
-func NewGetCommand(device contract.Device, command contract.Command, queryParams string, context context.Context, httpCaller internal.HttpCaller) (Executor, error) {
+func NewGetCommand(device contract.Device, command contract.Command, queryParams string, context context.Context,
+	httpCaller internal.HttpCaller, loggingClient logger.LoggingClient) (Executor, error) {
 	urlResult := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1) + "?" + queryParams
 	validURL, err := url.ParseRequestURI(urlResult)
 	if err != nil {
-		return serviceCommand{}, err
+		return serviceCommand{loggingClient: loggingClient}, err
 	}
 	request, err := http.NewRequest(http.MethodGet, validURL.String(), nil)
 	if err != nil {
-		return serviceCommand{}, err
+		return serviceCommand{loggingClient: loggingClient}, err
 	}
 
 	correlationID := context.Value(clients.CorrelationHeader)
@@ -42,8 +44,9 @@ func NewGetCommand(device contract.Device, command contract.Command, queryParams
 	}
 
 	return serviceCommand{
-		Device:     device,
-		HttpCaller: httpCaller,
-		Request:    request,
+		Device:        device,
+		HttpCaller:    httpCaller,
+		Request:       request,
+		loggingClient: loggingClient,
 	}, nil
 }

--- a/internal/core/command/get.go
+++ b/internal/core/command/get.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (
@@ -31,11 +32,11 @@ func NewGetCommand(device contract.Device, command contract.Command, queryParams
 	urlResult := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1) + "?" + queryParams
 	validURL, err := url.ParseRequestURI(urlResult)
 	if err != nil {
-		return serviceCommand{loggingClient: loggingClient}, err
+		return serviceCommand{}, err
 	}
 	request, err := http.NewRequest(http.MethodGet, validURL.String(), nil)
 	if err != nil {
-		return serviceCommand{loggingClient: loggingClient}, err
+		return serviceCommand{}, err
 	}
 
 	correlationID := context.Value(clients.CorrelationHeader)
@@ -43,10 +44,5 @@ func NewGetCommand(device contract.Device, command contract.Command, queryParams
 		request.Header.Set(clients.CorrelationHeader, correlationID.(string))
 	}
 
-	return serviceCommand{
-		Device:        device,
-		HttpCaller:    httpCaller,
-		Request:       request,
-		loggingClient: loggingClient,
-	}, nil
+	return NewServiceCommand(device, httpCaller, request, loggingClient), nil
 }

--- a/internal/core/command/get_test.go
+++ b/internal/core/command/get_test.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (
@@ -19,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -60,7 +62,7 @@ var testCommand = contract.Command{
 func TestNewGetCommandWithCorrelationId(t *testing.T) {
 	expectedCorrelationIDHeaderValue := "Testing"
 	testContext := context.WithValue(context.Background(), clients.CorrelationHeader, expectedCorrelationIDHeaderValue)
-	getCommand, _ := NewGetCommand(testDevice, testCommand, "", testContext, nil, mockLoggingClient)
+	getCommand, _ := NewGetCommand(testDevice, testCommand, "", testContext, nil, logger.NewMockClient())
 	actualCorrelationIDHeaderValue := getCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
 	if actualCorrelationIDHeaderValue == "" {
 		t.Errorf("The populated GetCommand's request should contain a correlation ID header value")
@@ -73,7 +75,7 @@ func TestNewGetCommandWithCorrelationId(t *testing.T) {
 
 func TestNewGetCommandWithQueryParams(t *testing.T) {
 	queryParams := "test=value1&test2=value2"
-	getCommand, _ := NewGetCommand(testDevice, testCommand, queryParams, context.Background(), nil, mockLoggingClient)
+	getCommand, _ := NewGetCommand(testDevice, testCommand, queryParams, context.Background(), nil, logger.NewMockClient())
 	req := getCommand.(serviceCommand).Request.URL
 	if req.Scheme != TestProtocol {
 		t.Errorf("Unexpected protocol")
@@ -91,13 +93,13 @@ func TestNewGetCommandWithQueryParams(t *testing.T) {
 }
 func TestNewGetCommandWithMalformedQueryParams(t *testing.T) {
 	queryParams := "!@#$%"
-	_, err := NewGetCommand(testDevice, testCommand, queryParams, context.Background(), nil, mockLoggingClient)
+	_, err := NewGetCommand(testDevice, testCommand, queryParams, context.Background(), nil, logger.NewMockClient())
 	if err == nil {
 		t.Errorf("Expected error for malformed query parameters")
 	}
 }
 func TestNewGetCommandNoCorrelationIDInContext(t *testing.T) {
-	getCommand, _ := NewGetCommand(testDevice, testCommand, "", context.Background(), nil, mockLoggingClient)
+	getCommand, _ := NewGetCommand(testDevice, testCommand, "", context.Background(), nil, logger.NewMockClient())
 	actualCorrelationIDHeaderValue := getCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
 	if actualCorrelationIDHeaderValue != "" {
 		t.Errorf("No correlation ID should be specified")
@@ -107,7 +109,7 @@ func TestNewGetCommandNoCorrelationIDInContext(t *testing.T) {
 func TestNewGetCommandInvalidBaseUrl(t *testing.T) {
 	device := testDevice
 	device.Service.Addressable.Address = "!@#$"
-	_, err := NewGetCommand(device, testCommand, "", context.Background(), nil, mockLoggingClient)
+	_, err := NewGetCommand(device, testCommand, "", context.Background(), nil, logger.NewMockClient())
 	if err == nil {
 		t.Errorf("The invalid URL error was not properly propagated to the caller")
 	}

--- a/internal/core/command/get_test.go
+++ b/internal/core/command/get_test.go
@@ -60,7 +60,7 @@ var testCommand = contract.Command{
 func TestNewGetCommandWithCorrelationId(t *testing.T) {
 	expectedCorrelationIDHeaderValue := "Testing"
 	testContext := context.WithValue(context.Background(), clients.CorrelationHeader, expectedCorrelationIDHeaderValue)
-	getCommand, _ := NewGetCommand(testDevice, testCommand, "", testContext, nil)
+	getCommand, _ := NewGetCommand(testDevice, testCommand, "", testContext, nil, mockLoggingClient)
 	actualCorrelationIDHeaderValue := getCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
 	if actualCorrelationIDHeaderValue == "" {
 		t.Errorf("The populated GetCommand's request should contain a correlation ID header value")
@@ -73,7 +73,7 @@ func TestNewGetCommandWithCorrelationId(t *testing.T) {
 
 func TestNewGetCommandWithQueryParams(t *testing.T) {
 	queryParams := "test=value1&test2=value2"
-	getCommand, _ := NewGetCommand(testDevice, testCommand, queryParams, context.Background(), nil)
+	getCommand, _ := NewGetCommand(testDevice, testCommand, queryParams, context.Background(), nil, mockLoggingClient)
 	req := getCommand.(serviceCommand).Request.URL
 	if req.Scheme != TestProtocol {
 		t.Errorf("Unexpected protocol")
@@ -91,13 +91,13 @@ func TestNewGetCommandWithQueryParams(t *testing.T) {
 }
 func TestNewGetCommandWithMalformedQueryParams(t *testing.T) {
 	queryParams := "!@#$%"
-	_, err := NewGetCommand(testDevice, testCommand, queryParams, context.Background(), nil)
+	_, err := NewGetCommand(testDevice, testCommand, queryParams, context.Background(), nil, mockLoggingClient)
 	if err == nil {
 		t.Errorf("Expected error for malformed query parameters")
 	}
 }
 func TestNewGetCommandNoCorrelationIDInContext(t *testing.T) {
-	getCommand, _ := NewGetCommand(testDevice, testCommand, "", context.Background(), nil)
+	getCommand, _ := NewGetCommand(testDevice, testCommand, "", context.Background(), nil, mockLoggingClient)
 	actualCorrelationIDHeaderValue := getCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
 	if actualCorrelationIDHeaderValue != "" {
 		t.Errorf("No correlation ID should be specified")
@@ -107,7 +107,7 @@ func TestNewGetCommandNoCorrelationIDInContext(t *testing.T) {
 func TestNewGetCommandInvalidBaseUrl(t *testing.T) {
 	device := testDevice
 	device.Service.Addressable.Address = "!@#$"
-	_, err := NewGetCommand(device, testCommand, "", context.Background(), nil)
+	_, err := NewGetCommand(device, testCommand, "", context.Background(), nil, mockLoggingClient)
 	if err == nil {
 		t.Errorf("The invalid URL error was not properly propagated to the caller")
 	}

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (
@@ -41,13 +42,10 @@ var httpErrorHandler errorconcept.ErrorHandler
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the command service.
 func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
-	// update global variables.
-	LoggingClient := container.LoggingClientFrom(dic.Get)
-	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
-	dbClient = container.DBClientFrom(dic.Get)
-
-	// initialize clients required by service.
+	loggingClient := container.LoggingClientFrom(dic.Get)
 	registryClient := container.RegistryFrom(dic.Get)
+	httpErrorHandler = errorconcept.NewErrorHandler(loggingClient)
+	dbClient = container.DBClientFrom(dic.Get)
 	mdc = metadata.NewDeviceClient(
 		types.EndpointParams{
 			ServiceKey:  clients.CoreMetaDataServiceKey,

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -26,14 +26,12 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 )
 
 // Global variables
 var Configuration = &ConfigurationStruct{}
-var LoggingClient logger.LoggingClient
 
 var mdc metadata.DeviceClient
 var dbClient interfaces.DBClient
@@ -44,7 +42,7 @@ var httpErrorHandler errorconcept.ErrorHandler
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the command service.
 func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
-	LoggingClient = container.LoggingClientFrom(dic.Get)
+	LoggingClient := container.LoggingClientFrom(dic.Get)
 	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
 	dbClient = container.DBClientFrom(dic.Get)
 

--- a/internal/core/command/interfaces.go
+++ b/internal/core/command/interfaces.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 // Executor interface used to execute commands

--- a/internal/core/command/put.go
+++ b/internal/core/command/put.go
@@ -26,8 +26,13 @@ import (
 )
 
 // NewPutCommand creates and Executor which can be used to execute the PUT related command.
-func NewPutCommand(device contract.Device, command contract.Command, body string, context context.Context,
-	httpCaller internal.HttpCaller, loggingClient logger.LoggingClient) (Executor, error) {
+func NewPutCommand(
+	device contract.Device,
+	command contract.Command,
+	body string,
+	context context.Context,
+	httpCaller internal.HttpCaller,
+	loggingClient logger.LoggingClient) (Executor, error) {
 	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Put.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
 	request, err := http.NewRequest(http.MethodPut, url, strings.NewReader(body))
 	if err != nil {
@@ -39,5 +44,5 @@ func NewPutCommand(device contract.Device, command contract.Command, body string
 		request.Header.Set(clients.CorrelationHeader, correlationID.(string))
 	}
 
-	return NewServiceCommand(device, httpCaller, request, loggingClient), nil
+	return newServiceCommand(device, httpCaller, request, loggingClient), nil
 }

--- a/internal/core/command/put.go
+++ b/internal/core/command/put.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (
@@ -30,7 +31,7 @@ func NewPutCommand(device contract.Device, command contract.Command, body string
 	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Put.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
 	request, err := http.NewRequest(http.MethodPut, url, strings.NewReader(body))
 	if err != nil {
-		return serviceCommand{loggingClient: loggingClient}, err
+		return serviceCommand{}, err
 	}
 
 	correlationID := context.Value(clients.CorrelationHeader)
@@ -38,10 +39,5 @@ func NewPutCommand(device contract.Device, command contract.Command, body string
 		request.Header.Set(clients.CorrelationHeader, correlationID.(string))
 	}
 
-	return serviceCommand{
-		Device:        device,
-		HttpCaller:    httpCaller,
-		Request:       request,
-		loggingClient: loggingClient,
-	}, nil
+	return NewServiceCommand(device, httpCaller, request, loggingClient), nil
 }

--- a/internal/core/command/put.go
+++ b/internal/core/command/put.go
@@ -20,15 +20,17 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 // NewPutCommand creates and Executor which can be used to execute the PUT related command.
-func NewPutCommand(device contract.Device, command contract.Command, body string, context context.Context, httpCaller internal.HttpCaller) (Executor, error) {
+func NewPutCommand(device contract.Device, command contract.Command, body string, context context.Context,
+	httpCaller internal.HttpCaller, loggingClient logger.LoggingClient) (Executor, error) {
 	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Put.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
 	request, err := http.NewRequest(http.MethodPut, url, strings.NewReader(body))
 	if err != nil {
-		return serviceCommand{}, err
+		return serviceCommand{loggingClient: loggingClient}, err
 	}
 
 	correlationID := context.Value(clients.CorrelationHeader)
@@ -37,8 +39,9 @@ func NewPutCommand(device contract.Device, command contract.Command, body string
 	}
 
 	return serviceCommand{
-		Device:     device,
-		HttpCaller: httpCaller,
-		Request:    request,
+		Device:        device,
+		HttpCaller:    httpCaller,
+		Request:       request,
+		loggingClient: loggingClient,
 	}, nil
 }

--- a/internal/core/command/put_test.go
+++ b/internal/core/command/put_test.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (
@@ -19,12 +20,13 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
 func TestNewPutCommandWithCorrelationId(t *testing.T) {
 	expectedCorrelationIDHeaderValue := "Testing"
 	testContext := context.WithValue(context.Background(), clients.CorrelationHeader, expectedCorrelationIDHeaderValue)
-	putCommand, _ := NewPutCommand(testDevice, testCommand, "Test body", testContext, nil, mockLoggingClient)
+	putCommand, _ := NewPutCommand(testDevice, testCommand, "Test body", testContext, nil, logger.NewMockClient())
 	actualCorrelationIDHeaderValue := putCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
 	if actualCorrelationIDHeaderValue == "" {
 		t.Errorf("The populated PutCommand's request should contain a correlation ID header value")
@@ -35,7 +37,7 @@ func TestNewPutCommandWithCorrelationId(t *testing.T) {
 	}
 }
 func TestNewPutCommandNoCorrelationIDInContext(t *testing.T) {
-	putCommand, _ := NewPutCommand(testDevice, testCommand, "Test Body", context.Background(), nil, mockLoggingClient)
+	putCommand, _ := NewPutCommand(testDevice, testCommand, "Test Body", context.Background(), nil, logger.NewMockClient())
 	actualCorrelationIDHeaderValue := putCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
 	if actualCorrelationIDHeaderValue != "" {
 		t.Errorf("No correlation ID should be specified")
@@ -46,7 +48,7 @@ func TestNewPutCommandInvalidBaseUrl(t *testing.T) {
 	device := testDevice
 	device.Service.Addressable.Address = "!@#$"
 
-	_, err := NewPutCommand(device, testCommand, "Test body", context.Background(), nil, mockLoggingClient)
+	_, err := NewPutCommand(device, testCommand, "Test body", context.Background(), nil, logger.NewMockClient())
 	if err != nil {
 		t.Errorf("The invalid URL error was not properly propegated to the caller")
 	}
@@ -55,7 +57,7 @@ func TestNewPutCommandInvalidBaseUrl(t *testing.T) {
 func TestNewPutCommandBody(t *testing.T) {
 	expectedRequestBody := "Test Request Body"
 	expectedRequestBodySize := len(expectedRequestBody)
-	putCommand, err := NewPutCommand(testDevice, testCommand, expectedRequestBody, context.Background(), nil, mockLoggingClient)
+	putCommand, err := NewPutCommand(testDevice, testCommand, expectedRequestBody, context.Background(), nil, logger.NewMockClient())
 
 	if err != nil {
 		t.Errorf("Unexpectedly failed while creating a PutCommand")

--- a/internal/core/command/put_test.go
+++ b/internal/core/command/put_test.go
@@ -24,7 +24,7 @@ import (
 func TestNewPutCommandWithCorrelationId(t *testing.T) {
 	expectedCorrelationIDHeaderValue := "Testing"
 	testContext := context.WithValue(context.Background(), clients.CorrelationHeader, expectedCorrelationIDHeaderValue)
-	putCommand, _ := NewPutCommand(testDevice, testCommand, "Test body", testContext, nil)
+	putCommand, _ := NewPutCommand(testDevice, testCommand, "Test body", testContext, nil, mockLoggingClient)
 	actualCorrelationIDHeaderValue := putCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
 	if actualCorrelationIDHeaderValue == "" {
 		t.Errorf("The populated PutCommand's request should contain a correlation ID header value")
@@ -35,7 +35,7 @@ func TestNewPutCommandWithCorrelationId(t *testing.T) {
 	}
 }
 func TestNewPutCommandNoCorrelationIDInContext(t *testing.T) {
-	putCommand, _ := NewPutCommand(testDevice, testCommand, "Test Body", context.Background(), nil)
+	putCommand, _ := NewPutCommand(testDevice, testCommand, "Test Body", context.Background(), nil, mockLoggingClient)
 	actualCorrelationIDHeaderValue := putCommand.(serviceCommand).Request.Header.Get(clients.CorrelationHeader)
 	if actualCorrelationIDHeaderValue != "" {
 		t.Errorf("No correlation ID should be specified")
@@ -46,7 +46,7 @@ func TestNewPutCommandInvalidBaseUrl(t *testing.T) {
 	device := testDevice
 	device.Service.Addressable.Address = "!@#$"
 
-	_, err := NewPutCommand(device, testCommand, "Test body", context.Background(), nil)
+	_, err := NewPutCommand(device, testCommand, "Test body", context.Background(), nil, mockLoggingClient)
 	if err != nil {
 		t.Errorf("The invalid URL error was not properly propegated to the caller")
 	}
@@ -55,7 +55,7 @@ func TestNewPutCommandInvalidBaseUrl(t *testing.T) {
 func TestNewPutCommandBody(t *testing.T) {
 	expectedRequestBody := "Test Request Body"
 	expectedRequestBodySize := len(expectedRequestBody)
-	putCommand, err := NewPutCommand(testDevice, testCommand, expectedRequestBody, context.Background(), nil)
+	putCommand, err := NewPutCommand(testDevice, testCommand, expectedRequestBody, context.Background(), nil, mockLoggingClient)
 
 	if err != nil {
 		t.Errorf("Unexpectedly failed while creating a PutCommand")

--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -19,18 +19,19 @@ import (
 	"net/http"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/gorilla/mux"
 )
 
-func restGetDeviceCommandByCommandID(w http.ResponseWriter, r *http.Request) {
-	issueDeviceCommand(w, r, false)
+func restGetDeviceCommandByCommandID(w http.ResponseWriter, r *http.Request, loggingClient logger.LoggingClient) {
+	issueDeviceCommand(w, r, false, loggingClient)
 }
 
-func restPutDeviceCommandByCommandID(w http.ResponseWriter, r *http.Request) {
-	issueDeviceCommand(w, r, true)
+func restPutDeviceCommandByCommandID(w http.ResponseWriter, r *http.Request, loggingClient logger.LoggingClient) {
+	issueDeviceCommand(w, r, true, loggingClient)
 }
 
-func issueDeviceCommand(w http.ResponseWriter, r *http.Request, isPutCommand bool) {
+func issueDeviceCommand(w http.ResponseWriter, r *http.Request, isPutCommand bool, loggingClient logger.LoggingClient) {
 	defer r.Body.Close()
 
 	vars := mux.Vars(r)
@@ -38,12 +39,12 @@ func issueDeviceCommand(w http.ResponseWriter, r *http.Request, isPutCommand boo
 	cid := vars[COMMANDID]
 	b, err := ioutil.ReadAll(r.Body)
 	if b == nil && err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		return
 	}
 
 	ctx := r.Context()
-	body, status := commandByDeviceID(did, cid, string(b), r.URL.RawQuery, isPutCommand, ctx)
+	body, status := commandByDeviceID(did, cid, string(b), r.URL.RawQuery, isPutCommand, ctx, loggingClient)
 	if status != http.StatusOK {
 		http.Error(w, body, status)
 	} else {
@@ -54,15 +55,15 @@ func issueDeviceCommand(w http.ResponseWriter, r *http.Request, isPutCommand boo
 	}
 }
 
-func restGetDeviceCommandByNames(w http.ResponseWriter, r *http.Request) {
-	issueDeviceCommandByNames(w, r, false)
+func restGetDeviceCommandByNames(w http.ResponseWriter, r *http.Request, loggingClient logger.LoggingClient) {
+	issueDeviceCommandByNames(w, r, false, loggingClient)
 }
 
-func restPutDeviceCommandByNames(w http.ResponseWriter, r *http.Request) {
-	issueDeviceCommandByNames(w, r, true)
+func restPutDeviceCommandByNames(w http.ResponseWriter, r *http.Request, loggingClient logger.LoggingClient) {
+	issueDeviceCommandByNames(w, r, true, loggingClient)
 }
 
-func issueDeviceCommandByNames(w http.ResponseWriter, r *http.Request, isPutCommand bool) {
+func issueDeviceCommandByNames(w http.ResponseWriter, r *http.Request, isPutCommand bool, loggingClient logger.LoggingClient) {
 	defer r.Body.Close()
 
 	vars := mux.Vars(r)
@@ -73,10 +74,10 @@ func issueDeviceCommandByNames(w http.ResponseWriter, r *http.Request, isPutComm
 
 	b, err := ioutil.ReadAll(r.Body)
 	if b == nil && err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		return
 	}
-	body, status := commandByNames(dn, cn, string(b), r.URL.RawQuery, isPutCommand, ctx)
+	body, status := commandByNames(dn, cn, string(b), r.URL.RawQuery, isPutCommand, ctx, loggingClient)
 
 	if status != http.StatusOK {
 		http.Error(w, body, status)
@@ -88,13 +89,13 @@ func issueDeviceCommandByNames(w http.ResponseWriter, r *http.Request, isPutComm
 	}
 }
 
-func restGetCommandsByDeviceID(w http.ResponseWriter, r *http.Request) {
+func restGetCommandsByDeviceID(w http.ResponseWriter, r *http.Request, loggingClient logger.LoggingClient) {
 	vars := mux.Vars(r)
 	did := vars[ID]
 	ctx := r.Context()
-	status, device, err := getCommandsByDeviceID(did, ctx)
+	status, device, err := getCommandsByDeviceID(did, ctx, loggingClient)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		http.Error(w, "Device not found", http.StatusNotFound)
 		return
 	} else if status != http.StatusOK {
@@ -105,13 +106,13 @@ func restGetCommandsByDeviceID(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(&device)
 }
 
-func restGetCommandsByDeviceName(w http.ResponseWriter, r *http.Request) {
+func restGetCommandsByDeviceName(w http.ResponseWriter, r *http.Request, loggingClient logger.LoggingClient) {
 	vars := mux.Vars(r)
 	dn := vars[NAME]
 	ctx := r.Context()
-	status, devices, err := getCommandsByDeviceName(dn, ctx)
+	status, devices, err := getCommandsByDeviceName(dn, ctx, loggingClient)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		http.Error(w, "Device not found", http.StatusNotFound)
 		return
 	} else if status != http.StatusOK {
@@ -122,11 +123,11 @@ func restGetCommandsByDeviceName(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(&devices)
 }
 
-func restGetAllCommands(w http.ResponseWriter, r *http.Request) {
+func restGetAllCommands(w http.ResponseWriter, r *http.Request, loggingClient logger.LoggingClient) {
 	ctx := r.Context()
-	status, devices, err := getCommands(ctx)
+	status, devices, err := getCommands(ctx, loggingClient)
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		w.WriteHeader(status)
 	} else if status != http.StatusOK {
 		w.WriteHeader(status)

--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (

--- a/internal/core/command/router.go
+++ b/internal/core/command/router.go
@@ -18,31 +18,38 @@ import (
 	"net/http"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/gorilla/mux"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
+	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 )
 
-func LoadRestRoutes() *mux.Router {
+func LoadRestRoutes(dic *di.Container) *mux.Router {
 	r := mux.NewRouter()
 
 	// Ping Resource
 	r.HandleFunc(clients.ApiPingRoute, pingHandler).Methods(http.MethodGet)
 
 	// Configuration
-	r.HandleFunc(clients.ApiConfigRoute, configHandler).Methods(http.MethodGet)
+	r.HandleFunc(clients.ApiConfigRoute, func(w http.ResponseWriter, r *http.Request) {
+		configHandler(w, bootstrapContainer.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 
 	// Metrics
-	r.HandleFunc(clients.ApiMetricsRoute, metricsHandler).Methods(http.MethodGet)
+	r.HandleFunc(clients.ApiMetricsRoute, func(w http.ResponseWriter, r *http.Request) {
+		metricsHandler(w, bootstrapContainer.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 
 	// Version
 	r.HandleFunc(clients.ApiVersionRoute, pkg.VersionHandler).Methods(http.MethodGet)
 
 	b := r.PathPrefix(clients.ApiBase).Subrouter()
 
-	loadDeviceRoutes(b)
+	loadDeviceRoutes(b, dic)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)
@@ -51,23 +58,37 @@ func LoadRestRoutes() *mux.Router {
 	return r
 }
 
-func loadDeviceRoutes(b *mux.Router) {
+func loadDeviceRoutes(b *mux.Router, dic *di.Container) {
 
-	b.HandleFunc("/device", restGetAllCommands).Methods(http.MethodGet)
+	b.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+		restGetAllCommands(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 
 	d := b.PathPrefix("/" + DEVICE).Subrouter()
 
 	// /api/<version>/device
-	d.HandleFunc("/{"+ID+"}", restGetCommandsByDeviceID).Methods(http.MethodGet)
-	d.HandleFunc("/{"+ID+"}/"+COMMAND+"/{"+COMMANDID+"}", restGetDeviceCommandByCommandID).Methods(http.MethodGet)
-	d.HandleFunc("/{"+ID+"}/"+COMMAND+"/{"+COMMANDID+"}", restPutDeviceCommandByCommandID).Methods(http.MethodPut)
+	d.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restGetCommandsByDeviceID(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+	d.HandleFunc("/{"+ID+"}/"+COMMAND+"/{"+COMMANDID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restGetDeviceCommandByCommandID(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+	d.HandleFunc("/{"+ID+"}/"+COMMAND+"/{"+COMMANDID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restPutDeviceCommandByCommandID(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
 
 	// /api/<version>/device/name
 	dn := d.PathPrefix("/" + NAME).Subrouter()
 
-	dn.HandleFunc("/{"+NAME+"}", restGetCommandsByDeviceName).Methods(http.MethodGet)
-	dn.HandleFunc("/{"+NAME+"}/"+COMMAND+"/{"+COMMANDNAME+"}", restGetDeviceCommandByNames).Methods(http.MethodGet)
-	dn.HandleFunc("/{"+NAME+"}/"+COMMAND+"/{"+COMMANDNAME+"}", restPutDeviceCommandByNames).Methods(http.MethodPut)
+	dn.HandleFunc("/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
+		restGetCommandsByDeviceName(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+	dn.HandleFunc("/{"+NAME+"}/"+COMMAND+"/{"+COMMANDNAME+"}", func(w http.ResponseWriter, r *http.Request) {
+		restGetCommandsByDeviceName(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+	dn.HandleFunc("/{"+NAME+"}/"+COMMAND+"/{"+COMMANDNAME+"}", func(w http.ResponseWriter, r *http.Request) {
+		restPutDeviceCommandByNames(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
 }
 
 // Test if the service is working
@@ -76,11 +97,11 @@ func pingHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte("pong"))
 }
 
-func configHandler(w http.ResponseWriter, _ *http.Request) {
+func configHandler(w http.ResponseWriter, LoggingClient logger.LoggingClient) {
 	pkg.Encode(Configuration, w, LoggingClient)
 }
 
-func metricsHandler(w http.ResponseWriter, _ *http.Request) {
+func metricsHandler(w http.ResponseWriter, LoggingClient logger.LoggingClient) {
 	s := telemetry.NewSystemUsage()
 
 	pkg.Encode(s, w, LoggingClient)

--- a/internal/core/command/router.go
+++ b/internal/core/command/router.go
@@ -97,14 +97,14 @@ func pingHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte("pong"))
 }
 
-func configHandler(w http.ResponseWriter, LoggingClient logger.LoggingClient) {
-	pkg.Encode(Configuration, w, LoggingClient)
+func configHandler(w http.ResponseWriter, loggingClient logger.LoggingClient) {
+	pkg.Encode(Configuration, w, loggingClient)
 }
 
-func metricsHandler(w http.ResponseWriter, LoggingClient logger.LoggingClient) {
+func metricsHandler(w http.ResponseWriter, loggingClient logger.LoggingClient) {
 	s := telemetry.NewSystemUsage()
 
-	pkg.Encode(s, w, LoggingClient)
+	pkg.Encode(s, w, loggingClient)
 
 	return
 }

--- a/internal/core/command/router.go
+++ b/internal/core/command/router.go
@@ -84,7 +84,7 @@ func loadDeviceRoutes(b *mux.Router, dic *di.Container) {
 		restGetCommandsByDeviceName(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
 	}).Methods(http.MethodGet)
 	dn.HandleFunc("/{"+NAME+"}/"+COMMAND+"/{"+COMMANDNAME+"}", func(w http.ResponseWriter, r *http.Request) {
-		restGetCommandsByDeviceName(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
+		restGetDeviceCommandByNames(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))
 	}).Methods(http.MethodGet)
 	dn.HandleFunc("/{"+NAME+"}/"+COMMAND+"/{"+COMMANDNAME+"}", func(w http.ResponseWriter, r *http.Request) {
 		restPutDeviceCommandByNames(w, r, bootstrapContainer.LoggingClientFrom(dic.Get))

--- a/internal/core/command/types.go
+++ b/internal/core/command/types.go
@@ -53,7 +53,10 @@ func (sc serviceCommand) Execute() (string, int, error) {
 	return buf.String(), resp.StatusCode, nil
 }
 
-func NewServiceCommand(device contract.Device, caller internal.HttpCaller, req *http.Request,
+func newServiceCommand(
+	device contract.Device,
+	caller internal.HttpCaller,
+	req *http.Request,
 	loggingClient logger.LoggingClient) serviceCommand {
 	return serviceCommand{
 		Device:        device,

--- a/internal/core/command/types.go
+++ b/internal/core/command/types.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -29,14 +30,19 @@ type serviceCommand struct {
 	contract.Device
 	internal.HttpCaller
 	*http.Request
+	loggingClient logger.LoggingClient
 }
 
 // Execute sends the command to the command service
 func (sc serviceCommand) Execute() (string, int, error) {
-	LoggingClient.Debug("Issuing" + sc.Request.Method + " command to: " + sc.Request.URL.String())
+	if sc.loggingClient != nil {
+		sc.loggingClient.Debug("Issuing" + sc.Request.Method + " command to: " + sc.Request.URL.String())
+	}
 	resp, reqErr := sc.HttpCaller.Do(sc.Request)
 	if reqErr != nil {
-		LoggingClient.Error(reqErr.Error())
+		if sc.loggingClient != nil {
+			sc.loggingClient.Error(reqErr.Error())
+		}
 		return "", http.StatusInternalServerError, reqErr
 
 	}

--- a/internal/core/command/types.go
+++ b/internal/core/command/types.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (
@@ -30,19 +31,15 @@ type serviceCommand struct {
 	contract.Device
 	internal.HttpCaller
 	*http.Request
-	loggingClient logger.LoggingClient
+	logger.LoggingClient
 }
 
 // Execute sends the command to the command service
 func (sc serviceCommand) Execute() (string, int, error) {
-	if sc.loggingClient != nil {
-		sc.loggingClient.Debug("Issuing" + sc.Request.Method + " command to: " + sc.Request.URL.String())
-	}
+	sc.LoggingClient.Debug("Issuing" + sc.Request.Method + " command to: " + sc.Request.URL.String())
 	resp, reqErr := sc.HttpCaller.Do(sc.Request)
 	if reqErr != nil {
-		if sc.loggingClient != nil {
-			sc.loggingClient.Error(reqErr.Error())
-		}
+		sc.LoggingClient.Error(reqErr.Error())
 		return "", http.StatusInternalServerError, reqErr
 
 	}
@@ -54,4 +51,14 @@ func (sc serviceCommand) Execute() (string, int, error) {
 		return "", DefaultErrorCode, readErr
 	}
 	return buf.String(), resp.StatusCode, nil
+}
+
+func NewServiceCommand(device contract.Device, caller internal.HttpCaller, req *http.Request,
+	loggingClient logger.LoggingClient) serviceCommand {
+	return serviceCommand{
+		Device:        device,
+		HttpCaller:    caller,
+		Request:       req,
+		LoggingClient: loggingClient,
+	}
 }

--- a/internal/core/command/types_test.go
+++ b/internal/core/command/types_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -58,7 +57,6 @@ func (MockBody) Close() error {
 func TestExecute(t *testing.T) {
 	expectedResponseBody := "Sample Response Body"
 	expectedResponseCode := http.StatusOK
-	LoggingClient = logger.MockLogger{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, expectedResponseBody)
 		w.WriteHeader(expectedResponseCode)
@@ -89,7 +87,6 @@ func TestExecute(t *testing.T) {
 }
 
 func TestExecuteHttpRequestError(t *testing.T) {
-	LoggingClient = logger.MockLogger{}
 	request, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	sc := serviceCommand{
 		Device: contract.Device{
@@ -106,7 +103,6 @@ func TestExecuteHttpRequestError(t *testing.T) {
 }
 
 func TestExecuteHttpReadResponseError(t *testing.T) {
-	LoggingClient = logger.MockLogger{}
 	request, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	sc := serviceCommand{
 		Device: contract.Device{

--- a/internal/core/command/types_test.go
+++ b/internal/core/command/types_test.go
@@ -66,7 +66,7 @@ func TestExecute(t *testing.T) {
 	defer ts.Close()
 
 	request, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
-	sc := NewServiceCommand(contract.Device{AdminState: contract.Unlocked}, &http.Client{}, request, logger.NewMockClient())
+	sc := newServiceCommand(contract.Device{AdminState: contract.Unlocked}, &http.Client{}, request, logger.NewMockClient())
 
 	body, responseCode, err := sc.Execute()
 	if err != nil {
@@ -84,7 +84,7 @@ func TestExecute(t *testing.T) {
 
 func TestExecuteHttpRequestError(t *testing.T) {
 	request, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
-	sc := NewServiceCommand(contract.Device{AdminState: contract.Unlocked}, &FailingMockHttpCaller{}, request, logger.NewMockClient())
+	sc := newServiceCommand(contract.Device{AdminState: contract.Unlocked}, &FailingMockHttpCaller{}, request, logger.NewMockClient())
 
 	_, _, err := sc.Execute()
 	if err == nil {
@@ -94,7 +94,7 @@ func TestExecuteHttpRequestError(t *testing.T) {
 
 func TestExecuteHttpReadResponseError(t *testing.T) {
 	request, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
-	sc := NewServiceCommand(contract.Device{AdminState: contract.Unlocked}, &ReadFailMockHttpCaller{}, request, logger.NewMockClient())
+	sc := newServiceCommand(contract.Device{AdminState: contract.Unlocked}, &ReadFailMockHttpCaller{}, request, logger.NewMockClient())
 
 	_, responseCode, err := sc.Execute()
 	if err == nil {

--- a/internal/core/command/types_test.go
+++ b/internal/core/command/types_test.go
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package command
 
 import (
@@ -20,6 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -64,13 +66,7 @@ func TestExecute(t *testing.T) {
 	defer ts.Close()
 
 	request, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
-	sc := serviceCommand{
-		Device: contract.Device{
-			AdminState: contract.Unlocked,
-		},
-		HttpCaller: &http.Client{},
-		Request:    request,
-	}
+	sc := NewServiceCommand(contract.Device{AdminState: contract.Unlocked}, &http.Client{}, request, logger.NewMockClient())
 
 	body, responseCode, err := sc.Execute()
 	if err != nil {
@@ -88,13 +84,7 @@ func TestExecute(t *testing.T) {
 
 func TestExecuteHttpRequestError(t *testing.T) {
 	request, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
-	sc := serviceCommand{
-		Device: contract.Device{
-			AdminState: contract.Unlocked,
-		},
-		HttpCaller: &FailingMockHttpCaller{},
-		Request:    request,
-	}
+	sc := NewServiceCommand(contract.Device{AdminState: contract.Unlocked}, &FailingMockHttpCaller{}, request, logger.NewMockClient())
 
 	_, _, err := sc.Execute()
 	if err == nil {
@@ -104,13 +94,7 @@ func TestExecuteHttpRequestError(t *testing.T) {
 
 func TestExecuteHttpReadResponseError(t *testing.T) {
 	request, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
-	sc := serviceCommand{
-		Device: contract.Device{
-			AdminState: contract.Unlocked,
-		},
-		HttpCaller: &ReadFailMockHttpCaller{},
-		Request:    request,
-	}
+	sc := NewServiceCommand(contract.Device{AdminState: contract.Unlocked}, &ReadFailMockHttpCaller{}, request, logger.NewMockClient())
 
 	_, responseCode, err := sc.Execute()
 	if err == nil {

--- a/internal/pkg/di/container.go
+++ b/internal/pkg/di/container.go
@@ -92,7 +92,9 @@ func NewContainer(serviceConstructors ServiceConstructorMap) *Container {
 		serviceMap: map[string]service{},
 		mutex:      sync.RWMutex{},
 	}
-	c.Update(serviceConstructors)
+	if serviceConstructors != nil {
+		c.Update(serviceConstructors)
+	}
 	return &c
 }
 


### PR DESCRIPTION
Fix #2013 

Update core-command to leverage the dependency injection container(DIC)
during bootstrap and pass a 'LoggingClient' instance down the call stack
to eliminate the need for the 'LoggingClient' global variable.

Signed-off-by: Brandon Forster <brandonforster@gmail.com>