### PR TITLE
fix issue 2077: init flag not being used in security-secretstore-setup

### DIFF
--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -43,13 +43,11 @@ func main() {
 		usage.HelpCallbackSecuritySecretStore()
 	}
 
-	var initNeeded bool
 	var insecureSkipVerify bool
 	var vaultInterval int
 	var configDir, profileDir string
 	var useRegistry bool
 
-	flag.BoolVar(&initNeeded, "init", false, "run init procedure for security service.")
 	flag.BoolVar(&insecureSkipVerify, "insecureSkipVerify", false, "skip server side SSL verification, mainly for self-signed cert")
 	flag.IntVar(&vaultInterval, "vaultInterval", 30, "time to wait between checking Vault status in seconds.")
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
@@ -80,7 +78,7 @@ func main() {
 		startupTimer,
 		dic,
 		[]interfaces.BootstrapHandler{
-			secretstore.NewBootstrapHandler(insecureSkipVerify, initNeeded, vaultInterval).Handler,
+			secretstore.NewBootstrapHandler(insecureSkipVerify, vaultInterval).Handler,
 		},
 	)
 }

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -80,7 +80,6 @@ Server Options:
 	-p, --profile <name>                Indicate configuration profile other than default
 	-r, --registry                      Indicates service should use Registry
 	--insecureSkipVerify=true/false     Indicates if skipping the server side SSL cert verifcation, similar to -k of curl
-	--init=true/false                   Indicates if security service should be initialized
 	--configfile=<file.toml>            Use a different config file (default: res/configuration.toml)
 	--vaultInterval=<seconds>           Indicates how long the program will pause between vault initialization attempts until it succeeds
 Common Options:

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -33,14 +33,12 @@ import (
 
 type Bootstrap struct {
 	insecureSkipVerify bool
-	initNeeded         bool
 	vaultInterval      int
 }
 
-func NewBootstrapHandler(insecureSkipVerify bool, initNeeded bool, vaultInterval int) *Bootstrap {
+func NewBootstrapHandler(insecureSkipVerify bool, vaultInterval int) *Bootstrap {
 	return &Bootstrap{
 		insecureSkipVerify: insecureSkipVerify,
-		initNeeded:         initNeeded,
 		vaultInterval:      vaultInterval,
 	}
 }


### PR DESCRIPTION
init is not being used in security-secretstore-setup so remove it from the codebase. This is to address #2077 

Signed-off-by: Tingyu Zeng <Tingyu.Zeng@rsa.com>