### PR TITLE
Refactor Metadata-related code to remove LoggingClient global variable.

### DIFF
--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -48,7 +48,8 @@ func main() {
 	flag.Usage = usage.HelpCallback
 	flag.Parse()
 
-	httpServer := httpserver.NewBootstrap(metadata.LoadRestRoutes())
+	dic := di.NewContainer(di.ServiceConstructorMap{})
+	httpServer := httpserver.NewBootstrap(metadata.LoadRestRoutes(dic))
 	bootstrap.Run(
 		configDir,
 		profileDir,
@@ -57,7 +58,7 @@ func main() {
 		clients.CoreMetaDataServiceKey,
 		metadata.Configuration,
 		startupTimer,
-		di.NewContainer(di.ServiceConstructorMap{}),
+		dic,
 		[]interfaces.BootstrapHandler{
 			secret.NewSecret().BootstrapHandler,
 			database.NewDatabase(&httpServer, metadata.Configuration).BootstrapHandler,

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 )
@@ -35,7 +34,6 @@ import (
 // Global variables
 var Configuration = &ConfigurationStruct{}
 var dbClient interfaces.DBClient
-var LoggingClient logger.LoggingClient
 var nc notifications.NotificationsClient
 var vdc coredata.ValueDescriptorClient
 var httpErrorHandler errorconcept.ErrorHandler
@@ -43,10 +41,9 @@ var httpErrorHandler errorconcept.ErrorHandler
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the metadata service.
 func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
-	LoggingClient = container.LoggingClientFrom(dic.Get)
 	dbClient = container.DBClientFrom(dic.Get)
 
-	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
+	httpErrorHandler = errorconcept.NewErrorHandler(container.LoggingClientFrom(dic.Get))
 
 	// initialize clients required by service.
 	registryClient := container.RegistryFrom(dic.Get)

--- a/internal/core/metadata/rest_addressable.go
+++ b/internal/core/metadata/rest_addressable.go
@@ -22,13 +22,19 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/operators/addressable"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
 	"github.com/gorilla/mux"
 )
 
-func restGetAllAddressables(w http.ResponseWriter, _ *http.Request) {
-	op := addressable.NewAddressableLoadAll(Configuration.Service, dbClient, LoggingClient)
+func restGetAllAddressables(
+	w http.ResponseWriter,
+	loggingClient logger.LoggingClient) {
+
+	op := addressable.NewAddressableLoadAll(Configuration.Service, dbClient, loggingClient)
 	addressables, err := op.Execute()
 	if err != nil {
 		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.LimitExceeded, errorconcept.Default.InternalServerError)
@@ -44,7 +50,11 @@ func restGetAllAddressables(w http.ResponseWriter, _ *http.Request) {
 
 // Add a new addressable
 // The name must be unique
-func restAddAddressable(w http.ResponseWriter, r *http.Request) {
+func restAddAddressable(
+	w http.ResponseWriter,
+	r *http.Request,
+	loggingClient logger.LoggingClient) {
+
 	defer r.Body.Close()
 	var a models.Addressable
 	err := json.NewDecoder(r.Body).Decode(&a)
@@ -69,13 +79,17 @@ func restAddAddressable(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(id))
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		return
 	}
 }
 
 // Update addressable by ID or name (ID used first)
-func restUpdateAddressable(w http.ResponseWriter, r *http.Request) {
+func restUpdateAddressable(
+	w http.ResponseWriter,
+	r *http.Request,
+	loggingClient logger.LoggingClient) {
+
 	defer r.Body.Close()
 	var a models.Addressable
 	err := json.NewDecoder(r.Body).Decode(&a)
@@ -102,7 +116,7 @@ func restUpdateAddressable(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte("true"))
 	if err != nil {
-		LoggingClient.Error(err.Error())
+		loggingClient.Error(err.Error())
 		return
 	}
 }

--- a/internal/core/metadata/rest_addressable_test.go
+++ b/internal/core/metadata/rest_addressable_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strconv"
 	"testing"
 
@@ -32,6 +31,7 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/mock"
 )
@@ -52,13 +52,9 @@ var ErrorPathParam = "%zz"
 // ErrorPortPathParam path parameter used to trigger an error in the `restGetAddressableByPort` function where the port variable is expected to be a number.
 var ErrorPortPathParam = "abc"
 
-func TestMain(m *testing.M) {
-	LoggingClient = logger.NewMockClient()
-	httpErrorHandler = errorconcept.NewErrorHandler(LoggingClient)
-	os.Exit(m.Run())
-}
-
 func TestGetAllAddressables(t *testing.T) {
+
+	httpErrorHandler = errorconcept.NewErrorHandler(logger.NewMockClient())
 	Configuration = &ConfigurationStruct{Service: config.ServiceInfo{MaxResultCount: 10}}
 	defer func() { Configuration = &ConfigurationStruct{} }()
 
@@ -98,8 +94,7 @@ func TestGetAllAddressables(t *testing.T) {
 
 			dbClient = tt.dbMock
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(restGetAllAddressables)
-			handler.ServeHTTP(rr, tt.request)
+			restGetAllAddressables(rr, logger.NewMockClient())
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -159,8 +154,7 @@ func TestAddAddressable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dbClient = tt.dbMock
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(restAddAddressable)
-			handler.ServeHTTP(rr, tt.request)
+			restAddAddressable(rr, tt.request, logger.NewMockClient())
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -233,8 +227,7 @@ func TestUpdateAddressable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dbClient = tt.dbMock
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(restUpdateAddressable)
-			handler.ServeHTTP(rr, tt.request)
+			restUpdateAddressable(rr, tt.request, logger.NewMockClient())
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)

--- a/internal/core/metadata/rest_command.go
+++ b/internal/core/metadata/rest_command.go
@@ -21,20 +21,30 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/operators/command"
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
 	"github.com/gorilla/mux"
 )
 
-func restGetAllCommands(w http.ResponseWriter, _ *http.Request) {
+func restGetAllCommands(
+	w http.ResponseWriter,
+	loggingClient logger.LoggingClient) {
+
 	op := command.NewCommandLoadAll(Configuration.Service, dbClient)
 	cmds, err := op.Execute()
 	if err != nil {
 		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.LimitExceeded, errorconcept.Default.InternalServerError)
 		return
 	}
-	pkg.Encode(&cmds, w, LoggingClient)
+	pkg.Encode(&cmds, w, loggingClient)
 }
 
-func restGetCommandById(w http.ResponseWriter, r *http.Request) {
+func restGetCommandById(
+	w http.ResponseWriter,
+	r *http.Request,
+	loggingClient logger.LoggingClient) {
+
 	vars := mux.Vars(r)
 	cid, err := url.QueryUnescape(vars[ID])
 	if err != nil {
@@ -48,10 +58,13 @@ func restGetCommandById(w http.ResponseWriter, r *http.Request) {
 		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
-	pkg.Encode(cmd, w, LoggingClient)
+	pkg.Encode(cmd, w, loggingClient)
 }
 
-func restGetCommandsByName(w http.ResponseWriter, r *http.Request) {
+func restGetCommandsByName(
+	w http.ResponseWriter,
+	r *http.Request,
+	loggingClient logger.LoggingClient) {
 	vars := mux.Vars(r)
 	n, err := url.QueryUnescape(vars[NAME])
 	if err != nil {
@@ -64,10 +77,14 @@ func restGetCommandsByName(w http.ResponseWriter, r *http.Request) {
 		httpErrorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
-	pkg.Encode(&cmds, w, LoggingClient)
+	pkg.Encode(&cmds, w, loggingClient)
 }
 
-func restGetCommandsByDeviceId(w http.ResponseWriter, r *http.Request) {
+func restGetCommandsByDeviceId(
+	w http.ResponseWriter,
+	r *http.Request,
+	loggingClient logger.LoggingClient) {
+
 	vars := mux.Vars(r)
 	did, err := url.QueryUnescape(vars[ID])
 	if err != nil {
@@ -81,5 +98,5 @@ func restGetCommandsByDeviceId(w http.ResponseWriter, r *http.Request) {
 		httpErrorHandler.HandleOneVariant(w, err, errorconcept.Common.ItemNotFound, errorconcept.Default.InternalServerError)
 		return
 	}
-	pkg.Encode(&commands, w, LoggingClient)
+	pkg.Encode(&commands, w, loggingClient)
 }

--- a/internal/core/metadata/rest_command_test.go
+++ b/internal/core/metadata/rest_command_test.go
@@ -10,8 +10,11 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
@@ -52,9 +55,7 @@ func TestGetCommandsByDeviceId(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dbClient = tt.dbMock
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(restGetCommandsByDeviceId)
-
-			handler.ServeHTTP(rr, tt.request)
+			restGetCommandsByDeviceId(rr, tt.request, logger.NewMockClient())
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -80,9 +81,7 @@ func TestGetAllCommands(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dbClient = tt.dbMock
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(restGetAllCommands)
-
-			handler.ServeHTTP(rr, tt.request)
+			restGetAllCommands(rr, logger.NewMockClient())
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -130,9 +129,7 @@ func TestGetCommandById(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dbClient = tt.dbMock
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(restGetCommandById)
-
-			handler.ServeHTTP(rr, tt.request)
+			restGetCommandById(rr, tt.request, logger.NewMockClient())
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -172,9 +169,7 @@ func TestGetCommandsByName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dbClient = tt.dbMock
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(restGetCommandsByName)
-
-			handler.ServeHTTP(rr, tt.request)
+			restGetCommandsByName(rr, tt.request, logger.NewMockClient())
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -199,7 +194,7 @@ var cmdNotFoundErr = types.NewErrItemNotFound(fmt.Sprintf("command with id %s no
 var deviceNotFoundErr = types.NewErrItemNotFound(fmt.Sprintf("device with id %s not found", deviceId))
 
 var commands = []contract.Command{
-	contract.Command{Name: fmt.Sprintf(commandName)},
+	{Name: fmt.Sprintf(commandName)},
 	{Name: fmt.Sprintf("Command 1")},
 	{Name: fmt.Sprintf("Command 2")},
 }

--- a/internal/core/metadata/rest_device_test.go
+++ b/internal/core/metadata/rest_device_test.go
@@ -22,18 +22,14 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/pkg/errors"
 )
 
 func TestGetAllDevices(t *testing.T) {
 	Configuration = &ConfigurationStruct{Service: config.ServiceInfo{MaxResultCount: 1}}
-	req, err := http.NewRequest(http.MethodGet, clients.ApiBase+"/"+DEVICE, nil)
-	if err != nil {
-		t.Error(err)
-		return
-	}
 
 	tests := []struct {
 		name           string
@@ -48,9 +44,7 @@ func TestGetAllDevices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dbClient = tt.dbMock
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(restGetAllDevices)
-
-			handler.ServeHTTP(rr, req)
+			restGetAllDevices(rr, logger.NewMockClient())
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)

--- a/internal/core/metadata/rest_deviceservice_test.go
+++ b/internal/core/metadata/rest_deviceservice_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
@@ -45,11 +47,6 @@ var testError = errors.New("some error")
 
 func TestGetAllDeviceServices(t *testing.T) {
 	Configuration = &ConfigurationStruct{Service: config.ServiceInfo{MaxResultCount: 1}}
-	req, err := http.NewRequest(http.MethodGet, testDeviceServiceURI, nil)
-	if err != nil {
-		t.Error(err)
-		return
-	}
 
 	tests := []struct {
 		name           string
@@ -64,9 +61,7 @@ func TestGetAllDeviceServices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dbClient = tt.dbMock
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(restGetAllDeviceServices)
-
-			handler.ServeHTTP(rr, req)
+			restGetAllDeviceServices(rr, logger.NewMockClient())
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -16,38 +16,46 @@ package metadata
 import (
 	"net/http"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/gorilla/mux"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/gorilla/mux"
 )
 
-func LoadRestRoutes() *mux.Router {
+func LoadRestRoutes(dic *di.Container) *mux.Router {
 	r := mux.NewRouter()
 
 	// Ping Resource
 	r.HandleFunc(clients.ApiPingRoute, pingHandler).Methods(http.MethodGet)
 
 	// Configuration
-	r.HandleFunc(clients.ApiConfigRoute, configHandler).Methods(http.MethodGet)
+	r.HandleFunc(clients.ApiConfigRoute, func(w http.ResponseWriter, r *http.Request) {
+		configHandler(w, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 
 	// Metrics
-	r.HandleFunc(clients.ApiMetricsRoute, metricsHandler).Methods(http.MethodGet)
+	r.HandleFunc(clients.ApiMetricsRoute, func(w http.ResponseWriter, r *http.Request) {
+		metricsHandler(w, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 
 	// Version
 	r.HandleFunc(clients.ApiVersionRoute, pkg.VersionHandler).Methods(http.MethodGet)
 
 	b := r.PathPrefix(clients.ApiBase).Subrouter()
 
-	loadDeviceRoutes(b)
-	loadDeviceProfileRoutes(b)
-	loadDeviceReportRoutes(b)
-	loadDeviceServiceRoutes(b)
-	loadProvisionWatcherRoutes(b)
-	loadAddressableRoutes(b)
-	loadCommandRoutes(b)
+	loadDeviceRoutes(b, dic)
+	loadDeviceProfileRoutes(b, dic)
+	loadDeviceReportRoutes(b, dic)
+	loadDeviceServiceRoutes(b, dic)
+	loadProvisionWatcherRoutes(b, dic)
+	loadAddressableRoutes(b, dic)
+	loadCommandRoutes(b, dic)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)
@@ -55,11 +63,17 @@ func LoadRestRoutes() *mux.Router {
 
 	return r
 }
-func loadDeviceRoutes(b *mux.Router) {
+func loadDeviceRoutes(b *mux.Router, dic *di.Container) {
 	// /api/v1/" + DEVICE
-	b.HandleFunc("/"+DEVICE, restAddNewDevice).Methods(http.MethodPost)
-	b.HandleFunc("/"+DEVICE, restUpdateDevice).Methods(http.MethodPut)
-	b.HandleFunc("/"+DEVICE, restGetAllDevices).Methods(http.MethodGet)
+	b.HandleFunc("/"+DEVICE, func(w http.ResponseWriter, r *http.Request) {
+		restAddNewDevice(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPost)
+	b.HandleFunc("/"+DEVICE, func(w http.ResponseWriter, r *http.Request) {
+		restUpdateDevice(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	b.HandleFunc("/"+DEVICE, func(w http.ResponseWriter, r *http.Request) {
+		restGetAllDevices(w, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 
 	d := b.PathPrefix("/" + DEVICE).Subrouter()
 
@@ -71,30 +85,64 @@ func loadDeviceRoutes(b *mux.Router) {
 
 	// /api/v1/" + DEVICE" + ID + "
 	d.HandleFunc("/{"+ID+"}", restGetDeviceById).Methods(http.MethodGet)
-	d.HandleFunc("/{"+ID+"}", restSetDeviceStateById).Methods(http.MethodPut)
-	d.HandleFunc("/"+ID+"/{"+ID+"}", restDeleteDeviceById).Methods(http.MethodDelete)
-	d.HandleFunc("/{"+ID+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}", restSetDeviceLastReportedById).Methods(http.MethodPut)
-	d.HandleFunc("/{"+ID+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}/{"+LASTREPORTEDNOTIFY+"}", restSetDeviceLastReportedByIdNotify).Methods(http.MethodPut)
-	d.HandleFunc("/{"+ID+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}", restSetDeviceLastConnectedById).Methods(http.MethodPut)
-	d.HandleFunc("/{"+ID+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}/{"+LASTCONNECTEDNOTIFY+"}", restSetLastConnectedByIdNotify).Methods(http.MethodPut)
-	d.HandleFunc("/"+CHECK+"/{"+ID+"}", restCheckForDevice).Methods(http.MethodGet)
+	d.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetDeviceStateById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	d.HandleFunc("/"+ID+"/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restDeleteDeviceById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodDelete)
+	d.HandleFunc("/{"+ID+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetDeviceLastReportedById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	d.HandleFunc("/{"+ID+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}/{"+LASTREPORTEDNOTIFY+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetDeviceLastReportedByIdNotify(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	d.HandleFunc("/{"+ID+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetDeviceLastConnectedById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	d.HandleFunc("/{"+ID+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}/{"+LASTCONNECTEDNOTIFY+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetLastConnectedByIdNotify(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	d.HandleFunc("/"+CHECK+"/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restCheckForDevice(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 
 	// /api/v1/" + DEVICE/" + NAME + "
 	n := d.PathPrefix("/" + NAME).Subrouter()
+
 	n.HandleFunc("/{"+NAME+"}", restGetDeviceByName).Methods(http.MethodGet)
-	n.HandleFunc("/{"+NAME+"}", restDeleteDeviceByName).Methods(http.MethodDelete)
-	n.HandleFunc("/{"+NAME+"}", restSetDeviceStateByDeviceName).Methods(http.MethodPut)
-	n.HandleFunc("/{"+NAME+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}", restSetDeviceLastReportedByName).Methods(http.MethodPut)
-	n.HandleFunc("/{"+NAME+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}/{"+LASTREPORTEDNOTIFY+"}", restSetDeviceLastReportedByNameNotify).Methods(http.MethodPut)
-	n.HandleFunc("/{"+NAME+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}", restSetDeviceLastConnectedByName).Methods(http.MethodPut)
-	n.HandleFunc("/{"+NAME+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}/{"+LASTCONNECTEDNOTIFY+"}", restSetDeviceLastConnectedByNameNotify).Methods(http.MethodPut)
+	n.HandleFunc("/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
+		restDeleteDeviceByName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodDelete)
+	n.HandleFunc("/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetDeviceStateByDeviceName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	n.HandleFunc("/{"+NAME+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetDeviceLastReportedByName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	n.HandleFunc("/{"+NAME+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}/{"+LASTREPORTEDNOTIFY+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetDeviceLastReportedByNameNotify(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	n.HandleFunc("/{"+NAME+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetDeviceLastConnectedByName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	n.HandleFunc("/{"+NAME+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}/{"+LASTCONNECTEDNOTIFY+"}", func(w http.ResponseWriter, r *http.Request) {
+		restSetDeviceLastConnectedByNameNotify(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+
 }
 
-func loadDeviceProfileRoutes(b *mux.Router) {
+func loadDeviceProfileRoutes(b *mux.Router, dic *di.Container) {
 	///api/v1/" + DEVICEPROFILE + "
-	b.HandleFunc("/"+DEVICEPROFILE+"", restGetAllDeviceProfiles).Methods(http.MethodGet)
-	b.HandleFunc("/"+DEVICEPROFILE+"", restAddDeviceProfile).Methods(http.MethodPost)
-	b.HandleFunc("/"+DEVICEPROFILE+"", restUpdateDeviceProfile).Methods(http.MethodPut)
+	b.HandleFunc("/"+DEVICEPROFILE+"", func(w http.ResponseWriter, r *http.Request) {
+		restGetAllDeviceProfiles(w, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+	b.HandleFunc("/"+DEVICEPROFILE+"", func(w http.ResponseWriter, r *http.Request) {
+		restAddDeviceProfile(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPost)
+	b.HandleFunc("/"+DEVICEPROFILE+"", func(w http.ResponseWriter, r *http.Request) {
+		restUpdateDeviceProfile(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
 
 	dp := b.PathPrefix("/" + DEVICEPROFILE).Subrouter()
 	dp.HandleFunc("/{"+ID+"}", restGetProfileByProfileId).Methods(http.MethodGet)
@@ -118,33 +166,52 @@ func loadDeviceProfileRoutes(b *mux.Router) {
 	dpy := dp.PathPrefix("/" + YAML).Subrouter()
 	// TODO add functionality
 	dpy.HandleFunc("/"+NAME+"/{"+NAME+"}", restGetYamlProfileByName).Methods(http.MethodGet)
-	dpy.HandleFunc("/{"+ID+"}", restGetYamlProfileById).Methods(http.MethodGet)
+	dpy.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restGetYamlProfileById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 }
-func loadDeviceReportRoutes(b *mux.Router) {
+func loadDeviceReportRoutes(b *mux.Router, dic *di.Container) {
 	// /api/v1/devicereport
-	b.HandleFunc("/"+DEVICEREPORT, restGetAllDeviceReports).Methods(http.MethodGet)
-	b.HandleFunc("/"+DEVICEREPORT, restAddDeviceReport).Methods(http.MethodPost)
-	b.HandleFunc("/"+DEVICEREPORT, restUpdateDeviceReport).Methods(http.MethodPut)
+	b.HandleFunc("/"+DEVICEREPORT, func(w http.ResponseWriter, r *http.Request) {
+		restGetAllDeviceReports(w, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+
+	b.HandleFunc("/"+DEVICEREPORT, func(w http.ResponseWriter, r *http.Request) {
+		restAddDeviceReport(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPost)
+	b.HandleFunc("/"+DEVICEREPORT, func(w http.ResponseWriter, r *http.Request) {
+		restUpdateDeviceReport(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
 
 	dr := b.PathPrefix("/" + DEVICEREPORT).Subrouter()
 	dr.HandleFunc("/{"+ID+"}", restGetReportById).Methods(http.MethodGet)
-	dr.HandleFunc("/"+ID+"/{"+ID+"}", restDeleteReportById).Methods(http.MethodDelete)
+	dr.HandleFunc("/"+ID+"/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restDeleteReportById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodDelete)
+
 	dr.HandleFunc("/"+DEVICENAME+"/{"+DEVICENAME+"}", restGetDeviceReportByDeviceName).Methods(http.MethodGet)
 
 	// /api/v1/devicereport/" + NAME + "
 	drn := dr.PathPrefix("/" + NAME).Subrouter()
 	drn.HandleFunc("/{"+NAME+"}", restGetReportByName).Methods(http.MethodGet)
-	drn.HandleFunc("/{"+NAME+"}", restDeleteReportByName).Methods(http.MethodDelete)
+	drn.HandleFunc("/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
+		restDeleteReportByName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodDelete)
 
 	// /api/v1/devicereport/valueDescriptorsFor/devicename
 	drvd := dr.PathPrefix("/" + VALUEDESCRIPTORSFOR).Subrouter()
 	drvd.HandleFunc("/{"+DEVICENAME+"}", restGetValueDescriptorsForDeviceName).Methods(http.MethodGet)
 }
-func loadDeviceServiceRoutes(b *mux.Router) {
+func loadDeviceServiceRoutes(b *mux.Router, dic *di.Container) {
 	// /api/v1/deviceservice
-	b.HandleFunc("/"+DEVICESERVICE, restGetAllDeviceServices).Methods(http.MethodGet)
+	b.HandleFunc("/"+DEVICESERVICE, func(w http.ResponseWriter, r *http.Request) {
+		restGetAllDeviceServices(w, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+
 	b.HandleFunc("/"+DEVICESERVICE, restAddDeviceService).Methods(http.MethodPost)
-	b.HandleFunc("/"+DEVICESERVICE, restUpdateDeviceService).Methods(http.MethodPut)
+	b.HandleFunc("/"+DEVICESERVICE, func(w http.ResponseWriter, r *http.Request) {
+		restUpdateDeviceService(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
 
 	ds := b.PathPrefix("/" + DEVICESERVICE).Subrouter()
 	ds.HandleFunc("/"+ADDRESSABLENAME+"/{"+ADDRESSABLENAME+"}", restGetServiceByAddressableName).Methods(http.MethodGet)
@@ -154,30 +221,62 @@ func loadDeviceServiceRoutes(b *mux.Router) {
 	// /api/v1/deviceservice/" + NAME + "
 	dsn := ds.PathPrefix("/" + NAME).Subrouter()
 	dsn.HandleFunc("/{"+NAME+"}", restGetServiceByName).Methods(http.MethodGet)
-	dsn.HandleFunc("/{"+NAME+"}", restDeleteServiceByName).Methods(http.MethodDelete)
+	dsn.HandleFunc("/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
+		restDeleteServiceByName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodDelete)
+
 	dsn.HandleFunc("/{"+NAME+"}/"+OPSTATE+"/{"+OPSTATE+"}", restUpdateServiceOpStateByName).Methods(http.MethodPut)
 	dsn.HandleFunc("/{"+NAME+"}/"+URLADMINSTATE+"/{"+ADMINSTATE+"}", restUpdateServiceAdminStateByName).Methods(http.MethodPut)
-	dsn.HandleFunc("/{"+NAME+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}", restUpdateServiceLastReportedByName).Methods(http.MethodPut)
-	dsn.HandleFunc("/{"+NAME+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}", restUpdateServiceLastConnectedByName).Methods(http.MethodPut)
+	dsn.HandleFunc("/{"+NAME+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}", func(w http.ResponseWriter, r *http.Request) {
+		restUpdateServiceLastReportedByName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	dsn.HandleFunc("/{"+NAME+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}", func(w http.ResponseWriter, r *http.Request) {
+		restUpdateServiceLastConnectedByName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
 
 	// /api/v1/"  + DEVICESERVICE + ID + "
 	ds.HandleFunc("/{"+ID+"}", restGetServiceById).Methods(http.MethodGet)
-	ds.HandleFunc("/"+ID+"/{"+ID+"}", restDeleteServiceById).Methods(http.MethodDelete)
+	ds.HandleFunc("/"+ID+"/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restDeleteServiceById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodDelete)
+
+	ds.HandleFunc("/"+ID+"/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restDeleteServiceById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodDelete)
+
 	ds.HandleFunc("/{"+ID+"}/"+OPSTATE+"/{"+OPSTATE+"}", restUpdateServiceOpStateById).Methods(http.MethodPut)
 	ds.HandleFunc("/{"+ID+"}/"+URLADMINSTATE+"/{"+ADMINSTATE+"}", restUpdateServiceAdminStateById).Methods(http.MethodPut)
-	ds.HandleFunc("/{"+ID+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}", restUpdateServiceLastReportedById).Methods(http.MethodPut)
-	ds.HandleFunc("/{"+ID+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}", restUpdateServiceLastConnectedById).Methods(http.MethodPut)
+	ds.HandleFunc("/{"+ID+"}/"+URLLASTREPORTED+"/{"+LASTREPORTED+"}", func(w http.ResponseWriter, r *http.Request) {
+		restUpdateServiceLastReportedById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	ds.HandleFunc("/{"+ID+"}/"+URLLASTCONNECTED+"/{"+LASTCONNECTED+"}", func(w http.ResponseWriter, r *http.Request) {
+		restUpdateServiceLastConnectedById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+
 }
 
-func loadProvisionWatcherRoutes(b *mux.Router) {
-	b.HandleFunc("/"+PROVISIONWATCHER, restAddProvisionWatcher).Methods(http.MethodPost)
-	b.HandleFunc("/"+PROVISIONWATCHER, restUpdateProvisionWatcher).Methods(http.MethodPut)
-	b.HandleFunc("/"+PROVISIONWATCHER, restGetProvisionWatchers).Methods(http.MethodGet)
+func loadProvisionWatcherRoutes(b *mux.Router, dic *di.Container) {
+	b.HandleFunc("/"+PROVISIONWATCHER, func(w http.ResponseWriter, r *http.Request) {
+		restAddProvisionWatcher(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPost)
+	b.HandleFunc("/"+PROVISIONWATCHER, func(w http.ResponseWriter, r *http.Request) {
+		restUpdateProvisionWatcher(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPut)
+	b.HandleFunc("/"+PROVISIONWATCHER, func(w http.ResponseWriter, r *http.Request) {
+		restGetProvisionWatchers(w)
+	}).Methods(http.MethodGet)
+
 	pw := b.PathPrefix("/" + PROVISIONWATCHER).Subrouter()
 	// /api/v1/provisionwatcher
-	pw.HandleFunc("/"+ID+"/{"+ID+"}", restDeleteProvisionWatcherById).Methods(http.MethodDelete)
+	pw.HandleFunc("/"+ID+"/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restDeleteProvisionWatcherById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodDelete)
+
 	pw.HandleFunc("/{"+ID+"}", restGetProvisionWatcherById).Methods(http.MethodGet)
-	pw.HandleFunc("/"+NAME+"/{"+NAME+"}", restDeleteProvisionWatcherByName).Methods(http.MethodDelete)
+	pw.HandleFunc("/"+NAME+"/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
+		restDeleteProvisionWatcherByName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodDelete)
+
 	pw.HandleFunc("/"+NAME+"/{"+NAME+"}", restGetProvisionWatcherByName).Methods(http.MethodGet)
 	pw.HandleFunc("/"+PROFILENAME+"/{"+NAME+"}", restGetProvisionWatchersByProfileName).Methods(http.MethodGet)
 	pw.HandleFunc("/"+PROFILE+"/{"+ID+"}", restGetProvisionWatchersByProfileId).Methods(http.MethodGet)
@@ -186,11 +285,19 @@ func loadProvisionWatcherRoutes(b *mux.Router) {
 	pw.HandleFunc("/"+IDENTIFIER+"/{"+KEY+"}/{"+VALUE+"}", restGetProvisionWatchersByIdentifier).Methods(http.MethodGet)
 
 }
-func loadAddressableRoutes(b *mux.Router) {
+func loadAddressableRoutes(b *mux.Router, dic *di.Container) {
 	// /api/v1/" + ADDRESSABLE + "
-	b.HandleFunc("/"+ADDRESSABLE, restGetAllAddressables).Methods(http.MethodGet)
-	b.HandleFunc("/"+ADDRESSABLE, restAddAddressable).Methods(http.MethodPost)
-	b.HandleFunc("/"+ADDRESSABLE, restUpdateAddressable).Methods(http.MethodPut)
+	b.HandleFunc("/"+ADDRESSABLE, func(w http.ResponseWriter, r *http.Request) {
+		restGetAllAddressables(w, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+
+	b.HandleFunc("/"+ADDRESSABLE, func(w http.ResponseWriter, r *http.Request) {
+		restAddAddressable(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPost)
+
+	b.HandleFunc("/"+ADDRESSABLE, func(w http.ResponseWriter, r *http.Request) {
+		restUpdateAddressable(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodPost)
 
 	a := b.PathPrefix("/" + ADDRESSABLE).Subrouter()
 	a.HandleFunc("/{"+ID+"}", restGetAddressableById).Methods(http.MethodGet)
@@ -202,31 +309,50 @@ func loadAddressableRoutes(b *mux.Router) {
 	a.HandleFunc("/"+PUBLISHER+"/{"+PUBLISHER+"}", restGetAddressableByPublisher).Methods(http.MethodGet)
 	a.HandleFunc("/"+ADDRESS+"/{"+ADDRESS+"}", restGetAddressableByAddress).Methods(http.MethodGet)
 }
-func loadCommandRoutes(b *mux.Router) {
+func loadCommandRoutes(b *mux.Router, dic *di.Container) {
 
 	// /api/v1/command
-	b.HandleFunc("/"+COMMAND, restGetAllCommands).Methods(http.MethodGet)
+	b.HandleFunc("/"+COMMAND, func(w http.ResponseWriter, r *http.Request) {
+		restGetAllCommands(w, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+
+	b.HandleFunc("/"+COMMAND, func(w http.ResponseWriter, r *http.Request) {
+		restGetAllCommands(w, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 
 	c := b.PathPrefix("/" + COMMAND).Subrouter()
-	c.HandleFunc("/{"+ID+"}", restGetCommandById).Methods(http.MethodGet)
-	c.HandleFunc("/"+NAME+"/{"+NAME+"}", restGetCommandsByName).Methods(http.MethodGet)
+	c.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restGetCommandById(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+	c.HandleFunc("/"+NAME+"/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
+		restGetCommandsByName(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
 
 	d := c.PathPrefix("/" + DEVICE).Subrouter()
-	d.HandleFunc("/{"+ID+"}", restGetCommandsByDeviceId).Methods(http.MethodGet)
+	d.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
+		restGetCommandsByDeviceId(w, r, container.LoggingClientFrom(dic.Get))
+	}).Methods(http.MethodGet)
+
 }
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set(clients.ContentType, clients.ContentTypeText)
 	w.Write([]byte("pong"))
 }
 
-func configHandler(w http.ResponseWriter, _ *http.Request) {
-	pkg.Encode(Configuration, w, LoggingClient)
+func configHandler(
+	w http.ResponseWriter,
+	loggingClient logger.LoggingClient) {
+
+	pkg.Encode(Configuration, w, loggingClient)
 }
 
-func metricsHandler(w http.ResponseWriter, _ *http.Request) {
+func metricsHandler(
+	w http.ResponseWriter,
+	loggingClient logger.LoggingClient) {
+
 	s := telemetry.NewSystemUsage()
 
-	pkg.Encode(s, w, LoggingClient)
+	pkg.Encode(s, w, loggingClient)
 
 	return
 }

--- a/internal/core/metadata/utils.go
+++ b/internal/core/metadata/utils.go
@@ -15,30 +15,10 @@ package metadata
 
 import (
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
-	"io"
-	"io/ioutil"
 )
-
-const (
-	ExceededMaxResultCount = "error, exceeded the max limit as defined in config"
-)
-
-// Printing function purely for debugging purposes
-// Print the body of a request to the console
-func printBody(r io.ReadCloser) {
-	body, err := ioutil.ReadAll(r)
-	bodyString := string(body)
-
-	if err != nil {
-		LoggingClient.Error(err.Error())
-	}
-
-	LoggingClient.Info(bodyString)
-}
 
 func checkMaxLimit(limit int) error {
 	if limit > Configuration.Service.MaxResultCount {
-		LoggingClient.Error(ExceededMaxResultCount)
 		return errors.NewErrLimitExceeded(limit)
 	}
 


### PR DESCRIPTION
Fix #2018 
- Update core-metadata to leverage the Dependency Injection Container(DIC) during bootstrap and pass a `LoggingClient` instance down the call stack to eliminate the need for the `LoggingClient` global variable.
- Update tests to use a DIC when loading REST routes as they will need the DIC to obtain a reference of the `LoggingClient`.
- Also, update any references to methods/functions which have updated signatures to accept a `LoggingClient` as part of changes to the production code.