### PR TITLE
Fix support-notifications was failing to send email for critical notification.

### DIFF
--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /go/src/github.com/edgexfoundry/edgex-go
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-RUN apk update && apk add make && apk add bash git
+RUN apk update && apk add make bash git ca-certificates
 
 COPY go.mod .
 #COPY go.sum .
@@ -30,9 +30,10 @@ FROM scratch
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Cavium'
 
-COPY --from=builder /bin/bash /bin/bash
+COPY --from=builder /bin/sh /bin/sh
+COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=builder /etc/ssl /etc/ssl
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/support-notifications/Attribution.txt /
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/support-notifications/support-notifications /
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/support-notifications/res/docker/configuration.toml /res/docker/configuration.toml
 ENTRYPOINT ["/support-notifications","--registry","--profile=docker","--confdir=/res"]
-


### PR DESCRIPTION
- This PR addresses: #2041 
- This fix is for the `Fuji` branch, and was made possible by invaluable assist from @tsconn23, and also @michaelestrin, and @AnthonyMBonafide 👍 