### PR TITLE
Gather System Management Metrics Asynchronously

### DIFF
--- a/internal/system/agent/direct/metrics.go
+++ b/internal/system/agent/direct/metrics.go
@@ -26,6 +26,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/system"
 	agentClients "github.com/edgexfoundry/edgex-go/internal/system/agent/clients"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/concurrent"
 	"github.com/edgexfoundry/edgex-go/internal/system/executor"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
@@ -60,16 +61,20 @@ func NewMetrics(
 }
 
 // metricsViaDirectService calls a service's metrics endpoint directly, interprets the response, and returns a Result.
-func (m *metrics) metricsViaDirectService(serviceName string, ctx context.Context) (system.Result, error) {
+func (m *metrics) metricsViaDirectService(ctx context.Context, serviceName string) system.Result {
 	client, ok := m.genClients.Get(serviceName)
 	if !ok {
 		if m.registryClient == nil {
-			return nil, fmt.Errorf("registryClient not initialized; required to handle unknown service: %s", serviceName)
+			return system.Failure(
+				serviceName,
+				executor.Metrics,
+				ExecutorType,
+				fmt.Sprintf("registryClient not initialized; required to handle unknown service: %s", serviceName))
 		}
 
 		// Service unknown to SMA, so ask the Registry whether `serviceName` is available.
 		if err := m.registryClient.IsServiceAvailable(serviceName); err != nil {
-			return nil, err
+			return system.Failure(serviceName, executor.Metrics, ExecutorType, err.Error())
 		}
 
 		m.loggingClient.Info(fmt.Sprintf("Registry responded with %s serviceName available", serviceName))
@@ -77,7 +82,14 @@ func (m *metrics) metricsViaDirectService(serviceName string, ctx context.Contex
 		// Since serviceName is unknown to SMA, ask the Registry for a ServiceEndpoint associated with `serviceName`
 		e, err := m.registryClient.GetServiceEndpoint(serviceName)
 		if err != nil {
-			return nil, fmt.Errorf("on attempting to get ServiceEndpoint for serviceName %s, got error: %v", serviceName, err.Error())
+			return system.Failure(
+				serviceName,
+				executor.Metrics,
+				ExecutorType,
+				fmt.Sprintf(
+					"on attempting to get ServiceEndpoint for serviceName %s, got error: %v",
+					serviceName,
+					err.Error()))
 		}
 
 		configClient := config.ClientInfo{
@@ -100,26 +112,33 @@ func (m *metrics) metricsViaDirectService(serviceName string, ctx context.Contex
 
 	result, err := client.FetchMetrics(ctx)
 	if err != nil {
-		return nil, err
+		return system.Failure(serviceName, executor.Metrics, ExecutorType, err.Error())
 	}
 
 	var s telemetry.SystemUsage
 	if err := json.NewDecoder(bytes.NewBuffer([]byte(result))).Decode(&s); err != nil {
-		return nil, fmt.Errorf("error decoding telemetry.SystemUsage: %s", err.Error())
+		return system.Failure(
+			serviceName,
+			executor.Metrics,
+			ExecutorType,
+			fmt.Sprintf("error decoding telemetry.SystemUsage: %s", err.Error()))
 	}
 
-	return system.MetricsSuccess(serviceName, ExecutorType, s.CpuBusyAvg, int64(s.Memory.Sys), []byte(result)), nil
+	return system.MetricsSuccess(serviceName, ExecutorType, s.CpuBusyAvg, int64(s.Memory.Sys), []byte(result))
 }
 
-func (m *metrics) Get(services []string, ctx context.Context) interface{} {
-	var result []interface{}
-	for _, service := range services {
-		out, err := m.metricsViaDirectService(service, ctx)
-		if err != nil {
-			result = append(result, system.Failure(service, executor.Metrics, ExecutorType, err.Error()))
-			continue
-		}
-		result = append(result, out)
+// Get implements the Metrics interface to obtain metrics directly from one or more services concurrently.
+func (m *metrics) Get(ctx context.Context, services []string) []interface{} {
+	var closures []concurrent.Closure
+	for index := range services {
+		closures = append(
+			closures,
+			func(serviceName string) concurrent.Closure {
+				return func() interface{} {
+					return m.metricsViaDirectService(ctx, serviceName)
+				}
+			}(services[index]),
+		)
 	}
-	return result
+	return concurrent.ExecuteAndAggregateResults(closures)
 }

--- a/internal/system/agent/executor/operation.go
+++ b/internal/system/agent/executor/operation.go
@@ -42,7 +42,7 @@ func NewOperations(
 }
 
 // operationViaExecutor delegates a start/stop/restart operation request to the configuration-defined executor.
-func (e operations) Do(services []string, operation string) interface{} {
+func (e operations) Do(services []string, operation string) []interface{} {
 	var result []interface{}
 	for _, serviceName := range services {
 		r, err := e.executor(e.executorPath, serviceName, operation)

--- a/internal/system/agent/executor/operation_test.go
+++ b/internal/system/agent/executor/operation_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestOperationDoWithNoServices(t *testing.T) {
-	executor := NewStub([]stubCall{})
+	executor := NewStub(map[string]stubCall{})
 	sut := NewOperations(executor.CommandExecutor, logger.NewMockClient(), "executorPathDoesNotMatter")
 
 	result := sut.Do([]string{}, "operationDoesNotMatter")
@@ -53,19 +53,23 @@ func TestOperationDoWithServices(t *testing.T) {
 		name           string
 		services       []string
 		expectedResult []interface{}
-		executorCalls  []stubCall
+		executorCalls  map[string]stubCall
 	}{
 		{
 			"one service with no error",
 			[]string{service1Name},
 			[]interface{}{response.Process(service1Result, loggingClient)},
-			[]stubCall{{[]string{executorPath, service1Name, operation}, service1Result, nil}},
+			map[string]stubCall{
+				service1Name: {[]string{executorPath, service1Name, operation}, service1Result, nil},
+			},
 		},
 		{
 			"one service with error",
 			[]string{service1Name},
 			[]interface{}{system.Failure(service1Name, operation, UnknownExecutorType, expectedError.Error())},
-			[]stubCall{{[]string{executorPath, service1Name, operation}, "", expectedError}},
+			map[string]stubCall{
+				service1Name: {[]string{executorPath, service1Name, operation}, "", expectedError},
+			},
 		},
 		{
 			"two services with no errors",
@@ -74,9 +78,9 @@ func TestOperationDoWithServices(t *testing.T) {
 				response.Process(service1Result, loggingClient),
 				response.Process(service2Result, loggingClient),
 			},
-			[]stubCall{
-				{[]string{executorPath, service1Name, operation}, service1Result, nil},
-				{[]string{executorPath, service2Name, operation}, service2Result, nil},
+			map[string]stubCall{
+				service1Name: {[]string{executorPath, service1Name, operation}, service1Result, nil},
+				service2Name: {[]string{executorPath, service2Name, operation}, service2Result, nil},
 			},
 		},
 		{
@@ -86,9 +90,9 @@ func TestOperationDoWithServices(t *testing.T) {
 				system.Failure(service1Name, operation, UnknownExecutorType, expectedError.Error()),
 				response.Process(service2Result, loggingClient),
 			},
-			[]stubCall{
-				{[]string{executorPath, service1Name, operation}, "", expectedError},
-				{[]string{executorPath, service2Name, operation}, service2Result, nil},
+			map[string]stubCall{
+				service1Name: {[]string{executorPath, service1Name, operation}, "", expectedError},
+				service2Name: {[]string{executorPath, service2Name, operation}, service2Result, nil},
 			},
 		},
 		{
@@ -98,9 +102,9 @@ func TestOperationDoWithServices(t *testing.T) {
 				response.Process(service1Result, loggingClient),
 				system.Failure(service2Name, operation, UnknownExecutorType, expectedError.Error()),
 			},
-			[]stubCall{
-				{[]string{executorPath, service1Name, operation}, service1Result, nil},
-				{[]string{executorPath, service2Name, operation}, "", expectedError},
+			map[string]stubCall{
+				service1Name: {[]string{executorPath, service1Name, operation}, service1Result, nil},
+				service2Name: {[]string{executorPath, service2Name, operation}, "", expectedError},
 			},
 		},
 		{
@@ -110,9 +114,9 @@ func TestOperationDoWithServices(t *testing.T) {
 				system.Failure(service1Name, operation, UnknownExecutorType, expectedError.Error()),
 				system.Failure(service2Name, operation, UnknownExecutorType, expectedError.Error()),
 			},
-			[]stubCall{
-				{[]string{executorPath, service1Name, operation}, "", expectedError},
-				{[]string{executorPath, service2Name, operation}, "", expectedError},
+			map[string]stubCall{
+				service1Name: {[]string{executorPath, service1Name, operation}, "", expectedError},
+				service2Name: {[]string{executorPath, service2Name, operation}, "", expectedError},
 			},
 		},
 	}
@@ -125,11 +129,20 @@ func TestOperationDoWithServices(t *testing.T) {
 			result := sut.Do(test.services, operation)
 
 			if assert.Equal(t, len(test.executorCalls), executor.Called) {
-				for key, executorCall := range test.executorCalls {
-					assertArgsAreEqual(t, executorCall.expectedArgs, executor.capturedArgs[key])
+				var expectedArgs []string
+				for key := range test.executorCalls {
+					expectedArgs = append(expectedArgs, argsToString(test.executorCalls[key].expectedArgs))
 				}
+
+				var capturedArgs []string
+				for key := range executor.capturedArgs {
+					capturedArgs = append(capturedArgs, argsToString(executor.capturedArgs[key]))
+				}
+
+				assertArgsAreEqualInAnyOrder(t, expectedArgs, capturedArgs)
 			}
-			assert.Equal(t, test.expectedResult, result)
+
+			assertResultsAreEqualInAnyOrder(t, test.expectedResult, result)
 		})
 	}
 }

--- a/internal/system/agent/getconfig/executor.go
+++ b/internal/system/agent/getconfig/executor.go
@@ -55,7 +55,7 @@ func NewExecutor(
 }
 
 // Do fulfills the GetExecutor contract and implements the functionality to retrieve a service's configuration.
-func (e executor) Do(serviceName string, ctx context.Context) (string, error) {
+func (e executor) Do(ctx context.Context, serviceName string) (string, error) {
 	var result string
 	client, ok := e.genClients.Get(serviceName)
 	if !ok {

--- a/internal/system/agent/getconfig/get.go
+++ b/internal/system/agent/getconfig/get.go
@@ -33,7 +33,7 @@ type resultType struct {
 
 // GetExecutor defines a contract for getting configuration for a service.
 type GetExecutor interface {
-	Do(service string, ctx context.Context) (string, error)
+	Do(ctx context.Context, service string) (string, error)
 }
 
 // get contains references to dependencies required to execute a get configuration request.
@@ -51,12 +51,12 @@ func New(executor GetExecutor, loggingClient logger.LoggingClient) *get {
 }
 
 // Do fulfills the GetConfig contract and implements the retrieval of configuration for multiple services.
-func (g get) Do(services []string, ctx context.Context) interface{} {
+func (g get) Do(ctx context.Context, services []string) interface{} {
 	result := resultType{
 		Configuration: resultConfigurationType{},
 	}
 	for _, service := range services {
-		c, err := g.executor.Do(service, ctx)
+		c, err := g.executor.Do(ctx, service)
 		if err != nil {
 			g.loggingClient.Error(fmt.Sprintf(err.Error()))
 			result.Configuration[service] = fmt.Sprintf(err.Error())

--- a/internal/system/agent/interfaces/config.go
+++ b/internal/system/agent/interfaces/config.go
@@ -21,7 +21,7 @@ import (
 )
 
 type GetConfig interface {
-	Do(services []string, ctx context.Context) interface{}
+	Do(ctx context.Context, services []string) interface{}
 }
 
 type SetConfig interface {

--- a/internal/system/agent/interfaces/operations.go
+++ b/internal/system/agent/interfaces/operations.go
@@ -16,5 +16,5 @@ package interfaces
 
 // Operations defines an operation execution abstraction.
 type Operations interface {
-	Do(services []string, operation string) interface{}
+	Do(services []string, operation string) []interface{}
 }

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -97,7 +97,7 @@ func metricsHandler(
 	loggingClient.Debug("retrieved service names")
 
 	vars := mux.Vars(r)
-	pkg.Encode(metricsImpl.Get(strings.Split(vars["services"], ","), r.Context()), w, loggingClient)
+	pkg.Encode(metricsImpl.Get(r.Context(), strings.Split(vars["services"], ",")), w, loggingClient)
 }
 
 // operationHandler implements a controller to execute a start/stop/restart operation request.
@@ -143,7 +143,7 @@ func getConfigHandler(
 	vars := mux.Vars(r)
 	loggingClient.Debug("retrieved service names")
 
-	pkg.Encode(getConfigImpl.Do(strings.Split(vars["services"], ","), r.Context()), w, loggingClient)
+	pkg.Encode(getConfigImpl.Do(r.Context(), strings.Split(vars["services"], ",")), w, loggingClient)
 }
 
 // setConfigHandler implements a controller to execute a set configuration request.


### PR DESCRIPTION
Implemented concurrent calls to individual services/external
executor to obtain metrics.  Updated context.Context parameter
passing to be idiomatic (i.e. first parameter).

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2008

Signed-off-by: Michael Estrin <m.estrin@dell.com>