### PR TITLE
Scheduler: Remove QueueClient global and refactor its code

### DIFF
--- a/internal/support/scheduler/schedule.go
+++ b/internal/support/scheduler/schedule.go
@@ -89,6 +89,17 @@ func addIntervalActionOperation(interval contract.Interval, intervalAction contr
 	intervalActionNameToIntervalActionIdMap[intervalAction.Name] = intervalAction.ID
 }
 
+type QueueClient struct {
+	loggingClient logger.LoggingClient
+}
+
+// NewClient
+func NewSchedulerQueueClient(loggingClient logger.LoggingClient) *QueueClient {
+	return &QueueClient{
+		loggingClient: loggingClient,
+	}
+}
+
 func (qc *QueueClient) Connect() (string, error) {
 	return "alive..", nil
 }

--- a/internal/support/scheduler/utils.go
+++ b/internal/support/scheduler/utils.go
@@ -17,8 +17,6 @@ import (
 	"regexp"
 	"strconv"
 	"time"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
 const (
@@ -101,17 +99,4 @@ func parseInt64(value string) int64 {
 		return 0
 	}
 	return int64(parsed)
-}
-
-// Scheduler Queue Client
-var currentQueueClient *QueueClient // Singleton used so that queueClient can use it to de-reference readings
-type QueueClient struct {
-	loggingClient logger.LoggingClient
-}
-
-// NewClient
-func NewSchedulerQueueClient(loggingClient logger.LoggingClient) *QueueClient {
-	queueClient := &QueueClient{loggingClient}
-	currentQueueClient = queueClient // Set the singleton
-	return queueClient
 }


### PR DESCRIPTION
QueueClient receiver and corresponding factory method moved to
schedule.go where the QueueClient method implementation lives.  Removed
unused currentQueueClient global.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2154

Signed-off-by: Michael Estrin <m.estrin@dell.com>