### PR TITLE
Refactoring to move security service keys from edgex-go to go-mod-core contracts.

### DIFF
--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy"
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/container"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 )
 
 func main() {
@@ -75,7 +76,7 @@ func main() {
 		profileDir,
 		internal.ConfigFileName,
 		useRegistry,
-		internal.SecurityProxySetupServiceKey,
+		clients.SecurityProxySetupServiceKey,
 		configuration,
 		startupTimer,
 		dic,

--- a/cmd/security-secrets-setup/main.go
+++ b/cmd/security-secrets-setup/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/secrets/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/secrets/container"
 	"github.com/edgexfoundry/edgex-go/internal/security/secrets/contract"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 )
 
 func wrappedMain() (*config.ConfigurationStruct, int) {
@@ -42,7 +43,7 @@ func wrappedMain() (*config.ConfigurationStruct, int) {
 	flag.Parse()
 
 	if flag.NArg() < 1 {
-		fmt.Println("Please specify subcommand for " + internal.SecuritySecretsSetupServiceKey)
+		fmt.Println("Please specify subcommand for " + clients.SecuritySecretsSetupServiceKey)
 		flag.Usage()
 		return nil, contract.StatusCodeExitNormal
 	}
@@ -62,7 +63,7 @@ func wrappedMain() (*config.ConfigurationStruct, int) {
 		bootstrap.EmptyProfileDir,
 		internal.ConfigFileName,
 		bootstrap.DoNotUseRegistry,
-		internal.SecuritySecretsSetupServiceKey,
+		clients.SecuritySecretsSetupServiceKey,
 		configuration,
 		startupTimer,
 		dic,

--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 )
 
 func main() {
@@ -74,7 +75,7 @@ func main() {
 		profileDir,
 		internal.ConfigFileName,
 		useRegistry,
-		internal.SecuritySecretStoreSetupServiceKey,
+		clients.SecuritySecretStoreSetupServiceKey,
 		configuration,
 		startupTimer,
 		dic,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eclipse/paho.mqtt.golang v1.1.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.34
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.35
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
 	github.com/edgexfoundry/go-mod-secrets v0.0.10

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -14,18 +14,15 @@
 package internal
 
 const (
-	BootTimeoutDefault                 = BootTimeoutSecondsDefault * 1000
-	BootTimeoutSecondsDefault          = 30
-	BootRetrySecondsDefault            = 1
-	ClientMonitorDefault               = 15000
-	ConfigFileName                     = "configuration.toml"
-	ConfigRegistryStemCore             = "edgex/core/"
-	ConfigRegistryStemSecurity         = "edgex/security/"
-	ConfigMajorVersion                 = "1.0/"
-	LogDurationKey                     = "duration"
-	SecuritySecretStoreSetupServiceKey = "edgex-security-secretstore-setup"
-	SecuritySecretsSetupServiceKey     = "edgex-security-secrets-setup"
-	SecurityProxySetupServiceKey       = "edgex-security-proxy-setup"
+	BootTimeoutDefault         = BootTimeoutSecondsDefault * 1000
+	BootTimeoutSecondsDefault  = 30
+	BootRetrySecondsDefault    = 1
+	ClientMonitorDefault       = 15000
+	ConfigFileName             = "configuration.toml"
+	ConfigRegistryStemCore     = "edgex/core/"
+	ConfigRegistryStemSecurity = "edgex/security/"
+	ConfigMajorVersion         = "1.0/"
+	LogDurationKey             = "duration"
 )
 
 const (


### PR DESCRIPTION
Refactoring to move security service keys from edgex-go to go-mod-core contracts.

Fixes #2174

Merge blocked by https://github.com/edgexfoundry/go-mod-core-contracts/pull/185

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>