### PR TITLE
Add metrics endpoint explanation in sys-mgmt service API raml

### DIFF
--- a/api/raml/system-agent.raml
+++ b/api/raml/system-agent.raml
@@ -66,10 +66,10 @@ schemas:
             repeat: false
     get:
         description: "Fetch the operating performance metrics of the specified EdgeX services by their unique names - returning null if none is found for the service. HTTP 500 for unknown or unanticipated issues"
-        displayName: get metrics for each of the names EdgeX services
+        displayName: get metrics for each of the named EdgeX services. 
         responses:
             "200":
-                description: an array of metrics
+                description: An array of metrics, reference obtained from Go [runtime pkg](https://golang.org/pkg/runtime/#MemStats). <br/> **Alloc** is the number bytes of allocated heap objects. <br/> **TotalAlloc** increases as heap objects are allocated, but unlike **Alloc**, it does not decrease when objects are freed. <br/> **Mallocs** is the cumulative count of heap objects allocated. <br/> The number of **LiveObjects** is **Mallocs** - **Frees**. <br/> **Sys** is the total bytes of memory obtained from the OS. 
                 body:
                     application/json:
                         schema: metric


### PR DESCRIPTION
Added some background information on the metrics returned from the sys-mgmt endpoint. 

t is based on the [official docs](https://golang.org/pkg/runtime/#MemStats) for the runtime pkg. It will help developers make sense of the API and integrate it into other monitoring solutions.

Signed-off-by: OdysLam <odyslam@gmail.com>