### PR TITLE
security-{proxy,secretstore}-setup/Dockerfile: use alpine to get curl

### DIFF
--- a/cmd/security-proxy-setup/Dockerfile
+++ b/cmd/security-proxy-setup/Dockerfile
@@ -16,7 +16,9 @@ COPY . .
 
 RUN make cmd/security-proxy-setup/security-proxy-setup
 
-FROM scratch
+FROM alpine
+
+RUN apk update && apk add curl && rm -rf /var/cache/apk/* 
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Dell Technologies, Inc.'

--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -18,6 +18,8 @@ RUN make cmd/security-secretstore-setup/security-secretstore-setup
 
 FROM alpine:3.10
 
+RUN apk update && apk add curl && rm -rf /var/cache/apk/* 
+
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Dell Technologies, Inc.'
 


### PR DESCRIPTION
We need `/bin/sh` and `curl` in both security-proxy-setup and security-secretstore-setup Docker iamges in order to run our dependency checks in the various dependency checks. 

See usage of this in the developer-scripts PR: https://github.com/edgexfoundry/developer-scripts/pull/172. That PR also contains full testing instructions for everything needed to fix #1710 for Fuji, but to test specifically this PR, all you need to do is build the containers and then start them with the docker-compose from developer-scripts and note that it works as before. I.e. run:

```
$ make docker_security_secretstore_setup docker_security_proxy_setup
```
and observe the containers build successfully. Then apply a patch to developer-scripts repo for the nightly-releases docker-compose.yml file like this:

```patch
diff --git a/releases/nightly-build/compose-files/docker-compose-nexus.yml b/releases/nightly-build/compose-files/docker-compose-nexus.yml
index 634e60d..639bd96 100644
--- a/releases/nightly-build/compose-files/docker-compose-nexus.yml
+++ b/releases/nightly-build/compose-files/docker-compose-nexus.yml
@@ -109,7 +109,7 @@ services:
       - consul
 
   vault-worker:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:1.1.0
+    image: edgexfoundry/docker-edgex-security-secretstore-setup-go:1.1.0-dev
     container_name: edgex-vault-worker
     hostname: edgex-vault-worker
     entrypoint: >
@@ -205,7 +205,7 @@ services:
         - consul
 
   edgex-proxy:
-    image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:1.1.0
+    image: edgexfoundry/docker-edgex-security-proxy-setup-go:1.1.0-dev
     container_name: edgex-proxy
     hostname: edgex-proxy
     entrypoint: >
``` 

Then run the docker-compose and see that the containers still start the same as they did before:

```
$ docker-compose -f ./releases/nightly-build/compose-files/docker-compose-nexus.yml up -d
$ docker logs edgex-proxy
$ docker logs edgex-vault-worker
```

Partially resolves #1710 