### PR TITLE
Refactor metadata to remove the vdc (i.e. ValueDescriptorClient) global variable.

### DIFF
--- a/internal/core/metadata/container/coredata.go
+++ b/internal/core/metadata/container/coredata.go
@@ -17,13 +17,13 @@ package container
 import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 )
 
-// NotificationsClientName contains the name of the NotificationsClient's implementation in the DIC.
-var NotificationsClientName = di.TypeInstanceToName((*notifications.NotificationsClient)(nil))
+// CoreDataValueDescriptorClientName contains the name of the CoreDataValueDescriptorClient's implementation in the DIC.
+var CoreDataValueDescriptorClientName = di.TypeInstanceToName((*coredata.ValueDescriptorClient)(nil))
 
-// NotificationsClientFrom helper function queries the DIC and returns the NotificationsClient's implementation.
-func NotificationsClientFrom(get di.Get) notifications.NotificationsClient {
-	return get(NotificationsClientName).(notifications.NotificationsClient)
+// CoreDataValueDescriptorClientFrom helper function queries the DIC and returns the CoreDataValueDescriptorClient's implementation.
+func CoreDataValueDescriptorClientFrom(get di.Get) coredata.ValueDescriptorClient {
+	return get(CoreDataValueDescriptorClientName).(coredata.ValueDescriptorClient)
 }

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 
@@ -57,7 +58,8 @@ func restAddDeviceProfile(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	errorHandler errorconcept.ErrorHandler) {
+	errorHandler errorconcept.ErrorHandler,
+	vdc coredata.ValueDescriptorClient) {
 
 	var dp models.DeviceProfile
 
@@ -93,7 +95,8 @@ func restUpdateDeviceProfile(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	errorHandler errorconcept.ErrorHandler) {
+	errorHandler errorconcept.ErrorHandler,
+	vdc coredata.ValueDescriptorClient) {
 
 	defer r.Body.Close()
 

--- a/internal/core/metadata/rest_deviceprofile_test.go
+++ b/internal/core/metadata/rest_deviceprofile_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	goErrors "errors"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +18,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
@@ -215,7 +215,6 @@ func TestAddDeviceProfile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vdc = tt.vdcMock
 			Configuration = &ConfigurationStruct{
 				Writable: WritableInfo{EnableValueDescriptorManagement: true},
 				Service:  config.ServiceInfo{MaxResultCount: 1}}
@@ -226,7 +225,8 @@ func TestAddDeviceProfile(t *testing.T) {
 				tt.request,
 				loggerMock,
 				tt.dbMock,
-				errorconcept.NewErrorHandler(loggerMock))
+				errorconcept.NewErrorHandler(loggerMock),
+				tt.vdcMock)
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
@@ -737,7 +737,6 @@ func TestUpdateDeviceProfile(t *testing.T) {
 			Configuration = &ConfigurationStruct{
 				Writable: WritableInfo{EnableValueDescriptorManagement: tt.enableValueDescriptorManagement},
 				Service:  config.ServiceInfo{MaxResultCount: 1}}
-			vdc = MockValueDescriptorClient{}
 			rr := httptest.NewRecorder()
 			var loggerMock = logger.NewMockClient()
 			restUpdateDeviceProfile(
@@ -745,7 +744,8 @@ func TestUpdateDeviceProfile(t *testing.T) {
 				tt.request,
 				loggerMock,
 				tt.dbMock,
-				errorconcept.NewErrorHandler(loggerMock))
+				errorconcept.NewErrorHandler(loggerMock),
+				MockValueDescriptorClient{})
 			response := rr.Result()
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -271,7 +271,8 @@ func loadDeviceProfileRoutes(b *mux.Router, dic *di.Container) {
 			r,
 			container.LoggingClientFrom(dic.Get),
 			container.DBClientFrom(dic.Get),
-			errorContainer.ErrorHandlerFrom(dic.Get))
+			errorContainer.ErrorHandlerFrom(dic.Get),
+			metadataContainer.CoreDataValueDescriptorClientFrom(dic.Get))
 	}).Methods(http.MethodPost)
 	b.HandleFunc("/"+DEVICEPROFILE+"", func(w http.ResponseWriter, r *http.Request) {
 		restUpdateDeviceProfile(
@@ -279,7 +280,8 @@ func loadDeviceProfileRoutes(b *mux.Router, dic *di.Container) {
 			r,
 			container.LoggingClientFrom(dic.Get),
 			container.DBClientFrom(dic.Get),
-			errorContainer.ErrorHandlerFrom(dic.Get))
+			errorContainer.ErrorHandlerFrom(dic.Get),
+			metadataContainer.CoreDataValueDescriptorClientFrom(dic.Get))
 	}).Methods(http.MethodPut)
 
 	dp := b.PathPrefix("/" + DEVICEPROFILE).Subrouter()


### PR DESCRIPTION
Fix #2022 

- As with the PR for the prior issue (#2021), a handful of blackbox failures are also present in `master` when I ran them; these failures are not related to the changes made per this (current) PR.