### PR TITLE
Remove platform dependencies from TokenProvider unit tests.

### DIFF
--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -142,7 +142,7 @@ func (b *Bootstrap) Handler(
 	<-healthOkCh
 
 	//Step 4: Launch token handler
-	tokenProvider := NewTokenProvider(ctx, loggingClient)
+	tokenProvider := NewTokenProvider(ctx, loggingClient, ExecWrapper{})
 	if configuration.SecretService.TokenProvider != "" {
 		if err := tokenProvider.SetConfiguration(configuration.SecretService); err != nil {
 			loggingClient.Error(fmt.Sprintf("failed to configure token provider: %s", err.Error()))

--- a/internal/security/secretstore/tokenprovider.go
+++ b/internal/security/secretstore/tokenprovider.go
@@ -29,22 +29,45 @@ import (
 
 const OneShotProvider = "oneshot"
 
+type ExecRunner interface {
+	LookPath(file string) (string, error)
+	CommandContext(ctx context.Context, name string, arg ...string) CmdRunner
+}
+
+type CmdRunner interface {
+	Start() error
+	Wait() error
+}
+
+type ExecWrapper struct{}
+
+func (w ExecWrapper) LookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+func (w ExecWrapper) CommandContext(ctx context.Context, name string, arg ...string) CmdRunner {
+	return exec.CommandContext(ctx, name, arg...)
+}
+
 type TokenProvider struct {
 	loggingClient logger.LoggingClient
 	ctx           context.Context
+	execRunner    ExecRunner
 	initialized   bool
 	config        secretstoreclient.SecretServiceInfo
 	resolvedPath  string
 }
 
 // NewTokenProvider creates a new TokenProvider
-func NewTokenProvider(ctx context.Context, loggingClient logger.LoggingClient) *TokenProvider {
+func NewTokenProvider(ctx context.Context, loggingClient logger.LoggingClient, execRunner ExecRunner) *TokenProvider {
 	return &TokenProvider{
 		loggingClient: loggingClient,
 		ctx:           ctx,
+		execRunner:    execRunner,
 	}
 }
 
+// SetConfiguration parses token provider configuration and resolves paths specified therein
 func (p *TokenProvider) SetConfiguration(config secretstoreclient.SecretServiceInfo) error {
 	var err error
 	p.config = config
@@ -53,7 +76,7 @@ func (p *TokenProvider) SetConfiguration(config secretstoreclient.SecretServiceI
 		p.loggingClient.Error(err.Error())
 		return err
 	}
-	resolvedPath, err := exec.LookPath(p.config.TokenProvider)
+	resolvedPath, err := p.execRunner.LookPath(p.config.TokenProvider)
 	if err != nil {
 		p.loggingClient.Error(fmt.Sprintf("Failed to locate %s on PATH: %s", p.config.TokenProvider, err.Error()))
 		return err
@@ -63,6 +86,7 @@ func (p *TokenProvider) SetConfiguration(config secretstoreclient.SecretServiceI
 	return nil
 }
 
+// Launch spawns the token provider function
 func (p *TokenProvider) Launch() error {
 	if !p.initialized {
 		err := fmt.Errorf("TokenProvider object not initialized; call SetConfiguration() first")
@@ -70,7 +94,7 @@ func (p *TokenProvider) Launch() error {
 	}
 
 	p.loggingClient.Info(fmt.Sprintf("Launching token provider %s with arguments %s", p.resolvedPath, strings.Join(p.config.TokenProviderArgs, " ")))
-	cmd := exec.CommandContext(p.ctx, p.resolvedPath, p.config.TokenProviderArgs...)
+	cmd := p.execRunner.CommandContext(p.ctx, p.resolvedPath, p.config.TokenProviderArgs...)
 	if err := cmd.Start(); err != nil {
 		// For example, this might occur if a shared library was missing
 		p.loggingClient.Error(fmt.Sprintf("%s failed to launch: %s", p.resolvedPath, err.Error()))

--- a/internal/security/secretstore/tokenprovider_linux_test.go
+++ b/internal/security/secretstore/tokenprovider_linux_test.go
@@ -1,0 +1,56 @@
+// +build linux
+
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package secretstore
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCreatesFile only runs on Linux and makes sure the code can
+// run a real executable taking real arguments.
+func TestCreatesFile(t *testing.T) {
+	const testfile = "/tmp/tokenprovider_linux_test.dat"
+	config := secretstoreclient.SecretServiceInfo{
+		TokenProvider:     "/usr/bin/touch",
+		TokenProviderType: OneShotProvider,
+		TokenProviderArgs: []string{testfile},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	err := os.RemoveAll(testfile)
+	defer os.RemoveAll(testfile) // cleanup
+
+	p := NewTokenProvider(ctx, logger.MockLogger{}, ExecWrapper{})
+	p.SetConfiguration(config)
+	assert.NoError(t, err)
+
+	p.Launch()
+	defer cancel()
+
+	file, err := os.Open(testfile)
+	defer file.Close()
+	assert.NoError(t, err) // fails if file wasn't created
+}


### PR DESCRIPTION
Remove platform dependencies from TokenProvider unit tests.

Fixes #2233.

Remove platform dependencies (assumption of /bin/false, /bin/true,
and /bin/echo) from the unit tests by injecting a dependency
that abstracts the concrete implementation of os.exec and os.Cmd.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>