### PR TITLE
Fix update device functionality to correct method

### DIFF
--- a/internal/core/metadata/operators/device/update.go
+++ b/internal/core/metadata/operators/device/update.go
@@ -140,7 +140,7 @@ func (op updateDevice) Execute() (err error) {
 
 	evt.DeviceId = op.device.Id
 	evt.DeviceName = op.device.Name
-	evt.HttpMethod = http.MethodPost
+	evt.HttpMethod = http.MethodPut
 	evt.ServiceId = op.device.Service.Id
 
 	op.events <- evt

--- a/internal/core/metadata/operators/device/update_test.go
+++ b/internal/core/metadata/operators/device/update_test.go
@@ -16,6 +16,7 @@ package device
 
 import (
 	"fmt"
+	"net/http"
 	"sync"
 	"testing"
 
@@ -58,6 +59,10 @@ func TestUpdateDevice(t *testing.T) {
 				if msg.Error != nil && !tt.expectError {
 					t.Errorf("%s error reported via channel: %s", t.Name(), msg.Error.Error())
 					return
+				}
+				// Ensure that all successful operations result in the correct action.
+				if !tt.expectError && msg.HttpMethod != http.MethodPut {
+					t.Errorf("Expected HTTP method 'PUT', but recieved '%s'", msg.HttpMethod)
 				}
 			}(&wg, t)
 


### PR DESCRIPTION
Fix #2119

Update the HTTP method from POST to PUT when invoking a callback for
a device service when a device has been updated.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>