### PR TITLE
Fixes issue #1710 for security proxy setup

### DIFF
--- a/internal/security/proxy/certs.go
+++ b/internal/security/proxy/certs.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal"
 )
@@ -58,9 +59,15 @@ func (cs certificate) Load() (*CertPair, error) {
 	if err != nil {
 		return nil, err
 	}
-	cp, err := cs.retrieve(t)
-	if err != nil {
-		return nil, err
+	var cp *CertPair
+	for {
+		cp, err = cs.retrieve(t)
+		if err != nil {
+			//return nil, err
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		break
 	}
 	err = cs.validate(cp)
 	if err != nil {


### PR DESCRIPTION
Fixes #1710  as part of dependency check for security proxy setup bootstrap starting.
Add for-loop of retries until it succeeds.

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>