### PR TITLE
Implement cmd/security-file-token-provider scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOCGO=CGO_ENABLED=1 GO111MODULE=on go
 DOCKERS=docker_config_seed docker_export_client docker_export_distro docker_core_data docker_core_metadata docker_core_command docker_support_logging docker_support_notifications docker_sys_mgmt_agent docker_support_scheduler docker_security_secrets_setup docker_security_proxy_setup docker_security_secretstore_setup
 .PHONY: $(DOCKERS)
 
-MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup cmd/security-secretstore-setup/security-secretstore-setup
+MICROSERVICES=cmd/config-seed/config-seed cmd/export-client/export-client cmd/export-distro/export-distro cmd/core-metadata/core-metadata cmd/core-data/core-data cmd/core-command/core-command cmd/support-logging/support-logging cmd/support-notifications/support-notifications cmd/sys-mgmt-executor/sys-mgmt-executor cmd/sys-mgmt-agent/sys-mgmt-agent cmd/support-scheduler/support-scheduler cmd/security-secrets-setup/security-secrets-setup cmd/security-proxy-setup/security-proxy-setup cmd/security-secretstore-setup/security-secretstore-setup cmd/security-file-token-provider/security-file-token-provider
 
 .PHONY: $(MICROSERVICES)
 
@@ -70,6 +70,8 @@ cmd/security-proxy-setup/security-proxy-setup:
 cmd/security-secretstore-setup/security-secretstore-setup:
 	$(GO) build $(GOFLAGS) -o ./cmd/security-secretstore-setup/security-secretstore-setup ./cmd/security-secretstore-setup
 
+cmd/security-file-token-provider/security-file-token-provider:
+	$(GO) build $(GOFLAGS) -o ./cmd/security-file-token-provider/security-file-token-provider ./cmd/security-file-token-provider
 
 clean:
 	rm -f $(MICROSERVICES)

--- a/cmd/security-file-token-provider/Attribution.txt
+++ b/cmd/security-file-token-provider/Attribution.txt
@@ -1,0 +1,151 @@
+The following open source projects are referenced by Security Secrets Setup:
+
+pkg/errors (BSD-2) https://github.com/pkg/errors
+https://github.com/pkg/errors/blob/master/LICENSE
+
+gorilla/mux (BSD-3) - https://github.com/gorilla/mux
+https://github.com/gorilla/mux/blob/master/LICENSE
+
+globalsign/mgo (unspecified) - https://github.com/globalsign/mgo
+https://github.com/globalsign/mgo/blob/master/LICENSE
+
+pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
+https://github.com/pebbe/zmq4/blob/master/LICENSE.txt
+
+go-kit/kit (MIT) github.com/go-kit/kit
+https://github.com/go-kit/kit/blob/master/LICENSE
+
+go-logfmt/logfmt (MIT) https://github.com/go-logfmt/logfmt
+https://github.com/go-logfmt/logfmt/blob/master/LICENSE
+
+robfig/cron (MIT) https://github.com/robfig/cron
+https://github.com/robfig/cron/blob/master/LICENSE
+
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
+google/uuid (BSD-3) https://github.com/google/uuid
+https://github.com/google/uuid/blob/master/LICENSE
+
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
+influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
+https://github.com/influxdata/influxdb/blob/master/LICENSE
+
+influxdata/platform (MIT) https://github.com/influxdata/platform
+https://github.com/influxdata/platform/blob/master/LICENSE
+
+eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
+https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
+
+mattn/go-xmpp (BSD-3) https://github.com/mattn/go-xmpp
+https://github.com/mattn/go-xmpp/blob/master/LICENSE
+
+BurntSushi/toml (MIT) https://github.com/BurntSushi/toml
+https://github.com/BurntSushi/toml/blob/master/COPYING
+
+mitchellh/consulstructure (MIT) https://github.com/mitchellh/consulstructure
+https://github.com/mitchellh/consulstructure/blob/master/LICENSE
+
+mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
+https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+mitchellh/copystructure (MIT) https://github.com/mitchellh/copystructure
+https://github.com/mitchellh/copystructure/blob/master/LICENSE
+
+mitchellh/reflectwalk (MIT) https://github.com/mitchellh/reflectwalk
+https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
+
+cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
+https://github.com/cenkalti/backoff/blob/master/LICENSE
+
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
+https://github.com/hashicorp/consul/blob/master/LICENSE
+
+hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
+https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
+
+hashicorp/go-rootcerts (Mozilla Public License 2.0) https://github.com/hashicorp/go-rootcerts
+https://github.com/hashicorp/go-rootcerts/blob/master/LICENSE
+
+mitchellh/go-homedir (MIT) https://github.com/mitchellh/go-homedir
+https://github.com/mitchellh/go-homedir/blob/master/LICENSE
+
+mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
+https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+hashicorp/serf (Mozilla Public License 2.0) https://github.com/hashicorp/serf
+https://github.com/hashicorp/serf/blob/master/LICENSE
+
+armon/go-metrics (MIT) https://github.com/armon/go-metrics
+https://github.com/armon/go-metrics/blob/master/LICENSE
+
+hashicorp/go-immutable-radix (Mozilla Public License 2.0) https://github.com/hashicorp/go-immutable-radix
+https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
+
+hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
+https://github.com/hashicorp/golang-lru/blob/master/LICENSE
+
+gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
+https://github.com/gomodule/redigo/blob/master/LICENSE
+
+OneOfOne/xxhash (Apache 2.0) https://github.com/OneOfOne/xxhash
+https://github.com/OneOfOne/xxhash/blob/master/LICENSE
+
+imdario/mergo (BSD-3) github.com/imdario/mergo
+https://github.com/imdario/mergo/blob/master/LICENSE
+
+magiconair/properties (BSD-2) https://github.com/magiconair/properties
+https://github.com/magiconair/properties/blob/master/LICENSE
+
+gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
+https://github.com/eapache/queue/blob/v1.1.0/LICENSE
+
+bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
+https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
+https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+ugorji/go (MIT) https://github.com/ugorji/go
+https://github.com/ugorji/go/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE

--- a/cmd/security-file-token-provider/README.md
+++ b/cmd/security-file-token-provider/README.md
@@ -1,0 +1,57 @@
+# Integration testing instructions for security-file-token-provider
+
+## Build
+
+Use Makefile in the base directory of this repository to build the docker image of security-secretes-setup:
+
+```sh
+make -C ../.. cmd/security-file-token-provider/security-file-token-provider
+```
+
+It should create an executable named `security-file-token-provider` in the current directory.
+
+## Run
+
+Run the `integrationtest.sh` script.
+
+```sh
+./integrationtest.sh
+```
+
+Verify the resulting output for correctness.
+The script will automatically fail if a subcommand
+returns a nonzero exit status.
+
+Afterwards, shut down the docker composition
+
+```sh
+docker-compose down
+```
+
+## Details
+
+The integration test script first starts Vault and Consul via a docker-compose.yml script.
+The script copies out the CA certificate and root token JSON file to the current directory.
+It then overwrites `res/configuration.toml` with some values to allow the integration test to run.
+The script then dumps a list of all policies, and a list of current Vault tokens.
+
+Next, the script runs `security-file-token-provider`
+
+Afterwards, the script then dumps the policies, Vault tokens,
+the policy it just created, and calls the token lookup command
+on the newly-created Vault token.
+
+## Testing with TLS
+
+In order to test with TLS, it is necessary to edit `/etc/hosts` and add
+an alias for edgex-vault:
+
+```
+127.0.0.1 edgex-vault
+```
+
+Then edit `integrationtest.sh` and uncomment `CaFilePath`.
+
+Re-run `integrationtest.sh` and verify that it makes a TLS connection to Vault.
+
+_BE SURE TO REMOVE THE EDITS FROM `/etc/hosts` WHEN YOU ARE DONE!_

--- a/cmd/security-file-token-provider/main.go
+++ b/cmd/security-file-token-provider/main.go
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package main
+
+import (
+	"flag"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
+	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/container"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+func main() {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	var configDir, profileDir string
+	var useRegistry bool
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallbackSecurityFileTokenProvider
+	flag.Parse()
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
+			return get(container.ConfigurationName)
+		},
+	})
+	bootstrap.Run(
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SecurityFileTokenProviderServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			fileprovider.Handler,
+		},
+	)
+}

--- a/cmd/security-file-token-provider/res/configuration.toml
+++ b/cmd/security-file-token-provider/res/configuration.toml
@@ -1,0 +1,19 @@
+[SecretService]
+Scheme = "https"
+Server = "localhost"
+ServerName = "edgex-vault"
+Port = 8200
+CaFilePath = '/tmp/edgex/secrets/ca/ca.pem'
+
+[TokenFileProvider]
+PrivilegedTokenPath = "resp-init.json"
+ConfigFile = "res/token-config.json"
+OutputDir = "/tmp"
+OutputFilename = "secrets-token.json"
+
+[Writable]
+LogLevel = 'DEBUG'
+
+[Logging]
+EnableRemote = false
+File = './logs/security-file-token-provider.log'

--- a/cmd/security-file-token-provider/res/docker/configuration.toml
+++ b/cmd/security-file-token-provider/res/docker/configuration.toml
@@ -1,0 +1,19 @@
+[SecretService]
+Scheme = "https"
+Server = "edgex-vault"
+ServerName = "edgex-vault"
+Port = 8200
+CaFilePath = '/tmp/edgex/secrets/ca/ca.pem'
+
+[TokenFileProvider]
+PrivilegedTokenPath = "resp-init.json"
+ConfigFile = "res/token-config.json"
+OutputDir = "/tmp"
+OutputFilename = "secrets-token.json"
+
+[Writable]
+LogLevel = 'DEBUG'
+
+[Logging]
+EnableRemote = false
+File = './logs/security-file-token-provider.log'

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -86,6 +86,16 @@ Common Options:
 	-h, --help                          Show this message
 `
 
+var securityFileTokenProviderUsageStr = `
+Usage: %s [options]
+Server Options:
+	-p, --profile <name>                Indicate configuration profile other than default
+	-r, --registry                      Indicates service should use Registry
+	--configfile=<file.toml>            Use a different config file (default: res/configuration.toml)
+Common Options:
+	-h, --help                          Show this message
+`
+
 // usage will print out the flag options for the server.
 func HelpCallback() {
 	fmt.Printf(usageStr, os.Args[0])
@@ -108,6 +118,12 @@ func HelpCallbackSecurityProxy() {
 
 func HelpCallbackSecuritySecretStore() {
 	msg := fmt.Sprintf(securitySecretStoreSetupUsageStr, os.Args[0])
+	fmt.Printf("%s\n", msg)
+	os.Exit(0)
+}
+
+func HelpCallbackSecurityFileTokenProvider() {
+	msg := fmt.Sprintf(securityFileTokenProviderUsageStr, os.Args[0])
 	fmt.Printf("%s\n", msg)
 	os.Exit(0)
 }

--- a/internal/security/fileprovider/config/config.go
+++ b/internal/security/fileprovider/config/config.go
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package config
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+)
+
+type ConfigurationStruct struct {
+	Writable          WritableInfo
+	Logging           config.LoggingInfo
+	SecretService     secretstoreclient.SecretServiceInfo
+	TokenFileProvider TokenFileProviderInfo
+}
+
+type WritableInfo struct {
+	LogLevel string
+	Title    string
+}
+
+type TokenFileProviderInfo struct {
+	// Path to Vault authorization token to be used by the service
+	PrivilegedTokenPath string
+	// Configuration file used to control token creation (default: res/token-config.json)
+	ConfigFile string
+	// Base directory for token file output
+	OutputDir string
+	// File name for token file (default: secrets-token.json)
+	OutputFilename string
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		// Check that information was successfully read from Registry
+		if configuration.SecretService.Port == 0 {
+			return false
+		}
+		*c = *configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Logging: c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {}
+
+// GetDatabaseInfo returns a database information map.
+func (c *ConfigurationStruct) GetDatabaseInfo() config.DatabaseInfo {
+	return nil
+}

--- a/internal/security/fileprovider/container/config.go
+++ b/internal/security/fileprovider/container/config.go
@@ -1,5 +1,7 @@
 /*******************************************************************************
- * Copyright 2019 Dell Inc.
+ * Copyright 2017 Dell Inc.
+ * Copyright 2018 Dell Technologies Inc.
+ * Copyright (c) 2019 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,36 +12,19 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- *
  *******************************************************************************/
 
-package secretstoreclient
+package container
 
 import (
-	"fmt"
-	"net/url"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
 )
 
-type SecretServiceInfo struct {
-	Scheme               string
-	Server               string
-	ServerName           string
-	Port                 int
-	CertPath             string
-	CaFilePath           string
-	CertFilePath         string
-	KeyFilePath          string
-	TokenFolderPath      string
-	TokenFile            string
-	VaultSecretShares    int
-	VaultSecretThreshold int
-}
+// ConfigurationName contains the name of the config.ConfigurationStruct implementation in the DIC.
+var ConfigurationName = di.TypeInstanceToName(config.ConfigurationStruct{})
 
-func (s SecretServiceInfo) GetSecretSvcBaseURL() string {
-	url := &url.URL{
-		Scheme: s.Scheme,
-		Host:   fmt.Sprintf("%s:%v", s.Server, s.Port),
-		Path:   "/",
-	}
-	return url.String()
+// ConfigurationFrom helper function queries the DIC and returns the config.ConfigurationStruct implementation.
+func ConfigurationFrom(get di.Get) *config.ConfigurationStruct {
+	return get(ConfigurationName).(*config.ConfigurationStruct)
 }

--- a/internal/security/fileprovider/init.go
+++ b/internal/security/fileprovider/init.go
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package fileprovider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenloader"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/container"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+)
+
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
+func Handler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
+	cfg := container.ConfigurationFrom(dic.Get)
+	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
+
+	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
+	tokenProvider := authtokenloader.NewAuthTokenLoader(fileOpener)
+
+	var req internal.HttpCaller
+	if caFilePath := cfg.SecretService.CaFilePath; caFilePath != "" {
+		loggingClient.Info("using certificate verification for secret store connection")
+		caReader, err := fileOpener.OpenFileReader(caFilePath, os.O_RDONLY, 0400)
+		if err != nil {
+			loggingClient.Error(fmt.Sprintf("failed to load CA certificate: %s", err.Error()))
+			return false
+		}
+		req = secretstoreclient.NewRequestor(loggingClient).WithTLS(caReader, cfg.SecretService.ServerName)
+	} else {
+		loggingClient.Info("bypassing certificate verification for secret store connection")
+		req = secretstoreclient.NewRequestor(loggingClient).Insecure()
+	}
+	vaultScheme := cfg.SecretService.Scheme
+	vaultHost := fmt.Sprintf("%s:%v", cfg.SecretService.Server, cfg.SecretService.Port)
+	vaultClient := secretstoreclient.NewSecretStoreClient(loggingClient, req, vaultScheme, vaultHost)
+
+	fileProvider := NewTokenProvider(loggingClient, fileOpener, tokenProvider, vaultClient)
+
+	fileProvider.SetConfiguration(cfg.SecretService, cfg.TokenFileProvider)
+	err := fileProvider.Run()
+
+	if err != nil {
+		loggingClient.Error(fmt.Sprintf("error occurred generating tokens: %s", err.Error()))
+	}
+
+	return false // Tell bootstrap.Run() to exit wait loop and terminate
+}

--- a/internal/security/fileprovider/interface.go
+++ b/internal/security/fileprovider/interface.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+)
+
+// TokenProvider is the interface that the main program expects
+// for implemeneting token generation
+type TokenProvider interface {
+	// Set configuration
+	SetConfiguration(secretConfig secretstoreclient.SecretServiceInfo, tokenConfig config.TokenFileProviderInfo)
+	// Generate tokens
+	Run() error
+}

--- a/internal/security/fileprovider/provider.go
+++ b/internal/security/fileprovider/provider.go
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package fileprovider
+
+import (
+	"errors"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/authtokenloader"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// fileTokenProvider stores instance data
+type fileTokenProvider struct {
+	logger        logger.LoggingClient
+	fileOpener    fileioperformer.FileIoPerformer
+	tokenProvider authtokenloader.AuthTokenLoader
+	vaultClient   secretstoreclient.SecretStoreClient
+	secretConfig  secretstoreclient.SecretServiceInfo
+	tokenConfig   config.TokenFileProviderInfo
+}
+
+// NewTokenProvider creates a new TokenProvider
+func NewTokenProvider(logger logger.LoggingClient,
+	fileOpener fileioperformer.FileIoPerformer,
+	tokenProvider authtokenloader.AuthTokenLoader,
+	vaultClient secretstoreclient.SecretStoreClient) TokenProvider {
+	return &fileTokenProvider{
+		logger:        logger,
+		fileOpener:    fileOpener,
+		tokenProvider: tokenProvider,
+		vaultClient:   vaultClient,
+	}
+}
+
+// Set configuration
+func (p *fileTokenProvider) SetConfiguration(secretConfig secretstoreclient.SecretServiceInfo, tokenConfig config.TokenFileProviderInfo) {
+	p.secretConfig = secretConfig
+	p.tokenConfig = tokenConfig
+}
+
+// Do whatever is needed
+func (p *fileTokenProvider) Run() error {
+	p.logger.Error("Implementation to be provided later")
+	return errors.New("Not implemented")
+}


### PR DESCRIPTION
This is the main program bootstrap skeleton for
cmd/security-file-token-provider as documented in
edgex-docs/security/token-file-provider.1.rst

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>