### PR TITLE
Add edgexproxy-cmd as app so it can be run by user

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -175,6 +175,12 @@ apps:
     plugs:
       - network
       - network-bind
+  edgexproxy-cmd:
+    adapter: none
+    command: bin/edgexproxy-wrapper.sh
+    plugs:
+      - network
+      - network-bind
   edgex-mongo:
     adapter: full
     after: [mongod]


### PR DESCRIPTION
Simply add it is app non-daemon. As mentioned, I've not tested this.