### PR TITLE
test-attribution-txt.sh: check for unused dependencies as well

### DIFF
--- a/bin/test-attribution-txt.sh
+++ b/bin/test-attribution-txt.sh
@@ -7,6 +7,10 @@ GIT_ROOT=$(dirname "$SCRIPT_DIR")
 
 EXIT_CODE=0
 
+# turn on nullglobbing so if there is nothing in cmd dir then we don't do
+# anything in the loops over cmd
+shopt -s nullglob
+
 cd "$GIT_ROOT"
 
 if [ -d vendor.bk ]; then
@@ -24,6 +28,11 @@ cleanup()
     if [ -d vendor.bk ]; then
         mv vendor.bk vendor
     fi
+    # remove any attribution dependency files from each of the cmd dirs
+    for cmd in cmd/* ; do
+        cd "$GIT_ROOT/$cmd"
+        rm -f dependency-*.bk
+    done
     exit $EXIT_CODE
 }
 
@@ -35,25 +44,45 @@ fi
 # create a vendor dir with the mod dependencies
 GO111MODULE=on go mod vendor
 
-# turn on nullglobbing so if there is nothing in cmd dir then we don't do
-# anything in this loop
-shopt -s nullglob
-
 for cmd in cmd/* ; do
     cd "$cmd"
-        if [ ! -f Attribution.txt ]; then
-            echo "An Attribution.txt file for $cmd is missing, please add"
-            EXIT_CODE=1
-        else
-            # loop over every library in the modules.txt file in vendor
-            while IFS= read -r lib; do
-                if ! grep -q "$lib" Attribution.txt; then 
-                    echo "An attribution for $lib is missing from in $cmd Attribution.txt, please add"
-                    # need to do this in a bash subshell, see SC2031
-                    (( EXIT_CODE=1 ))
+    if [ ! -f Attribution.txt ]; then
+        echo "An Attribution.txt file for $cmd is missing, please add"
+        EXIT_CODE=1
+    else
+        # loop over every library in the modules.txt file in vendor
+        while IFS= read -r lib; do
+            if ! grep -q "$lib" Attribution.txt; then 
+                echo "An attribution for $lib is missing from in $cmd Attribution.txt, please add"
+                # need to do this in a bash subshell, see SC2031
+                (( EXIT_CODE=1 ))
+            fi
+        done < <(grep '#' < "$GIT_ROOT/vendor/modules.txt" | awk '{print $2}')
+
+        # now check for stale, unused attributions
+        # we need to split the attribution.txt file by blank lines and put each
+        # dependency segment into it's own file for processing
+        tail -n +2 < Attribution.txt | awk -v RS= '{print > ("dependency-" NR ".bk")}' 
+        for dep in ./dependency-*.bk; do
+            # the format of the dependency is supposed to be
+            # PKG/NAME (LICENSE-TYPE) LIBRARY-LINK
+            # LICENSE-LINK
+            depName=$(head -n 1 "$dep" | awk '{print $1}')
+            if [ -z "$depName" ]; then
+                echo "invalid dependency format for $cmd/Attribution.txt"
+                EXIT_CODE=1
+                break
+            else
+                # check if the name of the library is in the modules, note that
+                # we don't use the link since the link could be ambiguous, but
+                # library names should always be unique
+                if ! grep "#" < "$GIT_ROOT/vendor/modules.txt" | awk '{print $2}' | grep -q "$depName"; then
+                    echo "Unnecessary attribution of $depName in $cmd/Attribution.txt, please remove"
+                    EXIT_CODE=1
                 fi
-            done < <(grep '#' < "$GIT_ROOT/vendor/modules.txt" | awk '{print $2}')
-        fi
+            fi
+        done
+    fi
     cd "$GIT_ROOT"
 done
 

--- a/cmd/config-seed/Attribution.txt
+++ b/cmd/config-seed/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/core-data/Attribution.txt
+++ b/cmd/core-data/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/export-client/Attribution.txt
+++ b/cmd/export-client/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/export-distro/Attribution.txt
+++ b/cmd/export-distro/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/security-file-token-provider/Attribution.txt
+++ b/cmd/security-file-token-provider/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/security-proxy-setup/Attribution.txt
+++ b/cmd/security-proxy-setup/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/security-secrets-setup/Attribution.txt
+++ b/cmd/security-secrets-setup/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/security-secretstore-setup/Attribution.txt
+++ b/cmd/security-secretstore-setup/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme

--- a/cmd/sys-mgmt-executor/Attribution.txt
+++ b/cmd/sys-mgmt-executor/Attribution.txt
@@ -30,12 +30,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
 https://github.com/pelletier/go-toml/blob/master/LICENSE
 
-influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
-https://github.com/influxdata/influxdb/blob/master/LICENSE
-
-influxdata/platform (MIT) https://github.com/influxdata/platform
-https://github.com/influxdata/platform/blob/master/LICENSE
-
 eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
 https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 
@@ -119,9 +113,6 @@ https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
 
 edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
 https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
-
-gorilla/context (BSD-3) https://github.com/gorilla/context
-https://github.com/gorilla/context/blob/master/LICENSE
 
 kr/logfmt (Unspecified) https://github.com/kr/logfmt
 https://github.com/kr/logfmt/blob/master/Readme


### PR DESCRIPTION
Also check that we don't have unnecessary attributions here as well, since devs can also remove dependencies that we don't need to attribute anymore.

This also fixes all of the attributions that are unneeded, namely gorilla/context and the influxdb libraries we used to use with export-distro but dropped IIRC. 