### PR TITLE
Add app-service-config with rules-engine profile to the snap (master)

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -22,6 +22,9 @@ ALL_SERVICES="$ALL_SERVICES support-logging"
 ALL_SERVICES="$ALL_SERVICES support-scheduler"
 ALL_SERVICES="$ALL_SERVICES support-rulesengine"
 
+# app-services
+ALL_SERVICES="$ALL_SERVICES app-service-configurable"
+
 # export services
 ALL_SERVICES="$ALL_SERVICES export-distro"
 ALL_SERVICES="$ALL_SERVICES export-client"
@@ -110,6 +113,13 @@ for key in $ALL_SERVICES; do
             fi
             handle_svc "vault" "$status"
             handle_svc "security-secretstore-setup" "$status"
+            ;;
+        support-rulesengine)
+            # if we are turning rulesengine on, make sure 
+            # app-service-configurable is on too
+            if [ "$status" = "on" ]; then
+                handle_svc "app-service-configurable" "on"
+            fi
             ;;
         *)
             # default case for all other services just enable/disable the service using

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -8,6 +8,7 @@ SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
 
 # install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
 # into $SNAP_DATA/config
+# note that app-service-configurable is handled separately
 mkdir -p "$SNAP_DATA/config"
 for service in edgex-mongo security-proxy-setup security-secrets-setup security-secretstore-setup core-command config-seed core-data core-metadata export-client export-distro support-logging support-notifications support-scheduler sys-mgmt-agent device-random device-virtual; do
     if [ ! -f "$SNAP_DATA/config/$service/res/configuration.toml" ]; then
@@ -20,6 +21,21 @@ for service in edgex-mongo security-proxy-setup security-secrets-setup security-
             "$SNAP_DATA/config/$service/res/configuration.toml"
     fi
 done
+
+# handle app-service-configurable's various profiles:
+# 1. ensure all the directories from app-service-configurable exist
+# 2. copy the config files from $SNAP into $SNAP_DATA
+# 3. replace the various env vars that might be in that config file with their
+#    "current" symlink equivalent
+mkdir -p "$SNAP_DATA/config/app-service-configurable/res/rules-engine"
+RULES_ENGINE_PROFILE_CONFIG="config/app-service-configurable/res/rules-engine/configuration.toml"
+if [ ! -f "$SNAP_DATA/$RULES_ENGINE_PROFILE_CONFIG" ]; then
+    cp "$SNAP/$RULES_ENGINE_PROFILE_CONFIG" "$SNAP_DATA/$RULES_ENGINE_PROFILE_CONFIG"
+    sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
+        -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
+        -e "s@\$SNAP@$SNAP_CURRENT@g" \
+        "$SNAP_DATA/$RULES_ENGINE_PROFILE_CONFIG"
+fi
 
 # handle device-random device profile
 cp "$SNAP/config/device-random/res/device.random.yaml" "$SNAP_DATA/config/device-random/res/device.random.yaml"
@@ -171,7 +187,9 @@ snapctl stop "$SNAP_NAME.postgres"
 # finally, disable and turn off non-default services
 # by default, we want the export-*, support-*, device-*, and redis services 
 # off.
-for svc in export-distro export-client support-notifications support-scheduler support-logging support-rulesengine device-random device-virtual redis; do
+# also the app-service-configurable service since that is meant to replace the 
+# export services
+for svc in export-distro export-client support-notifications support-scheduler support-logging app-service-configurable support-rulesengine device-random device-virtual redis; do
     # set the service as off, so that the setting is persistent after a refresh
     # due to snapd bug: https://bugs.launchpad.net/snapd/+bug/1818306
     snapctl set $svc=off

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -333,6 +333,11 @@ apps:
       CONSUL_ADDR: "consul://localhost:8500"
     daemon: simple
     plugs: [network, network-bind]
+  app-service-configurable:
+    adapter: full
+    command: bin/app-service-configurable -confdir $SNAP_DATA/config/app-service-configurable/res -profile rules-engine --registry
+    daemon: simple
+    plugs: [network, network-bind]
 
   # helper commands the snap exposes
   security-proxy-setup-cmd:
@@ -1241,3 +1246,29 @@ parts:
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-random/Attribution.txt"
       install -DT "./LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-random/LICENSE"
+
+  app-service-config:
+    source: https://github.com/edgexfoundry/app-service-configurable.git
+    source-branch: master
+    plugin: make
+    build-packages: [gcc, git, libzmq3-dev, pkg-config]
+    stage-packages: [libzmq5]
+    after: [go]
+    override-build: |
+      cd $SNAPCRAFT_PART_SRC
+      make build
+
+      # install the service binary
+      install -DT "./app-service-configurable" \
+         "$SNAPCRAFT_PART_INSTALL/bin/app-service-configurable"
+
+      # replace relative log paths in configuration.toml files with fully qualified paths
+      # prefixed with $SNAP_COMMON
+      mkdir -p "$SNAPCRAFT_PART_INSTALL/config/app-service-configurable/res/rules-engine"
+      cat "res/rules-engine/configuration.toml" | sed -e s:\./logs/:\\'$SNAP_COMMON/'\: > \
+        "$SNAPCRAFT_PART_INSTALL/config/app-service-configurable/res/rules-engine/configuration.toml"
+
+      install -DT "./Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/app-service-configurable/Attribution.txt"
+      install -DT "./LICENSE" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/app-service-configurable/LICENSE"


### PR DESCRIPTION
Duplicate of #2116 for Geneva/master.

Unclear what we want to do long term with this, but since we don't have a new replacement rules engine yet and the export services are supposed to be dropped sometime this cycle, let's just make sure that master is in the same state as Fuji w/respect to using rules-engine.

Also note that this builds from master app-service-configurable rather than the tagged 1.0 release of that repo since we want master to be rolling.