### PR TITLE
Remove chEvent global variable from core-data

### DIFF
--- a/internal/core/data/container/events.go
+++ b/internal/core/data/container/events.go
@@ -1,0 +1,32 @@
+/********************************************************************************
+ *  Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package container
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+)
+
+// EventsChannelName contains the name of the Events channel instance in the DIC.
+var EventsChannelName = "CoreDataEventsChannel"
+
+// PublisherEventsChannelFrom helper function queries the DIC and returns the Events channel instance used for
+// publishing over the channel.
+//
+// NOTE If there is a need to obtain a consuming version of the channel create a new helper function which will get the
+// channel from the container and cast it to a consuming channel. The type casting will aid in avoiding errors by
+// restricting functionality.
+func PublisherEventsChannelFrom(get di.Get) chan<- interface{} {
+	return get(EventsChannelName).(chan interface{})
+}

--- a/internal/core/data/device_test.go
+++ b/internal/core/data/device_test.go
@@ -139,7 +139,7 @@ func buildReadings() []contract.Reading {
 	return readings
 }
 
-func handleDomainEvents(bitEvents []bool, wait *sync.WaitGroup, t *testing.T) {
+func handleDomainEvents(bitEvents []bool, chEvents <-chan interface{}, wait *sync.WaitGroup, t *testing.T) {
 	until := time.Now().Add(500 * time.Millisecond) // Kill this loop after half second.
 	for time.Now().Before(until) {
 		select {

--- a/internal/core/data/domain_events.go
+++ b/internal/core/data/domain_events.go
@@ -20,12 +20,12 @@ type DeviceLastReported struct {
 	DeviceName string
 }
 
-//An event indicating that the service associated with the device that just reported data is alive.
+// An event indicating that the service associated with the device that just reported data is alive.
 type DeviceServiceLastReported struct {
 	DeviceName string
 }
 
-func initEventHandlers(loggingClient logger.LoggingClient) {
+func initEventHandlers(loggingClient logger.LoggingClient, chEvents <-chan interface{}) {
 	go func() {
 		for {
 			select {

--- a/internal/core/data/event.go
+++ b/internal/core/data/event.go
@@ -92,7 +92,8 @@ func getEvents(limit int, dbClient interfaces.DBClient) ([]contract.Event, error
 func addNewEvent(
 	e models.Event, ctx context.Context,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) (string, error) {
+	dbClient interfaces.DBClient,
+	chEvents chan<- interface{}) (string, error) {
 
 	err := checkDevice(e.Device, ctx)
 	if err != nil {


### PR DESCRIPTION
Fix #2026

Remove the global variable chEvent and instead use the DI container to
pass the reference to the channel to different parts of the system.

Update function arguments to accept either publishing or consuming Go
channels so that the intent of the function is clear and also to avoid
errors at compile time.

Update tests to work with the new function signatures.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>