### PR TITLE
security-secretstore-setup: refactor to remove LoggingClient global variable

### DIFF
--- a/internal/security/secretstore/certs_test.go
+++ b/internal/security/secretstore/certs_test.go
@@ -44,8 +44,6 @@ func TestGetAccessToken(t *testing.T) {
 }
 
 func TestRetrieve(t *testing.T) {
-	LoggingClient = logger.MockLogger{}
-
 	certPath := "testCertPath"
 	token := "token"
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -86,7 +84,8 @@ func TestRetrieve(t *testing.T) {
 		Scheme: "https",
 	}
 
-	cs := NewCerts(NewRequester(true), certPath, "")
+	mockLogger := logger.MockLogger{}
+	cs := NewCerts(NewRequester(true, mockLogger), certPath, "", mockLogger)
 	cp, err := cs.retrieve(token)
 	if err != nil {
 		t.Errorf("failed to retrieve cert pair")

--- a/internal/security/secretstore/password.go
+++ b/internal/security/secretstore/password.go
@@ -23,9 +23,11 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/cloudflare/gokey"
-
 	"github.com/edgexfoundry/edgex-go/internal"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/cloudflare/gokey"
 )
 
 // CredentialGenerator returns a credential generated with random algorithm for secret store
@@ -70,13 +72,24 @@ type UserPasswordPair struct {
 }
 
 type Cred struct {
-	client    internal.HttpCaller
-	tokenPath string
-	generator CredentialGenerator
+	client        internal.HttpCaller
+	tokenPath     string
+	generator     CredentialGenerator
+	loggingClient logger.LoggingClient
 }
 
-func NewCred(caller internal.HttpCaller, tpath string, generator CredentialGenerator) Cred {
-	return Cred{client: caller, tokenPath: tpath, generator: generator}
+func NewCred(
+	caller internal.HttpCaller,
+	tpath string,
+	generator CredentialGenerator,
+	loggingClient logger.LoggingClient) Cred {
+
+	return Cred{
+		client:        caller,
+		tokenPath:     tpath,
+		generator:     generator,
+		loggingClient: loggingClient,
+	}
 }
 
 func (cr *Cred) AlreadyInStore(path string) (bool, error) {
@@ -114,7 +127,7 @@ func (cr *Cred) retrieve(t string, path string) (*UserPasswordPair, error) {
 	req, err := http.NewRequest(http.MethodGet, credUrl, nil)
 	if err != nil {
 		e := fmt.Errorf("error creating http request: %v", err.Error())
-		LoggingClient.Error(e.Error())
+		cr.loggingClient.Error(e.Error())
 		return nil, e
 	}
 
@@ -122,7 +135,7 @@ func (cr *Cred) retrieve(t string, path string) (*UserPasswordPair, error) {
 	resp, err := cr.client.Do(req)
 	if err != nil {
 		e := fmt.Errorf("failed to retrieve the credential pair on path %s with error %s", path, err.Error())
-		LoggingClient.Error(e.Error())
+		cr.loggingClient.Error(e.Error())
 		return nil, e
 	}
 	defer resp.Body.Close()
@@ -130,17 +143,17 @@ func (cr *Cred) retrieve(t string, path string) (*UserPasswordPair, error) {
 	cred := CredCollect{}
 
 	if resp.StatusCode == http.StatusNotFound {
-		LoggingClient.Info(fmt.Sprintf("credential pair NOT found in secret store @/%s, status: %s", path, resp.Status))
+		cr.loggingClient.Info(fmt.Sprintf("credential pair NOT found in secret store @/%s, status: %s", path, resp.Status))
 		return nil, errNotFound
 	} else if resp.StatusCode != http.StatusOK {
 		e := fmt.Errorf("failed to retrieve the credential pair on path %s with error code %d", path, resp.StatusCode)
-		LoggingClient.Error(e.Error())
+		cr.loggingClient.Error(e.Error())
 		return nil, e
 	}
 
 	if err = json.NewDecoder(resp.Body).Decode(&cred); err != nil {
 		e := fmt.Errorf("error decoding json response when retrieving credential pair: %s", err.Error())
-		LoggingClient.Error(e.Error())
+		cr.loggingClient.Error(e.Error())
 		return nil, e
 	}
 
@@ -151,14 +164,14 @@ func (cr *Cred) credPathURL(path string) (string, error) {
 	baseURL, err := url.Parse(Configuration.SecretService.GetSecretSvcBaseURL())
 	if err != nil {
 		e := fmt.Errorf("error parsing secret-service url:  %s", err.Error())
-		LoggingClient.Error(e.Error())
+		cr.loggingClient.Error(e.Error())
 		return "", err
 	}
 
 	p, err := url.Parse(path)
 	if err != nil {
 		e := fmt.Errorf("error parsing secret-service credpath: %s", err.Error())
-		LoggingClient.Error(e.Error())
+		cr.loggingClient.Error(e.Error())
 		return "", err
 	}
 
@@ -176,7 +189,7 @@ func (cr *Cred) UploadToStore(pair *UserPasswordPair, path string) error {
 		return err
 	}
 
-	LoggingClient.Debug("trying to upload the credential pair into secret store")
+	cr.loggingClient.Debug("trying to upload the credential pair into secret store")
 	jsonBytes, err := json.Marshal(pair)
 	body := bytes.NewBuffer(jsonBytes)
 
@@ -188,7 +201,7 @@ func (cr *Cred) UploadToStore(pair *UserPasswordPair, path string) error {
 	req, err := http.NewRequest(http.MethodPost, credURL, body)
 	if err != nil {
 		e := fmt.Errorf("error creating http request: %v", err.Error())
-		LoggingClient.Error(e.Error())
+		cr.loggingClient.Error(e.Error())
 		return e
 	}
 
@@ -196,7 +209,7 @@ func (cr *Cred) UploadToStore(pair *UserPasswordPair, path string) error {
 	resp, err := cr.client.Do(req)
 	if err != nil {
 		e := fmt.Sprintf("failed to upload the credential pair on path %s: %s", path, err.Error())
-		LoggingClient.Error(e)
+		cr.loggingClient.Error(e)
 		return err
 	}
 	defer resp.Body.Close()
@@ -207,10 +220,10 @@ func (cr *Cred) UploadToStore(pair *UserPasswordPair, path string) error {
 			return err
 		}
 		e := fmt.Errorf("failed to load the credential pair to the secret store: %s %s", resp.Status, string(b))
-		LoggingClient.Error(e.Error())
+		cr.loggingClient.Error(e.Error())
 		return e
 	}
 
-	LoggingClient.Info("successfully uploaded the credential pair into secret store")
+	cr.loggingClient.Info("successfully uploaded the credential pair into secret store")
 	return nil
 }

--- a/internal/security/secretstore/password_test.go
+++ b/internal/security/secretstore/password_test.go
@@ -29,10 +29,9 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
-	LoggingClient = logger.MockLogger{}
 	tokenPath := "testdata/test-resp-init.json"
 	gk := NewGokeyGenerator(tokenPath)
-	cr := NewCred(&http.Client{}, tokenPath, gk)
+	cr := NewCred(&http.Client{}, tokenPath, gk, logger.MockLogger{})
 
 	realm1 := "service1"
 	realm2 := "service2"
@@ -53,8 +52,6 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestRetrieveCred(t *testing.T) {
-	LoggingClient = logger.MockLogger{}
-
 	credPath := "testCredPath"
 	token := "token"
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -95,7 +92,8 @@ func TestRetrieveCred(t *testing.T) {
 		Scheme: "https",
 	}
 
-	cr := NewCred(NewRequester(true), "", NewGokeyGenerator(""))
+	mockLogger := logger.MockLogger{}
+	cr := NewCred(NewRequester(true, mockLogger), "", NewGokeyGenerator(""), mockLogger)
 	pair, err := cr.retrieve(token, credPath)
 	if err != nil {
 		t.Errorf("failed to retrieve credential pair")

--- a/internal/security/secretstore/requester.go
+++ b/internal/security/secretstore/requester.go
@@ -22,9 +22,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
-func NewRequester(skipVerify bool) *http.Client {
+func NewRequester(skipVerify bool, loggingClient logger.LoggingClient) *http.Client {
 	var tr *http.Transport
 
 	if skipVerify {
@@ -34,10 +36,10 @@ func NewRequester(skipVerify bool) *http.Client {
 	} else {
 		caCert, err := ioutil.ReadFile(Configuration.SecretService.CaFilePath)
 		if err != nil {
-			LoggingClient.Error("failed to load rootCA certificate.")
+			loggingClient.Error("failed to load rootCA certificate.")
 			return nil
 		}
-		LoggingClient.Info("successfully loaded rootCA certificate.")
+		loggingClient.Info("successfully loaded rootCA certificate.")
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 


### PR DESCRIPTION
Fixes: https://github.com/edgexfoundry/edgex-go/issues/2127

Dependency on (includes work from) https://github.com/edgexfoundry/edgex-go/pull/2126. That PR must be reviewed and merged prior to this one.