### PR TITLE
Fix bug #2213: invalid init flag for vault-worker

### DIFF
--- a/cmd/security-secretstore-setup/entrypoint.sh
+++ b/cmd/security-secretstore-setup/entrypoint.sh
@@ -36,6 +36,6 @@ until /consul/scripts/consul-svc-healthy.sh security-secrets-setup; do
     sleep 1; 
 done;
 
-/security-secretstore-setup --init=true --vaultInterval=10
+/security-secretstore-setup --vaultInterval=10
 
 exec "$@"


### PR DESCRIPTION
 This PR is to remove the invalid or no-longer existing flag, `--init`, for `security-secretstore-setup` (aka vault-worker).

 The init flag was removed from PR #2188 but this place from the entrypoint script was omitted at that time so the bug is was introduced.

 Fixes issue #2213


Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>