### PR TITLE
Add configuration for SecretClient retries (fuji)

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -51,6 +51,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/core-command/res/docker/configuration.toml
+++ b/cmd/core-command/res/docker/configuration.toml
@@ -51,6 +51,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -63,6 +63,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/core-data/res/docker/configuration.toml
+++ b/cmd/core-data/res/docker/configuration.toml
@@ -62,6 +62,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -63,6 +63,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/core-metadata/res/docker/configuration.toml
+++ b/cmd/core-metadata/res/docker/configuration.toml
@@ -62,6 +62,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/export-client/res/configuration.toml
+++ b/cmd/export-client/res/configuration.toml
@@ -50,6 +50,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/export-client/res/docker/configuration.toml
+++ b/cmd/export-client/res/docker/configuration.toml
@@ -50,6 +50,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/support-logging/res/configuration.toml
+++ b/cmd/support-logging/res/configuration.toml
@@ -39,6 +39,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/support-logging/res/docker/configuration.toml
+++ b/cmd/support-logging/res/docker/configuration.toml
@@ -39,6 +39,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -55,6 +55,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/support-notifications/res/docker/configuration.toml
+++ b/cmd/support-notifications/res/docker/configuration.toml
@@ -55,6 +55,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -73,6 +73,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/support-scheduler/res/docker/configuration.toml
+++ b/cmd/support-scheduler/res/docker/configuration.toml
@@ -73,6 +73,10 @@ Protocol = 'https'
 RootCaCertPath = '/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem'
 ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
+# Number of attemtps to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry in nanoseconds.
+RetryWaitPeriod = 1000000000
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.33
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
-	github.com/edgexfoundry/go-mod-secrets v0.0.7
+	github.com/edgexfoundry/go-mod-secrets v0.0.9
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/internal/pkg/bootstrap/handlers/secret/secret.go
+++ b/internal/pkg/bootstrap/handlers/secret/secret.go
@@ -80,14 +80,16 @@ func (s *SecretProvider) BootstrapHandler(
 // If a tokenfile is present it will override the Authentication.AuthToken value.
 func (s *SecretProvider) getSecretConfig(secretStoreInfo config.SecretStoreInfo) (vault.SecretConfig, error) {
 	secretConfig := vault.SecretConfig{
-		Host:           secretStoreInfo.Host,
-		Port:           secretStoreInfo.Port,
-		Path:           secretStoreInfo.Path,
-		Protocol:       secretStoreInfo.Protocol,
-		Namespace:      secretStoreInfo.Namespace,
-		RootCaCertPath: secretStoreInfo.RootCaCertPath,
-		ServerName:     secretStoreInfo.ServerName,
-		Authentication: secretStoreInfo.Authentication,
+		Host:                    secretStoreInfo.Host,
+		Port:                    secretStoreInfo.Port,
+		Path:                    secretStoreInfo.Path,
+		Protocol:                secretStoreInfo.Protocol,
+		Namespace:               secretStoreInfo.Namespace,
+		RootCaCertPath:          secretStoreInfo.RootCaCertPath,
+		ServerName:              secretStoreInfo.ServerName,
+		Authentication:          secretStoreInfo.Authentication,
+		AdditionalRetryAttempts: secretStoreInfo.AdditionalRetryAttempts,
+		RetryWaitPeriod:         secretStoreInfo.RetryWaitPeriod,
 	}
 
 	if !s.isSecurityEnabled() || secretStoreInfo.TokenFile == "" {


### PR DESCRIPTION
Fix #2080

Add configuration properties needed to leverage the retry logic within
the SecretClient. This helps address the issue of temporal coupling,
when security is enabled, between services, and bootstrapping steps by
giving some grace period for dependencies before unsuccessfully
exiting(shutting down) the service.

Update to use the latest version of `go-mod-secrets` which has the retry
logic.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>