### PR TITLE
Add edgexproxy-cmd as app so it can be run by user

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -175,6 +175,12 @@ apps:
     plugs:
       - network
       - network-bind
+  edgexproxy-cmd:
+    adapter: none
+    command: bin/edgexproxy
+    plugs:
+      - network
+      - network-bind
   edgex-mongo:
     adapter: full
     after: [mongod]


### PR DESCRIPTION
Untested, as mentioned previously. Might want to change edgexproxy (snapcraft daemon) to  edgexproxy-daemon so that the command introduced here can be named simply edgexproxy: let me know.

Fixes https://github.com/edgexfoundry/edgex-go/issues/1472