### PR TITLE
(fuji) Delete event func for Redis misses the deletion of pushed and device collection

### DIFF
--- a/internal/pkg/db/redis/data.go
+++ b/internal/pkg/db/redis/data.go
@@ -109,7 +109,7 @@ func (c *Client) UpdateEvent(e correlation.Event) (err error) {
 
 	id := event.ID
 
-	o, err := eventByID(conn, id, false)
+	o, err := eventByID(conn, id)
 	if err != nil {
 		if err == redis.ErrNil {
 			return db.ErrNotFound
@@ -137,7 +137,7 @@ func (c *Client) EventById(id string) (event contract.Event, err error) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	event, err = eventByID(conn, id, false)
+	event, err = eventByID(conn, id)
 	if err != nil {
 		if err == redis.ErrNil {
 			return event, db.ErrNotFound
@@ -1089,7 +1089,7 @@ func addEvent(conn redis.Conn, e correlation.Event) (id string, err error) {
 }
 
 func deleteEvent(conn redis.Conn, id string) error {
-	o, err := eventByID(conn, id, true)
+	o, err := eventByID(conn, id)
 	if err != nil {
 		if err == redis.ErrNil {
 			return db.ErrNotFound
@@ -1118,7 +1118,7 @@ func deleteEvent(conn redis.Conn, id string) error {
 	return nil
 }
 
-func eventByID(conn redis.Conn, id string, skipReadings bool) (event contract.Event, err error) {
+func eventByID(conn redis.Conn, id string) (event contract.Event, err error) {
 	obj, err := redis.Bytes(conn.Do("GET", id))
 	if err == redis.ErrNil {
 		return event, db.ErrNotFound
@@ -1127,7 +1127,7 @@ func eventByID(conn redis.Conn, id string, skipReadings bool) (event contract.Ev
 		return event, err
 	}
 
-	event, err = unmarshalEvent(obj, skipReadings)
+	event, err = unmarshalEvent(obj)
 	if err != nil {
 		return event, err
 	}

--- a/internal/pkg/db/redis/event.go
+++ b/internal/pkg/db/redis/event.go
@@ -50,7 +50,7 @@ func marshalEvent(event correlation.Event) (out []byte, err error) {
 func unmarshalEvents(objects [][]byte, events []contract.Event) (err error) {
 	for i, o := range objects {
 		if len(o) > 0 {
-			events[i], err = unmarshalEvent(o, false)
+			events[i], err = unmarshalEvent(o)
 			if err != nil {
 				return err
 			}
@@ -60,7 +60,7 @@ func unmarshalEvents(objects [][]byte, events []contract.Event) (err error) {
 	return nil
 }
 
-func unmarshalEvent(o []byte, skipReadings bool) (contract.Event, error) {
+func unmarshalEvent(o []byte) (contract.Event, error) {
 	var s redisEvent
 
 	err := json.Unmarshal(o, &s)
@@ -80,10 +80,6 @@ func unmarshalEvent(o []byte, skipReadings bool) (contract.Event, error) {
 	conn, err := getConnection()
 	if err != nil {
 		return contract.Event{}, err
-	}
-
-	if skipReadings {
-		return event, nil
 	}
 
 	defer conn.Close()

--- a/internal/pkg/db/redis/event.go
+++ b/internal/pkg/db/redis/event.go
@@ -81,7 +81,6 @@ func unmarshalEvent(o []byte) (contract.Event, error) {
 	if err != nil {
 		return contract.Event{}, err
 	}
-
 	defer conn.Close()
 
 	objects, err := getObjectsByRange(conn, db.EventsCollection+":readings:"+s.ID, 0, -1)

--- a/internal/pkg/db/redis/queries.go
+++ b/internal/pkg/db/redis/queries.go
@@ -112,12 +112,14 @@ func getObjectsByValues(conn redis.Conn, vals ...string) (objects [][]byte, err 
 	return objects, nil
 }
 
-// getObjectsByRange retrieves the entries for keys enumerated in a sorted set. The entries are retrieved in the sorted set order.
+// getObjectsByRange retrieves the entries for keys enumerated in a sorted set.
+// The entries are retrieved in the sorted set order.
 func getObjectsByRange(conn redis.Conn, key string, start, end int) (objects [][]byte, err error) {
 	return getObjectsBySomeRange(conn, "ZRANGE", key, start, end)
 }
 
-// getObjectsByRevRange retrieves the entries for keys enumerated in a sorted set. The entries are retrieved in the reverse sorted set order.
+// getObjectsByRevRange retrieves the entries for keys enumerated in a sorted set.
+// The entries are retrieved in the reverse sorted set order.
 func getObjectsByRevRange(conn redis.Conn, key string, start int, end int) (objects [][]byte, err error) {
 	return getObjectsBySomeRange(conn, "ZREVRANGE", key, start, end)
 }
@@ -135,6 +137,10 @@ func getObjectsBySomeRange(conn redis.Conn, command string, key string, start in
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if len(objects) == 1 && objects[0] == nil {
+		objects = [][]byte{}
 	}
 
 	return objects, nil


### PR DESCRIPTION
#2076 in Fuji.

Verification steps:

Start Redis. Start core-data with Redis configured as the DB.

First, flush your Redis database with this redis-cli command:
`redis-cli FLUSHALL`

Run the following cURL command:

```
curl -X POST \
  http://localhost:48080/api/v1/event \
  -H 'Accept: */*' \
  -H 'Accept-Encoding: gzip, deflate' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Length: 230' \
  -H 'Content-Type: application/json' \
  -H 'Host: localhost:48080' \
  -H 'cache-control: no-cache' \
  -d '{  
   "origin":1471806386919,
   "device":"cartachometer",
   "readings":[  
      {  
        "origin":1471806386919,
		"device":"cartachometer",
        "name":"luminousIntensity",
        "value":"40"
      }
   ]
}'
```


Copy the UUID returned by the request. Run this additional cURL command to delete the event:

```
curl -X DELETE \
  http://localhost:48080/api/v1/event/id/{UUID} \
  -H 'Accept: */*' \
  -H 'Accept-Encoding: gzip, deflate' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Length: 0' \
  -H 'Host: localhost:48080' \
  -H 'cache-control: no-cache'
```

Finally, run this redis-cli command to verify that the event is deleted and there is nothing in the database:
`redis-cli --scan --pattern '*'`

There should be no returned output from that command.