### PR TITLE
Remove msgClient global variable for core-data

### DIFF
--- a/internal/core/data/container/messaging.go
+++ b/internal/core/data/container/messaging.go
@@ -1,0 +1,29 @@
+/********************************************************************************
+ *  Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package container
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
+
+	"github.com/edgexfoundry/go-mod-messaging/messaging"
+)
+
+// MessagingClientName contains the name of the messaging client instance in the DIC.
+var MessagingClientName = di.TypeInstanceToName((*messaging.MessageClient)(nil))
+
+// MessagingClientFrom helper function queries the DIC and returns the messaging client.
+func MessagingClientFrom(get di.Get) messaging.MessageClient {
+	return get(MessagingClientName).(messaging.MessageClient)
+}

--- a/internal/core/data/event_test.go
+++ b/internal/core/data/event_test.go
@@ -201,7 +201,7 @@ func TestAddEventWithPersistence(t *testing.T) {
 	reset()
 
 	// no need to mock this since it's all in process
-	msgClient, _ = messaging.NewMessageClient(msgTypes.MessageBusConfig{
+	msgClient, _ := messaging.NewMessageClient(msgTypes.MessageBusConfig{
 		PublishHost: msgTypes.HostInfo{
 			Host:     "*",
 			Protocol: "tcp",
@@ -225,7 +225,8 @@ func TestAddEventWithPersistence(t *testing.T) {
 		context.Background(),
 		logger.NewMockClient(),
 		dbClientMock,
-		chEvents)
+		chEvents,
+		msgClient)
 
 	Configuration.Writable.PersistData = false
 	if err != nil {
@@ -244,6 +245,15 @@ func TestAddEventWithPersistence(t *testing.T) {
 
 func TestAddEventNoPersistence(t *testing.T) {
 	reset()
+	msgClient, _ := messaging.NewMessageClient(msgTypes.MessageBusConfig{
+		PublishHost: msgTypes.HostInfo{
+			Host:     "*",
+			Protocol: "tcp",
+			Port:     5563,
+		},
+		Type: "zero",
+	})
+
 	dbClientMock := newAddEventMockDB(false)
 	Configuration.Writable.PersistData = false
 	evt := models.Event{Device: testDeviceName, Origin: testOrigin, Readings: buildReadings()}
@@ -259,7 +269,8 @@ func TestAddEventNoPersistence(t *testing.T) {
 		context.Background(),
 		logger.NewMockClient(),
 		dbClientMock,
-		chEvents)
+		chEvents,
+		msgClient)
 
 	if err != nil {
 		t.Errorf(err.Error())


### PR DESCRIPTION
Fix #2027

Remove the msgClient global variable in favor of using the DI container
for passing around an instance during bootstrap. Update functions which
were referring to the global variable to instead accept an instance as
function arguments.

Update tests to work with the changes to the production code.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>