### PR TITLE
Remove unused request parameter from controller functions

### DIFF
--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -20,16 +20,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-	"github.com/edgexfoundry/go-mod-messaging/messaging"
-	"github.com/gorilla/mux"
-
 	dataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/container"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
-	"github.com/edgexfoundry/edgex-go/internal/core/data/operators/reading"
+	readingOperator "github.com/edgexfoundry/edgex-go/internal/core/data/operators/reading"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/operators/value_descriptor"
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
@@ -38,6 +32,14 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/edgexfoundry/go-mod-messaging/messaging"
+
+	"github.com/gorilla/mux"
 )
 
 // ValueDescriptorUsageReadLimit limit of readings obtained for a given value descriptor to determine if the value
@@ -48,179 +50,235 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 	r := mux.NewRouter()
 
 	// Ping Resource
-	r.HandleFunc(clients.ApiPingRoute, pingHandler).Methods(http.MethodGet)
+	r.HandleFunc(
+		clients.ApiPingRoute,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(clients.ContentType, clients.ContentTypeText)
+			_, _ = w.Write([]byte("pong"))
+		}).Methods(http.MethodGet)
 
 	// Configuration
-	r.HandleFunc(clients.ApiConfigRoute, func(writer http.ResponseWriter, request *http.Request) {
-		configHandler(writer, request, container.LoggingClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	r.HandleFunc(
+		clients.ApiConfigRoute,
+		func(w http.ResponseWriter, _ *http.Request) {
+			pkg.Encode(Configuration, w, container.LoggingClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
 	// Metrics
-	r.HandleFunc(clients.ApiMetricsRoute, func(writer http.ResponseWriter, request *http.Request) {
-		metricsHandler(writer, request, container.LoggingClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	r.HandleFunc(
+		clients.ApiMetricsRoute,
+		func(w http.ResponseWriter, _ *http.Request) {
+			pkg.Encode(telemetry.NewSystemUsage(), w, container.LoggingClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
 	// Version
 	r.HandleFunc(clients.ApiVersionRoute, pkg.VersionHandler).Methods(http.MethodGet)
 
 	// Events
-	r.HandleFunc(clients.ApiEventRoute, func(writer http.ResponseWriter, request *http.Request) {
-		eventHandler(
-			writer,
-			request,
-			container.LoggingClientFrom(dic.Get),
-			container.DBClientFrom(dic.Get),
-			dataContainer.PublisherEventsChannelFrom(dic.Get),
-			dataContainer.MessagingClientFrom(dic.Get))
-
-	}).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
+	r.HandleFunc(
+		clients.ApiEventRoute,
+		func(w http.ResponseWriter, r *http.Request) {
+			eventHandler(
+				w,
+				r,
+				container.LoggingClientFrom(dic.Get),
+				container.DBClientFrom(dic.Get),
+				dataContainer.PublisherEventsChannelFrom(dic.Get),
+				dataContainer.MessagingClientFrom(dic.Get))
+		}).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
 
 	e := r.PathPrefix(clients.ApiEventRoute).Subrouter()
 
-	e.HandleFunc("/"+SCRUB, func(writer http.ResponseWriter, request *http.Request) {
-		scrubHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodDelete)
+	e.HandleFunc(
+		"/"+SCRUB,
+		func(w http.ResponseWriter, r *http.Request) {
+			scrubHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodDelete)
 
-	e.HandleFunc("/"+SCRUBALL, func(writer http.ResponseWriter, request *http.Request) {
-		scrubAllHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodDelete)
+	e.HandleFunc(
+		"/"+SCRUBALL,
+		func(w http.ResponseWriter, r *http.Request) {
+			scrubAllHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodDelete)
 
-	e.HandleFunc("/"+COUNT, func(writer http.ResponseWriter, request *http.Request) {
-		eventCountHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	e.HandleFunc(
+		"/"+COUNT,
+		func(w http.ResponseWriter, r *http.Request) {
+			eventCountHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	e.HandleFunc("/"+COUNT+"/{"+DEVICEID_PARAM+"}", func(writer http.ResponseWriter, request *http.Request) {
-		eventCountByDeviceIdHandler(writer, request, container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	e.HandleFunc(
+		"/"+COUNT+"/{"+DEVICEID_PARAM+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			eventCountByDeviceIdHandler(w, r, container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	e.HandleFunc("/{"+ID+"}", func(writer http.ResponseWriter, request *http.Request) {
-		getEventByIdHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	e.HandleFunc(
+		"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			getEventByIdHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	e.HandleFunc("/"+ID+"/{"+ID+"}", func(writer http.ResponseWriter, request *http.Request) {
-		eventIdHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodDelete, http.MethodPut)
+	e.HandleFunc(
+		"/"+ID+"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			eventIdHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodDelete, http.MethodPut)
 
-	e.HandleFunc("/"+CHECKSUM+"/{"+CHECKSUM+"}", func(writer http.ResponseWriter, request *http.Request) {
-		putEventChecksumHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodPut)
+	e.HandleFunc(
+		"/"+CHECKSUM+"/{"+CHECKSUM+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			putEventChecksumHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodPut)
 
 	e.HandleFunc(
 		"/"+DEVICE+"/{"+DEVICEID_PARAM+"}/{"+LIMIT+":[0-9]+}",
-		func(writer http.ResponseWriter, request *http.Request) {
-			getEventByDeviceHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		func(w http.ResponseWriter, r *http.Request) {
+			getEventByDeviceHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
 		}).Methods(http.MethodGet)
-	e.HandleFunc("/"+DEVICE+"/{"+DEVICEID_PARAM+"}", func(writer http.ResponseWriter, request *http.Request) {
-		deleteByDeviceIdHandler(writer, request, container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodDelete)
+	e.HandleFunc(
+		"/"+DEVICE+"/{"+DEVICEID_PARAM+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			deleteByDeviceIdHandler(w, r, container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodDelete)
 
-	e.HandleFunc("/"+REMOVEOLD+"/"+AGE+"/{"+AGE+":[0-9]+}", func(writer http.ResponseWriter, request *http.Request) {
-		eventByAgeHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodDelete)
+	e.HandleFunc(
+		"/"+REMOVEOLD+"/"+AGE+"/{"+AGE+":[0-9]+}",
+		func(w http.ResponseWriter, r *http.Request) {
+			eventByAgeHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodDelete)
 
 	e.HandleFunc(
 		"/{"+START+":[0-9]+}/{"+END+":[0-9]+}/{"+LIMIT+":[0-9]+}",
-		func(writer http.ResponseWriter, request *http.Request) {
-			eventByCreationTimeHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		func(w http.ResponseWriter, r *http.Request) {
+			eventByCreationTimeHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	// Readings
-	r.HandleFunc(clients.ApiReadingRoute, func(writer http.ResponseWriter, request *http.Request) {
-		readingHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
+	r.HandleFunc(
+		clients.ApiReadingRoute,
+		func(w http.ResponseWriter, r *http.Request) {
+			readingHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
 
 	rd := r.PathPrefix(clients.ApiReadingRoute).Subrouter()
 
-	rd.HandleFunc("/"+COUNT, func(writer http.ResponseWriter, request *http.Request) {
-		readingCountHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	rd.HandleFunc(
+		"/"+COUNT,
+		func(w http.ResponseWriter, r *http.Request) {
+			readingCountHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	rd.HandleFunc("/"+ID+"/{"+ID+"}", func(writer http.ResponseWriter, request *http.Request) {
-		deleteReadingByIdHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodDelete)
+	rd.HandleFunc(
+		"/"+ID+"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			deleteReadingByIdHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodDelete)
 
-	rd.HandleFunc("/{"+ID+"}", func(writer http.ResponseWriter, request *http.Request) {
-		getReadingByIdHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	rd.HandleFunc(
+		"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			getReadingByIdHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
 		"/"+DEVICE+"/{"+DEVICEID_PARAM+"}/{"+LIMIT+":[0-9]+}",
-		func(writer http.ResponseWriter, request *http.Request) {
-			readingByDeviceHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		func(w http.ResponseWriter, r *http.Request) {
+			readingByDeviceHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
 		"/"+NAME+"/{"+NAME+"}/{"+LIMIT+":[0-9]+}",
-		func(writer http.ResponseWriter, request *http.Request) {
-			readingbyValueDescriptorHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		func(w http.ResponseWriter, r *http.Request) {
+			readingbyValueDescriptorHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
 		"/"+UOMLABEL+"/{"+UOMLABEL_PARAM+"}/{"+LIMIT+":[0-9]+}",
-		func(writer http.ResponseWriter, request *http.Request) {
-			readingByUomLabelHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		func(w http.ResponseWriter, r *http.Request) {
+			readingByUomLabelHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
-	rd.HandleFunc("/"+LABEL+"/{"+LABEL+"}/{"+LIMIT+":[0-9]+}", func(writer http.ResponseWriter, request *http.Request) {
-		readingByLabelHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	rd.HandleFunc(
+		"/"+LABEL+"/{"+LABEL+"}/{"+LIMIT+":[0-9]+}",
+		func(w http.ResponseWriter, r *http.Request) {
+			readingByLabelHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	rd.HandleFunc("/"+TYPE+"/{"+TYPE+"}/{"+LIMIT+":[0-9]+}", func(writer http.ResponseWriter, request *http.Request) {
-		readingByTypeHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	rd.HandleFunc(
+		"/"+TYPE+"/{"+TYPE+"}/{"+LIMIT+":[0-9]+}",
+		func(w http.ResponseWriter, r *http.Request) {
+			readingByTypeHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
 		"/{"+START+":[0-9]+}/{"+END+":[0-9]+}/{"+LIMIT+":[0-9]+}",
-		func(writer http.ResponseWriter, request *http.Request) {
-			readingByCreationTimeHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		func(w http.ResponseWriter, r *http.Request) {
+			readingByCreationTimeHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
 		"/"+NAME+"/{"+NAME+"}/"+DEVICE+"/{"+DEVICE+"}/{"+LIMIT+":[0-9]+}",
-		func(writer http.ResponseWriter, request *http.Request) {
-			readingByValueDescriptorAndDeviceHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		func(w http.ResponseWriter, r *http.Request) {
+			readingByValueDescriptorAndDeviceHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	// Value descriptors
 	r.HandleFunc(
 		clients.ApiValueDescriptorRoute,
-		func(writer http.ResponseWriter, request *http.Request) {
-			valueDescriptorHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		func(w http.ResponseWriter, r *http.Request) {
+			valueDescriptorHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
 		}).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
 
 	vd := r.PathPrefix(clients.ApiValueDescriptorRoute).Subrouter()
 
-	vd.HandleFunc("/"+USAGE, func(writer http.ResponseWriter, request *http.Request) {
-		restValueDescriptorsUsageHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	vd.HandleFunc(
+		"/"+USAGE,
+		func(w http.ResponseWriter, r *http.Request) {
+			restValueDescriptorsUsageHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	vd.HandleFunc("/"+ID+"/{"+ID+"}", func(writer http.ResponseWriter, request *http.Request) {
-		deleteValueDescriptorByIdHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodDelete)
+	vd.HandleFunc(
+		"/"+ID+"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			deleteValueDescriptorByIdHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodDelete)
 
-	vd.HandleFunc("/"+NAME+"/{"+NAME+"}", func(writer http.ResponseWriter, request *http.Request) {
-		valueDescriptorByNameHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet, http.MethodDelete)
+	vd.HandleFunc(
+		"/"+NAME+"/{"+NAME+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			valueDescriptorByNameHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet, http.MethodDelete)
 
-	vd.HandleFunc("/{"+ID+"}", func(writer http.ResponseWriter, request *http.Request) {
-		valueDescriptorByIdHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	vd.HandleFunc(
+		"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			valueDescriptorByIdHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	vd.HandleFunc("/"+UOMLABEL+"/{"+UOMLABEL_PARAM+"}", func(writer http.ResponseWriter, request *http.Request) {
-		valueDescriptorByUomLabelHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	vd.HandleFunc(
+		"/"+UOMLABEL+"/{"+UOMLABEL_PARAM+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			valueDescriptorByUomLabelHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	vd.HandleFunc("/"+LABEL+"/{"+LABEL+"}", func(writer http.ResponseWriter, request *http.Request) {
-		valueDescriptorByLabelHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	vd.HandleFunc(
+		"/"+LABEL+"/{"+LABEL+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			valueDescriptorByLabelHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	vd.HandleFunc("/"+DEVICENAME+"/{"+DEVICE+"}", func(writer http.ResponseWriter, request *http.Request) {
-		valueDescriptorByDeviceHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	vd.HandleFunc(
+		"/"+DEVICENAME+"/{"+DEVICE+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			valueDescriptorByDeviceHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	vd.HandleFunc("/"+DEVICEID+"/{"+ID+"}", func(writer http.ResponseWriter, request *http.Request) {
-		valueDescriptorByDeviceIdHandler(writer, request, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	vd.HandleFunc(
+		"/"+DEVICEID+"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			valueDescriptorByDeviceIdHandler(w, r, container.LoggingClientFrom(dic.Get), container.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)
@@ -239,7 +297,7 @@ func eventCountHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	count, err := countEvents(dbClient)
 	if err != nil {
@@ -261,7 +319,7 @@ deviceID - ID of the device to get count for
 /api/v1/event/count/{deviceId}
 */
 func eventCountByDeviceIdHandler(w http.ResponseWriter, r *http.Request, dbClient interfaces.DBClient) {
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	id, err := url.QueryUnescape(vars["deviceId"])
@@ -282,7 +340,7 @@ func eventCountByDeviceIdHandler(w http.ResponseWriter, r *http.Request, dbClien
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(strconv.Itoa(count)))
+	_, _ = w.Write([]byte(strconv.Itoa(count)))
 }
 
 // Remove all the old events and associated readings (by age)
@@ -293,7 +351,7 @@ func eventByAgeHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	age, err := strconv.ParseInt(vars["age"], 10, 64)
@@ -313,7 +371,7 @@ func eventByAgeHandler(
 
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(strconv.Itoa(count)))
+	_, _ = w.Write([]byte(strconv.Itoa(count)))
 }
 
 /*
@@ -333,7 +391,7 @@ func eventHandler(
 	msgClient messaging.MessageClient) {
 
 	if r.Body != nil {
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 	}
 
 	ctx := r.Context()
@@ -374,7 +432,7 @@ func eventHandler(
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(newId))
+		_, _ = w.Write([]byte(newId))
 		break
 		// Update an existing event, but do not update the readings
 	case http.MethodPut:
@@ -407,7 +465,7 @@ func eventHandler(
 
 		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
+		_, _ = w.Write([]byte("true"))
 	}
 }
 
@@ -419,7 +477,7 @@ func scrubAllHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	loggingClient.Info("Deleting all events from database")
 
@@ -443,7 +501,7 @@ func getEventByIdHandler(
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 	}
 
 	// URL parameters
@@ -475,7 +533,7 @@ func getEventByDeviceHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	limit := vars["limit"]
@@ -535,7 +593,7 @@ func eventIdHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	id := vars["id"]
@@ -563,7 +621,7 @@ func eventIdHandler(
 
 		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
+		_, _ = w.Write([]byte("true"))
 		break
 		// Delete the event and all of it's readings
 	case http.MethodDelete:
@@ -579,7 +637,7 @@ func eventIdHandler(
 		}
 		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
+		_, _ = w.Write([]byte("true"))
 	}
 }
 
@@ -595,7 +653,7 @@ func putEventChecksumHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	checksum := vars["checksum"]
@@ -626,7 +684,7 @@ func putEventChecksumHandler(
 // 404 - device ID not found in metadata
 // 503 - service unavailable
 func deleteByDeviceIdHandler(w http.ResponseWriter, r *http.Request, dbClient interfaces.DBClient) {
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	deviceId, err := url.QueryUnescape(vars["deviceId"])
@@ -657,7 +715,7 @@ func deleteByDeviceIdHandler(w http.ResponseWriter, r *http.Request, dbClient in
 
 		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(strconv.Itoa(count)))
+		_, _ = w.Write([]byte(strconv.Itoa(count)))
 	}
 }
 
@@ -673,7 +731,7 @@ func eventByCreationTimeHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	start, err := strconv.ParseInt(vars["start"], 10, 64)
@@ -725,7 +783,7 @@ func scrubHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	switch r.Method {
 	case http.MethodDelete:
@@ -737,18 +795,8 @@ func scrubHandler(
 
 		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(strconv.Itoa(count)))
+		_, _ = w.Write([]byte(strconv.Itoa(count)))
 	}
-}
-
-// Test if the service is working
-func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set(clients.ContentType, clients.ContentTypeText)
-	w.Write([]byte("pong"))
-}
-
-func configHandler(w http.ResponseWriter, r *http.Request, loggingClient logger.LoggingClient) {
-	pkg.Encode(Configuration, w, loggingClient)
 }
 
 // Reading handler
@@ -759,7 +807,7 @@ func readingHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	ctx := r.Context()
 
@@ -811,9 +859,9 @@ func readingHandler(
 			}
 
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(id))
+			_, _ = w.Write([]byte(id))
 		} else {
-			// Didn't save the reading in the database
+			// Didn't save the readingOperator in the database
 			pkg.Encode("unsaved", w, loggingClient)
 		}
 	case http.MethodPut:
@@ -847,20 +895,20 @@ func readingHandler(
 
 		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
+		_, _ = w.Write([]byte("true"))
 	}
 }
 
-// Get a reading by id
-// HTTP 404 not found if the reading can't be found by the ID
-// api/v1/reading/{id}
+// Get a readingOperator by id
+// HTTP 404 not found if the readingOperator can't be found by the ID
+// api/v1/readingOperator/{id}
 func getReadingByIdHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	id := vars["id"]
@@ -881,14 +929,14 @@ func getReadingByIdHandler(
 }
 
 // Return a count for the number of readings in core data
-// api/v1/reading/count
+// api/v1/readingOperator/count
 func readingCountHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	switch r.Method {
 	case http.MethodGet:
@@ -906,15 +954,15 @@ func readingCountHandler(
 	}
 }
 
-// Delete a reading by its id
-// api/v1/reading/id/{id}
+// Delete a readingOperator by its id
+// api/v1/readingOperator/id/{id}
 func deleteReadingByIdHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	id := vars["id"]
@@ -933,21 +981,21 @@ func deleteReadingByIdHandler(
 
 		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
+		_, _ = w.Write([]byte("true"))
 	}
 }
 
 // Get all the readings for the device - sort by creation date
 // 404 - device ID or name doesn't match
 // 413 - max count exceeded
-// api/v1/reading/device/{deviceId}/{limit}
+// api/v1/readingOperator/device/{deviceId}/{limit}
 func readingByDeviceHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	limit, err := strconv.Atoi(vars["limit"])
@@ -989,14 +1037,14 @@ func readingByDeviceHandler(
 
 // Return a list of readings associated with a value descriptor, limited by limit
 // HTTP 413 (limit exceeded) if the limit is greater than max limit
-// api/v1/reading/name/{name}/{limit}
+// api/v1/readingOperator/name/{name}/{limit}
 func readingbyValueDescriptorHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	name, err := url.QueryUnescape(vars["name"])
@@ -1022,14 +1070,14 @@ func readingbyValueDescriptorHandler(
 }
 
 // Return a list of readings based on the UOM label for the value decriptor
-// api/v1/reading/uomlabel/{uomLabel}/{limit}
+// api/v1/readingOperator/uomlabel/{uomLabel}/{limit}
 func readingByUomLabelHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 
@@ -1077,14 +1125,14 @@ func readingByUomLabelHandler(
 
 // Get readings by the value descriptor (specified by the label)
 // 413 - limit exceeded
-// api/v1/reading/label/{label}/{limit}
+// api/v1/readingOperator/label/{label}/{limit}
 func readingByLabelHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	label, err := url.QueryUnescape(vars["label"])
@@ -1129,14 +1177,14 @@ func readingByLabelHandler(
 
 // Return a list of readings who's value descriptor has the type
 // 413 - number exceeds the current limit
-// /reading/type/{type}/{limit}
+// /readingOperator/type/{type}/{limit}
 func readingByTypeHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 
@@ -1180,14 +1228,14 @@ func readingByTypeHandler(
 }
 
 // Return a list of readings between the start and end (creation time)
-// /reading/{start}/{end}/{limit}
+// /readingOperator/{start}/{end}/{limit}
 func readingByCreationTimeHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	start, err := strconv.ParseInt(vars["start"], 10, 64)
@@ -1226,14 +1274,14 @@ func readingByCreationTimeHandler(
 
 // Return a list of redings associated with the device and value descriptor
 // Limit exceeded exception 413 if the limit exceeds the max limit
-// api/v1/reading/name/{name}/device/{device}/{limit}
+// api/v1/readingOperator/name/{name}/device/{device}/{limit}
 func readingByValueDescriptorAndDeviceHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	ctx := r.Context()
@@ -1305,7 +1353,7 @@ func valueDescriptorHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	switch r.Method {
 	case http.MethodGet:
@@ -1352,7 +1400,7 @@ func valueDescriptorHandler(
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(id))
+		_, _ = w.Write([]byte(id))
 	case http.MethodPut:
 		vd, err := decodeValueDescriptor(r.Body, loggingClient)
 		if err != nil {
@@ -1384,7 +1432,7 @@ func valueDescriptorHandler(
 
 		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
+		_, _ = w.Write([]byte("true"))
 	}
 }
 
@@ -1397,7 +1445,7 @@ func deleteValueDescriptorByIdHandler(w http.ResponseWriter,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	id := vars["id"]
@@ -1420,7 +1468,7 @@ func deleteValueDescriptorByIdHandler(w http.ResponseWriter,
 
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("true"))
+	_, _ = w.Write([]byte("true"))
 }
 
 // Value descriptors based on name
@@ -1431,7 +1479,7 @@ func valueDescriptorByNameHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	name, err := url.QueryUnescape(vars["name"])
@@ -1471,7 +1519,7 @@ func valueDescriptorByNameHandler(
 
 		w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("true"))
+		_, _ = w.Write([]byte("true"))
 	}
 }
 
@@ -1484,7 +1532,7 @@ func valueDescriptorByIdHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	id := vars["id"]
@@ -1513,7 +1561,7 @@ func valueDescriptorByUomLabelHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	uomLabel, err := url.QueryUnescape(vars["uomLabel"])
@@ -1548,7 +1596,7 @@ func valueDescriptorByLabelHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	label, err := url.QueryUnescape(vars["label"])
@@ -1584,7 +1632,7 @@ func valueDescriptorByDeviceHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 
@@ -1621,7 +1669,7 @@ func valueDescriptorByDeviceIdHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 
@@ -1695,9 +1743,9 @@ func restValueDescriptorsUsageHandler(
 	// Use this data structure so that we can obtain the desired JSON format. Please see RAML for response format
 	// information.
 	resp := make([]map[string]bool, 0)
-	var ops reading.GetReadingsExecutor
+	var ops readingOperator.GetReadingsExecutor
 	for _, vd := range vds {
-		ops = reading.NewGetReadingsNameExecutor(
+		ops = readingOperator.NewGetReadingsNameExecutor(
 			vd.Name,
 			ValueDescriptorUsageReadLimit,
 			dbClient,
@@ -1718,12 +1766,4 @@ func restValueDescriptorsUsageHandler(
 	}
 
 	pkg.Encode(resp, w, loggingClient)
-}
-
-func metricsHandler(w http.ResponseWriter, _ *http.Request, loggingClient logger.LoggingClient) {
-	s := telemetry.NewSystemUsage()
-
-	pkg.Encode(s, w, loggingClient)
-
-	return
 }

--- a/internal/export/client/router.go
+++ b/internal/export/client/router.go
@@ -14,13 +14,14 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
 	"github.com/gorilla/mux"
 )
 
 // Test if the service is working
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set(clients.ContentType, clients.ContentTypeText)
-	w.Write([]byte("pong"))
+	_, _ = w.Write([]byte("pong"))
 }
 
 func configHandler(w http.ResponseWriter, _ *http.Request) {
@@ -28,11 +29,7 @@ func configHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func metricsHandler(w http.ResponseWriter, _ *http.Request) {
-	s := telemetry.NewSystemUsage()
-
-	pkg.Encode(s, w, LoggingClient)
-
-	return
+	pkg.Encode(telemetry.NewSystemUsage(), w, LoggingClient)
 }
 
 func LoadRestRoutes() *mux.Router {

--- a/internal/export/distro/router.go
+++ b/internal/export/distro/router.go
@@ -9,7 +9,6 @@ package distro
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -25,7 +24,7 @@ import (
 // Test if the service is working
 func pingHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set(clients.ContentType, clients.ContentTypeText)
-	w.Write([]byte("pong"))
+	_, _ = w.Write([]byte("pong"))
 }
 
 func configHandler(w http.ResponseWriter, _ *http.Request) {
@@ -37,7 +36,7 @@ func replyNotifyRegistrations(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		LoggingClient.Error(fmt.Sprintf("Failed read body. Error: %s", err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, err.Error())
+		_, _ = w.Write([]byte(err.Error()))
 		return
 	}
 
@@ -45,7 +44,7 @@ func replyNotifyRegistrations(w http.ResponseWriter, r *http.Request) {
 	if err := json.Unmarshal(data, &update); err != nil {
 		LoggingClient.Error(fmt.Sprintf("Failed to parse %X", data))
 		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, err.Error())
+		_, _ = w.Write([]byte(err.Error()))
 		return
 	}
 	if update.Name == "" || update.Operation == "" {
@@ -66,11 +65,7 @@ func replyNotifyRegistrations(w http.ResponseWriter, r *http.Request) {
 }
 
 func metricsHandler(w http.ResponseWriter, _ *http.Request) {
-	s := telemetry.NewSystemUsage()
-
-	pkg.Encode(s, w, LoggingClient)
-
-	return
+	pkg.Encode(telemetry.NewSystemUsage(), w, LoggingClient)
 }
 
 func LoadRestRoutes() *mux.Router {

--- a/internal/support/notifications/utils.go
+++ b/internal/support/notifications/utils.go
@@ -20,12 +20,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	notificationsConfig "github.com/edgexfoundry/edgex-go/internal/support/notifications/config"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
@@ -44,12 +42,6 @@ func printBody(r io.ReadCloser) {
 	}
 
 	fmt.Println(bodyString)
-}
-
-// Test if the service is working
-func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set(clients.ContentType, clients.ContentTypeText)
-	w.Write([]byte("pong"))
 }
 
 func checkMaxLimit(limit int, loggingClient logger.LoggingClient, config notificationsConfig.ConfigurationStruct) error {

--- a/internal/support/scheduler/router.go
+++ b/internal/support/scheduler/router.go
@@ -17,200 +17,213 @@ package scheduler
 import (
 	"net/http"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/gorilla/mux"
-
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
 	bootstrapContainer "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/di"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
-	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/config"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/gorilla/mux"
 )
 
 func LoadRestRoutes(dic *di.Container) *mux.Router {
 	r := mux.NewRouter()
 
 	// Ping Resource
-	r.HandleFunc(clients.ApiPingRoute, func(w http.ResponseWriter, _ *http.Request) {
-		pingHandler(w)
-	}).Methods(http.MethodGet)
+	r.HandleFunc(clients.
+		ApiPingRoute,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(clients.ContentType, clients.ContentTypeText)
+			_, _ = w.Write([]byte("pong"))
+		}).Methods(http.MethodGet)
 
 	// Configuration
-	r.HandleFunc(clients.ApiConfigRoute, func(w http.ResponseWriter, _ *http.Request) {
-		configHandler(
-			w,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			container.ConfigurationFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	r.HandleFunc(clients.
+		ApiConfigRoute,
+		func(w http.ResponseWriter, _ *http.Request) {
+			pkg.Encode(container.ConfigurationFrom(dic.Get), w, bootstrapContainer.LoggingClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
 	// Metrics
-	r.HandleFunc(clients.ApiMetricsRoute, func(w http.ResponseWriter, _ *http.Request) {
-		metricsHandler(
-			w,
-			bootstrapContainer.LoggingClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	r.HandleFunc(clients.
+		ApiMetricsRoute,
+		func(w http.ResponseWriter, _ *http.Request) {
+			pkg.Encode(telemetry.NewSystemUsage(), w, bootstrapContainer.LoggingClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
 	// Version
 	r.HandleFunc(clients.ApiVersionRoute, pkg.VersionHandler).Methods(http.MethodGet)
 
 	// Interval
-	r.HandleFunc(clients.ApiIntervalRoute, func(w http.ResponseWriter, r *http.Request) {
-		restGetIntervals(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.ConfigurationFrom(dic.Get))
-	}).Methods(http.MethodGet)
-	r.HandleFunc(clients.ApiIntervalRoute, func(w http.ResponseWriter, r *http.Request) {
-		restUpdateInterval(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.QueueFrom(dic.Get))
-	}).Methods(http.MethodPut)
-	r.HandleFunc(clients.ApiIntervalRoute, func(w http.ResponseWriter, r *http.Request) {
-		restAddInterval(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.QueueFrom(dic.Get))
-	}).Methods(http.MethodPost)
+	r.HandleFunc(clients.
+		ApiIntervalRoute,
+		func(w http.ResponseWriter, r *http.Request) {
+			restGetIntervals(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.ConfigurationFrom(dic.Get))
+		}).Methods(http.MethodGet)
+	r.HandleFunc(clients.
+		ApiIntervalRoute,
+		func(w http.ResponseWriter, r *http.Request) {
+			restUpdateInterval(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.QueueFrom(dic.Get))
+		}).Methods(http.MethodPut)
+	r.HandleFunc(clients.
+		ApiIntervalRoute,
+		func(w http.ResponseWriter, r *http.Request) {
+			restAddInterval(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.QueueFrom(dic.Get))
+		}).Methods(http.MethodPost)
 	interval := r.PathPrefix(clients.ApiIntervalRoute).Subrouter()
-	interval.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
-		restGetIntervalByID(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
-	interval.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
-		restDeleteIntervalByID(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.QueueFrom(dic.Get))
-	}).Methods(http.MethodDelete)
-	interval.HandleFunc("/"+NAME+"/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
-		restGetIntervalByName(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
-	interval.HandleFunc("/"+NAME+"/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
-		restDeleteIntervalByName(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.QueueFrom(dic.Get))
-	}).Methods(http.MethodDelete)
+	interval.HandleFunc(
+		"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			restGetIntervalByID(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
+	interval.HandleFunc(
+		"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			restDeleteIntervalByID(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.QueueFrom(dic.Get))
+		}).Methods(http.MethodDelete)
+	interval.HandleFunc(
+		"/"+NAME+"/{"+NAME+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			restGetIntervalByName(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
+	interval.HandleFunc(
+		"/"+NAME+"/{"+NAME+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			restDeleteIntervalByName(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.QueueFrom(dic.Get))
+		}).Methods(http.MethodDelete)
 	// Scrub "Intervals and IntervalActions"
-	interval.HandleFunc("/"+SCRUB+"/", func(w http.ResponseWriter, r *http.Request) {
-		restScrubAllIntervals(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
-	}).Methods(http.MethodDelete)
+	interval.HandleFunc(
+		"/"+SCRUB+"/",
+		func(w http.ResponseWriter, r *http.Request) {
+			restScrubAllIntervals(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get))
+		}).Methods(http.MethodDelete)
 
 	// IntervalAction
-	r.HandleFunc(clients.ApiIntervalActionRoute, func(w http.ResponseWriter, r *http.Request) {
-		restGetIntervalAction(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.ConfigurationFrom(dic.Get))
-	}).Methods(http.MethodGet)
-	r.HandleFunc(clients.ApiIntervalActionRoute, func(w http.ResponseWriter, r *http.Request) {
-		restAddIntervalAction(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.QueueFrom(dic.Get))
-	}).Methods(http.MethodPost)
-	r.HandleFunc(clients.ApiIntervalActionRoute, func(w http.ResponseWriter, r *http.Request) {
-		intervalActionHandler(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.QueueFrom(dic.Get),
-			container.ConfigurationFrom(dic.Get))
-	}).Methods(http.MethodPut)
+	r.HandleFunc(clients.
+		ApiIntervalActionRoute,
+		func(w http.ResponseWriter, r *http.Request) {
+			restGetIntervalAction(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.ConfigurationFrom(dic.Get))
+		}).Methods(http.MethodGet)
+	r.HandleFunc(clients.
+		ApiIntervalActionRoute,
+		func(w http.ResponseWriter, r *http.Request) {
+			restAddIntervalAction(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.QueueFrom(dic.Get))
+		}).Methods(http.MethodPost)
+	r.HandleFunc(clients.
+		ApiIntervalActionRoute,
+		func(w http.ResponseWriter, r *http.Request) {
+			intervalActionHandler(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.QueueFrom(dic.Get),
+				container.ConfigurationFrom(dic.Get))
+		}).Methods(http.MethodPut)
 	intervalAction := r.PathPrefix(clients.ApiIntervalActionRoute).Subrouter()
-	intervalAction.HandleFunc("/{"+ID+"}", func(w http.ResponseWriter, r *http.Request) {
-		intervalActionByIdHandler(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.QueueFrom(dic.Get))
-	}).Methods(http.MethodGet, http.MethodDelete)
-	intervalAction.HandleFunc("/"+NAME+"/{"+NAME+"}", func(w http.ResponseWriter, r *http.Request) {
-		intervalActionByNameHandler(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get),
-			container.QueueFrom(dic.Get))
-	}).Methods(http.MethodGet, http.MethodDelete)
-	intervalAction.HandleFunc("/"+TARGET+"/{"+TARGET+"}", func(w http.ResponseWriter, r *http.Request) {
-		intervalActionByTargetHandler(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
-	intervalAction.HandleFunc("/"+INTERVAL+"/{"+INTERVAL+"}", func(w http.ResponseWriter, r *http.Request) {
-		intervalActionByIntervalHandler(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	intervalAction.HandleFunc(
+		"/{"+ID+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			intervalActionByIdHandler(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.QueueFrom(dic.Get))
+		}).Methods(http.MethodGet, http.MethodDelete)
+	intervalAction.HandleFunc(
+		"/"+NAME+"/{"+NAME+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			intervalActionByNameHandler(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get),
+				container.QueueFrom(dic.Get))
+		}).Methods(http.MethodGet, http.MethodDelete)
+	intervalAction.HandleFunc(
+		"/"+TARGET+"/{"+TARGET+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			intervalActionByTargetHandler(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
+	intervalAction.HandleFunc(
+		"/"+INTERVAL+"/{"+INTERVAL+"}",
+		func(w http.ResponseWriter, r *http.Request) {
+			intervalActionByIntervalHandler(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
 	// Scrub "IntervalActions"
-	intervalAction.HandleFunc("/"+SCRUB+"/", func(w http.ResponseWriter, r *http.Request) {
-		scrubIntervalActionsHandler(
-			w,
-			r,
-			bootstrapContainer.LoggingClientFrom(dic.Get),
-			bootstrapContainer.DBClientFrom(dic.Get))
-	}).Methods(http.MethodDelete)
+	intervalAction.HandleFunc(
+		"/"+SCRUB+"/",
+		func(w http.ResponseWriter, r *http.Request) {
+			scrubIntervalActionsHandler(
+				w,
+				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
+				bootstrapContainer.DBClientFrom(dic.Get))
+		}).Methods(http.MethodDelete)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)
 	r.Use(correlation.OnRequestBegin)
 
 	return r
-}
-
-// Test if the service is working
-func pingHandler(w http.ResponseWriter) {
-	w.Header().Set(clients.ContentType, clients.ContentTypeText)
-	w.Write([]byte("pong"))
-}
-
-func configHandler(
-	w http.ResponseWriter,
-	loggingClient logger.LoggingClient,
-	configuration *config.ConfigurationStruct) {
-
-	pkg.Encode(configuration, w, loggingClient)
-}
-
-func metricsHandler(w http.ResponseWriter, loggingClient logger.LoggingClient) {
-	s := telemetry.NewSystemUsage()
-
-	pkg.Encode(s, w, loggingClient)
 }

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -42,26 +42,41 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 
 	b := r.PathPrefix("/api/v1").Subrouter()
 
-	b.HandleFunc("/operation", func(w http.ResponseWriter, r *http.Request) {
-		operationHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), container.OperationsFrom(dic.Get))
-	}).Methods(http.MethodPost)
+	b.HandleFunc(
+		"/operation",
+		func(w http.ResponseWriter, r *http.Request) {
+			operationHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), container.OperationsFrom(dic.Get))
+		}).Methods(http.MethodPost)
 
-	b.HandleFunc("/config/{services}", func(w http.ResponseWriter, r *http.Request) {
-		getConfigHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), container.GetConfigFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	b.HandleFunc(
+		"/config/{services}",
+		func(w http.ResponseWriter, r *http.Request) {
+			getConfigHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), container.GetConfigFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	b.HandleFunc("/config/{services}", func(w http.ResponseWriter, r *http.Request) {
-		setConfigHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), container.SetConfigFrom(dic.Get))
-	}).Methods(http.MethodPut)
+	b.HandleFunc(
+		"/config/{services}",
+		func(w http.ResponseWriter, r *http.Request) {
+			setConfigHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), container.SetConfigFrom(dic.Get))
+		}).Methods(http.MethodPut)
 
-	b.HandleFunc("/metrics/{services}", func(w http.ResponseWriter, r *http.Request) {
-		metricsHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), container.MetricsFrom(dic.Get))
-	}).Methods(http.MethodGet)
+	b.HandleFunc(
+		"/metrics/{services}",
+		func(w http.ResponseWriter, r *http.Request) {
+			metricsHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), container.MetricsFrom(dic.Get))
+		}).Methods(http.MethodGet)
 
-	b.HandleFunc("/health/{services}", func(w http.ResponseWriter, r *http.Request) {
-		healthHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), bootstrapContainer.RegistryFrom(dic.Get))
-	}).Methods(http.MethodGet)
-	b.HandleFunc("/ping", pingHandler).Methods(http.MethodGet)
+	b.HandleFunc(
+		"/health/{services}",
+		func(w http.ResponseWriter, r *http.Request) {
+			healthHandler(w, r, bootstrapContainer.LoggingClientFrom(dic.Get), bootstrapContainer.RegistryFrom(dic.Get))
+		}).Methods(http.MethodGet)
+	b.HandleFunc(
+		"/ping",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(clients.ContentType, clients.ContentTypeText)
+			_, _ = w.Write([]byte("pong"))
+		}).Methods(http.MethodGet)
 
 	r.HandleFunc(clients.ApiVersionRoute, pkg.VersionHandler).Methods(http.MethodGet)
 
@@ -70,12 +85,6 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 	r.Use(correlation.OnRequestBegin)
 
 	return r
-}
-
-// pingHandler implements a controller to execute a ping request.
-func pingHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set(clients.ContentType, clients.ContentTypeText)
-	w.Write([]byte("pong"))
 }
 
 // metricsHandler implements a controller to execute a metrics request.
@@ -98,7 +107,7 @@ func operationHandler(
 	loggingClient logger.LoggingClient,
 	operationsImpl interfaces.Operations) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -144,7 +153,7 @@ func setConfigHandler(
 	loggingClient logger.LoggingClient,
 	setConfigImpl interfaces.SetConfig) {
 
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
 	loggingClient.Debug("retrieved service names")


### PR DESCRIPTION
Removed unused request parameters from controller functions.  Cleaned
up formatting. Cleaned up io.WriteString() usage; now consistently
using w.Write(). Explicitly ignoring errors from w.Write() and
r.Body.Close().  Folded metrics, configuration, and ping controller
functions into routing definition closures (except for export
services which are being archived before Geneva release).

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2074

Signed-off-by: Michael Estrin <m.estrin@dell.com>