### PR TITLE
Add app-service-config with rules-engine profile to the snap

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -22,6 +22,9 @@ ALL_SERVICES="$ALL_SERVICES support-logging"
 ALL_SERVICES="$ALL_SERVICES support-scheduler"
 ALL_SERVICES="$ALL_SERVICES support-rulesengine"
 
+# app-services
+ALL_SERVICES="$ALL_SERVICES app-service-configurable"
+
 # export services
 ALL_SERVICES="$ALL_SERVICES export-distro"
 ALL_SERVICES="$ALL_SERVICES export-client"
@@ -110,6 +113,13 @@ for key in $ALL_SERVICES; do
             fi
             handle_svc "vault" "$status"
             handle_svc "security-secretstore-setup" "$status"
+            ;;
+        support-rulesengine)
+            # if we are turning rulesengine on, make sure 
+            # app-service-configurable is on too
+            if [ "$status" = "on" ]; then
+                handle_svc "app-service-configurable" "on"
+            fi
             ;;
         *)
             # default case for all other services just enable/disable the service using

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -8,6 +8,7 @@ SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
 
 # install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
 # into $SNAP_DATA/config
+# note that app-service-configurable is handled separately
 mkdir -p "$SNAP_DATA/config"
 for service in edgex-mongo security-proxy-setup security-secrets-setup security-secretstore-setup core-command config-seed core-data core-metadata export-client export-distro support-logging support-notifications support-scheduler sys-mgmt-agent device-random device-virtual; do
     if [ ! -f "$SNAP_DATA/config/$service/res/configuration.toml" ]; then
@@ -20,6 +21,26 @@ for service in edgex-mongo security-proxy-setup security-secrets-setup security-
             "$SNAP_DATA/config/$service/res/configuration.toml"
     fi
 done
+
+# handle app-service-configurable's various profiles:
+# 1. ensure all the directories from app-service-configurable exist
+# 2. copy the config files from $SNAP into $SNAP_DATA
+# 3. replace the various env vars that might be in that config file with their
+#    "current" symlink equivalent
+mkdir -p "$SNAP_DATA/config/app-service-configurable"
+cd "$SNAP/config/app-service-configurable"
+find . -maxdepth 2 -type d -exec mkdir -p "$SNAP_DATA/config/app-service-configurable/"{} \;
+find ./res -name "configuration.toml" | \
+    while read -r fname; do
+	if [ ! -f "$SNAP_DATA/config/app-service-configurable/$fname" ]; then
+	    cp "./$fname" "$SNAP_DATA/config/app-service-configurable/$fname"
+
+            sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
+                -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
+                -e "s@\$SNAP@$SNAP_CURRENT@g" \
+                "$SNAP_DATA/config/app-service-configurable/$fname"
+        fi
+    done
 
 # handle device-random device profile
 cp "$SNAP/config/device-random/res/device.random.yaml" "$SNAP_DATA/config/device-random/res/device.random.yaml"
@@ -171,7 +192,9 @@ snapctl stop "$SNAP_NAME.postgres"
 # finally, disable and turn off non-default services
 # by default, we want the export-*, support-*, device-*, and redis services 
 # off.
-for svc in export-distro export-client support-notifications support-scheduler support-logging support-rulesengine device-random device-virtual redis; do
+# also the app-service-configurable service since that is meant to replace the 
+# export services
+for svc in export-distro export-client support-notifications support-scheduler support-logging app-service-configurable support-rulesengine device-random device-virtual redis; do
     # set the service as off, so that the setting is persistent after a refresh
     # due to snapd bug: https://bugs.launchpad.net/snapd/+bug/1818306
     snapctl set $svc=off

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -330,6 +330,11 @@ apps:
       CONSUL_ADDR: "consul://localhost:8500"
     daemon: simple
     plugs: [network, network-bind]
+  app-service-configurable:
+    adapter: full
+    command: bin/app-service-configurable -confdir $SNAP_DATA/config/app-service-configurable/res -profile rules-engine --registry
+    daemon: simple
+    plugs: [network, network-bind]
 
   # helper commands the snap exposes
   security-proxy-setup-cmd:
@@ -1174,3 +1179,34 @@ parts:
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-random/Attribution.txt"
       install -DT "./LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-random/LICENSE"
+
+  app-service-config:
+    source: https://github.com/edgexfoundry/app-service-configurable.git
+    source-tag: v1.0.0
+    plugin: make
+    build-packages: [gcc, git, libzmq3-dev, pkg-config]
+    stage-packages: [libzmq5]
+    after: [go]
+    override-build: |
+      cd $SNAPCRAFT_PART_SRC
+      make build
+
+      # install the service binary
+      install -DT "./app-service-configurable" \
+         "$SNAPCRAFT_PART_INSTALL/bin/app-service-configurable"
+
+      # create config dirs
+      find ./res -maxdepth 1 -type d -exec install -d "$SNAPCRAFT_PART_INSTALL/config/app-service-configurable/"{} \;
+
+      # replace relative log paths in configuration.toml files with fully qualified paths
+      # prefixed with $SNAP_COMMON
+      find ./res -name "configuration.toml" | \
+          while read fname; do
+               cat "$fname" | sed -e s:\./logs/:\\'$SNAP_COMMON/'\: > \
+              "$SNAPCRAFT_PART_INSTALL/config/app-service-configurable/$fname"
+          done
+
+      install -DT "./Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/app-service-configurable/Attribution.txt"
+      install -DT "./LICENSE" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/app-service-configurable/LICENSE"


### PR DESCRIPTION
Add the app-service-configurable service to the snap so that it can be used with the rules-engine profile in place of the export services for Fuji when a user wants to use support-rulesengine.

To test this, build the snap and then install it. Then:

- [x] Check that app-service-configurable is disabled by default
```
$ snap services edgexfoundry.app-service-configurable
Service                                Startup   Current   Notes
edgexfoundry.app-service-configurable  disabled  inactive  -
```

- [x] Turning on support-rulesengine will also turn on the app-service-configurable service:

```
$ snap set edgexfoundry support-rulesengine=on
$ snap services edgexfoundry.app-service-configurable
Service                                Startup  Current  Notes
```

- [x] After app-service-configurable is started it is running with the rules-engine profile (indicated by `app=AppService-rules-engine` in the log output here):
```
edgexfoundry.app-service-configurable  enabled  active   -
$ snap logs edgexfoundry.app-service-configurable 
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.087281208Z app=AppService-rules-engine source=sdk.go:662 msg="Listening for changes from registry"
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.087296057Z app=AppService-rules-engine source=telemetry.go:79 msg="Starting CPU Usage Average loop"
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.091976547Z app=AppService-rules-engine source=main.go:43 msg="Loading Configurable Pipeline..."
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.098097641Z app=AppService-rules-engine source=sdk.go:690 msg="Writable configuration has been updated from Registry"
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.106220898Z app=AppService-rules-engine source=sdk.go:508 msg="MessageBus trigger selected"
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.109691598Z app=AppService-rules-engine source=sdk.go:759 msg="Reloaded Configurable Pipeline from Registry"
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.114009216Z app=AppService-rules-engine source=messaging.go:46 msg="Initializing Message Bus Trigger. Subscribing to topic: events on port 5563 , Publish Topic:  on port 5566"
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.118777304Z app=AppService-rules-engine source=sdk.go:154 msg="StoreAndForward disabled. Not running retry loop."
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.127130702Z app=AppService-rules-engine source=sdk.go:157 msg="AppServiceConfigurable-rules-engine has Started"
2019-11-12T16:52:52Z edgexfoundry.app-service-configurable[14568]: level=INFO ts=2019-11-12T16:52:52.131084595Z app=AppService-rules-engine source=server.go:232 msg="Starting HTTP Server on port :50001"
```

Fixes #2115