### PR TITLE
snapcraft.yaml: add security-proxy-setup-cmd

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -332,6 +332,10 @@ apps:
     plugs: [network, network-bind]
 
   # helper commands the snap exposes
+  security-proxy-setup-cmd:
+    adapter: none
+    command: bin/security-proxy-setup
+    plugs: [home, removable-media, network]
   redis-cli:
     adapter: full
     command: bin/redis-cli


### PR DESCRIPTION
This is a user command for running security-proxy-setup to create tokens, etc.
The home and removable-media plugs are for reading config files outside of the snap's writable area.

To test, build the snap and run:

- [x] security-proxy-setup-cmd runs help message:

```
$ edgexfoundry.security-proxy-setup-cmd --help

Usage: /snap/edgexfoundry/x1/bin/security-proxy-setup [options]
Server Options:
    -p, --profile <name>              Indicate configuration profile other than default
    -r, --registry                    Indicates service should use Registry
        --insecureSkipVerify=true/false   Indicates if skipping the server side SSL cert verification, similar to -k of curl
        --init=true/false                 Indicates if security service should be initialized
        --reset=true/false                Indicate if security service should be reset to initialization status
        --useradd=<username>              Create an account and return JWT
        --group=<groupname>               Group name the user belongs to
        --userdel=<username>              Delete an account
        --configfile=<file.toml>          Use a different config file (default: res/configuration.toml)

Common Options:
        -h, --help                        Show this message
```

- [ ] security-proxy-setup-cmd is able to create a user in Kong and write out the access token file to a file in $HOME, etc.

```
$ sudo edgexfoundry.security-proxy-setup-cmd -confdir /var/snap/edgexfoundry/current/config/security-proxy-setup/res/ --useradd=me --group=admin
level=ERROR ts=2019-11-11T16:40:35.72123771Z app=edgex-security-proxy-setup source=logger.go:73 msg="logTarget cannot be blank, using stdout only"
level=INFO ts=2019-11-11T16:40:35.722062026Z app=edgex-security-proxy-setup source=requestor.go:40 msg="successfully loaded rootCA certificate."
level=INFO ts=2019-11-11T16:40:35.731691399Z app=edgex-security-proxy-setup source=service.go:64 msg="the service on http://127.0.0.1:8001 is up successfully"
level=INFO ts=2019-11-11T16:40:35.741342414Z app=edgex-security-proxy-setup source=consumer.go:67 msg="successful to create consumer me for edgex-kong service"
level=INFO ts=2019-11-11T16:40:35.750189892Z app=edgex-security-proxy-setup source=consumer.go:100 msg="successful to associate consumer me with group admin"
level=INFO ts=2019-11-11T16:40:35.75318026Z app=edgex-security-proxy-setup source=consumer.go:117 msg="autheticate the user with jwt authentication."
level=INFO ts=2019-11-11T16:40:35.760748671Z app=edgex-security-proxy-setup source=consumer.go:152 msg="successful on retrieving JWT credential for consumer me"
the access token for user me is: <BIGLONGUUIDSTRINGTHING>. Please keep the token for accessing edgex services
$ cat accessToken.json
{
  "User": "me",
  "Token": "<BIGLONGUUIDSTRINGTHING>"
}
```

Fixes #1472 for Fuji.