### PR TITLE
Fix event deleting func with redis DB.

### DIFF
--- a/internal/pkg/db/redis/queries.go
+++ b/internal/pkg/db/redis/queries.go
@@ -132,15 +132,18 @@ func getObjectsBySomeRange(conn redis.Conn, command string, key string, start in
 		return nil, err
 	}
 
+	var result [][]byte
 	if len(ids) > 0 {
-		objects, err = redis.ByteSlices(conn.Do("MGET", ids...))
+		result, err = redis.ByteSlices(conn.Do("MGET", ids...))
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if len(objects) == 1 && objects[0] == nil {
-		objects = [][]byte{}
+	for _, obj := range result {
+		if obj != nil {
+			objects = append(objects, obj)
+		}
 	}
 
 	return objects, nil


### PR DESCRIPTION
The issue where Redis events were not being deleted correctly. 
The nil object will cause the reading unmarshal error "unexpected end of JSON input", so check every object and then return the result.

Fix #2187 