### PR TITLE
Remove dbClient global variable from core-data

### DIFF
--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -36,7 +35,6 @@ import (
 
 // Global variables
 var Configuration = &ConfigurationStruct{}
-var dbClient interfaces.DBClient
 
 // TODO: Refactor names in separate PR: See comments on PR #1133
 var chEvents chan interface{} // A channel for "domain events" sourced from event operations
@@ -50,7 +48,6 @@ var httpErrorHandler errorconcept.ErrorHandler
 func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
 	loggingClient := container.LoggingClientFrom(dic.Get)
-	dbClient = container.DBClientFrom(dic.Get)
 
 	httpErrorHandler = errorconcept.NewErrorHandler(loggingClient)
 

--- a/internal/core/data/reading_test.go
+++ b/internal/core/data/reading_test.go
@@ -29,11 +29,7 @@ func newReadingsMockDB() interfaces.DBClient {
 func TestGetAllReadings(t *testing.T) {
 	reset()
 	Configuration.Service.MaxResultCount = 5
-
-	dbClient = newReadingsMockDB()
-
-	_, err := getAllReadings(logger.NewMockClient())
-
+	_, err := getAllReadings(logger.NewMockClient(), newReadingsMockDB())
 	if err != nil {
 		t.Errorf("Unexpected error thrown getting all readings: %s", err.Error())
 	}
@@ -42,10 +38,7 @@ func TestGetAllReadings(t *testing.T) {
 func TestGetAllReadingsOverLimit(t *testing.T) {
 	reset()
 	Configuration.Service.MaxResultCount = 1
-
-	dbClient = newReadingsMockDB()
-
-	_, err := getAllReadings(logger.NewMockClient())
+	_, err := getAllReadings(logger.NewMockClient(), newReadingsMockDB())
 
 	if err != nil {
 		switch err.(type) {
@@ -64,14 +57,9 @@ func TestGetAllReadingsOverLimit(t *testing.T) {
 func TestGetAllReadingsError(t *testing.T) {
 	reset()
 	Configuration.Service.MaxResultCount = 5
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("Readings").Return([]models.Reading{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getAllReadings(logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("Readings").Return([]models.Reading{}, fmt.Errorf("some error"))
+	_, err := getAllReadings(logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error getting all readings")
 	}
@@ -79,14 +67,9 @@ func TestGetAllReadingsError(t *testing.T) {
 
 func TestAddReading(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("AddReading", mock.Anything).Return("", nil)
-
-	dbClient = myMock
-
-	_, err := addReading(models.Reading{Name: "valid"}, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("AddReading", mock.Anything).Return("", nil)
+	_, err := addReading(models.Reading{Name: "valid"}, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error adding reading")
 	}
@@ -94,14 +77,9 @@ func TestAddReading(t *testing.T) {
 
 func TestAddReadingError(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("AddReading", mock.Anything).Return("", fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := addReading(models.Reading{}, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("AddReading", mock.Anything).Return("", fmt.Errorf("some error"))
+	_, err := addReading(models.Reading{}, logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error adding reading")
 	}
@@ -109,14 +87,9 @@ func TestAddReadingError(t *testing.T) {
 
 func TestGetReadingById(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingById", mock.Anything).Return(models.Reading{}, nil)
-
-	dbClient = myMock
-
-	_, err := getReadingById("valid", logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingById", mock.Anything).Return(models.Reading{}, nil)
+	_, err := getReadingById("valid", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting reading by ID")
 	}
@@ -124,14 +97,9 @@ func TestGetReadingById(t *testing.T) {
 
 func TestGetReadingByIdNotFound(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingById", mock.Anything).Return(models.Reading{}, db.ErrNotFound)
-
-	dbClient = myMock
-
-	_, err := getReadingById("404", logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingById", mock.Anything).Return(models.Reading{}, db.ErrNotFound)
+	_, err := getReadingById("404", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		switch err.(type) {
 		case errors.ErrDbNotFound:
@@ -148,14 +116,9 @@ func TestGetReadingByIdNotFound(t *testing.T) {
 
 func TestGetReadingByIdError(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingById", mock.Anything).Return(models.Reading{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getReadingById("error", logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingById", mock.Anything).Return(models.Reading{}, fmt.Errorf("some error"))
+	_, err := getReadingById("error", logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error getting reading by ID with some error")
 	}
@@ -163,48 +126,33 @@ func TestGetReadingByIdError(t *testing.T) {
 
 func TestDeleteReadingById(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("DeleteReadingById", mock.Anything).Return(nil).Once()
-
-	dbClient = myMock
-
-	err := deleteReadingById("valid", logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("DeleteReadingById", mock.Anything).Return(nil).Once()
+	err := deleteReadingById("valid", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error deleting reading by ID")
 	}
 
-	myMock.AssertExpectations(t)
+	dbClientMock.AssertExpectations(t)
 }
 
 func TestDeleteReadingByIdError(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("DeleteReadingById", mock.Anything).Return(fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	err := deleteReadingById("invalid", logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("DeleteReadingById", mock.Anything).Return(fmt.Errorf("some error"))
+	err := deleteReadingById("invalid", logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error deleting reading by ID")
 	}
 
-	myMock.AssertExpectations(t)
+	dbClientMock.AssertExpectations(t)
 }
 
 func TestCountReadings(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingCount").Return(2, nil)
-
-	dbClient = myMock
-
-	_, err := countReadings(logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingCount").Return(2, nil)
+	_, err := countReadings(logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error in CountReadings")
 	}
@@ -212,14 +160,9 @@ func TestCountReadings(t *testing.T) {
 
 func TestCountReadingsError(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingCount").Return(2, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := countReadings(logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingCount").Return(2, fmt.Errorf("some error"))
+	_, err := countReadings(logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error in CountReadings")
 	}
@@ -227,14 +170,9 @@ func TestCountReadingsError(t *testing.T) {
 
 func TestGetReadingsByDevice(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByDevice", mock.Anything, mock.Anything).Return(buildReadings(), nil)
-
-	dbClient = myMock
-
-	expectedReadings, err := getReadingsByDevice("valid", 0, context.Background(), logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByDevice", mock.Anything, mock.Anything).Return(buildReadings(), nil)
+	expectedReadings, err := getReadingsByDevice("valid", 0, context.Background(), logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error in getReadingsByDevice")
 	}
@@ -246,14 +184,9 @@ func TestGetReadingsByDevice(t *testing.T) {
 
 func TestGetReadingsByDeviceError(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByDevice", mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getReadingsByDevice("error", 0, context.Background(), logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByDevice", mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
+	_, err := getReadingsByDevice("error", 0, context.Background(), logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error in getReadingsByDevice")
 	}
@@ -261,14 +194,9 @@ func TestGetReadingsByDeviceError(t *testing.T) {
 
 func TestGetReadingsByValueDescriptor(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
-
-	dbClient = myMock
-
-	_, err := getReadingsByValueDescriptor("valid", 0, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
+	_, err := getReadingsByValueDescriptor("valid", 0, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting readings by value descriptor")
 	}
@@ -276,10 +204,7 @@ func TestGetReadingsByValueDescriptor(t *testing.T) {
 
 func TestGetReadingsByValueDescriptorOverLimit(t *testing.T) {
 	reset()
-	dbClient = nil
-
-	_, err := getReadingsByValueDescriptor("", math.MaxInt32, logger.NewMockClient())
-
+	_, err := getReadingsByValueDescriptor("", math.MaxInt32, logger.NewMockClient(), nil)
 	if err == nil {
 		t.Errorf("Expected error getting readings by value descriptor")
 	}
@@ -287,14 +212,9 @@ func TestGetReadingsByValueDescriptorOverLimit(t *testing.T) {
 
 func TestGetReadingsByValueDescriptorError(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getReadingsByValueDescriptor("error", 0, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
+	_, err := getReadingsByValueDescriptor("error", 0, logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error in getting readings by value descriptor")
 	}
@@ -302,14 +222,9 @@ func TestGetReadingsByValueDescriptorError(t *testing.T) {
 
 func TestGetReadingsByValueDescriptorNames(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByValueDescriptorNames", mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
-
-	dbClient = myMock
-
-	_, err := getReadingsByValueDescriptorNames([]string{"valid"}, 0, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByValueDescriptorNames", mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
+	_, err := getReadingsByValueDescriptorNames([]string{"valid"}, 0, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting readings by value descriptor names")
 	}
@@ -317,14 +232,9 @@ func TestGetReadingsByValueDescriptorNames(t *testing.T) {
 
 func TestGetReadingsByValueDescriptorNamesError(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByValueDescriptorNames", mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getReadingsByValueDescriptorNames([]string{"error"}, 0, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByValueDescriptorNames", mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
+	_, err := getReadingsByValueDescriptorNames([]string{"error"}, 0, logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error in getting readings by value descriptor names")
 	}
@@ -332,14 +242,9 @@ func TestGetReadingsByValueDescriptorNamesError(t *testing.T) {
 
 func TestGetReadingsByCreationTime(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByCreationTime", mock.Anything, mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
-
-	dbClient = myMock
-
-	_, err := getReadingsByCreationTime(0xBEEF, 0, 0, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByCreationTime", mock.Anything, mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
+	_, err := getReadingsByCreationTime(0xBEEF, 0, 0, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting readings by creation time")
 	}
@@ -347,14 +252,9 @@ func TestGetReadingsByCreationTime(t *testing.T) {
 
 func TestGetReadingsByCreationTimeError(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByCreationTime", mock.Anything, mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getReadingsByCreationTime(0xDEADBEEF, 0, 0, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByCreationTime", mock.Anything, mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
+	_, err := getReadingsByCreationTime(0xDEADBEEF, 0, 0, logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error in getting readings by creation time")
 	}
@@ -362,14 +262,9 @@ func TestGetReadingsByCreationTimeError(t *testing.T) {
 
 func TestGetReadingsByDeviceAndValueDescriptor(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByDeviceAndValueDescriptor", mock.Anything, mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
-
-	dbClient = myMock
-
-	_, err := getReadingsByDeviceAndValueDescriptor("valid", "valid", 0, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByDeviceAndValueDescriptor", mock.Anything, mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
+	_, err := getReadingsByDeviceAndValueDescriptor("valid", "valid", 0, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting readings by device and value descriptor")
 	}
@@ -377,14 +272,9 @@ func TestGetReadingsByDeviceAndValueDescriptor(t *testing.T) {
 
 func TestGetReadingsByDeviceAndValueDescriptorError(t *testing.T) {
 	reset()
-	myMock := &dbMock.DBClient{}
-
-	myMock.On("ReadingsByDeviceAndValueDescriptor", mock.Anything, mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getReadingsByDeviceAndValueDescriptor("error", "error", 0, logger.NewMockClient())
-
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByDeviceAndValueDescriptor", mock.Anything, mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
+	_, err := getReadingsByDeviceAndValueDescriptor("error", "error", 0, logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error in getting readings by device and value descriptor")
 	}

--- a/internal/core/data/router_test.go
+++ b/internal/core/data/router_test.go
@@ -180,10 +180,9 @@ func TestRestValueDescriptorsUsageHandler(t *testing.T) {
 			defer func() { Configuration = &ConfigurationStruct{} }()
 
 			httpErrorHandler = errorconcept.NewErrorHandler(logger.NewMockClient())
-			dbClient = tt.dbMock
 			Configuration.Service = tt.config
 			rr := httptest.NewRecorder()
-			restValueDescriptorsUsageHandler(rr, tt.request, logger.NewMockClient())
+			restValueDescriptorsUsageHandler(rr, tt.request, logger.NewMockClient(), tt.dbMock)
 			response := rr.Result()
 			b, _ := ioutil.ReadAll(response.Body)
 			var r []map[string]bool

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -24,6 +24,7 @@ import (
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
@@ -54,7 +55,11 @@ func validateFormatString(v contract.ValueDescriptor, loggingClient logger.Loggi
 	return nil
 }
 
-func getValueDescriptorByName(name string, loggingClient logger.LoggingClient) (vd contract.ValueDescriptor, err error) {
+func getValueDescriptorByName(
+	name string,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (vd contract.ValueDescriptor, err error) {
+
 	vd, err = dbClient.ValueDescriptorByName(name)
 
 	if err != nil {
@@ -69,7 +74,11 @@ func getValueDescriptorByName(name string, loggingClient logger.LoggingClient) (
 	return vd, nil
 }
 
-func getValueDescriptorById(id string, loggingClient logger.LoggingClient) (vd contract.ValueDescriptor, err error) {
+func getValueDescriptorById(
+	id string,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (vd contract.ValueDescriptor, err error) {
+
 	vd, err = dbClient.ValueDescriptorById(id)
 
 	if err != nil {
@@ -86,7 +95,11 @@ func getValueDescriptorById(id string, loggingClient logger.LoggingClient) (vd c
 	return vd, nil
 }
 
-func getValueDescriptorsByUomLabel(uomLabel string, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByUomLabel(
+	uomLabel string,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
+
 	vdList, err = dbClient.ValueDescriptorsByUomLabel(uomLabel)
 
 	if err != nil {
@@ -101,7 +114,11 @@ func getValueDescriptorsByUomLabel(uomLabel string, loggingClient logger.Logging
 	return vdList, nil
 }
 
-func getValueDescriptorsByLabel(label string, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByLabel(
+	label string,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
+
 	vdList, err = dbClient.ValueDescriptorsByLabel(label)
 
 	if err != nil {
@@ -116,7 +133,11 @@ func getValueDescriptorsByLabel(label string, loggingClient logger.LoggingClient
 	return vdList, nil
 }
 
-func getValueDescriptorsByType(typ string, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByType(
+	typ string,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
+
 	vdList, err = dbClient.ValueDescriptorsByType(typ)
 
 	if err != nil {
@@ -131,7 +152,11 @@ func getValueDescriptorsByType(typ string, loggingClient logger.LoggingClient) (
 	return vdList, nil
 }
 
-func getValueDescriptorsByDevice(device contract.Device, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByDevice(
+	device contract.Device,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
+
 	// Get the names of the value descriptors
 	vdNames := []string{}
 	device.AllAssociatedValueDescriptors(&vdNames)
@@ -139,7 +164,7 @@ func getValueDescriptorsByDevice(device contract.Device, loggingClient logger.Lo
 	// Get the value descriptors
 	vdList = []contract.ValueDescriptor{}
 	for _, name := range vdNames {
-		vd, err := getValueDescriptorByName(name, loggingClient)
+		vd, err := getValueDescriptorByName(name, loggingClient, dbClient)
 
 		// Not an error if not found
 		if err != nil {
@@ -157,7 +182,12 @@ func getValueDescriptorsByDevice(device contract.Device, loggingClient logger.Lo
 	return vdList, nil
 }
 
-func getValueDescriptorsByDeviceName(name string, ctx context.Context, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByDeviceName(
+	name string,
+	ctx context.Context,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
+
 	// Get the device
 	device, err := mdc.DeviceForName(name, ctx)
 	if err != nil {
@@ -165,10 +195,15 @@ func getValueDescriptorsByDeviceName(name string, ctx context.Context, loggingCl
 		return []contract.ValueDescriptor{}, err
 	}
 
-	return getValueDescriptorsByDevice(device, loggingClient)
+	return getValueDescriptorsByDevice(device, loggingClient, dbClient)
 }
 
-func getValueDescriptorsByDeviceId(id string, ctx context.Context, loggingClient logger.LoggingClient) (vdList []contract.ValueDescriptor, err error) {
+func getValueDescriptorsByDeviceId(
+	id string,
+	ctx context.Context,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
+
 	// Get the device
 	device, err := mdc.Device(id, ctx)
 	if err != nil {
@@ -176,10 +211,13 @@ func getValueDescriptorsByDeviceId(id string, ctx context.Context, loggingClient
 		return []contract.ValueDescriptor{}, err
 	}
 
-	return getValueDescriptorsByDevice(device, loggingClient)
+	return getValueDescriptorsByDevice(device, loggingClient, dbClient)
 }
 
-func getAllValueDescriptors(loggingClient logger.LoggingClient) (vd []contract.ValueDescriptor, err error) {
+func getAllValueDescriptors(
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (vd []contract.ValueDescriptor, err error) {
+
 	vd, err = dbClient.ValueDescriptors()
 	if err != nil {
 		loggingClient.Error(err.Error())
@@ -189,7 +227,10 @@ func getAllValueDescriptors(loggingClient logger.LoggingClient) (vd []contract.V
 	return vd, nil
 }
 
-func decodeValueDescriptor(reader io.ReadCloser, loggingClient logger.LoggingClient) (vd contract.ValueDescriptor, err error) {
+func decodeValueDescriptor(
+	reader io.ReadCloser,
+	loggingClient logger.LoggingClient) (vd contract.ValueDescriptor, err error) {
+
 	v := contract.ValueDescriptor{}
 	err = json.NewDecoder(reader).Decode(&v)
 	// Problems decoding
@@ -207,7 +248,11 @@ func decodeValueDescriptor(reader io.ReadCloser, loggingClient logger.LoggingCli
 	return v, nil
 }
 
-func addValueDescriptor(vd contract.ValueDescriptor, loggingClient logger.LoggingClient) (id string, err error) {
+func addValueDescriptor(
+	vd contract.ValueDescriptor,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) (id string, err error) {
+
 	id, err = dbClient.AddValueDescriptor(vd)
 	if err != nil {
 		loggingClient.Error(err.Error())
@@ -221,8 +266,12 @@ func addValueDescriptor(vd contract.ValueDescriptor, loggingClient logger.Loggin
 	return id, nil
 }
 
-func updateValueDescriptor(from contract.ValueDescriptor, loggingClient logger.LoggingClient) error {
-	to, err := getValueDescriptorById(from.Id, loggingClient)
+func updateValueDescriptor(
+	from contract.ValueDescriptor,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) error {
+
+	to, err := getValueDescriptorById(from.Id, loggingClient, dbClient)
 	if err != nil {
 		return err
 	}
@@ -259,7 +308,7 @@ func updateValueDescriptor(from contract.ValueDescriptor, loggingClient logger.L
 	if from.Name != "" {
 		// Check if value descriptor is still in use by readings if the name changes
 		if from.Name != to.Name {
-			r, err := getReadingsByValueDescriptor(to.Name, 10, loggingClient) // Arbitrary limit, we're just checking if there are any readings
+			r, err := getReadingsByValueDescriptor(to.Name, 10, loggingClient, dbClient) // Arbitrary limit, we're just checking if there are any readings
 			if err != nil {
 				loggingClient.Error("Error checking the readings for the value descriptor: " + err.Error())
 				return err
@@ -297,7 +346,11 @@ func updateValueDescriptor(from contract.ValueDescriptor, loggingClient logger.L
 	return nil
 }
 
-func deleteValueDescriptor(vd contract.ValueDescriptor, loggingClient logger.LoggingClient) error {
+func deleteValueDescriptor(
+	vd contract.ValueDescriptor,
+	loggingClient logger.LoggingClient,
+	dbClient interfaces.DBClient) error {
+
 	// Check if the value descriptor is still in use by readings
 	readings, err := dbClient.ReadingsByValueDescriptor(vd.Name, 10)
 	if err != nil {
@@ -318,28 +371,28 @@ func deleteValueDescriptor(vd contract.ValueDescriptor, loggingClient logger.Log
 	return nil
 }
 
-func deleteValueDescriptorByName(name string, loggingClient logger.LoggingClient) error {
+func deleteValueDescriptorByName(name string, loggingClient logger.LoggingClient, dbClient interfaces.DBClient) error {
 	// Check if the value descriptor exists
-	vd, err := getValueDescriptorByName(name, loggingClient)
+	vd, err := getValueDescriptorByName(name, loggingClient, dbClient)
 	if err != nil {
 		return err
 	}
 
-	if err = deleteValueDescriptor(vd, loggingClient); err != nil {
+	if err = deleteValueDescriptor(vd, loggingClient, dbClient); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func deleteValueDescriptorById(id string, loggingClient logger.LoggingClient) error {
+func deleteValueDescriptorById(id string, loggingClient logger.LoggingClient, dbClient interfaces.DBClient) error {
 	// Check if the value descriptor exists
-	vd, err := getValueDescriptorById(id, loggingClient)
+	vd, err := getValueDescriptorById(id, loggingClient, dbClient)
 	if err != nil {
 		return err
 	}
 
-	if err = deleteValueDescriptor(vd, loggingClient); err != nil {
+	if err = deleteValueDescriptor(vd, loggingClient, dbClient); err != nil {
 		return err
 	}
 

--- a/internal/core/data/valuedescriptor_test.go
+++ b/internal/core/data/valuedescriptor_test.go
@@ -44,14 +44,9 @@ func TestValidateFormatStringInvalid(t *testing.T) {
 
 func TestGetValueDescriptorByName(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorByName", mock.Anything).Return(models.ValueDescriptor{Id: testUUIDString}, nil)
-
-	dbClient = myMock
-
-	valueDescriptor, err := getValueDescriptorByName("valid", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorByName", mock.Anything).Return(models.ValueDescriptor{Id: testUUIDString}, nil)
+	valueDescriptor, err := getValueDescriptorByName("valid", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by name")
 	}
@@ -63,14 +58,9 @@ func TestGetValueDescriptorByName(t *testing.T) {
 
 func TestGetValueDescriptorByNameNotFound(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorByName", mock.Anything).Return(models.ValueDescriptor{}, db.ErrNotFound)
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorByName("404", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorByName", mock.Anything).Return(models.ValueDescriptor{}, db.ErrNotFound)
+	_, err := getValueDescriptorByName("404", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		switch err.(type) {
 		case errors.ErrDbNotFound:
@@ -87,14 +77,9 @@ func TestGetValueDescriptorByNameNotFound(t *testing.T) {
 
 func TestGetValueDescriptorByNameError(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorByName", mock.Anything).Return(models.ValueDescriptor{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorByName("error", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorByName", mock.Anything).Return(models.ValueDescriptor{}, fmt.Errorf("some error"))
+	_, err := getValueDescriptorByName("error", logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by name with some error")
 	}
@@ -102,14 +87,9 @@ func TestGetValueDescriptorByNameError(t *testing.T) {
 
 func TestGetValueDescriptorById(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorById", mock.Anything).Return(models.ValueDescriptor{Id: testUUIDString}, nil)
-
-	dbClient = myMock
-
-	valueDescriptor, err := getValueDescriptorById("valid", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorById", mock.Anything).Return(models.ValueDescriptor{Id: testUUIDString}, nil)
+	valueDescriptor, err := getValueDescriptorById("valid", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by ID")
 	}
@@ -121,14 +101,9 @@ func TestGetValueDescriptorById(t *testing.T) {
 
 func TestGetValueDescriptorByIdNotFound(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorById", mock.Anything).Return(models.ValueDescriptor{}, db.ErrNotFound)
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorById("404", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorById", mock.Anything).Return(models.ValueDescriptor{}, db.ErrNotFound)
+	_, err := getValueDescriptorById("404", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		switch err.(type) {
 		case errors.ErrDbNotFound:
@@ -145,14 +120,9 @@ func TestGetValueDescriptorByIdNotFound(t *testing.T) {
 
 func TestGetValueDescriptorByIdError(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorById", mock.Anything).Return(models.ValueDescriptor{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorById("error", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorById", mock.Anything).Return(models.ValueDescriptor{}, fmt.Errorf("some error"))
+	_, err := getValueDescriptorById("error", logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by ID with some error")
 	}
@@ -160,14 +130,9 @@ func TestGetValueDescriptorByIdError(t *testing.T) {
 
 func TestGetValueDescriptorsByUomLabel(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorsByUomLabel", mock.Anything).Return([]models.ValueDescriptor{}, nil)
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorsByUomLabel("valid", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorsByUomLabel", mock.Anything).Return([]models.ValueDescriptor{}, nil)
+	_, err := getValueDescriptorsByUomLabel("valid", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by UOM label")
 	}
@@ -175,14 +140,9 @@ func TestGetValueDescriptorsByUomLabel(t *testing.T) {
 
 func TestGetValueDescriptorsByUomLabelNotFound(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorsByUomLabel", mock.Anything).Return([]models.ValueDescriptor{}, db.ErrNotFound)
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorsByUomLabel("404", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorsByUomLabel", mock.Anything).Return([]models.ValueDescriptor{}, db.ErrNotFound)
+	_, err := getValueDescriptorsByUomLabel("404", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		switch err.(type) {
 		case errors.ErrDbNotFound:
@@ -199,14 +159,9 @@ func TestGetValueDescriptorsByUomLabelNotFound(t *testing.T) {
 
 func TestGetValueDescriptorsByUomLabelError(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorsByUomLabel", mock.Anything).Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorsByUomLabel("error", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorsByUomLabel", mock.Anything).Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
+	_, err := getValueDescriptorsByUomLabel("error", logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by UOM label with some error")
 	}
@@ -214,16 +169,11 @@ func TestGetValueDescriptorsByUomLabelError(t *testing.T) {
 
 func TestGetValueDescriptorsByLabel(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorsByLabel", mock.MatchedBy(func(name string) bool {
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorsByLabel", mock.MatchedBy(func(name string) bool {
 		return name == testUUIDString
 	})).Return([]models.ValueDescriptor{{Id: testUUIDString}}, nil)
-
-	dbClient = myMock
-
-	valueDescriptor, err := getValueDescriptorsByLabel(testUUIDString, logger.NewMockClient())
-
+	valueDescriptor, err := getValueDescriptorsByLabel(testUUIDString, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by label")
 	}
@@ -235,14 +185,9 @@ func TestGetValueDescriptorsByLabel(t *testing.T) {
 
 func TestGetValueDescriptorsByLabelNotFound(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorsByLabel", mock.Anything).Return([]models.ValueDescriptor{}, db.ErrNotFound)
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorsByLabel("404", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorsByLabel", mock.Anything).Return([]models.ValueDescriptor{}, db.ErrNotFound)
+	_, err := getValueDescriptorsByLabel("404", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		switch err.(type) {
 		case errors.ErrDbNotFound:
@@ -259,14 +204,9 @@ func TestGetValueDescriptorsByLabelNotFound(t *testing.T) {
 
 func TestGetValueDescriptorsByLabelError(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorsByLabel", mock.Anything).Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorsByLabel("error", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorsByLabel", mock.Anything).Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
+	_, err := getValueDescriptorsByLabel("error", logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by label with some error")
 	}
@@ -274,14 +214,9 @@ func TestGetValueDescriptorsByLabelError(t *testing.T) {
 
 func TestGetValueDescriptorsByType(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorsByType", mock.Anything).Return([]models.ValueDescriptor{}, nil)
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorsByType("valid", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorsByType", mock.Anything).Return([]models.ValueDescriptor{}, nil)
+	_, err := getValueDescriptorsByType("valid", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by type")
 	}
@@ -289,14 +224,9 @@ func TestGetValueDescriptorsByType(t *testing.T) {
 
 func TestGetValueDescriptorsByTypeNotFound(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorsByType", mock.Anything).Return([]models.ValueDescriptor{}, db.ErrNotFound)
-
-	dbClient = myMock
-
-	_, err := getValueDescriptorsByType("404", logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorsByType", mock.Anything).Return([]models.ValueDescriptor{}, db.ErrNotFound)
+	_, err := getValueDescriptorsByType("404", logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		switch err.(type) {
 		case errors.ErrDbNotFound:
@@ -313,14 +243,10 @@ func TestGetValueDescriptorsByTypeNotFound(t *testing.T) {
 
 func TestGetValueDescriptorsByTypeError(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptorsByType", mock.Anything).Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptorsByType", mock.Anything).Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
 	mdc = newMockDeviceClient()
-
-	_, err := getValueDescriptorsByType("R", logger.NewMockClient())
+	_, err := getValueDescriptorsByType("R", logger.NewMockClient(), dbClientMock)
 
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by type with some error")
@@ -329,10 +255,7 @@ func TestGetValueDescriptorsByTypeError(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceName(t *testing.T) {
 	reset()
-	dbClient = nil
-
-	_, err := getValueDescriptorsByDeviceName(testDeviceName, context.Background(), logger.NewMockClient())
-
+	_, err := getValueDescriptorsByDeviceName(testDeviceName, context.Background(), logger.NewMockClient(), nil)
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by device name")
 	}
@@ -340,10 +263,7 @@ func TestGetValueDescriptorsByDeviceName(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceNameNotFound(t *testing.T) {
 	reset()
-	dbClient = nil
-
-	_, err := getValueDescriptorsByDeviceName("404", context.Background(), logger.NewMockClient())
-
+	_, err := getValueDescriptorsByDeviceName("404", context.Background(), logger.NewMockClient(), nil)
 	if err != nil {
 		switch err := err.(type) {
 		case types.ErrServiceClient:
@@ -363,10 +283,7 @@ func TestGetValueDescriptorsByDeviceNameNotFound(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceNameError(t *testing.T) {
 	reset()
-	dbClient = nil
-
-	_, err := getValueDescriptorsByDeviceName("error", context.Background(), logger.NewMockClient())
-
+	_, err := getValueDescriptorsByDeviceName("error", context.Background(), logger.NewMockClient(), nil)
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by device name with some error")
 	}
@@ -374,10 +291,7 @@ func TestGetValueDescriptorsByDeviceNameError(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceId(t *testing.T) {
 	reset()
-	dbClient = nil
-
-	_, err := getValueDescriptorsByDeviceId("valid", context.Background(), logger.NewMockClient())
-
+	_, err := getValueDescriptorsByDeviceId("valid", context.Background(), logger.NewMockClient(), nil)
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by device id")
 	}
@@ -385,10 +299,7 @@ func TestGetValueDescriptorsByDeviceId(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceIdNotFound(t *testing.T) {
 	reset()
-	dbClient = nil
-
-	_, err := getValueDescriptorsByDeviceId("404", context.Background(), logger.NewMockClient())
-
+	_, err := getValueDescriptorsByDeviceId("404", context.Background(), logger.NewMockClient(), nil)
 	if err != nil {
 		switch err := err.(type) {
 		case types.ErrServiceClient:
@@ -408,10 +319,7 @@ func TestGetValueDescriptorsByDeviceIdNotFound(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceIdError(t *testing.T) {
 	reset()
-	dbClient = nil
-
-	_, err := getValueDescriptorsByDeviceId("error", context.Background(), logger.NewMockClient())
-
+	_, err := getValueDescriptorsByDeviceId("error", context.Background(), logger.NewMockClient(), nil)
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by device id with some error")
 	}
@@ -419,18 +327,14 @@ func TestGetValueDescriptorsByDeviceIdError(t *testing.T) {
 
 func TestGetAllValueDescriptors(t *testing.T) {
 	reset()
-
 	vds := []models.ValueDescriptor{
 		{Id: testUUIDString},
 		{Id: testBsonString},
 	}
 
-	myMock := &mocks.DBClient{}
-	myMock.On("ValueDescriptors").Return(vds, nil)
-	dbClient = myMock
-
-	_, err := getAllValueDescriptors(logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptors").Return(vds, nil)
+	_, err := getAllValueDescriptors(logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error getting all value descriptors")
 	}
@@ -438,14 +342,9 @@ func TestGetAllValueDescriptors(t *testing.T) {
 
 func TestGetAllValueDescriptorsError(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ValueDescriptors").Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := getAllValueDescriptors(logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ValueDescriptors").Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
+	_, err := getAllValueDescriptors(logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error getting all value descriptors some error")
 	}
@@ -453,14 +352,9 @@ func TestGetAllValueDescriptorsError(t *testing.T) {
 
 func TestAddValueDescriptor(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("AddValueDescriptor", mock.Anything).Return("", nil)
-
-	dbClient = myMock
-
-	_, err := addValueDescriptor(models.ValueDescriptor{Name: "valid"}, logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("AddValueDescriptor", mock.Anything).Return("", nil)
+	_, err := addValueDescriptor(models.ValueDescriptor{Name: "valid"}, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error adding value descriptor")
 	}
@@ -468,14 +362,9 @@ func TestAddValueDescriptor(t *testing.T) {
 
 func TestAddDuplicateValueDescriptor(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("AddValueDescriptor", mock.Anything).Return("", db.ErrNotUnique)
-
-	dbClient = myMock
-
-	_, err := addValueDescriptor(models.ValueDescriptor{Name: "409"}, logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("AddValueDescriptor", mock.Anything).Return("", db.ErrNotUnique)
+	_, err := addValueDescriptor(models.ValueDescriptor{Name: "409"}, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		switch err.(type) {
 		case errors.ErrDuplicateValueDescriptorName:
@@ -492,14 +381,9 @@ func TestAddDuplicateValueDescriptor(t *testing.T) {
 
 func TestAddValueDescriptorError(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("AddValueDescriptor", mock.Anything).Return("", fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	_, err := addValueDescriptor(models.ValueDescriptor{}, logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("AddValueDescriptor", mock.Anything).Return("", fmt.Errorf("some error"))
+	_, err := addValueDescriptor(models.ValueDescriptor{}, logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error adding value descriptor some error")
 	}
@@ -507,15 +391,10 @@ func TestAddValueDescriptorError(t *testing.T) {
 
 func TestDeleteValueDescriptor(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("DeleteValueDescriptorById", mock.Anything).Return(nil)
-	myMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
-
-	dbClient = myMock
-
-	err := deleteValueDescriptor(models.ValueDescriptor{Name: "valid", Id: testBsonString}, logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("DeleteValueDescriptorById", mock.Anything).Return(nil)
+	dbClientMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
+	err := deleteValueDescriptor(models.ValueDescriptor{Name: "valid", Id: testBsonString}, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		t.Errorf("Unexpected error deleting value descriptor")
 	}
@@ -523,14 +402,9 @@ func TestDeleteValueDescriptor(t *testing.T) {
 
 func TestDeleteValueDescriptorInUse(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{{Id: testUUIDString}}, nil)
-
-	dbClient = myMock
-
-	err := deleteValueDescriptor(models.ValueDescriptor{Name: "409"}, logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{{Id: testUUIDString}}, nil)
+	err := deleteValueDescriptor(models.ValueDescriptor{Name: "409"}, logger.NewMockClient(), dbClientMock)
 	if err != nil {
 		switch err.(type) {
 		case errors.ErrValueDescriptorInUse:
@@ -547,14 +421,9 @@ func TestDeleteValueDescriptorInUse(t *testing.T) {
 
 func TestDeleteValueDescriptorErrorReadingsLookup(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	err := deleteValueDescriptor(models.ValueDescriptor{}, logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
+	err := deleteValueDescriptor(models.ValueDescriptor{}, logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error deleting value descriptor some error looking up readings")
 	}
@@ -562,15 +431,10 @@ func TestDeleteValueDescriptorErrorReadingsLookup(t *testing.T) {
 
 func TestDeleteValueDescriptorError(t *testing.T) {
 	reset()
-	myMock := &mocks.DBClient{}
-
-	myMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
-	myMock.On("DeleteValueDescriptorById", mock.Anything).Return(fmt.Errorf("some error"))
-
-	dbClient = myMock
-
-	err := deleteValueDescriptor(models.ValueDescriptor{Name: "validErrorTest"}, logger.NewMockClient())
-
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("ReadingsByValueDescriptor", mock.Anything, mock.Anything).Return([]models.Reading{}, nil)
+	dbClientMock.On("DeleteValueDescriptorById", mock.Anything).Return(fmt.Errorf("some error"))
+	err := deleteValueDescriptor(models.ValueDescriptor{Name: "validErrorTest"}, logger.NewMockClient(), dbClientMock)
 	if err == nil {
 		t.Errorf("Expected error deleting value descriptor some error")
 	}


### PR DESCRIPTION
Fix #2025

Remove dbClient global variable from the core-data service/package(s)
and update the routers to get the dbClient from th DI container and pass
it to the necessary REST handlers. Also, update any functions/methods
which were referring to the dbClient global variable to rather accept an
instance of the DBClient interface.

Update tests to conform to the changes to the production code.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>