### PR TITLE
Specify XDG_RUNTIME_DIR as /tmp for security-secrets-setup in the snap (master)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -136,6 +136,8 @@ apps:
     adapter: full
     command: bin/security-secrets-setup -confdir $SNAP_DATA/config/security-secrets-setup/res generate
     daemon: oneshot
+    environment:
+      XDG_RUNTIME_DIR: /tmp
     start-timeout: 15m
   vault:
     adapter: none


### PR DESCRIPTION
Duplicate of https://github.com/edgexfoundry/edgex-go/pull/2139 but for master. 