### PR TITLE
Specify XDG_RUNTIME_DIR as /tmp for security-secrets-setup in the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -135,6 +135,8 @@ apps:
     adapter: full
     command: bin/security-secrets-setup -confdir $SNAP_DATA/config/security-secrets-setup/res generate
     daemon: oneshot
+    environment:
+      XDG_RUNTIME_DIR: /tmp
     start-timeout: 15m
   vault:
     adapter: none


### PR DESCRIPTION
This avoids https://github.com/edgexfoundry/edgex-go/issues/2138 because we are
able to make directories as needed in /tmp, where we are unable to create
the root directory of $XDG_RUNTIME_DIR of /run/user/0 due to one or both of
these snapd bugs:

- https://bugs.launchpad.net/snap-confine/+bug/1620442
- https://bugs.launchpad.net/snappy/+bug/1656340

Signed-off-by: Ian Johnson <ian.johnson@canonical.com>

Fixes #2138 for Fuji

To test this, you need to build the snap and install it in strict mode with `--dangerous` because installing with devmode will not trigger the denial. Attempting to install in strict mode without this patch will fail as in the referenced issue. Specifically do this on a Linux machine after [installing snapd](https://snapcraft.io/docs/installing-snapd):


If you are running a native linux machine (i.e. not a VM):
```
$ sudo snap install snapcraft --classic
$ sudo snap install multipass --classic
$ git clone github.com/anonymouse64/edgex-go
$ cd edgex-go
$ git checkout bugfix/2138
$ rm -f edgexfoundry*.snap # delete any other edgexfoundry snaps
$ snapcraft
$ sudo snap install edgexfoundry*.snap --dangerous
```

If you are running inside a VM instead do:
```
$ sudo snap install snapcraft --classic
$ sudo snap install lxd
$ sudo lxd init --auto
$ git clone github.com/anonymouse64/edgex-go
$ cd edgex-go
$ git checkout bugfix/2138
$ rm -f edgexfoundry*.snap # delete any other edgexfoundry snaps
$ snapcraft --use-lxd
$ sudo snap install edgexfoundry*.snap --dangerous
```

If the `snap install` command at the end fails, then the test fails, but it should say something like:

```
$ snap install edgexfoundry_1.1.0-20191114+b078d749_amd64.snap --dangerous
edgexfoundry 1.1.0-20191114+b078d749 installed
```