### PR TITLE
Fix the incorrect Redis command names (master)

### DIFF
--- a/internal/pkg/db/redis/queries.go
+++ b/internal/pkg/db/redis/queries.go
@@ -114,12 +114,12 @@ func getObjectsByValues(conn redis.Conn, vals ...string) (objects [][]byte, err 
 
 // getObjectsByRange retrieves the entries for keys enumerated in a sorted set. The entries are retrieved in the sorted set order.
 func getObjectsByRange(conn redis.Conn, key string, start, end int) (objects [][]byte, err error) {
-	return getObjectsBySomeRange(conn, "RANGE", key, start, end)
+	return getObjectsBySomeRange(conn, "ZRANGE", key, start, end)
 }
 
 // getObjectsByRevRange retrieves the entries for keys enumerated in a sorted set. The entries are retrieved in the reverse sorted set order.
 func getObjectsByRevRange(conn redis.Conn, key string, start int, end int) (objects [][]byte, err error) {
-	return getObjectsBySomeRange(conn, "REVRANGE", key, start, end)
+	return getObjectsBySomeRange(conn, "ZREVRANGE", key, start, end)
 }
 
 // getObjectsBySomeRange retrieves the entries for keys enumerated in a sorted set using the specified Redis range


### PR DESCRIPTION
fix #2064

"RANGE" -> "ZRANGE"
"REVRANGE" -> "ZREVRANGE"

Signed-off-by: Felix Ting <felix@iotechsys.com>