### PR TITLE
Endpointer Clean Up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.33
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.34
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
 	github.com/edgexfoundry/go-mod-secrets v0.0.9

--- a/internal/pkg/endpoint/endpoint.go
+++ b/internal/pkg/endpoint/endpoint.go
@@ -27,18 +27,21 @@ type Endpoint struct {
 	RegistryClient *registry.Client
 }
 
-func (e Endpoint) Monitor(params types.EndpointParams, ch chan string) {
-	for {
+func (e Endpoint) Monitor(params types.EndpointParams) chan string {
+	ch := make(chan string, 1)
+	ch <- e.fetch(params)
+	go func() {
 		url, err := e.buildURL(params)
 		if err != nil {
 			fmt.Fprintln(os.Stdout, err.Error())
 		}
 		ch <- url
 		time.Sleep(time.Millisecond * time.Duration(params.Interval))
-	}
+	}()
+	return ch
 }
 
-func (e Endpoint) Fetch(params types.EndpointParams) string {
+func (e Endpoint) fetch(params types.EndpointParams) string {
 	url, err := e.buildURL(params)
 	if err != nil {
 		fmt.Fprintln(os.Stdout, err.Error())


### PR DESCRIPTION
Alternate Endpointer contract implementation that encapsulates go routine and stream creation and avoids exposing recently added Fetch() method.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2099

Signed-off-by: Michael Estrin <m.estrin@dell.com>