### PR TITLE
Scheduler: Remove scClient global variable

### DIFF
--- a/internal/support/scheduler/container/queue.go
+++ b/internal/support/scheduler/container/queue.go
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package container
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/interfaces"
+)
+
+// QueueName contains the name of scheduler's SchedulerQueueClient implementation in the DIC.
+var QueueName = di.TypeInstanceToName((*interfaces.SchedulerQueueClient)(nil))
+
+// QueueFrom helper function queries the DIC and returns scheduler's SchedulerQueueClient implementation.
+func QueueFrom(get di.Get) interfaces.SchedulerQueueClient {
+	return get(QueueName).(interfaces.SchedulerQueueClient)
+}

--- a/internal/support/scheduler/interval.go
+++ b/internal/support/scheduler/interval.go
@@ -39,7 +39,11 @@ func getIntervals(limit int, dbClient interfaces.DBClient) ([]contract.Interval,
 	return intervals, err
 }
 
-func addNewInterval(interval contract.Interval, dbClient interfaces.DBClient) (string, error) {
+func addNewInterval(
+	interval contract.Interval,
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) (string, error) {
+
 	name := interval.Name
 
 	// Check if the name is unique

--- a/internal/support/scheduler/interval_action.go
+++ b/internal/support/scheduler/interval_action.go
@@ -23,7 +23,11 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/interfaces"
 )
 
-func addNewIntervalAction(intervalAction contract.IntervalAction, dbClient interfaces.DBClient) (string, error) {
+func addNewIntervalAction(
+	intervalAction contract.IntervalAction,
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) (string, error) {
+
 	name := intervalAction.Name
 
 	// Validate the IntervalAction is not in use
@@ -72,7 +76,11 @@ func addNewIntervalAction(intervalAction contract.IntervalAction, dbClient inter
 	return ID, nil
 }
 
-func updateIntervalAction(from contract.IntervalAction, dbClient interfaces.DBClient) error {
+func updateIntervalAction(
+	from contract.IntervalAction,
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) error {
+
 	to, err := dbClient.IntervalActionById(from.ID)
 	if err != nil {
 		// check by name
@@ -232,7 +240,10 @@ func getIntervalActionsByInterval(interval string, dbClient interfaces.DBClient)
 	return intervalActions, err
 }
 
-func deleteIntervalActionById(id string, dbClient interfaces.DBClient) error {
+func deleteIntervalActionById(
+	id string,
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) error {
 
 	// check in memory first
 	inMemory, err := scClient.QueryIntervalActionByID(id)
@@ -262,7 +273,11 @@ func deleteIntervalActionById(id string, dbClient interfaces.DBClient) error {
 	return nil
 }
 
-func deleteIntervalActionByName(name string, dbClient interfaces.DBClient) error {
+func deleteIntervalActionByName(
+	name string,
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) error {
+
 	// check in memory first
 	inMemory, err := scClient.QueryIntervalActionByName(name)
 	if err != nil {

--- a/internal/support/scheduler/interval_action_test.go
+++ b/internal/support/scheduler/interval_action_test.go
@@ -157,9 +157,8 @@ func TestUpdateIntervalAction(t *testing.T) {
 		mock.Anything).Return(models.IntervalAction{}, errors.New("mock db not found"))
 
 	nIntervalAction := models.IntervalAction{Name: testIntervalActionName, Target: testIntervalActionTarget, Origin: testOrigin, Interval: testIntervalActionInterval}
-	scClient = mySchedulerMock
 
-	err := updateIntervalAction(nIntervalAction, myMock)
+	err := updateIntervalAction(nIntervalAction, myMock, mySchedulerMock)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -189,10 +188,7 @@ func TestDeleteIntervalActionById(t *testing.T) {
 	mySchedulerMock.On("RemoveIntervalActionQueue",
 		mock.Anything).Return(nil)
 
-	// assign clients to mocks
-	scClient = mySchedulerMock
-
-	err := deleteIntervalActionById(testUUIDString, myMock)
+	err := deleteIntervalActionById(testUUIDString, myMock, mySchedulerMock)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/internal/support/scheduler/interval_test.go
+++ b/internal/support/scheduler/interval_test.go
@@ -130,9 +130,7 @@ func TestAddIntervalFailOnExistingName(t *testing.T) {
 
 	nInterval := models.Interval{Name: testInterval.Name, Timestamps: testTimestamps}
 
-	scClient = mySchedulerMock
-
-	_, err := addNewInterval(nInterval, myMock)
+	_, err := addNewInterval(nInterval, myMock, mySchedulerMock)
 	if err != nil {
 		switch err.(type) {
 		case errorsSched.ErrIntervalNameInUse:
@@ -165,9 +163,7 @@ func TestAddIntervalFailOnInvalidTimeFormat(t *testing.T) {
 
 	nInterval := models.Interval{Name: testInterval.Name, Start: "34343", Timestamps: testTimestamps}
 
-	scClient = mySchedulerMock
-
-	_, err := addNewInterval(nInterval, myMock)
+	_, err := addNewInterval(nInterval, myMock, mySchedulerMock)
 	if err != nil {
 		switch err.(type) {
 		case errorsSched.ErrInvalidTimeFormat:

--- a/internal/support/scheduler/rest_interval.go
+++ b/internal/support/scheduler/rest_interval.go
@@ -56,7 +56,8 @@ func restUpdateInterval(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) {
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) {
 
 	if r.Body != nil {
 		defer r.Body.Close()
@@ -102,7 +103,8 @@ func restAddInterval(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) {
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) {
 
 	if r.Body != nil {
 		defer r.Body.Close()
@@ -174,7 +176,8 @@ func restDeleteIntervalByID(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) {
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) {
 
 	if r.Body != nil {
 		defer r.Body.Close()
@@ -248,7 +251,8 @@ func restDeleteIntervalByName(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) {
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) {
 
 	defer r.Body.Close()
 

--- a/internal/support/scheduler/rest_interval_test.go
+++ b/internal/support/scheduler/rest_interval_test.go
@@ -159,9 +159,8 @@ func TestAddInterval(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scClient = tt.scClient
 			rr := httptest.NewRecorder()
-			restAddInterval(rr, tt.request, logger.NewMockClient(), tt.dbMock)
+			restAddInterval(rr, tt.request, logger.NewMockClient(), tt.dbMock, tt.scClient)
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -239,9 +238,8 @@ func TestUpdateInterval(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scClient = tt.scClient
 			rr := httptest.NewRecorder()
-			restUpdateInterval(rr, tt.request, logger.NewMockClient(), tt.dbMock)
+			restUpdateInterval(rr, tt.request, logger.NewMockClient(), tt.dbMock, tt.scClient)
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -570,9 +568,8 @@ func TestDeleteIntervalById(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			Configuration = &ConfigurationStruct{Service: config.ServiceInfo{MaxResultCount: 1}}
-			scClient = tt.scMock
 			rr := httptest.NewRecorder()
-			restDeleteIntervalByID(rr, tt.request, logger.NewMockClient(), tt.dbMock)
+			restDeleteIntervalByID(rr, tt.request, logger.NewMockClient(), tt.dbMock, tt.scMock)
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -738,9 +735,8 @@ func TestDeleteIntervalByName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			Configuration = &ConfigurationStruct{Service: config.ServiceInfo{MaxResultCount: 1}}
-			scClient = tt.scMock
 			rr := httptest.NewRecorder()
-			restDeleteIntervalByName(rr, tt.request, logger.NewMockClient(), tt.dbMock)
+			restDeleteIntervalByName(rr, tt.request, logger.NewMockClient(), tt.dbMock, tt.scMock)
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -773,7 +769,6 @@ func TestScrubIntervals(t *testing.T) {
 		name           string
 		request        *http.Request
 		dbMock         interfaces.DBClient
-		scMock         interfaces.SchedulerQueueClient
 		expectedStatus int
 	}{
 
@@ -781,21 +776,18 @@ func TestScrubIntervals(t *testing.T) {
 			name:           "OK",
 			request:        createScrubDeleteRequest(),
 			dbMock:         createMockScrubDeleterSuccess(),
-			scMock:         createMockNameSCDeleterSuccess(),
 			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "Unknown Error",
 			request:        createScrubDeleteRequest(),
 			dbMock:         createMockScrubDeleterErr(),
-			scMock:         createMockNameSCDeleterSuccess(),
 			expectedStatus: http.StatusInternalServerError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			Configuration = &ConfigurationStruct{Service: config.ServiceInfo{MaxResultCount: 1}}
-			scClient = tt.scMock
 			rr := httptest.NewRecorder()
 			restScrubAllIntervals(rr, tt.request, logger.NewMockClient(), tt.dbMock)
 			response := rr.Result()

--- a/internal/support/scheduler/rest_intervalaction.go
+++ b/internal/support/scheduler/rest_intervalaction.go
@@ -61,7 +61,8 @@ func restAddIntervalAction(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) {
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) {
 
 	if r.Body != nil {
 		defer r.Body.Close()
@@ -107,7 +108,8 @@ func intervalActionHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) {
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) {
 
 	if r.Body != nil {
 		defer r.Body.Close()
@@ -136,7 +138,7 @@ func intervalActionHandler(
 		}
 		loggingClient.Info("posting new intervalAction: " + intervalAction.String())
 
-		newId, err := addNewIntervalAction(intervalAction, dbClient)
+		newId, err := addNewIntervalAction(intervalAction, dbClient, scClient)
 		if err != nil {
 			switch t := err.(type) {
 			case errors.ErrIntervalActionNameInUse:
@@ -168,7 +170,7 @@ func intervalActionHandler(
 		}
 
 		loggingClient.Info("Updating IntervalAction: " + from.ID)
-		err = updateIntervalAction(from, dbClient)
+		err = updateIntervalAction(from, dbClient, scClient)
 		if err != nil {
 			switch t := err.(type) {
 			case errors.ErrIntervalNotFound:
@@ -206,7 +208,8 @@ func intervalActionByIdHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) {
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) {
 
 	if r.Body != nil {
 		defer r.Body.Close()
@@ -237,7 +240,7 @@ func intervalActionByIdHandler(
 		pkg.Encode(intervalAction, w, loggingClient)
 		// Post a new Interval Action
 	case http.MethodDelete:
-		if err = deleteIntervalActionById(id, dbClient); err != nil {
+		if err = deleteIntervalActionById(id, dbClient, scClient); err != nil {
 			switch err.(type) {
 			case errors.ErrIntervalActionNotFound:
 				http.Error(w, err.Error(), http.StatusBadRequest)
@@ -263,7 +266,8 @@ func intervalActionByNameHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) {
+	dbClient interfaces.DBClient,
+	scClient interfaces.SchedulerQueueClient) {
 
 	if r.Body != nil {
 		defer r.Body.Close()
@@ -294,7 +298,7 @@ func intervalActionByNameHandler(
 		pkg.Encode(intervalAction, w, loggingClient)
 		// Post a new Interval Action
 	case http.MethodDelete:
-		if err = deleteIntervalActionByName(name, dbClient); err != nil {
+		if err = deleteIntervalActionByName(name, dbClient, scClient); err != nil {
 			switch err.(type) {
 			case errors.ErrIntervalActionNotFound:
 				http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/support/scheduler/rest_intervalaction_test.go
+++ b/internal/support/scheduler/rest_intervalaction_test.go
@@ -148,9 +148,8 @@ func TestAddIntervalAction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scClient = tt.scClient
 			rr := httptest.NewRecorder()
-			restAddIntervalAction(rr, tt.request, logger.NewMockClient(), tt.dbMock)
+			restAddIntervalAction(rr, tt.request, logger.NewMockClient(), tt.dbMock, tt.scClient)
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)

--- a/internal/support/scheduler/router.go
+++ b/internal/support/scheduler/router.go
@@ -26,6 +26,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
 )
 
 func LoadRestRoutes(dic *di.Container) *mux.Router {
@@ -66,14 +67,16 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 			w,
 			r,
 			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
+			bootstrapContainer.DBClientFrom(dic.Get),
+			container.QueueFrom(dic.Get))
 	}).Methods(http.MethodPut)
 	r.HandleFunc(clients.ApiIntervalRoute, func(w http.ResponseWriter, r *http.Request) {
 		restAddInterval(
 			w,
 			r,
 			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
+			bootstrapContainer.DBClientFrom(dic.Get),
+			container.QueueFrom(dic.Get))
 	}).Methods(http.MethodPost)
 	interval := r.PathPrefix(clients.ApiIntervalRoute).Subrouter()
 	interval.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
@@ -88,7 +91,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 			w,
 			r,
 			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
+			bootstrapContainer.DBClientFrom(dic.Get),
+			container.QueueFrom(dic.Get))
 	}).Methods(http.MethodDelete)
 	interval.HandleFunc("/"+NAME+"/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
 		restGetIntervalByName(
@@ -102,7 +106,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 			w,
 			r,
 			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
+			bootstrapContainer.DBClientFrom(dic.Get),
+			container.QueueFrom(dic.Get))
 	}).Methods(http.MethodDelete)
 	// Scrub "Intervals and IntervalActions"
 	interval.HandleFunc("/"+SCRUB+"/", func(w http.ResponseWriter, r *http.Request) {
@@ -126,14 +131,16 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 			w,
 			r,
 			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
+			bootstrapContainer.DBClientFrom(dic.Get),
+			container.QueueFrom(dic.Get))
 	}).Methods(http.MethodPost)
 	r.HandleFunc(clients.ApiIntervalActionRoute, func(w http.ResponseWriter, r *http.Request) {
 		intervalActionHandler(
 			w,
 			r,
 			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
+			bootstrapContainer.DBClientFrom(dic.Get),
+			container.QueueFrom(dic.Get))
 	}).Methods(http.MethodPut)
 	intervalAction := r.PathPrefix(clients.ApiIntervalActionRoute).Subrouter()
 	intervalAction.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
@@ -141,14 +148,16 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 			w,
 			r,
 			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
+			bootstrapContainer.DBClientFrom(dic.Get),
+			container.QueueFrom(dic.Get))
 	}).Methods(http.MethodGet, http.MethodDelete)
 	intervalAction.HandleFunc("/"+NAME+"/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
 		intervalActionByNameHandler(
 			w,
 			r,
 			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
+			bootstrapContainer.DBClientFrom(dic.Get),
+			container.QueueFrom(dic.Get))
 	}).Methods(http.MethodGet, http.MethodDelete)
 	intervalAction.HandleFunc("/"+TARGET+"/{"+TARGET+"}", func(w http.ResponseWriter, r *http.Request) {
 		intervalActionByTargetHandler(


### PR DESCRIPTION
Fixes #2037.

Requires merge from #2176 first.

To verify, run the unit and blackbox tests.