### PR TITLE
many/configuration.toml: use time.Duration string for RetryWaitPeriod

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -53,8 +53,8 @@ ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/core-command/res/docker/configuration.toml
+++ b/cmd/core-command/res/docker/configuration.toml
@@ -53,8 +53,8 @@ ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -65,8 +65,8 @@ ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/core-data/res/docker/configuration.toml
+++ b/cmd/core-data/res/docker/configuration.toml
@@ -64,8 +64,8 @@ ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -65,8 +65,8 @@ ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/core-metadata/res/docker/configuration.toml
+++ b/cmd/core-metadata/res/docker/configuration.toml
@@ -64,8 +64,8 @@ ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/export-client/res/configuration.toml
+++ b/cmd/export-client/res/configuration.toml
@@ -52,8 +52,8 @@ ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/export-client/res/docker/configuration.toml
+++ b/cmd/export-client/res/docker/configuration.toml
@@ -52,8 +52,8 @@ ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/support-logging/res/configuration.toml
+++ b/cmd/support-logging/res/configuration.toml
@@ -41,8 +41,8 @@ ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/support-logging/res/docker/configuration.toml
+++ b/cmd/support-logging/res/docker/configuration.toml
@@ -41,8 +41,8 @@ ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -57,8 +57,8 @@ ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/support-notifications/res/docker/configuration.toml
+++ b/cmd/support-notifications/res/docker/configuration.toml
@@ -57,8 +57,8 @@ ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -75,8 +75,8 @@ ServerName = 'localhost'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
   AuthToken = 'edgex'

--- a/cmd/support-scheduler/res/docker/configuration.toml
+++ b/cmd/support-scheduler/res/docker/configuration.toml
@@ -75,8 +75,8 @@ ServerName = 'edgex-vault'
 TokenFile = '/vault/config/assets/resp-init.json'
 # Number of attemtps to retry retrieving secrets before failing to start the service.
 AdditionalRetryAttempts = 10
-# Amount of time to wait before attempting another retry in nanoseconds.
-RetryWaitPeriod = 1000000000
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.33
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
-	github.com/edgexfoundry/go-mod-secrets v0.0.9
+	github.com/edgexfoundry/go-mod-secrets v0.0.10
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -901,7 +901,7 @@ parts:
          "$SNAPCRAFT_PART_INSTALL"/jar/support-rulesengine/support-rulesengine.jar
 
       # FIXME:
-      # copy service license into /usr/share/java/doc, because the
+      # copy service license into /usr/share/java/doc, because the 
       # jdk plugin has a bug which prevents any files from /usr/share/doc
       # to be staged or primed.
       install -DT "./Attribution.txt" \


### PR DESCRIPTION
This is in concert with a change to go-mod-secrets to do the parsing in go-mod-secrets.

Note that this can't be merged until after https://github.com/edgexfoundry/go-mod-secrets/pull/38 is merged. I need to push a commit here changing the go.mod to use the updated version of go-mod-secrets after the go-mod-secrets PR is merged and the merge job runs tagging the repo with a new release. 

To test this, I suggest building all of the docker containers here and then testing this alongside my outstanding developer-scripts PR here: https://github.com/edgexfoundry/developer-scripts/pull/175 which with https://github.com/edgexfoundry/docker-edgex-consul/pull/7 and https://github.com/edgexfoundry/docker-edgex-mongo/pull/67 will make edgex-mongo fully deterministic and ordered after it's dependencies. See <link> for full testing details.

Fixes #2092 