### PR TITLE
Remove Unnecessary DIC definition in service's main.go

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/command/config"
 	container "github.com/edgexfoundry/edgex-go/internal/core/command/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
@@ -55,9 +54,6 @@ func main() {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
-		},
-		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return get(container.ConfigurationName)
 		},
 	})
 	httpServer := httpserver.NewBootstrap(command.LoadRestRoutes(dic))

--- a/cmd/security-file-token-provider/main.go
+++ b/cmd/security-file-token-provider/main.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -50,9 +49,6 @@ func main() {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
-		},
-		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return get(container.ConfigurationName)
 		},
 	})
 	bootstrap.Run(

--- a/cmd/security-proxy-setup/main.go
+++ b/cmd/security-proxy-setup/main.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -66,9 +65,6 @@ func main() {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
-		},
-		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return get(container.ConfigurationName)
 		},
 	})
 	bootstrap.Run(

--- a/cmd/security-secrets-setup/main.go
+++ b/cmd/security-secrets-setup/main.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -52,9 +51,6 @@ func wrappedMain() (*config.ConfigurationStruct, int) {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
-		},
-		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return get(container.ConfigurationName)
 		},
 	})
 	serviceHandler := secrets.NewBootstrapHandler()

--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
@@ -63,9 +62,6 @@ func main() {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
-		},
-		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return get(container.ConfigurationName)
 		},
 	})
 	bootstrap.Run(

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
@@ -61,9 +60,6 @@ func main() {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
-		},
-		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return get(container.ConfigurationName)
 		},
 	})
 	httpServer := httpserver.NewBootstrap(notifications.LoadRestRoutes(dic))

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
@@ -55,9 +54,6 @@ func main() {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
-		},
-		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return get(container.ConfigurationName)
 		},
 	})
 

--- a/cmd/sys-mgmt-agent/main.go
+++ b/cmd/sys-mgmt-agent/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap"
-	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/httpserver"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/message"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
@@ -52,9 +51,6 @@ func main() {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
-		},
-		bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return get(container.ConfigurationName)
 		},
 	})
 	httpServer := httpserver.NewBootstrap(agent.LoadRestRoutes(dic))


### PR DESCRIPTION
Removed redundant definition of ConfigurationInterfaceName in
dependency injection container instantiation in each core
service's main.go.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2206
Signed-off-by: Michael Estrin <m.estrin@dell.com>