### PR TITLE
Split customized vault into two docker images- part 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,13 +171,11 @@ docker_sys_mgmt_agent:
 		.
 
 docker_security_secrets_setup:
-	# TODO: split this up and rename it when security-secrets-setup is a 
-	# different container
 	docker build \
 		-f cmd/security-secrets-setup/Dockerfile \
 		--label "git_sha=$(GIT_SHA)" \
-		-t edgexfoundry/docker-edgex-secret-store-go:$(GIT_SHA) \
-		-t edgexfoundry/docker-edgex-secret-store-go:$(DOCKER_TAG) \
+		-t edgexfoundry/docker-edgex-secrets-setup-go:$(GIT_SHA) \
+		-t edgexfoundry/docker-edgex-secrets-setup-go:$(DOCKER_TAG) \
 		.
 
 docker_security_proxy_setup:

--- a/cmd/security-secrets-setup/Dockerfile
+++ b/cmd/security-secrets-setup/Dockerfile
@@ -44,25 +44,23 @@ COPY . .
 
 RUN make cmd/security-secrets-setup/security-secrets-setup
 
-FROM vault:1.0.2
+FROM alpine:latest
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-      copyright='Copyright (c) 2019: Dell Technologies, Inc.'
+      copyright='Copyright (c) 2019: Dell Technologies, Inc.  Copyright (c) 2019 Intel Corporation'
 
 USER root
 
 # install necessary tools
-RUN apk update && apk add ca-certificates dumb-init jq \
+RUN apk update && apk add ca-certificates dumb-init \
     && rm -rf /var/cache/apk/* 
 
-ENV BASE_DIR=/vault
-
-# Vault Config File
-WORKDIR $BASE_DIR/config
-COPY --from=build-env /edgex-go/cmd/security-secrets-setup/res/local-tls.hcl ./local.hcl
+ENV BASE_DIR=/edgex/security-secrets-setup
 
 WORKDIR $BASE_DIR
-RUN mkdir res
+RUN mkdir res && \
+    mkdir -p /vault/init && \
+    mkdir /vault/staging
 
 # Vault PKI/TLS setup/config binary
 COPY --from=build-env /edgex-go/cmd/security-secrets-setup/security-secrets-setup .
@@ -73,6 +71,10 @@ COPY --from=build-env /edgex-go/cmd/security-secrets-setup/res/pkisetup-vault.js
 # Kong PKI/TLS materials
 COPY --from=build-env /edgex-go/cmd/security-secrets-setup/res/pkisetup-kong.json ./res
 
+# Vault's startup script
+COPY --from=build-env /edgex-go/cmd/security-secrets-setup/start_vault.sh /vault/staging
+RUN chmod +x /vault/staging/start_vault.sh
+
 # setup the entry point script
 # it uses `dumb-init` as the top-level process to reap any
 # zombie processes created by sub-processes
@@ -80,13 +82,8 @@ COPY --from=build-env /edgex-go/cmd/security-secrets-setup/entrypoint.sh /usr/lo
 RUN chmod +x /usr/local/bin/entrypoint.sh \
     && ln -s /usr/local/bin/entrypoint.sh /
 
-# Create assets folder (needed for unseal key/s, root token and tmp)
-# Run CA/Vault and Kong PKI/TLS setups and peform housekeeping tasks
-RUN mkdir $BASE_DIR/config/assets && \
-    chown -R vault:vault $BASE_DIR && \
-    chmod 644 $BASE_DIR/config/local.hcl && \
-    chmod 744 security-secrets-setup
-
-VOLUME $BASE_DIR/config
+RUN chmod 755 security-secrets-setup
 
 ENTRYPOINT ["entrypoint.sh"]
+
+CMD [ "generate" ]

--- a/cmd/security-secrets-setup/entrypoint.sh
+++ b/cmd/security-secrets-setup/entrypoint.sh
@@ -24,53 +24,36 @@ set -e
 # thus more graceful termination of all sub-processes if any.
 
 # runtime directory is set per user:
-export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(echo $(id -u))}
-
-PKI_INIT_RUNTIME_DIR=${XDG_RUNTIME_DIR}/${PKI_INIT_DIR}
+XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(echo $(id -u))}
+PATH="$BASE_DIR:$PATH"
+VAULT_TLS_PATH=${VAULT_TLS_PATH:-/run/edgex/secrets/edgex-vault}
+export XDG_RUNTIME_DIR PATH VAULT_TLS_PATH
 
 # debug output:
 echo XDG_RUNTIME_DIR $XDG_RUNTIME_DIR
-echo PKI_INIT_RUNTIME_DIR $PKI_INIT_RUNTIME_DIR
+echo BASE_DIR $BASE_DIR
 
-# configuration for TLS materials:
-PKI_CONFIG_JSON_DIR="res"
-PKI_SETUP_VAULT_FILE=${PKI_CONFIG_JSON_DIR}"/pkisetup-vault.json"
-PKI_SETUP_KONG_FILE=${PKI_CONFIG_JSON_DIR}"/pkisetup-kong.json"
-
-# check if files exists
-if [ ! -f "${PKI_SETUP_VAULT_FILE}" ]; then
-    echo "Error: certificate config file for Vault is missing"
-    exit 1
+# if running security-secrets-setup subcommand
+# build full command line into positional args
+if [ "$1" = 'generate' -o "$1" = 'cache' -o "$1" = 'import' -o "$1" = 'legacy' ]; then
+    set -- security-secrets-setup "$@"
 fi
 
-if [ ! -f "${PKI_SETUP_KONG_FILE}" ]; then
-    echo "Error: certificate config file for Kong is missing"
-    exit 1
+instvaultscript=""
+posthook=""
+if [ "$1" = 'security-secrets-setup' ]; then
+    # update the start_vault script for vault starting
+    instvaultscript="cp /vault/staging/start_vault.sh /vault/init/start_vault.sh"
+    # grant permissions of folders for vault:vault
+    posthook="chown -Rh 100:1000 ${VAULT_TLS_PATH}"
 fi
 
-# the working dir should be in vault dir based upon the current Docker image
-BASE_DIR="${BASE_DIR:-/vault}"
-cd $BASE_DIR
-CERT_DIR=$(jq -r '.working_dir' ${PKI_SETUP_VAULT_FILE})
-CERT_SUBDIR=$(jq -r '.pki_setup_dir' ${PKI_SETUP_VAULT_FILE})
-ROOT_NAME=$(jq -r '.x509_root_ca_parameters | .ca_name' ${PKI_SETUP_VAULT_FILE})
-CERT_EXEC="${CERT_EXEC:-./security-secrets-setup}"
-# check to see if the root certificate generate with security-secrets-setup already exists
-# if so then do not generate a new set of them
-if [ ! -f "$CERT_DIR/$CERT_SUBDIR/$ROOT_NAME/$ROOT_NAME.pem" ]; then
-    ${CERT_EXEC} legacy --config ${PKI_SETUP_VAULT_FILE}
-    [ $? -eq 0 ] || (echo "failed to generate TLS assets for Vault" && exit 1)
+echo "Executing $@"
+"$@"
 
-    ${CERT_EXEC} legacy --config ${PKI_SETUP_KONG_FILE}
-    [ $? -eq 0 ] || (echo "failed to generate TLS assets for Kong" && exit 1)
-
-    # delete CA private key
-    rm "$PWD/$CERT_DIR/$CERT_SUBDIR/$ROOT_NAME/$ROOT_NAME.priv.key"
-    [ $? -eq 0 ] || (echo "failed to delete sensitive CA private key" && exit 1)
-
-    # take ownership
-    chown -R vault:vault $PWD/$CERT_DIR/$CERT_SUBDIR || true
-fi 
-
-# run the Vault's docker-entry script 
-source /usr/local/bin/docker-entrypoint.sh
+if [ "$1" = 'security-secrets-setup' ]; then
+    echo "Installing Vault's startup script"
+    $instvaultscript
+    echo "Executing hook=$posthook"
+    $posthook
+fi

--- a/cmd/security-secrets-setup/start_vault.sh
+++ b/cmd/security-secrets-setup/start_vault.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/dumb-init /bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2019 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+set -e
+
+VAULT_TLS_PATH=${VAULT_TLS_PATH:-/run/edgex/secrets/edgex-vault}
+
+VAULT_LOCAL_CONFIG='
+listener "tcp" { 
+              address = "edgex-vault:8200" 
+              tls_disable = "0" 
+              cluster_address = "edgex-vault:8201" 
+              tls_min_version = "tls12" 
+              tls_client_ca_file ="'${VAULT_TLS_PATH}'/ca.pem" 
+              tls_cert_file ="'${VAULT_TLS_PATH}'/server.crt" 
+              tls_key_file = "'${VAULT_TLS_PATH}'/server.key" 
+              tls_perfer_server_cipher_suites = "true"
+          } 
+          backend "consul" { 
+              path = "vault/" 
+              address = "edgex-core-consul:8500" 
+              scheme = "http" 
+              redirect_addr = "https://edgex-vault:8200" 
+              cluster_addr = "https://edgex-vault:8201" 
+          } 
+          default_lease_ttl = "168h" 
+          max_lease_ttl = "720h"
+'
+
+echo "VAULT_LOCAL_CONFIG:" ${VAULT_LOCAL_CONFIG}
+
+export VAULT_TLS_PATH VAULT_LOCAL_CONFIG
+
+# Before Vault can start up, the TLS certificates are required.
+# By default, these certificates are generated via security-secrets-setup
+# application service and the sentinel files are produced when it is done.
+# Thus, we check the sentinel file here:
+
+SENTILNEL_FILE=${VAULT_TLS_PATH}/.security-secrets-setup.complete
+while test ! -f ${SENTILNEL_FILE}; do
+    echo 'waiting for security-secrets-setup done';
+    sleep 1;
+done;
+
+echo 'Starting edgex-vault...'
+exec /usr/local/bin/docker-entrypoint.sh server -log-level=info

--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -18,7 +18,8 @@ RUN make cmd/security-secretstore-setup/security-secretstore-setup
 
 FROM alpine:3.10
 
-RUN apk update && apk add curl && rm -rf /var/cache/apk/* 
+RUN apk update && apk add ca-certificates dumb-init curl \
+    && rm -rf /var/cache/apk/* 
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Dell Technologies, Inc.'
@@ -29,4 +30,9 @@ COPY --from=builder /edgex-go/cmd/security-secretstore-setup/res/docker/configur
 
 COPY --from=builder /edgex-go/cmd/security-secretstore-setup/security-secretstore-setup .
 
-ENTRYPOINT ["./security-secretstore-setup","--init=true"]
+# setup the entry point script
+COPY --from=builder /edgex-go/cmd/security-secretstore-setup/entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && ln -s /usr/local/bin/entrypoint.sh /
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/cmd/security-secretstore-setup/entrypoint.sh
+++ b/cmd/security-secretstore-setup/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/dumb-init /bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2019 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+set -e
+
+echo "creating /vault/config/assets"
+
+# create token directory and
+# grant permissions of folders for vault:vault
+mkdir -p /vault/config/assets
+chown -Rh 100:1000 /vault/
+
+echo "starting vault-worker..."
+
+# need to wait until security-secrets-setup produces the necessary TLS assets
+# before start the vault-worker
+
+until /consul/scripts/consul-svc-healthy.sh security-secrets-setup; do 
+    echo 'waiting for security-secrets-setup'; 
+    sleep 1; 
+done;
+
+/security-secretstore-setup --init=true --vaultInterval=10
+
+exec "$@"


### PR DESCRIPTION
This PR attempts to address issues #1716.  There are a couple steps to accomplish that:

1. Split the docker image file from inhering the Vault
2. Update the newly generated TLS paths (Related PRs: https://github.com/edgexfoundry/docker-edgex-mongo/pull/71, )
3. Update the consul checking scripts (Related PR: https://github.com/edgexfoundry/docker-edgex-consul/pull/10)

The focus of this PR is on the **step 1**.

  The original customized edgex-vault docker image is broken into two separate images:
    the official Vault docker image from HashiCorp and the `security-secrets-setup` docker image

 - add customized docker entrypoint script for starting vault
 - use sentinel files for readiness check of TLS cert of vault because vault image does not have curl command available
 - prepare cross-mount volume /vault/init for customized startup script
 - remove creation of /vault/config/assets folder from security-secrets-setup and
   create that folder from entrypoint of security-secretstore-setup (aka vault-worker)

## Testing steps
1. Build the new docker images for both `security-secrets-setup` and `security-secretstore-setup`:
```sh
$ make docker_security_secrets_setup
$ make docker_security_secretstore_setup
```
2. Run the secrets-setup docker container:
```sh
$ docker run --tmpfs /run  -v /run/edgex/secrets:/run/edgex/secrets -v vault-init:/vault/init edgexfoundry/docker-edgex-secrets-setup-go:1.1.1-dev
```
If running ok, one should expect to see console outputs like this:
```sh
XDG_RUNTIME_DIR /run/user/0
BASE_DIR /edgex/security-secrets-setup
Executing security-secrets-setup generate
level=ERROR ts=2019-11-18T23:40:17.197784157Z app=edgex-security-secrets-setup source=logger.go:73 msg="logTarget cannot be blank, using stdout only"
Creating directory: /edgex/security-secrets-setup/logs
{
    "CACertFile": "/run/user/0/edgex/security-secrets-setup/scratch/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem",
    "CACountry": "US",
    "CAKeyFile": "/run/user/0/edgex/security-secrets-setup/scratch/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.priv.key",
    "CALocality": "San Francisco",
    "CAName": "EdgeXFoundryCA",
    "CAOrg": "EdgeXFoundry",
    "CAState": "CA",
    "DumpKeys": false,
    "ECCurve": 384,
    "ECScheme": true,
    "NewCA": true,
    "RSAKeySize": 4096,
    "RSAScheme": false,
    "TLSAltFqdn": "edgex-vault.local",
    "TLSCertFile": "/run/user/0/edgex/security-secrets-setup/scratch/config/pki/EdgeXFoundryCA/edgex-vault.pem",
    "TLSCountry": "US",
    "TLSDomain": "local",
    "TLSFqdn": "edgex-vault",
    "TLSHost": "edgex-vault",
    "TLSKeyFile": "/run/user/0/edgex/security-secrets-setup/scratch/config/pki/EdgeXFoundryCA/edgex-vault.priv.key",
    "TLSLocality": "San Francisco",
    "TLSOrg": "Vault",
    "TLSState": "CA"
}
{
    "CACertFile": "/run/user/0/edgex/security-secrets-setup/scratch/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem",
    "CACountry": "US",
    "CAKeyFile": "/run/user/0/edgex/security-secrets-setup/scratch/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.priv.key",
    "CALocality": "San Francisco",
    "CAName": "EdgeXFoundryCA",
    "CAOrg": "EdgeXFoundry",
    "CAState": "CA",
    "DumpKeys": false,
    "ECCurve": 384,
    "ECScheme": true,
    "NewCA": false,
    "RSAKeySize": 4096,
    "RSAScheme": false,
    "TLSAltFqdn": "edgex-kong.local",
    "TLSCertFile": "/run/user/0/edgex/security-secrets-setup/scratch/config/pki/EdgeXFoundryCA/edgex-kong.pem",
    "TLSCountry": "US",
    "TLSDomain": "local",
    "TLSFqdn": "edgex-kong",
    "TLSHost": "edgex-kong",
    "TLSKeyFile": "/run/user/0/edgex/security-secrets-setup/scratch/config/pki/EdgeXFoundryCA/edgex-kong.priv.key",
    "TLSLocality": "San Francisco",
    "TLSOrg": "Kong",
    "TLSState": "CA"
}
level=INFO ts=2019-11-18T23:40:17.241470347Z app=edgex-security-secrets-setup source=generate.go:211 msg="pki-init generation completes"
Installing Vault's startup script
Executing hook=chown -Rh 100:1000 /run/edgex/secrets/edgex-vault
```

3. Run consul: you will need one from [Fuji branch of edgex-consul](https://github.com/edgexfoundry/docker-edgex-consul/tree/fuji) and modify the [security-secrets-setup-checker.sh](https://github.com/edgexfoundry/docker-edgex-consul/blob/fuji/scripts/security-secrets-setup-checker.sh) to check the sentinel files like:
```sh
#!/bin/sh -ex

# check that the root CA exists
# the new way of checking just the sentinel files which will have all TLS assets
test -f /run/edgex/secrets/ca/.security-secrets-setup.complete
```
and currently, there is an open PR for this: https://github.com/edgexfoundry/docker-edgex-consul/pull/10  

and then do a docker build `make docker`.

create docker bridge network if not exists yet:
```sh
docker network create edgex-network
```

Then run edgex-consul docker container like
```sh
docker run --rm --network edgex-network --net-alias edgex-core-consul -v consul-config:/consul/config -v consul-data:/consul/data -v consul-scripts:/consul/scripts -v vault-config:/vault/config -v /run/edgex/secrets:/run/edgex/secrets:ro -p 8400:8400 -p 8500:8500 edgexfoundry/docker-edgex-consul:1.1.0
```
make sure edgex-consul runs up ok.

4. Finally, starts up the Docker Hashicorp Vault like:
```sh
docker run --rm --privileged --entrypoint "/vault/init/start_vault.sh" --network edgex-network --net-alias edgex-vault -p 8200:8200 -e VAULT_ADDR=https://edgex-vault:8200 -e VAULT_CONFIG_DIR=/vault/config -e VAULT_UI=true -v vault-file:/vault/file -v vault-logs:/vault/logs -v vault-init:/vault/init:ro -v /run/edgex/secrets/edgex-vault:/run/edgex/secrets/edgex-vault:ro vault:1.0.3
```

If everything works, one should expect to see Vault starts up listening like:
```sh
VAULT_LOCAL_CONFIG: listener "tcp" { address = "edgex-vault:8200" tls_disable = "0" cluster_address = "edgex-vault:8201" tls_min_version = "tls12" tls_client_ca_file ="/run/edgex/secrets/edgex-vault/ca.pem" tls_cert_file ="/run/edgex/secrets/edgex-vault/server.crt" tls_key_file = "/run/edgex/secrets/edgex-vault/server.key" tls_perfer_server_cipher_suites = "true" } backend "consul" { path = "vault/" address = "edgex-core-consul:8500" scheme = "http" redirect_addr = "https://edgex-vault:8200" cluster_addr = "https://edgex-vault:8201" } default_lease_ttl = "168h" max_lease_ttl = "720h"
Starting edgex-vault...
==> Vault server configuration:

             Api Address: https://edgex-vault:8200
                     Cgo: disabled
         Cluster Address: https://edgex-vault:8201
              Listener 1: tcp (addr: "edgex-vault:8200", cluster address: "edgex-vault:8201", max_request_duration: "1m30s", max_request_size: "33554432", tls: "enabled")
               Log Level: info
                   Mlock: supported: true, enabled: true
                 Storage: consul (HA available)
                 Version: Vault v1.0.3
             Version Sha: 85909e3373aa743c34a6a0ab59131f61fd9e8e43

==> Vault server started! Log data will stream in below:

```

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>