### PR TITLE
[FUJI BRANCH] Fix nil panic when configuration.toml can't be loaded.

### DIFF
--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -64,6 +64,10 @@ func main() {
 		BootTimeout: internal.BootTimeoutDefault,
 	}
 	startup.Bootstrap(params, proxy.Retry, logBeforeInit)
+	if proxy.Configuration == nil {
+		// proxy.LoggingClient wasn't initialized either
+		os.Exit(1)
+	}
 
 	req := proxy.NewRequestor(insecureSkipVerify, proxy.Configuration.Writable.RequestTimeout)
 

--- a/internal/security/proxy/init.go
+++ b/internal/security/proxy/init.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 // Global variables
@@ -35,6 +36,11 @@ func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sy
 		var err error
 		// When looping, only handle configuration if it hasn't already been set.
 		if Configuration == nil {
+			// Next two lines are workaround for issue #1814 (nil panic while logging)
+			// where config.LoadFromFile depends on a global LoggingClient that isn't set anywhere
+			// Remove this workaround once this tool is migrated to common bootstrap.
+			lc := logger.NewClient(internal.SecurityProxySetupServiceKey, false, "", models.InfoLog)
+			config.LoggingClient = lc
 			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
 			if err != nil {
 				ch <- err


### PR DESCRIPTION
Fix nil panic when configuration.toml can't be loaded.

Fixes #1814 

When configuration.toml can't be loaded, the
LoggingClient global variable isn't initialized,
causing main program to panic when it attempts
to log that configuration.toml can't be loaded.

This is a temporary workaround until security-proxy-setup
is migrated to the common bootstrap.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>