### PR TITLE
(fuji) Fixed bug with using Redis for core-command in Docker.

### DIFF
--- a/cmd/config-seed/Dockerfile
+++ b/cmd/config-seed/Dockerfile
@@ -49,7 +49,7 @@ COPY ./cmd ./cmd-redis
 # Databases.Primary.Type = redisdb 
 # Databases.Primary.Port = 6379
 # Databases.Primary.Host = edgex-redis
-RUN for svc in core-data core-metadata export-client support-notifications support-scheduler; do \
+RUN for svc in core-command core-data core-metadata export-client support-notifications support-scheduler; do \
     configFile=./cmd-redis/$svc/res/docker/configuration.toml && \
     toml2json --preserve-key-order "$configFile" | \
     jq -r '.Databases.Primary.Type = "redisdb" | .Databases.Primary.Port = 6379 | .Databases.Primary.Host = "edgex-redis"' | \


### PR DESCRIPTION
Fixes #2108 in Fuji.

Signed-off-by: Brandon Forster <brandonforster@gmail.com>

Verification steps:

1. Create a local docker image for `config-seed`.
2. Build a container using that image.
3. Edit http://github.com/edgexfoundry/developer-scripts/blob/master/releases/nightly-build/compose-files/docker-compose-nexus-redis-no-secty.yml so that your local container is pulled instead of the remote Nexus image. This will be on line 70.
4. Allow the build to run and proceed.
5. Ensure core-command has not died.
6. After the containers are running, inspect Consul at http://localhost:8500/ui/
7. Navigate to the core-command configuration, and visually inspect that Redis is set as the default provider.