### PR TITLE
Feature/issue 2029 coredata remove msc global

### DIFF
--- a/internal/core/data/device.go
+++ b/internal/core/data/device.go
@@ -61,7 +61,8 @@ func updateDeviceLastReportedConnected(device string, loggingClient logger.Loggi
 func updateDeviceServiceLastReportedConnected(
 	device string,
 	loggingClient logger.LoggingClient,
-	mdc metadata.DeviceClient) {
+	mdc metadata.DeviceClient,
+	msc metadata.DeviceServiceClient) {
 
 	if !Configuration.Writable.ServiceUpdateLastConnected {
 		loggingClient.Debug("Skipping update of device service connected/reported times for:  " + device)

--- a/internal/core/data/domain_events.go
+++ b/internal/core/data/domain_events.go
@@ -28,7 +28,12 @@ type DeviceServiceLastReported struct {
 	DeviceName string
 }
 
-func initEventHandlers(loggingClient logger.LoggingClient, chEvents <-chan interface{}, mdc metadata.DeviceClient) {
+func initEventHandlers(
+	loggingClient logger.LoggingClient,
+	chEvents <-chan interface{},
+	mdc metadata.DeviceClient,
+	msc metadata.DeviceServiceClient) {
+
 	go func() {
 		for {
 			select {
@@ -41,7 +46,7 @@ func initEventHandlers(loggingClient logger.LoggingClient, chEvents <-chan inter
 						break
 					case DeviceServiceLastReported:
 						dslr := e.(DeviceServiceLastReported)
-						updateDeviceServiceLastReportedConnected(dslr.DeviceName, loggingClient, mdc)
+						updateDeviceServiceLastReportedConnected(dslr.DeviceName, loggingClient, mdc, msc)
 						break
 					}
 				} else {

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -37,10 +37,6 @@ import (
 
 // Global variables
 var Configuration = &ConfigurationStruct{}
-
-// TODO: Refactor names in separate PR: See comments on PR #1133
-var msc metadata.DeviceServiceClient
-
 var httpErrorHandler errorconcept.ErrorHandler
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
@@ -60,7 +56,7 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 			Interval:    Configuration.Service.ClientMonitor,
 		},
 		endpoint.Endpoint{RegistryClient: &registryClient})
-	msc = metadata.NewDeviceServiceClient(
+	msc := metadata.NewDeviceServiceClient(
 		types.EndpointParams{
 			ServiceKey:  clients.CoreMetaDataServiceKey,
 			Path:        clients.ApiDeviceServiceRoute,
@@ -88,7 +84,7 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 
 	chEvents := make(chan interface{}, 100)
 	// initialize event handlers
-	initEventHandlers(loggingClient, chEvents, mdc)
+	initEventHandlers(loggingClient, chEvents, mdc, msc)
 
 	dic.Update(di.ServiceConstructorMap{
 		dataContainer.MetadataDeviceClientName: func(get di.Get) interface{} {


### PR DESCRIPTION
  
    Fix #2029
    
    Remove mdc(Metadata DeviceService client) global and instead pass an
    instance to the functions/methods which need it.
    
    Update functions/methods referring to the mdc global variable to accept
    the client as arguments.
    
    Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>
