### PR TITLE
Fix orphaned event checksum data for Redis

### DIFF
--- a/internal/pkg/db/redis/event.go
+++ b/internal/pkg/db/redis/event.go
@@ -16,9 +16,10 @@ package redis
 import (
 	"encoding/json"
 
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
 	correlation "github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 	"github.com/gomodule/redigo/redis"
 )
@@ -61,9 +62,7 @@ func unmarshalEvents(objects [][]byte, events []contract.Event) (err error) {
 }
 
 func unmarshalEvent(o []byte) (contract.Event, error) {
-	var s redisEvent
-
-	err := json.Unmarshal(o, &s)
+	s, err := unmarshalRedisEvent(o)
 	if err != nil {
 		return contract.Event{}, err
 	}
@@ -97,6 +96,18 @@ func unmarshalEvent(o []byte) (contract.Event, error) {
 		if err != nil {
 			return contract.Event{}, err
 		}
+	}
+
+	return event, nil
+}
+
+// unmarshalRedisEvent constructs a redisEvent type from the provided bytes.
+func unmarshalRedisEvent(o []byte) (redisEvent, error) {
+	var event redisEvent
+
+	err := json.Unmarshal(o, &event)
+	if err != nil {
+		return redisEvent{}, err
 	}
 
 	return event, nil


### PR DESCRIPTION
Fix #2143

Update the deleteEvent function to perform an extra lookup for the
checksum value associated with the event to be deleted and remove the
lingering data. The additional lookup is necessary since there are three
different types of Events(correlation,contract,and redisEvent) being
used within the Redis implementation of the DBClient and the one being
used for common lookups(contract) does not have the checksum information
so it is lost during serialization. The approach is the most direct and
non-invasive solution. Other attempts to clean-up and reduce the
divergence of the types being used resulted in unrelated Blackbox test
failures.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>