### PR TITLE
many/configuration.toml: set default security key values, fix proxy SNIs

### DIFF
--- a/bin/edgex-launch.sh
+++ b/bin/edgex-launch.sh
@@ -21,6 +21,9 @@ function cleanup {
 	pkill edgex
 }
 
+# disable secret-store integration
+export EDGEX_SECURITY_SECRET_STORE=false
+
 ###
 # Support logging
 ###

--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -48,6 +48,9 @@ Port = 8200
 # Use the core-meta data secrets due to core-command using core-meta-data's database for persistance.
 Path = '/v1/secret/edgex/metadata/'
 Protocol = 'https'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'localhost'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -60,6 +60,9 @@ Host = 'localhost'
 Port = 8200
 Path = '/v1/secret/edgex/coredata/'
 Protocol = 'https'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'localhost'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -60,6 +60,9 @@ Host = 'localhost'
 Port = 8200
 Path = '/v1/secret/edgex/metadata/'
 Protocol = 'https'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'localhost'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/export-client/res/configuration.toml
+++ b/cmd/export-client/res/configuration.toml
@@ -47,6 +47,9 @@ Host = 'localhost'
 Port = 8200
 Path = '/v1/secret/edgex/exportclient/'
 Protocol = 'https'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'localhost'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -48,7 +48,7 @@ HealthCheckPath = "v1/sys/health"
 CertPath = "v1/secret/edgex/pki/tls/edgex-kong"
 TokenPath = "res/resp-init.json"
 CACertPath = "res/EdgeXFoundryCA/EdgeXFoundryCA.pem"
-SNIS = ["edgex-kong"]
+SNIS = ["localhost"]
 
 [Clients]
   [Clients.Coredata]

--- a/cmd/support-logging/res/configuration.toml
+++ b/cmd/support-logging/res/configuration.toml
@@ -36,6 +36,9 @@ Host = 'localhost'
 Port = 8200
 Path = '/v1/secret/edgex/logging/'
 Protocol = 'https'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'localhost'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -52,6 +52,9 @@ Host = 'localhost'
 Port = 8200
 Path = '/v1/secret/edgex/notifications/'
 Protocol = 'https'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'localhost'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -70,6 +70,9 @@ Host = 'localhost'
 Port = 8200
 Path = '/v1/secret/edgex/scheduler/'
 Protocol = 'https'
+RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
+ServerName = 'localhost'
+TokenFile = '/vault/config/assets/resp-init.json'
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'


### PR DESCRIPTION
See the commit messages for a more thorough explanation, but basically we should be consistent in setting these values for a few reasons, one of which is that it greatly simplifies setting up the security workflow for the snap as a part of my work on #1840

If we don't do this, then I have to either:
- convert the toml file to json to use jq to set these values, then convert back to toml
- use a really nasty sed expression to replace lines with stuff that is really going above the matching lines so that we can insert these keys into the middle of the file

Neither of which I really want to do.

The regression potential here is pretty low since we're simply adding default values (same as for the docker configuration.toml) to config files.

The other change here is changing the default `SNIS` setting for security-proxy-setup to localhost instead of edgex-kong for the non-docker configuration.toml file.