### PR TITLE
Remove global variable mdc from core data

### DIFF
--- a/internal/core/data/container/metadata.go
+++ b/internal/core/data/container/metadata.go
@@ -1,0 +1,29 @@
+/********************************************************************************
+ *  Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package container
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+)
+
+// MetadataDeviceClientName contains the name of the Metadata device client instance in the DIC.
+var MetadataDeviceClientName = "MetadataDeviceClient"
+
+// MetadataDeviceClientFrom helper function queries the DIC and returns the Metadata device client instance.
+func MetadataDeviceClientFrom(get di.Get) metadata.DeviceClient {
+	return get(MetadataDeviceClientName).(metadata.DeviceClient)
+}

--- a/internal/core/data/device.go
+++ b/internal/core/data/device.go
@@ -17,12 +17,13 @@ import (
 	"context"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
 // Update when the device was last reported connected
-func updateDeviceLastReportedConnected(device string, loggingClient logger.LoggingClient) {
+func updateDeviceLastReportedConnected(device string, loggingClient logger.LoggingClient, mdc metadata.DeviceClient) {
 	// Config set to skip update last reported
 	if !Configuration.Writable.DeviceUpdateLastConnected {
 		loggingClient.Debug("Skipping update of device connected/reported times for:  " + device)
@@ -43,7 +44,7 @@ func updateDeviceLastReportedConnected(device string, loggingClient logger.Loggi
 
 	t := db.MakeTimestamp()
 	// Found device, now update lastReported
-	//Use of context.Background because this function is invoked asynchronously from a channel
+	// Use of context.Background because this function is invoked asynchronously from a channel
 	err = mdc.UpdateLastConnectedByName(d.Name, t, context.Background())
 	if err != nil {
 		loggingClient.Error("Problems updating last connected value for device: " + d.Name)
@@ -57,7 +58,11 @@ func updateDeviceLastReportedConnected(device string, loggingClient logger.Loggi
 }
 
 // Update when the device service was last reported connected
-func updateDeviceServiceLastReportedConnected(device string, loggingClient logger.LoggingClient) {
+func updateDeviceServiceLastReportedConnected(
+	device string,
+	loggingClient logger.LoggingClient,
+	mdc metadata.DeviceClient) {
+
 	if !Configuration.Writable.ServiceUpdateLastConnected {
 		loggingClient.Debug("Skipping update of device service connected/reported times for:  " + device)
 		return
@@ -85,12 +90,12 @@ func updateDeviceServiceLastReportedConnected(device string, loggingClient logge
 		return
 	}
 
-	//Use of context.Background because this function is invoked asynchronously from a channel
+	// Use of context.Background because this function is invoked asynchronously from a channel
 	msc.UpdateLastConnected(s.Id, t, context.Background())
 	msc.UpdateLastReported(s.Id, t, context.Background())
 }
 
-func checkDevice(device string, ctx context.Context) error {
+func checkDevice(device string, ctx context.Context, mdc metadata.DeviceClient) error {
 	if Configuration.Writable.MetaDataCheck {
 		_, err := mdc.CheckForDevice(device, ctx)
 		if err != nil {

--- a/internal/core/data/domain_events.go
+++ b/internal/core/data/domain_events.go
@@ -13,7 +13,10 @@
  *******************************************************************************/
 package data
 
-import "github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+)
 
 // An event indicating that a given device has just reported some data
 type DeviceLastReported struct {
@@ -25,7 +28,7 @@ type DeviceServiceLastReported struct {
 	DeviceName string
 }
 
-func initEventHandlers(loggingClient logger.LoggingClient, chEvents <-chan interface{}) {
+func initEventHandlers(loggingClient logger.LoggingClient, chEvents <-chan interface{}, mdc metadata.DeviceClient) {
 	go func() {
 		for {
 			select {
@@ -34,11 +37,11 @@ func initEventHandlers(loggingClient logger.LoggingClient, chEvents <-chan inter
 					switch e.(type) {
 					case DeviceLastReported:
 						dlr := e.(DeviceLastReported)
-						updateDeviceLastReportedConnected(dlr.DeviceName, loggingClient)
+						updateDeviceLastReportedConnected(dlr.DeviceName, loggingClient, mdc)
 						break
 					case DeviceServiceLastReported:
 						dslr := e.(DeviceServiceLastReported)
-						updateDeviceServiceLastReportedConnected(dslr.DeviceName, loggingClient)
+						updateDeviceServiceLastReportedConnected(dslr.DeviceName, loggingClient, mdc)
 						break
 					}
 				} else {

--- a/internal/core/data/reading.go
+++ b/internal/core/data/reading.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
@@ -194,9 +195,10 @@ func getReadingsByDevice(
 	limit int,
 	ctx context.Context,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) (readings []contract.Reading, err error) {
+	dbClient interfaces.DBClient,
+	mdc metadata.DeviceClient) (readings []contract.Reading, err error) {
 
-	if checkDevice(deviceId, ctx) != nil {
+	if checkDevice(deviceId, ctx, mdc) != nil {
 		loggingClient.Error(fmt.Sprintf("error checking device %s %v", deviceId, err))
 
 		return []contract.Reading{}, err

--- a/internal/core/data/reading_test.go
+++ b/internal/core/data/reading_test.go
@@ -172,7 +172,7 @@ func TestGetReadingsByDevice(t *testing.T) {
 	reset()
 	dbClientMock := &dbMock.DBClient{}
 	dbClientMock.On("ReadingsByDevice", mock.Anything, mock.Anything).Return(buildReadings(), nil)
-	expectedReadings, err := getReadingsByDevice("valid", 0, context.Background(), logger.NewMockClient(), dbClientMock)
+	expectedReadings, err := getReadingsByDevice("valid", 0, context.Background(), logger.NewMockClient(), dbClientMock, newMockDeviceClient())
 	if err != nil {
 		t.Errorf("Unexpected error in getReadingsByDevice")
 	}
@@ -186,7 +186,7 @@ func TestGetReadingsByDeviceError(t *testing.T) {
 	reset()
 	dbClientMock := &dbMock.DBClient{}
 	dbClientMock.On("ReadingsByDevice", mock.Anything, mock.Anything).Return([]models.Reading{}, fmt.Errorf("some error"))
-	_, err := getReadingsByDevice("error", 0, context.Background(), logger.NewMockClient(), dbClientMock)
+	_, err := getReadingsByDevice("error", 0, context.Background(), logger.NewMockClient(), dbClientMock, newMockDeviceClient())
 	if err == nil {
 		t.Errorf("Expected error in getReadingsByDevice")
 	}

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
@@ -186,7 +187,8 @@ func getValueDescriptorsByDeviceName(
 	name string,
 	ctx context.Context,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
+	dbClient interfaces.DBClient,
+	mdc metadata.DeviceClient) (vdList []contract.ValueDescriptor, err error) {
 
 	// Get the device
 	device, err := mdc.DeviceForName(name, ctx)
@@ -202,7 +204,8 @@ func getValueDescriptorsByDeviceId(
 	id string,
 	ctx context.Context,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
+	dbClient interfaces.DBClient,
+	mdc metadata.DeviceClient) (vdList []contract.ValueDescriptor, err error) {
 
 	// Get the device
 	device, err := mdc.Device(id, ctx)

--- a/internal/core/data/valuedescriptor_test.go
+++ b/internal/core/data/valuedescriptor_test.go
@@ -245,7 +245,6 @@ func TestGetValueDescriptorsByTypeError(t *testing.T) {
 	reset()
 	dbClientMock := &mocks.DBClient{}
 	dbClientMock.On("ValueDescriptorsByType", mock.Anything).Return([]models.ValueDescriptor{}, fmt.Errorf("some error"))
-	mdc = newMockDeviceClient()
 	_, err := getValueDescriptorsByType("R", logger.NewMockClient(), dbClientMock)
 
 	if err == nil {
@@ -255,7 +254,7 @@ func TestGetValueDescriptorsByTypeError(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceName(t *testing.T) {
 	reset()
-	_, err := getValueDescriptorsByDeviceName(testDeviceName, context.Background(), logger.NewMockClient(), nil)
+	_, err := getValueDescriptorsByDeviceName(testDeviceName, context.Background(), logger.NewMockClient(), nil, newMockDeviceClient())
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by device name")
 	}
@@ -263,7 +262,7 @@ func TestGetValueDescriptorsByDeviceName(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceNameNotFound(t *testing.T) {
 	reset()
-	_, err := getValueDescriptorsByDeviceName("404", context.Background(), logger.NewMockClient(), nil)
+	_, err := getValueDescriptorsByDeviceName("404", context.Background(), logger.NewMockClient(), nil, newMockDeviceClient())
 	if err != nil {
 		switch err := err.(type) {
 		case types.ErrServiceClient:
@@ -283,7 +282,7 @@ func TestGetValueDescriptorsByDeviceNameNotFound(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceNameError(t *testing.T) {
 	reset()
-	_, err := getValueDescriptorsByDeviceName("error", context.Background(), logger.NewMockClient(), nil)
+	_, err := getValueDescriptorsByDeviceName("error", context.Background(), logger.NewMockClient(), nil, newMockDeviceClient())
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by device name with some error")
 	}
@@ -291,7 +290,7 @@ func TestGetValueDescriptorsByDeviceNameError(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceId(t *testing.T) {
 	reset()
-	_, err := getValueDescriptorsByDeviceId("valid", context.Background(), logger.NewMockClient(), nil)
+	_, err := getValueDescriptorsByDeviceId("valid", context.Background(), logger.NewMockClient(), nil, newMockDeviceClient())
 	if err != nil {
 		t.Errorf("Unexpected error getting value descriptor by device id")
 	}
@@ -299,7 +298,7 @@ func TestGetValueDescriptorsByDeviceId(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceIdNotFound(t *testing.T) {
 	reset()
-	_, err := getValueDescriptorsByDeviceId("404", context.Background(), logger.NewMockClient(), nil)
+	_, err := getValueDescriptorsByDeviceId("404", context.Background(), logger.NewMockClient(), nil, newMockDeviceClient())
 	if err != nil {
 		switch err := err.(type) {
 		case types.ErrServiceClient:
@@ -319,7 +318,7 @@ func TestGetValueDescriptorsByDeviceIdNotFound(t *testing.T) {
 
 func TestGetValueDescriptorsByDeviceIdError(t *testing.T) {
 	reset()
-	_, err := getValueDescriptorsByDeviceId("error", context.Background(), logger.NewMockClient(), nil)
+	_, err := getValueDescriptorsByDeviceId("error", context.Background(), logger.NewMockClient(), nil, newMockDeviceClient())
 	if err == nil {
 		t.Errorf("Expected error getting value descriptor by device id with some error")
 	}


### PR DESCRIPTION
Fix #2028

Remove the global variable mdc(metadata client), and instead use the DI
container to create and pass an instance to functions/methods which need
it.

Update function/method signatures to accept the metadata client as a
parameter.

Update tests to work with changes to the production code.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>