### PR TITLE
Add API calls to SecretStoreClient needed for future PRs

### DIFF
--- a/internal/security/secretstoreclient/const.go
+++ b/internal/security/secretstoreclient/const.go
@@ -17,11 +17,18 @@
 package secretstoreclient
 
 const (
-	VaultToken       = "X-Vault-Token"
-	VaultHealthAPI   = "/v1/sys/health"
-	VaultInitAPI     = "/v1/sys/init"
-	VaultUnsealAPI   = "/v1/sys/unseal"
-	JSONContentType  = "application/json"
-	CreatePolicyPath = "/v1/sys/policies/acl/%s"
-	CreateTokenAPI   = "/v1/auth/token/create"
+	VaultToken            = "X-Vault-Token"
+	VaultHealthAPI        = "/v1/sys/health"
+	VaultInitAPI          = "/v1/sys/init"
+	VaultUnsealAPI        = "/v1/sys/unseal"
+	JSONContentType       = "application/json"
+	CreatePolicyPath      = "/v1/sys/policies/acl/%s"
+	CreateTokenAPI        = "/v1/auth/token/create"
+	ListAccessorsAPI      = "/v1/auth/token/accessors"
+	RevokeAccessorAPI     = "/v1/auth/token/revoke-accessor"
+	LookupAccessorAPI     = "/v1/auth/token/lookup-accessor"
+	LookupSelfAPI         = "/v1/auth/token/lookup-self"
+	RevokeSelfAPI         = "/v1/auth/token/revoke-self"
+	RootTokenControlAPI   = "/v1/sys/generate-root/attempt"
+	RootTokenRetrievalAPI = "/v1/sys/generate-root/update"
 )

--- a/internal/security/secretstoreclient/interface.go
+++ b/internal/security/secretstoreclient/interface.go
@@ -29,4 +29,10 @@ type SecretStoreClient interface {
 		policyName string, policyDocument string) (statusCode int, err error)
 	CreateToken(token string,
 		parameters map[string]interface{}, response interface{}) (statusCode int, err error)
+	ListAccessors(token string, accessors *[]string) (statusCode int, err error)
+	RevokeAccessor(token string, accessor string) (statusCode int, err error)
+	LookupAccessor(token string, accessor string, tokenMetadata *TokenMetadata) (statusCode int, err error)
+	LookupSelf(token string, tokenMetadata *TokenMetadata) (statusCode int, err error)
+	RevokeSelf(token string) (statusCode int, err error)
+	RegenRootToken(vmkReader io.Reader, rootToken *string) (err error)
 }

--- a/internal/security/secretstoreclient/messages.go
+++ b/internal/security/secretstoreclient/messages.go
@@ -63,8 +63,15 @@ type RevokeTokenAccessorRequest struct {
 
 // TokenMetadata has introspection data about a token
 type TokenMetadata struct {
-	Accessor   string `json:"accessor"`
-	ExpireTime string `json:"expire_time"`
+	Accessor   string   `json:"accessor"`
+	ExpireTime string   `json:"expire_time"`
+	Path       string   `json:"path"`
+	Policies   []string `json:"policies"`
+}
+
+// LookupAccessorRequest is used by accessor lookup API
+type LookupAccessorRequest struct {
+	Accessor string `json:"accessor"`
 }
 
 // TokenLookupResponse is the response to the token lookup API
@@ -72,8 +79,8 @@ type TokenLookupResponse struct {
 	Data TokenMetadata
 }
 
-// RootTokenControlRespose is the response to /v1/sys/generate-root/attempt
-type RootTokenControlRespose struct {
+// RootTokenControlResponse is the response to /v1/sys/generate-root/attempt
+type RootTokenControlResponse struct {
 	Complete bool   `json:"complete"`
 	Nonce    string `json:"nonce"`
 	Otp      string `json:"otp"`

--- a/internal/security/secretstoreclient/mocks/mock.go
+++ b/internal/security/secretstoreclient/mocks/mock.go
@@ -56,3 +56,39 @@ func (m *MockSecretStoreClient) CreateToken(token string, parameters map[string]
 	arguments := m.Called(token, parameters, response)
 	return arguments.Int(0), arguments.Error(1)
 }
+
+func (m *MockSecretStoreClient) ListAccessors(token string, accessors *[]string) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(token, accessors)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockSecretStoreClient) RevokeAccessor(token string, accessor string) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(token, accessor)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockSecretStoreClient) LookupAccessor(token string, accessor string, tokenMetadata *TokenMetadata) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(token, accessor, tokenMetadata)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockSecretStoreClient) LookupSelf(token string, tokenMetadata *TokenMetadata) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(token, tokenMetadata)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockSecretStoreClient) RevokeSelf(token string) (statusCode int, err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(token)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *MockSecretStoreClient) RegenRootToken(vmkReader io.Reader, rootToken *string) (err error) {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	arguments := m.Called(vmkReader, rootToken)
+	return arguments.Error(0)
+}

--- a/internal/security/secretstoreclient/mocks/mock_test.go
+++ b/internal/security/secretstoreclient/mocks/mock_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestMockInterfaceType(t *testing.T) {
@@ -70,7 +71,7 @@ func TestMockInstallPolicy(t *testing.T) {
 	mockClient.On("InstallPolicy", "fake-token", "foo", "bar").Return(http.StatusOK, nil)
 
 	rc, err := mockClient.InstallPolicy("fake-token", "foo", "bar")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rc)
 	mockClient.AssertExpectations(t)
 }
@@ -82,7 +83,70 @@ func TestMockCreateToken(t *testing.T) {
 	mockClient.On("CreateToken", "fake-token", params, response).Return(http.StatusOK, nil)
 
 	rc, err := mockClient.CreateToken("fake-token", params, response)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockListAccessors(t *testing.T) {
+	var response []string
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("ListAccessors", "fake-token", mock.Anything).Return(http.StatusOK, nil)
+
+	rc, err := mockClient.ListAccessors("fake-token", &response)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockRevokeAccessor(t *testing.T) {
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("RevokeAccessor", "fake-token", "someaccessor").Return(http.StatusNoContent, nil)
+
+	rc, err := mockClient.RevokeAccessor("fake-token", "someaccessor")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockLookupAccessor(t *testing.T) {
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("LookupAccessor", "fake-token", "8609694a-cdbc-db9b-d345-e782dbb562ed", mock.Anything).Return(http.StatusOK, nil)
+
+	var tokenMetadata TokenMetadata
+	rc, err := mockClient.LookupAccessor("fake-token", "8609694a-cdbc-db9b-d345-e782dbb562ed", &tokenMetadata)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockLookupSelf(t *testing.T) {
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("LookupSelf", "fake-token", mock.Anything).Return(http.StatusOK, nil)
+
+	var tokenMetadata TokenMetadata
+	rc, err := mockClient.LookupSelf("fake-token", &tokenMetadata)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockRevokeSelf(t *testing.T) {
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("RevokeSelf", "fake-token", mock.Anything).Return(http.StatusOK, nil)
+
+	rc, err := mockClient.RevokeSelf("fake-token")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rc)
+	mockClient.AssertExpectations(t)
+}
+
+func TestMockRegenRootToken(t *testing.T) {
+	mockClient := &MockSecretStoreClient{}
+	mockClient.On("RegenRootToken", mock.Anything, mock.Anything).Return(nil)
+
+	var rootToken string
+	err := mockClient.RegenRootToken(nil, &rootToken)
+	assert.NoError(t, err)
 	mockClient.AssertExpectations(t)
 }

--- a/internal/security/secretstoreclient/roottoken.go
+++ b/internal/security/secretstoreclient/roottoken.go
@@ -1,0 +1,176 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package secretstoreclient
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+)
+
+func (vc *vaultClient) RegenRootToken(vmkReader io.Reader, rootToken *string) (err error) {
+	// cancel any previous generation attempt
+	// start root token generation --> nonce, otp
+	// provide keys, nonce --> encoded token
+	// encoded token + otp --> root token
+	// caller should revoke root token when done with it
+	var nonce string
+	var otp string
+	var encodedToken string
+
+	if err := vc.rootTokenCancelPrevious(); err != nil {
+		vc.logger.Warn(fmt.Sprintf("failed to cancel previous root token generation: %s", err.Error()))
+		// Not fatal, continue
+	}
+
+	if err := vc.rootTokenStartGeneration(&nonce, &otp); err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to start root token generation: %s", err.Error()))
+		return err
+	}
+
+	if err := vc.rootTokenSubmitKeys(vmkReader, nonce, &encodedToken); err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to generate new root token: %s", err.Error()))
+		return err
+	} else if encodedToken == "" {
+		err := errors.New("insufficient key shares to regenerate root token")
+		vc.logger.Error(err.Error())
+		return err
+	}
+
+	if err := vc.rootTokenDecodeToken(encodedToken, otp, rootToken); err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to decode root token: %s", err.Error()))
+		return err
+	}
+
+	return nil
+}
+
+func (vc *vaultClient) rootTokenCancelPrevious() error {
+	_, err := vc.doRequest(commonRequestArgs{
+		AuthToken:            "",
+		Method:               http.MethodDelete,
+		Path:                 RootTokenControlAPI,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "cancel previous root token generation",
+		ExpectedStatusCode:   http.StatusNoContent,
+		ResponseObject:       nil,
+	})
+	return err
+}
+
+func (vc *vaultClient) rootTokenStartGeneration(nonce *string, otp *string) error {
+	var response RootTokenControlResponse
+	_, err := vc.doRequest(commonRequestArgs{
+		AuthToken:            "",
+		Method:               http.MethodPut,
+		Path:                 RootTokenControlAPI,
+		JSONObject:           struct{}{},
+		BodyReader:           nil,
+		OperationDescription: "start root token generation",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+	*nonce = response.Nonce
+	*otp = response.Otp
+	return err
+}
+
+func (vc *vaultClient) rootTokenSubmitKeys(vmkReader io.Reader, nonce string, encodedToken *string) error {
+	readCloser := fileioperformer.MakeReadCloser(vmkReader)
+	rawBytes, err := ioutil.ReadAll(readCloser)
+	defer readCloser.Close()
+	if err != nil {
+		msg := fmt.Sprintf("failed to read the Vault JSON response init file: %s", err.Error())
+		vc.logger.Error(msg)
+		return errors.New(msg)
+	}
+
+	initResp := InitResponse{}
+	if err = json.Unmarshal(rawBytes, &initResp); err != nil {
+		msg := fmt.Sprintf("failed to build the JSON structure from the init response body: %s", err.Error())
+		vc.logger.Error(msg)
+		return errors.New(msg)
+	}
+
+	for _, key := range initResp.KeysBase64 {
+		complete, err := vc.rootTokenSubmitKey(key, nonce, encodedToken)
+		if err != nil {
+			vc.logger.Error(fmt.Sprintf("root token retrieval aborted due to error: %s", err.Error()))
+			return err
+		} else if complete {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (vc *vaultClient) rootTokenSubmitKey(key string, nonce string, encodedToken *string) (bool, error) {
+	params := RootTokenRetrievalRequest{
+		Key:   key,
+		Nonce: nonce,
+	}
+	var response RootTokenRetrievalResponse
+	_, err := vc.doRequest(commonRequestArgs{
+		AuthToken:            "",
+		Method:               http.MethodPut,
+		Path:                 RootTokenRetrievalAPI,
+		JSONObject:           params,
+		BodyReader:           nil,
+		OperationDescription: "submit root token keyshare",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+	if response.Complete {
+		*encodedToken = response.EncodedToken
+	}
+	return response.Complete, err
+}
+
+func (vc *vaultClient) rootTokenDecodeToken(encodedToken string, otp string, rootToken *string) error {
+	// otp is base62 ascii pad cast to raw bytes
+	// encodedToken is unpadded (raw) base64
+	// XOR the otp bytes with the encoded token bytes to recover the root token
+
+	encodedBytes, err := base64.RawStdEncoding.DecodeString(encodedToken)
+	if err != nil {
+		vc.logger.Error(fmt.Sprintf("failed to base64 decode the encoded token: %s", err.Error()))
+		return err
+	}
+
+	otpBytes := []byte(otp)
+
+	if len(encodedBytes) != len(otpBytes) {
+		return fmt.Errorf("Invalid input to rootTokenDecodeToken - array length mismatch: %d != %d", len(encodedBytes), len(otpBytes))
+	}
+
+	decodedBytes := make([]byte, len(encodedBytes))
+
+	for i := range decodedBytes {
+		decodedBytes[i] = encodedBytes[i] ^ otpBytes[i]
+	}
+
+	*rootToken = string(decodedBytes)
+	return nil
+}

--- a/internal/security/secretstoreclient/roottoken_test.go
+++ b/internal/security/secretstoreclient/roottoken_test.go
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package secretstoreclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileioperformer"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegenRootToken(t *testing.T) {
+	// Arrange
+	assert := assert.New(t)
+	mockLogger := logger.MockLogger{}
+
+	requestNumber := 0
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestNumber++
+		theMethod := r.Method
+		thePath := r.URL.EscapedPath()
+		switch requestNumber {
+		case 1:
+			assert.Equal("DELETE", theMethod)
+			assert.Equal(RootTokenControlAPI, thePath)
+			w.WriteHeader(http.StatusNoContent)
+		case 2:
+			assert.Equal("PUT", theMethod)
+			assert.Equal(RootTokenControlAPI, thePath)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(RootTokenControlResponse{
+				Complete: false,
+				Otp:      "jzEHVfxe6w0Q0yz5jQuvlQG557",
+				Nonce:    "2dbd10f1-8528-6246-09e7-82b25b8aba63",
+			})
+		case 3:
+			assert.Equal("PUT", theMethod)
+			assert.Equal(RootTokenRetrievalAPI, thePath)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(RootTokenRetrievalResponse{
+				Complete:     true,
+				EncodedToken: "GVQfeQ5eIQ5+IlczQy0JBw80ITI6FHFme3w",
+			})
+		}
+	}))
+	defer ts.Close()
+
+	host := strings.Replace(ts.URL, "https://", "", -1)
+	vc := NewSecretStoreClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
+
+	// Act
+	config := SecretServiceInfo{
+		TokenFolderPath:   "testdata",
+		TokenFile:         "test-resp-init.json",
+		VaultSecretShares: 1,
+	}
+	vmkReader, err := fileioperformer.NewDefaultFileIoPerformer().OpenFileReader(filepath.Join(config.TokenFolderPath, config.TokenFile), os.O_RDONLY, 0400)
+	var rootToken string
+	err = vc.RegenRootToken(vmkReader, &rootToken)
+
+	// Assert
+	assert.Nil(err)
+	assert.Equal("s.Z1X8YkHUgbsTs2eeTDVE6SNK", string(rootToken))
+}

--- a/internal/security/secretstoreclient/vault.go
+++ b/internal/security/secretstoreclient/vault.go
@@ -141,7 +141,6 @@ func (vc *vaultClient) InstallPolicy(token string, policyName string, policyDocu
 		ExpectedStatusCode:   http.StatusNoContent,
 		ResponseObject:       nil,
 	})
-
 }
 
 func (vc *vaultClient) CreateToken(token string, parameters map[string]interface{}, response interface{}) (int, error) {
@@ -154,5 +153,81 @@ func (vc *vaultClient) CreateToken(token string, parameters map[string]interface
 		OperationDescription: "create token",
 		ExpectedStatusCode:   http.StatusOK,
 		ResponseObject:       response,
+	})
+}
+
+func (vc *vaultClient) ListAccessors(token string, accessors *[]string) (statusCode int, err error) {
+	var response ListTokenAccessorsResponse
+	code, err := vc.doRequest(commonRequestArgs{
+		AuthToken:            token,
+		Method:               "LIST",
+		Path:                 ListAccessorsAPI,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "list token accessors",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+	*accessors = response.Data.Keys
+	return code, err
+}
+
+func (vc *vaultClient) RevokeAccessor(token string, accessor string) (statusCode int, err error) {
+	parameters := RevokeTokenAccessorRequest{Accessor: accessor}
+	return vc.doRequest(commonRequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodPost,
+		Path:                 RevokeAccessorAPI,
+		JSONObject:           parameters,
+		BodyReader:           nil,
+		OperationDescription: "revoke token accessor",
+		ExpectedStatusCode:   http.StatusNoContent,
+		ResponseObject:       nil,
+	})
+}
+
+func (vc *vaultClient) LookupAccessor(token string, accessor string, tokenMetadata *TokenMetadata) (statusCode int, err error) {
+	parameters := LookupAccessorRequest{Accessor: accessor}
+	var response TokenLookupResponse
+	code, err := vc.doRequest(commonRequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodPost,
+		Path:                 LookupAccessorAPI,
+		JSONObject:           parameters,
+		BodyReader:           nil,
+		OperationDescription: "lookup accessor",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+	*tokenMetadata = response.Data
+	return code, err
+}
+
+func (vc *vaultClient) LookupSelf(token string, tokenMetadata *TokenMetadata) (statusCode int, err error) {
+	var response TokenLookupResponse
+	code, err := vc.doRequest(commonRequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodGet,
+		Path:                 LookupSelfAPI,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "lookup self token",
+		ExpectedStatusCode:   http.StatusOK,
+		ResponseObject:       &response,
+	})
+	*tokenMetadata = response.Data
+	return code, err
+}
+
+func (vc *vaultClient) RevokeSelf(token string) (statusCode int, err error) {
+	return vc.doRequest(commonRequestArgs{
+		AuthToken:            token,
+		Method:               http.MethodPost,
+		Path:                 RevokeSelfAPI,
+		JSONObject:           nil,
+		BodyReader:           nil,
+		OperationDescription: "revoke self token",
+		ExpectedStatusCode:   http.StatusNoContent,
+		ResponseObject:       nil,
 	})
 }


### PR DESCRIPTION
Add a number of API calls to the SecretStoreClient
that will be needed to implement Geneva release
security features. These calls support revokation
of previously issued tokens, revokation of the root
token, and generation of new root tokens from
the Vault master key.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>