### PR TITLE
Refactor Bootstrap context.Context usage to be idomatic

### DIFF
--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -33,7 +33,7 @@ import (
 )
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the command service.
-func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	registryClient := bootstrapContainer.RegistryFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -45,7 +45,7 @@ var msc metadata.DeviceServiceClient
 var httpErrorHandler errorconcept.ErrorHandler
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
-func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
 	loggingClient := container.LoggingClientFrom(dic.Get)
 

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -36,8 +36,7 @@ import (
 var Configuration = &ConfigurationStruct{}
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the metadata service.
-func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
-
+func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	// initialize clients required by service.
 	registryClient := container.RegistryFrom(dic.Get)
 

--- a/internal/export/client/init.go
+++ b/internal/export/client/init.go
@@ -30,7 +30,8 @@ var Configuration = &ConfigurationStruct{}
 var dc distro.DistroClient
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the export-client service.
-func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
+
 	// update global variables.
 	LoggingClient = container.LoggingClientFrom(dic.Get)
 	dbClient = container.DBClientFrom(dic.Get)

--- a/internal/export/distro/init.go
+++ b/internal/export/distro/init.go
@@ -59,7 +59,7 @@ func initializeClients(useRegistry bool, registryClient registry.Client) (messag
 }
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the export-distro service.
-func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
 	LoggingClient = container.LoggingClientFrom(dic.Get)
 

--- a/internal/pkg/bootstrap/configuration/registry.go
+++ b/internal/pkg/bootstrap/configuration/registry.go
@@ -105,8 +105,8 @@ func UpdateFromRegistry(
 // writable struct and this function explicitly updates the loggingClient's log level when new configuration changes
 // are received.
 func ListenForChanges(
-	wg *sync.WaitGroup,
 	ctx context.Context,
+	wg *sync.WaitGroup,
 	config interfaces.Configuration,
 	loggingClient logger.LoggingClient,
 	registryClient registry.Client) {

--- a/internal/pkg/bootstrap/handlers/database/database.go
+++ b/internal/pkg/bootstrap/handlers/database/database.go
@@ -94,8 +94,8 @@ func (d Database) newDBClient(loggingClient logger.LoggingClient, credentials co
 
 // BootstrapHandler fulfills the BootstrapHandler contract and initializes the database.
 func (d Database) BootstrapHandler(
+	ctx context.Context,
 	wg *sync.WaitGroup,
-	context context.Context,
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 
@@ -141,7 +141,7 @@ func (d Database) BootstrapHandler(
 	go func() {
 		defer wg.Done()
 
-		<-context.Done()
+		<-ctx.Done()
 		for {
 			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
 			if d.httpServer.IsRunning() == false {

--- a/internal/pkg/bootstrap/handlers/httpserver/httpserver.go
+++ b/internal/pkg/bootstrap/handlers/httpserver/httpserver.go
@@ -53,8 +53,8 @@ func (b *HttpServer) IsRunning() bool {
 // and another that waits on closure of a context's done channel before calling Shutdown() to cleanly shut down the
 // http server.
 func (b *HttpServer) BootstrapHandler(
-	wg *sync.WaitGroup,
 	ctx context.Context,
+	wg *sync.WaitGroup,
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 

--- a/internal/pkg/bootstrap/handlers/message/message.go
+++ b/internal/pkg/bootstrap/handlers/message/message.go
@@ -41,8 +41,8 @@ func NewBootstrap(serviceKey, version string) StartMessage {
 // BootstrapHandler fulfills the BootstrapHandler contract.  It creates no go routines.  It logs a "standard" set of
 // messages when the service first starts up successfully.
 func (h StartMessage) BootstrapHandler(
+	ctx context.Context,
 	wg *sync.WaitGroup,
-	context context.Context,
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 

--- a/internal/pkg/bootstrap/handlers/secret/secret.go
+++ b/internal/pkg/bootstrap/handlers/secret/secret.go
@@ -45,10 +45,11 @@ func NewSecret() *SecretProvider {
 // BootstrapHandlers to obtain sensitive data, such as database credentials. This BootstrapHandler should be processed
 // before other BootstrapHandlers, possibly even first since it has not other dependencies.
 func (s *SecretProvider) BootstrapHandler(
+	ctx context.Context,
 	wg *sync.WaitGroup,
-	context context.Context,
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
+
 	loggingClient := container.LoggingClientFrom(dic.Get)
 
 	configuration := container.ConfigurationFrom(dic.Get)

--- a/internal/pkg/bootstrap/interfaces/handler.go
+++ b/internal/pkg/bootstrap/interfaces/handler.go
@@ -25,7 +25,7 @@ import (
 // BootstrapHandler defines the contract each bootstrap handler must fulfill.  Implementation returns true if the
 // handler completed successfully, false if it did not.
 type BootstrapHandler func(
+	ctx context.Context,
 	wg *sync.WaitGroup,
-	context context.Context,
 	startupTimer startup.Timer,
 	dic *di.Container) (success bool)

--- a/internal/pkg/telemetry/telemetry.go
+++ b/internal/pkg/telemetry/telemetry.go
@@ -81,7 +81,7 @@ func cpuUsageAverage() {
 // BootstrapHandler fulfills the BootstrapHandler contract.  It creates a go routine to periodically sample CPU usage
 // and is intended to supersede the existing StartCpuUsageAverage() function when the new bootstrap package is used
 // by all of the core services.
-func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	loggingClient := container.LoggingClientFrom(dic.Get)
 	loggingClient.Info("Telemetry starting")
 

--- a/internal/security/proxy/init.go
+++ b/internal/security/proxy/init.go
@@ -68,7 +68,12 @@ func (b *Bootstrap) haltIfError(loggingClient logger.LoggingClient, err error) {
 }
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
-func (b *Bootstrap) Handler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func (b *Bootstrap) Handler(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	startupTimer startup.Timer,
+	dic *di.Container) bool {
+
 	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 

--- a/internal/security/secrets/init.go
+++ b/internal/security/secrets/init.go
@@ -40,7 +40,12 @@ func NewBootstrapHandler() *Bootstrap {
 }
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
-func (b *Bootstrap) Handler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func (b *Bootstrap) Handler(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	startupTimer startup.Timer,
+	dic *di.Container) bool {
+
 	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -44,7 +44,12 @@ func NewBootstrapHandler(insecureSkipVerify bool, vaultInterval int) *Bootstrap 
 }
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
-func (b *Bootstrap) Handler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func (b *Bootstrap) Handler(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	startupTimer startup.Timer,
+	dic *di.Container) bool {
+
 	configuration := container.ConfigurationFrom(dic.Get)
 	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
 

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -56,8 +56,8 @@ func getPersistence(credentials config.Credentials) (persistence, error) {
 }
 
 func (s ServiceInit) BootstrapHandler(
-	wg *sync.WaitGroup,
 	ctx context.Context,
+	wg *sync.WaitGroup,
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -28,7 +28,12 @@ import (
 )
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the scheduler service.
-func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func BootstrapHandler(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	startupTimer startup.Timer,
+	dic *di.Container) bool {
+
 	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -36,7 +36,7 @@ import (
 )
 
 // BootstrapHandler fulfills the BootstrapHandler contract.  It implements agent-specific initialization.
-func BootstrapHandler(wg *sync.WaitGroup, ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	configuration := container.ConfigurationFrom(dic.Get)
 
 	// validate metrics implementation


### PR DESCRIPTION
Moved context to be first parameter in function/method calls; ensure
named ctx.  See https://golang.org/pkg/context/

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2195

Signed-off-by: Michael Estrin <m.estrin@dell.com>