### PR TITLE
snapcraft.yaml: upgrade Kong to 1.3.0, upgrade MongoDB to 4.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -988,10 +988,12 @@ parts:
       ln -s ../nginx/sbin/nginx nginx
       # the openresty build system also hard-codes the path to nginx inside
       # the "resty" binary so we need to change that
-      # TODO: make this use $SNAP as an env var directly rather than 
-      # hard-coding /snap/edgexfoundry/current as $SNAP
+      if [ -z "$SNAPCRAFT_PROJECT_NAME" ]; then
+        echo "SNAPCRAFT_PROJECT_NAME is undefined, snapcraft upstream change?"
+        exit 1
+      fi
       sed -i \
-        -e s@$SNAPCRAFT_PART_INSTALL/nginx/sbin/nginx@/snap/edgexfoundry/current/nginx/sbin/nginx@ \
+        -e s@$SNAPCRAFT_PART_INSTALL/nginx/sbin/nginx@/snap/$SNAPCRAFT_PROJECT_NAME/current/nginx/sbin/nginx@ \
         resty
 
   kong:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,7 +89,7 @@ apps:
   mongod:
     adapter: full
     after: [core-config-seed]
-    command: bin/mongod --dbpath $SNAP_DATA/mongo/db --logpath $SNAP_COMMON/mongodb.log --smallfiles
+    command: bin/mongod --dbpath $SNAP_DATA/mongo/db --logpath $SNAP_COMMON/mongodb.log
     daemon: simple
     plugs: [hardware-observe, network, network-bind, system-observe]
     stop-command: bin/mongod --shutdown --dbpath $SNAP_DATA/mongo/db
@@ -617,17 +617,17 @@ parts:
   mongodb:
     plugin: dump
     source:
-      - on amd64: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.4.10.tgz
+      - on amd64: http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.0.tgz
       - else:
-          - on arm64: https://fastdl.mongodb.org/linux/mongodb-linux-arm64-ubuntu1604-3.4.10.tgz
+          - on arm64: http://downloads.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-4.2.0.tgz
       - else fail
     organize:
-      GNU-AGPL-3.0: usr/share/doc/mongodb/GNU-AGPL-3.0
       MPL-2: usr/share/doc/mongodb/MPL-2
       README: usr/share/doc/mongodb/README
       THIRD-PARTY-NOTICES: usr/share/doc/mongodb/THIRD-PARTY-NOTICES
+      LICENSE-Community.txt: usr/share/doc/mongodb/LICENSE-Community.txt
     stage-packages:
-      - libssl1.0.0
+      - libssl1.1
     stage:
       - -bin/bsondump
       - -bin/mongoexport

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -948,12 +948,33 @@ parts:
       patches: openresty-kong-patches
     stage: [openresty-kong-patches]
     prime: [-*]
+  lua-kong-nginx-module:
+    source: https://github.com/Kong/lua-kong-nginx-module.git
+    source-tag: 0.0.4
+    plugin: nil
+    override-build: |
+      # install the static lualib dir into the final snap, the compiled parts
+      # will be installed into the snap as part of the OpenResty part build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/lualib/resty/kong
+      cp -r $SNAPCRAFT_PART_SRC/lualib/resty/kong/tls.lua $SNAPCRAFT_PART_INSTALL/lualib/resty/kong/tls.lua
+
+      # copy the necessary soruce files from here into a module specific dir in
+      # $SNAPCRAFT_STAGE because some of these files such as config conflict 
+      # with files that Kong generates/needs, so we want these to be in their
+      # own dir for OpenResty to compile with
+      mkdir -p $SNAPCRAFT_STAGE/lua-kong-nginx-module
+      for f in lualib src config Makefile; do
+        cp -r "$SNAPCRAFT_PART_SRC/$f" "$SNAPCRAFT_STAGE/lua-kong-nginx-module/$f"
+      done
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/lua-kong-nginx-module
+      cp LICENSE $SNAPCRAFT_PART_INSTALL/usr/share/lua-kong-nginx-module/LICENSE
+
   openresty:
     # see comment on kong's after spec for why we order after snapcraft-preload
     # here
-    after: [openresty-kong-patches, snapcraft-preload]
+    after: [openresty-kong-patches, snapcraft-preload, lua-kong-nginx-module]
     plugin: autotools
-    source: https://openresty.org/download/openresty-1.13.6.2.tar.gz
+    source: https://openresty.org/download/openresty-1.15.8.1.tar.gz
     install-via: prefix
     # configure options here from https://getkong.org/install/source/
     configflags:
@@ -963,12 +984,13 @@ parts:
       - --with-http_ssl_module
       - --with-http_stub_status_module
       - --with-http_v2_module
+      - --add-module=$SNAPCRAFT_STAGE/lua-kong-nginx-module
     build-packages:
       - build-essential
       - libpcre3-dev
       - perl
       - curl
-      - libssl1.0-dev
+      - libssl-dev
       - zlib1g-dev
     stage-packages:
       - perl
@@ -976,7 +998,7 @@ parts:
       snapcraftctl pull
       cd $SNAPCRAFT_PART_SRC/bundle
       # apply patches from openresty-kong-patches
-      for i in $SNAPCRAFT_STAGE/openresty-kong-patches/1.13.6.2/*.patch; do 
+      for i in $SNAPCRAFT_STAGE/openresty-kong-patches/1.15.8.1/*.patch; do
         patch -p1 < $i
       done
     override-build: |
@@ -997,7 +1019,45 @@ parts:
       sed -i \
         -e s@$SNAPCRAFT_PART_INSTALL/nginx/sbin/nginx@/snap/$SNAPCRAFT_PROJECT_NAME/current/nginx/sbin/nginx@ \
         resty
-
+  lua:
+    # this dependency is somewhat artificial, because
+    # when iterating on the openresty parts if you just rebuild openresty,
+    # without also rebuilding lua, then kong will fail because it can't find
+    # luarocks.cfg somewhere...
+    # not sure why re-building openresty causes the luarocks config file to be
+    # messed up, but if we order it like so then rebuilding any one of them will
+    # always work
+    # openresty -> lua -> luarocks -> kong
+    # this may have to do with installing lua and luarocks into $SNAPCRAFT_STAGE
+    after: [openresty]
+    source: https://www.lua.org/ftp/lua-5.1.5.tar.gz
+    source-type: tar
+    plugin: make
+    make-parameters: [linux]
+    build-packages:
+      - libreadline-dev
+      - libncurses5-dev
+    override-build: |
+      # patch the Makefile to use $SNAPCRAFT_STAGE for the INSTALL_TOP variable
+      # which unfortunately is not settable using an environment variable and thus needs
+      # this manual patch
+      sed -i "s@INSTALL_TOP= /usr/local@INSTALL_TOP=$SNAPCRAFT_STAGE@" Makefile
+      snapcraftctl build
+  luarocks:
+    after: [lua]
+    plugin: autotools
+    source: https://github.com/luarocks/luarocks.git
+    source-branch: v3.1.3
+    source-depth: 1
+    override-build: |
+      ./configure \
+        --prefix=$SNAPCRAFT_STAGE \
+        --lua-suffix=jit \
+        --with-lua=$SNAPCRAFT_STAGE \
+        --with-lua-include=$SNAPCRAFT_STAGE/luajit/include/luajit-2.1 \
+        --lua-version=5.1
+      make build
+      make install
   kong:
     # order this part after snapcraft-preload because there are include paths
     # that snapcraft will generate for this parts to auto-include in the
@@ -1010,14 +1070,14 @@ parts:
     # ideally this would just be a "before: " on the snapcraft-preload part, but
     # snapcraft doesn't support that, see
     # https://bugs.launchpad.net/snapcraft/+bug/1848493
-    after: [snapcraft-preload]
+    after: [snapcraft-preload, luarocks]
     source: https://github.com/kong/kong.git
     plugin: nil
-    source-tag: 1.0.3
+    source-tag: 1.3.0
     source-depth: 1
     build-packages:
       - unzip
-      - libssl1.0-dev
+      - libssl-dev
       - libpcre3-dev
       - libyaml-dev
       - luarocks
@@ -1075,7 +1135,7 @@ parts:
         chmod +x $cmd
       done
 
-      # TODO: the json2lua script references $SNAPCRAFT_PART_INSTALL in some 
+      # TODO: the json2lua script references $SNAPCRAFT_PART_INSTALL in some
       # paths it tries to load things from, probably worth fixing that to use
       # $SNAP, etc. but currently json2lua seems unused so not changing it now
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -972,14 +972,16 @@ parts:
       - zlib1g-dev
     stage-packages:
       - perl
-    override-build: |
+    override-pull: |
+      snapcraftctl pull
       cd $SNAPCRAFT_PART_SRC/bundle
       # apply patches from openresty-kong-patches
       for i in $SNAPCRAFT_STAGE/openresty-kong-patches/1.13.6.2/*.patch; do 
         patch -p1 < $i
       done
+    override-build: |
       snapcraftctl build
-      # openresty will make an absolute symbolic link of openresty to the 
+      # openresty will make an absolute symbolic link of openresty to the
       # nginx binary, so we need to delete that and replace it with a relative
       # symlink
       cd $SNAPCRAFT_PART_INSTALL/bin


### PR DESCRIPTION
This PR switches to using Kong 1.3, which requires re-adding back the lua and luarocks parts since the versions of those in the ubuntu bionic archives are too old to build Kong 1.3. Additionally, to build Kong 1.3 we also have to add a new Lua module to OpenResty, lua-kong-nginx-module.

Since MongoDB 4.2 links against libssl 1.1, and MongoDB 3.4 links against libssl 1.0, we need to make that change in sync with changing Kong because Kong 1.0 cannot link against libssl 1.1, but Kong 1.3 can link against libssl 1.1. I think that Kong and company can be built to link against libssl 1.0, but that is not the default so I didn't want to add extra work for myself to first upgrade Kong to 1.3 using libssl 1.0, only to switch to libssl 1.1 immediately afterwards when upgrading MongoDB. Thus these things are both a part of this PR.

**Note**: you will need to do a fresh build, if you have a pre-existing build environment that already built Kong and OpenResty snapcraft will fail to clean it properly, so just purge that build environment and do a fresh build. 

To test, build the snap and make sure:
- [x] Kong is started and we can create a user in Kong with security-proxy-setup-cmd:

```
$ snap services edgexfoundry.kong-daemon
Service                   Startup  Current  Notes
edgexfoundry.kong-daemon  enabled  active   -
$ sudo edgexfoundry.security-proxy-setup-cmd -confdir /var/snap/edgexfoundry/current/config/security-proxy-setup/res/ --useradd=me --group=admin
< works >
```

- [x] MongoDB starts successfully and writes to it's log file, and edgex-mongo is able to initialize the database:

```
$ snap services edgexfoundry.mongod
Service              Startup  Current  Notes
edgexfoundry.mongod  enabled  active   -
$ journalctl --no-hostname -e --no-pager -u snap.edgexfoundry.edgex-mongo.service
Nov 12 07:16:22 systemd[1]: Starting Service for snap application edgexfoundry.edgex-mongo...
Nov 12 07:16:22 edgexfoundry.edgex-mongo[49591]: level=ERROR ts=2019-11-12T13:16:22.6866078Z app=edgex-mongo source=logger.go:105 msg="logTarget cannot be blank, using stdout only"
Nov 12 07:16:22 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:22.686689895Z app=edgex-mongo source=main.go:32 msg="starting edgex-mongo process ..."
Nov 12 07:16:22 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:22.686699433Z app=edgex-mongo source=config.go:38 msg="loading configuration considering the secret store"
Nov 12 07:16:22 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:22.686714241Z app=edgex-mongo source=init.go:47 msg="config file location: /var/snap/edgexfoundry/x1/config/edgex-mongo/res/configuration.toml"
Nov 12 07:16:22 edgexfoundry.edgex-mongo[49591]: level=ERROR ts=2019-11-12T13:16:22.754307255Z app=edgex-mongo source=logger.go:105 msg="logTarget cannot be blank, using stdout only"
Nov 12 07:16:22 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:22.77964928Z app=edgex-mongo source=client.go:46 msg="Settting up admin database"
Nov 12 07:16:22 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:22.878595468Z app=edgex-mongo source=client.go:46 msg="Settting up application-service database"
Nov 12 07:16:23 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:23.039002332Z app=edgex-mongo source=client.go:46 msg="Settting up authorization database"
Nov 12 07:16:23 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:23.092819151Z app=edgex-mongo source=client.go:46 msg="Settting up metadata database"
Nov 12 07:16:23 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:23.602914535Z app=edgex-mongo source=client.go:46 msg="Settting up exportclient database"
Nov 12 07:16:23 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:23.667399105Z app=edgex-mongo source=client.go:46 msg="Settting up scheduler database"
Nov 12 07:16:23 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:23.826446171Z app=edgex-mongo source=client.go:46 msg="Settting up logging database"
Nov 12 07:16:23 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:23.898932315Z app=edgex-mongo source=client.go:46 msg="Settting up rulesengine database"
Nov 12 07:16:23 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:23.946518959Z app=edgex-mongo source=client.go:46 msg="Settting up coredata database"
Nov 12 07:16:24 edgexfoundry.edgex-mongo[49591]: level=INFO ts=2019-11-12T13:16:24.175017241Z app=edgex-mongo source=client.go:46 msg="Settting up notifications database"
Nov 12 07:16:24 systemd[1]: snap.edgexfoundry.edgex-mongo.service: Succeeded.
Nov 12 07:16:24 systemd[1]: Started Service for snap application edgexfoundry.edgex-mongo.
```

I haven't had a chance to confirm arm64 is still working, but I re-enabled the security proxy for arm64 since in theory Kong 1.3 should support arm64 properly now. I will try to test this on my Raspberry Pi 3B+ sometime today and confirm back that it works.

Fixes #1698 for Fuji
Fixes #2110 for Fuji