### PR TITLE
Rename non-global logging client references

### DIFF
--- a/internal/core/command/device.go
+++ b/internal/core/command/device.go
@@ -35,7 +35,7 @@ func executeCommandByDeviceID(
 	queryParams string,
 	isPutCommand bool,
 	ctx context.Context,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient) (string, error) {
 
@@ -66,7 +66,7 @@ func executeCommandByDeviceID(
 		return "", errors.NewErrCommandNotAssociatedWithDevice(commandID, deviceID)
 	}
 
-	return executeCommandByDevice(d, c, body, queryParams, isPutCommand, ctx, loggingClient)
+	return executeCommandByDevice(d, c, body, queryParams, isPutCommand, ctx, lc)
 }
 
 func executeCommandByName(
@@ -76,7 +76,7 @@ func executeCommandByName(
 	queryParams string,
 	isPutCommand bool,
 	ctx context.Context,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient) (string, error) {
 
@@ -94,7 +94,7 @@ func executeCommandByName(
 		return "", err
 	}
 
-	return executeCommandByDevice(d, command, body, queryParams, isPutCommand, ctx, loggingClient)
+	return executeCommandByDevice(d, command, body, queryParams, isPutCommand, ctx, lc)
 }
 
 func executeCommandByDevice(
@@ -104,14 +104,14 @@ func executeCommandByDevice(
 	queryParams string,
 	isPutCommand bool,
 	ctx context.Context,
-	loggingClient logger.LoggingClient) (string, error) {
+	lc logger.LoggingClient) (string, error) {
 
 	var ex Executor
 	var err error
 	if isPutCommand {
-		ex, err = NewPutCommand(device, command, body, ctx, &http.Client{}, loggingClient)
+		ex, err = NewPutCommand(device, command, body, ctx, &http.Client{}, lc)
 	} else {
-		ex, err = NewGetCommand(device, command, queryParams, ctx, &http.Client{}, loggingClient)
+		ex, err = NewGetCommand(device, command, queryParams, ctx, &http.Client{}, lc)
 	}
 
 	if err != nil {

--- a/internal/core/command/get.go
+++ b/internal/core/command/get.go
@@ -33,7 +33,7 @@ func NewGetCommand(
 	queryParams string,
 	context context.Context,
 	httpCaller internal.HttpCaller,
-	loggingClient logger.LoggingClient) (Executor, error) {
+	lc logger.LoggingClient) (Executor, error) {
 	urlResult := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Get.Action.Path, DEVICEIDURLPARAM, device.Id, -1) + "?" + queryParams
 	validURL, err := url.ParseRequestURI(urlResult)
 	if err != nil {
@@ -49,5 +49,5 @@ func NewGetCommand(
 		request.Header.Set(clients.CorrelationHeader, correlationID.(string))
 	}
 
-	return newServiceCommand(device, httpCaller, request, loggingClient), nil
+	return newServiceCommand(device, httpCaller, request, lc), nil
 }

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -37,7 +37,7 @@ import (
 func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	registryClient := bootstrapContainer.RegistryFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
-	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 
 	// initialize clients required by the service
 	dic.Update(di.ServiceConstructorMap{
@@ -53,7 +53,7 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 				endpoint.Endpoint{RegistryClient: &registryClient})
 		},
 		errorContainer.ErrorHandlerName: func(get di.Get) interface{} {
-			return errorconcept.NewErrorHandler(loggingClient)
+			return errorconcept.NewErrorHandler(lc)
 		},
 	})
 

--- a/internal/core/command/put.go
+++ b/internal/core/command/put.go
@@ -32,7 +32,7 @@ func NewPutCommand(
 	body string,
 	context context.Context,
 	httpCaller internal.HttpCaller,
-	loggingClient logger.LoggingClient) (Executor, error) {
+	lc logger.LoggingClient) (Executor, error) {
 	url := device.Service.Addressable.GetBaseURL() + strings.Replace(command.Put.Action.Path, DEVICEIDURLPARAM, device.Id, -1)
 	request, err := http.NewRequest(http.MethodPut, url, strings.NewReader(body))
 	if err != nil {
@@ -44,5 +44,5 @@ func NewPutCommand(
 		request.Header.Set(clients.CorrelationHeader, correlationID.(string))
 	}
 
-	return newServiceCommand(device, httpCaller, request, loggingClient), nil
+	return newServiceCommand(device, httpCaller, request, lc), nil
 }

--- a/internal/core/command/restDevice.go
+++ b/internal/core/command/restDevice.go
@@ -32,30 +32,30 @@ import (
 func restGetDeviceCommandByCommandID(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
 	httpErrorHandler errorconcept.ErrorHandler) {
 
-	issueDeviceCommand(w, r, false, loggingClient, dbClient, deviceClient, httpErrorHandler)
+	issueDeviceCommand(w, r, false, lc, dbClient, deviceClient, httpErrorHandler)
 }
 
 func restPutDeviceCommandByCommandID(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
 	httpErrorHandler errorconcept.ErrorHandler) {
 
-	issueDeviceCommand(w, r, true, loggingClient, dbClient, deviceClient, httpErrorHandler)
+	issueDeviceCommand(w, r, true, lc, dbClient, deviceClient, httpErrorHandler)
 }
 
 func issueDeviceCommand(
 	w http.ResponseWriter,
 	r *http.Request,
 	isPutCommand bool,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
 	httpErrorHandler errorconcept.ErrorHandler) {
@@ -67,7 +67,7 @@ func issueDeviceCommand(
 	cid := vars[COMMANDID]
 	b, err := ioutil.ReadAll(r.Body)
 	if b == nil && err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
@@ -79,7 +79,7 @@ func issueDeviceCommand(
 		r.URL.RawQuery,
 		isPutCommand,
 		ctx,
-		loggingClient,
+		lc,
 		dbClient,
 		deviceClient)
 	if err != nil {
@@ -104,30 +104,30 @@ func issueDeviceCommand(
 func restGetDeviceCommandByNames(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
 	httpErrorHandler errorconcept.ErrorHandler) {
 
-	issueDeviceCommandByNames(w, r, false, loggingClient, dbClient, deviceClient, httpErrorHandler)
+	issueDeviceCommandByNames(w, r, false, lc, dbClient, deviceClient, httpErrorHandler)
 }
 
 func restPutDeviceCommandByNames(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
 	httpErrorHandler errorconcept.ErrorHandler) {
 
-	issueDeviceCommandByNames(w, r, true, loggingClient, dbClient, deviceClient, httpErrorHandler)
+	issueDeviceCommandByNames(w, r, true, lc, dbClient, deviceClient, httpErrorHandler)
 }
 
 func issueDeviceCommandByNames(
 	w http.ResponseWriter,
 	r *http.Request,
 	isPutCommand bool,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
 	httpErrorHandler errorconcept.ErrorHandler) {
@@ -152,7 +152,7 @@ func issueDeviceCommandByNames(
 		r.URL.RawQuery,
 		isPutCommand,
 		ctx,
-		loggingClient,
+		lc,
 		dbClient,
 		deviceClient)
 

--- a/internal/core/command/types.go
+++ b/internal/core/command/types.go
@@ -57,11 +57,11 @@ func newServiceCommand(
 	device contract.Device,
 	caller internal.HttpCaller,
 	req *http.Request,
-	loggingClient logger.LoggingClient) serviceCommand {
+	lc logger.LoggingClient) serviceCommand {
 	return serviceCommand{
 		Device:        device,
 		HttpCaller:    caller,
 		Request:       req,
-		LoggingClient: loggingClient,
+		LoggingClient: lc,
 	}
 }

--- a/internal/core/data/device.go
+++ b/internal/core/data/device.go
@@ -26,25 +26,24 @@ import (
 // Update when the device was last reported connected
 func updateDeviceLastReportedConnected(
 	device string,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	mdc metadata.DeviceClient,
 	configuration *config.ConfigurationStruct) {
-
 	// Config set to skip update last reported
 	if !configuration.Writable.DeviceUpdateLastConnected {
-		loggingClient.Debug("Skipping update of device connected/reported times for:  " + device)
+		lc.Debug("Skipping update of device connected/reported times for:  " + device)
 		return
 	}
 
 	d, err := mdc.CheckForDevice(device, context.Background())
 	if err != nil {
-		loggingClient.Error("Error getting device " + device + ": " + err.Error())
+		lc.Error("Error getting device " + device + ": " + err.Error())
 		return
 	}
 
 	// Couldn't find device
 	if len(d.Name) == 0 {
-		loggingClient.Error("Error updating device connected/reported times.  Unknown device with identifier of:  " + device)
+		lc.Error("Error updating device connected/reported times.  Unknown device with identifier of:  " + device)
 		return
 	}
 
@@ -53,12 +52,12 @@ func updateDeviceLastReportedConnected(
 	// Use of context.Background because this function is invoked asynchronously from a channel
 	err = mdc.UpdateLastConnectedByName(d.Name, t, context.Background())
 	if err != nil {
-		loggingClient.Error("Problems updating last connected value for device: " + d.Name)
+		lc.Error("Problems updating last connected value for device: " + d.Name)
 		return
 	}
 	err = mdc.UpdateLastReportedByName(d.Name, t, context.Background())
 	if err != nil {
-		loggingClient.Error("Problems updating last reported value for device: " + d.Name)
+		lc.Error("Problems updating last reported value for device: " + d.Name)
 	}
 	return
 }
@@ -66,13 +65,13 @@ func updateDeviceLastReportedConnected(
 // Update when the device service was last reported connected
 func updateDeviceServiceLastReportedConnected(
 	device string,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	mdc metadata.DeviceClient,
 	msc metadata.DeviceServiceClient,
 	configuration *config.ConfigurationStruct) {
 
 	if !configuration.Writable.ServiceUpdateLastConnected {
-		loggingClient.Debug("Skipping update of device service connected/reported times for:  " + device)
+		lc.Debug("Skipping update of device service connected/reported times for:  " + device)
 		return
 	}
 
@@ -81,20 +80,20 @@ func updateDeviceServiceLastReportedConnected(
 	// Get the device
 	d, err := mdc.CheckForDevice(device, context.Background())
 	if err != nil {
-		loggingClient.Error("Error getting device " + device + ": " + err.Error())
+		lc.Error("Error getting device " + device + ": " + err.Error())
 		return
 	}
 
 	// Couldn't find device
 	if len(d.Name) == 0 {
-		loggingClient.Error("Error updating device connected/reported times.  Unknown device with identifier of:  " + device)
+		lc.Error("Error updating device connected/reported times.  Unknown device with identifier of:  " + device)
 		return
 	}
 
 	// Get the device service
 	s := d.Service
 	if &s == nil {
-		loggingClient.Error("Error updating device service connected/reported times.  Unknown device service in device:  " + d.Name)
+		lc.Error("Error updating device service connected/reported times.  Unknown device service in device:  " + d.Name)
 		return
 	}
 

--- a/internal/core/data/domain_events.go
+++ b/internal/core/data/domain_events.go
@@ -31,12 +31,11 @@ type DeviceServiceLastReported struct {
 }
 
 func initEventHandlers(
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	chEvents <-chan interface{},
 	mdc metadata.DeviceClient,
 	msc metadata.DeviceServiceClient,
 	configuration *config.ConfigurationStruct) {
-
 	go func() {
 		for {
 			select {
@@ -45,11 +44,11 @@ func initEventHandlers(
 					switch e.(type) {
 					case DeviceLastReported:
 						dlr := e.(DeviceLastReported)
-						updateDeviceLastReportedConnected(dlr.DeviceName, loggingClient, mdc, configuration)
+						updateDeviceLastReportedConnected(dlr.DeviceName, lc, mdc, configuration)
 						break
 					case DeviceServiceLastReported:
 						dslr := e.(DeviceServiceLastReported)
-						updateDeviceServiceLastReportedConnected(dslr.DeviceName, loggingClient, mdc, msc, configuration)
+						updateDeviceServiceLastReportedConnected(dslr.DeviceName, lc, mdc, msc, configuration)
 						break
 					}
 				} else {

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -37,7 +37,7 @@ import (
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
 func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	// update global variables.
-	loggingClient := container.LoggingClientFrom(dic.Get)
+	lc := container.LoggingClientFrom(dic.Get)
 	configuration := dataContainer.ConfigurationFrom(dic.Get)
 
 	// initialize clients required by service.
@@ -73,13 +73,13 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 		})
 
 	if err != nil {
-		loggingClient.Error(fmt.Sprintf("failed to create messaging client: %s", err.Error()))
+		lc.Error(fmt.Sprintf("failed to create messaging client: %s", err.Error()))
 		return false
 	}
 
 	chEvents := make(chan interface{}, 100)
 	// initialize event handlers
-	initEventHandlers(loggingClient, chEvents, mdc, msc, configuration)
+	initEventHandlers(lc, chEvents, mdc, msc, configuration)
 
 	dic.Update(di.ServiceConstructorMap{
 		dataContainer.MetadataDeviceClientName: func(get di.Get) interface{} {
@@ -92,7 +92,7 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 			return chEvents
 		},
 		errorContainer.ErrorHandlerName: func(get di.Get) interface{} {
-			return errorconcept.NewErrorHandler(loggingClient)
+			return errorconcept.NewErrorHandler(lc)
 		},
 	})
 

--- a/internal/core/data/utils.go
+++ b/internal/core/data/utils.go
@@ -25,20 +25,20 @@ import (
 
 // Printing function purely for debugging purposes
 // Print the body of a request to the console
-func printBody(r io.ReadCloser, loggingClient logger.LoggingClient) {
+func printBody(r io.ReadCloser, lc logger.LoggingClient) {
 	body, err := ioutil.ReadAll(r)
 	bodyString := string(body)
 
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 	}
 
-	loggingClient.Info(bodyString)
+	lc.Info(bodyString)
 }
 
-func checkMaxLimit(limit int, loggingClient logger.LoggingClient, configuration *config.ConfigurationStruct) error {
+func checkMaxLimit(limit int, lc logger.LoggingClient, configuration *config.ConfigurationStruct) error {
 	if limit > configuration.Service.MaxResultCount {
-		loggingClient.Error(maxExceededString)
+		lc.Error(maxExceededString)
 		return errors.NewErrLimitExceeded(limit)
 	}
 

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -36,7 +36,7 @@ const (
 )
 
 // Check if the value descriptor matches the format string regular expression
-func validateFormatString(v contract.ValueDescriptor, loggingClient logger.LoggingClient) error {
+func validateFormatString(v contract.ValueDescriptor, lc logger.LoggingClient) error {
 	// No formatting specified
 	if v.Formatting == "" {
 		return nil
@@ -45,12 +45,12 @@ func validateFormatString(v contract.ValueDescriptor, loggingClient logger.Loggi
 	match, err := regexp.MatchString(formatSpecifier, v.Formatting)
 
 	if err != nil {
-		loggingClient.Error("Error checking for format string for value descriptor " + v.Name)
+		lc.Error("Error checking for format string for value descriptor " + v.Name)
 		return err
 	}
 	if !match {
 		err = fmt.Errorf("format is not a valid printf format")
-		loggingClient.Error(fmt.Sprintf("Error posting value descriptor. %s", err.Error()))
+		lc.Error(fmt.Sprintf("Error posting value descriptor. %s", err.Error()))
 		return errors.NewErrValueDescriptorInvalid(v.Name, err)
 	}
 
@@ -59,13 +59,13 @@ func validateFormatString(v contract.ValueDescriptor, loggingClient logger.Loggi
 
 func getValueDescriptorByName(
 	name string,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) (vd contract.ValueDescriptor, err error) {
 
 	vd, err = dbClient.ValueDescriptorByName(name)
 
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		if err == db.ErrNotFound {
 			return contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else {
@@ -78,13 +78,13 @@ func getValueDescriptorByName(
 
 func getValueDescriptorById(
 	id string,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) (vd contract.ValueDescriptor, err error) {
 
 	vd, err = dbClient.ValueDescriptorById(id)
 
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		if err == db.ErrNotFound {
 			return contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else if err == db.ErrInvalidObjectId {
@@ -99,13 +99,13 @@ func getValueDescriptorById(
 
 func getValueDescriptorsByUomLabel(
 	uomLabel string,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
 
 	vdList, err = dbClient.ValueDescriptorsByUomLabel(uomLabel)
 
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		if err == db.ErrNotFound {
 			return []contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else {
@@ -118,13 +118,13 @@ func getValueDescriptorsByUomLabel(
 
 func getValueDescriptorsByLabel(
 	label string,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
 
 	vdList, err = dbClient.ValueDescriptorsByLabel(label)
 
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		if err == db.ErrNotFound {
 			return []contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else {
@@ -137,13 +137,13 @@ func getValueDescriptorsByLabel(
 
 func getValueDescriptorsByType(
 	typ string,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
 
 	vdList, err = dbClient.ValueDescriptorsByType(typ)
 
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		if err == db.ErrNotFound {
 			return []contract.ValueDescriptor{}, errors.NewErrDbNotFound()
 		} else {
@@ -156,7 +156,7 @@ func getValueDescriptorsByType(
 
 func getValueDescriptorsByDevice(
 	device contract.Device,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) (vdList []contract.ValueDescriptor, err error) {
 
 	// Get the names of the value descriptors
@@ -166,7 +166,7 @@ func getValueDescriptorsByDevice(
 	// Get the value descriptors
 	vdList = []contract.ValueDescriptor{}
 	for _, name := range vdNames {
-		vd, err := getValueDescriptorByName(name, loggingClient, dbClient)
+		vd, err := getValueDescriptorByName(name, lc, dbClient)
 
 		// Not an error if not found
 		if err != nil {
@@ -187,44 +187,44 @@ func getValueDescriptorsByDevice(
 func getValueDescriptorsByDeviceName(
 	name string,
 	ctx context.Context,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient) (vdList []contract.ValueDescriptor, err error) {
 
 	// Get the device
 	device, err := mdc.DeviceForName(name, ctx)
 	if err != nil {
-		loggingClient.Error("Problem getting device from metadata: " + err.Error())
+		lc.Error("Problem getting device from metadata: " + err.Error())
 		return []contract.ValueDescriptor{}, err
 	}
 
-	return getValueDescriptorsByDevice(device, loggingClient, dbClient)
+	return getValueDescriptorsByDevice(device, lc, dbClient)
 }
 
 func getValueDescriptorsByDeviceId(
 	id string,
 	ctx context.Context,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient) (vdList []contract.ValueDescriptor, err error) {
 
 	// Get the device
 	device, err := mdc.Device(id, ctx)
 	if err != nil {
-		loggingClient.Error("Problem getting device from metadata: " + err.Error())
+		lc.Error("Problem getting device from metadata: " + err.Error())
 		return []contract.ValueDescriptor{}, err
 	}
 
-	return getValueDescriptorsByDevice(device, loggingClient, dbClient)
+	return getValueDescriptorsByDevice(device, lc, dbClient)
 }
 
 func getAllValueDescriptors(
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) (vd []contract.ValueDescriptor, err error) {
 
 	vd, err = dbClient.ValueDescriptors()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return nil, err
 	}
 
@@ -233,18 +233,18 @@ func getAllValueDescriptors(
 
 func decodeValueDescriptor(
 	reader io.ReadCloser,
-	loggingClient logger.LoggingClient) (vd contract.ValueDescriptor, err error) {
+	lc logger.LoggingClient) (vd contract.ValueDescriptor, err error) {
 
 	v := contract.ValueDescriptor{}
 	err = json.NewDecoder(reader).Decode(&v)
 	// Problems decoding
 	if err != nil {
-		loggingClient.Error("Error decoding the value descriptor: " + err.Error())
+		lc.Error("Error decoding the value descriptor: " + err.Error())
 		return contract.ValueDescriptor{}, errors.NewErrJsonDecoding(v.Name)
 	}
 
 	// Check the formatting
-	err = validateFormatString(v, loggingClient)
+	err = validateFormatString(v, lc)
 	if err != nil {
 		return contract.ValueDescriptor{}, err
 	}
@@ -254,12 +254,12 @@ func decodeValueDescriptor(
 
 func addValueDescriptor(
 	vd contract.ValueDescriptor,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) (id string, err error) {
 
 	id, err = dbClient.AddValueDescriptor(vd)
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		if err == db.ErrNotUnique {
 			return "", errors.NewErrDuplicateValueDescriptorName(vd.Name)
 		} else {
@@ -272,11 +272,11 @@ func addValueDescriptor(
 
 func updateValueDescriptor(
 	from contract.ValueDescriptor,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	configuration *config.ConfigurationStruct) error {
 
-	to, err := getValueDescriptorById(from.Id, loggingClient, dbClient)
+	to, err := getValueDescriptorById(from.Id, lc, dbClient)
 	if err != nil {
 		return err
 	}
@@ -291,11 +291,11 @@ func updateValueDescriptor(
 	if from.Formatting != "" {
 		match, err := regexp.MatchString(formatSpecifier, from.Formatting)
 		if err != nil {
-			loggingClient.Error("Error checking formatting for updated value descriptor")
+			lc.Error("Error checking formatting for updated value descriptor")
 			return err
 		}
 		if !match {
-			loggingClient.Error("value descriptor's format string doesn't fit the required pattern: " + formatSpecifier)
+			lc.Error("value descriptor's format string doesn't fit the required pattern: " + formatSpecifier)
 			return errors.NewErrValueDescriptorInvalid(from.Name, err)
 		}
 		to.Formatting = from.Formatting
@@ -313,14 +313,14 @@ func updateValueDescriptor(
 	if from.Name != "" {
 		// Check if value descriptor is still in use by readings if the name changes
 		if from.Name != to.Name {
-			r, err := getReadingsByValueDescriptor(to.Name, 10, loggingClient, dbClient, configuration) // Arbitrary limit, we're just checking if there are any readings
+			r, err := getReadingsByValueDescriptor(to.Name, 10, lc, dbClient, configuration) // Arbitrary limit, we're just checking if there are any readings
 			if err != nil {
-				loggingClient.Error("Error checking the readings for the value descriptor: " + err.Error())
+				lc.Error("Error checking the readings for the value descriptor: " + err.Error())
 				return err
 			}
 			// Value descriptor is still in use
 			if len(r) != 0 {
-				loggingClient.Error("Data integrity issue.  Value Descriptor with name:  " + from.Name + " is still referenced by existing readings.")
+				lc.Error("Data integrity issue.  Value Descriptor with name:  " + from.Name + " is still referenced by existing readings.")
 				return errors.NewErrValueDescriptorInUse(from.Name)
 			}
 		}
@@ -340,10 +340,10 @@ func updateValueDescriptor(
 	err = dbClient.UpdateValueDescriptor(to)
 	if err != nil {
 		if err == db.ErrNotUnique {
-			loggingClient.Error("Value descriptor name is not unique")
+			lc.Error("Value descriptor name is not unique")
 			return errors.NewErrDuplicateValueDescriptorName(to.Name)
 		} else {
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			return err
 		}
 	}
@@ -353,51 +353,51 @@ func updateValueDescriptor(
 
 func deleteValueDescriptor(
 	vd contract.ValueDescriptor,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) error {
 
 	// Check if the value descriptor is still in use by readings
 	readings, err := dbClient.ReadingsByValueDescriptor(vd.Name, 10)
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return err
 	}
 	if len(readings) > 0 {
-		loggingClient.Error("Data integrity issue.  Value Descriptor is still referenced by existing readings.")
+		lc.Error("Data integrity issue.  Value Descriptor is still referenced by existing readings.")
 		return errors.NewErrValueDescriptorInUse(vd.Name)
 	}
 
 	// Delete the value descriptor
 	if err = dbClient.DeleteValueDescriptorById(vd.Id); err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return err
 	}
 
 	return nil
 }
 
-func deleteValueDescriptorByName(name string, loggingClient logger.LoggingClient, dbClient interfaces.DBClient) error {
+func deleteValueDescriptorByName(name string, lc logger.LoggingClient, dbClient interfaces.DBClient) error {
 	// Check if the value descriptor exists
-	vd, err := getValueDescriptorByName(name, loggingClient, dbClient)
+	vd, err := getValueDescriptorByName(name, lc, dbClient)
 	if err != nil {
 		return err
 	}
 
-	if err = deleteValueDescriptor(vd, loggingClient, dbClient); err != nil {
+	if err = deleteValueDescriptor(vd, lc, dbClient); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func deleteValueDescriptorById(id string, loggingClient logger.LoggingClient, dbClient interfaces.DBClient) error {
+func deleteValueDescriptorById(id string, lc logger.LoggingClient, dbClient interfaces.DBClient) error {
 	// Check if the value descriptor exists
-	vd, err := getValueDescriptorById(id, loggingClient, dbClient)
+	vd, err := getValueDescriptorById(id, lc, dbClient)
 	if err != nil {
 		return err
 	}
 
-	if err = deleteValueDescriptor(vd, loggingClient, dbClient); err != nil {
+	if err = deleteValueDescriptor(vd, lc, dbClient); err != nil {
 		return err
 	}
 

--- a/internal/core/metadata/operators/device_profile/value_descriptor.go
+++ b/internal/core/metadata/operators/device_profile/value_descriptor.go
@@ -54,12 +54,12 @@ func (a addValueDescriptor) Execute() error {
 }
 
 // NewAddValueDescriptorExecutor creates a new ValueDescriptorAddExecutor.
-func NewAddValueDescriptorExecutor(ctx context.Context, client ValueDescriptorAdder, loggingClient logger.LoggingClient, drs ...contract.DeviceResource) ValueDescriptorAddExecutor {
+func NewAddValueDescriptorExecutor(ctx context.Context, client ValueDescriptorAdder, lc logger.LoggingClient, drs ...contract.DeviceResource) ValueDescriptorAddExecutor {
 	return addValueDescriptor{
 		ctx:    ctx,
 		drs:    drs,
 		client: client,
-		logger: loggingClient,
+		logger: lc,
 	}
 }
 

--- a/internal/core/metadata/rest_addressable.go
+++ b/internal/core/metadata/rest_addressable.go
@@ -34,12 +34,12 @@ import (
 
 func restGetAllAddressables(
 	w http.ResponseWriter,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler,
 	configuration *config.ConfigurationStruct) {
 
-	op := addressable.NewAddressableLoadAll(configuration.Service, dbClient, loggingClient)
+	op := addressable.NewAddressableLoadAll(configuration.Service, dbClient, lc)
 	addressables, err := op.Execute()
 	if err != nil {
 		errorHandler.HandleOneVariant(
@@ -61,7 +61,7 @@ func restGetAllAddressables(
 func restAddAddressable(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -89,7 +89,7 @@ func restAddAddressable(
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte(id))
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 }
@@ -98,7 +98,7 @@ func restAddAddressable(
 func restUpdateAddressable(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -128,7 +128,7 @@ func restUpdateAddressable(
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write([]byte("true"))
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 }

--- a/internal/core/metadata/rest_command.go
+++ b/internal/core/metadata/rest_command.go
@@ -31,7 +31,7 @@ import (
 
 func restGetAllCommands(
 	w http.ResponseWriter,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler,
 	configuration *config.ConfigurationStruct) {
@@ -46,13 +46,13 @@ func restGetAllCommands(
 			errorconcept.Default.InternalServerError)
 		return
 	}
-	pkg.Encode(&cmds, w, loggingClient)
+	pkg.Encode(&cmds, w, lc)
 }
 
 func restGetCommandById(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -73,13 +73,13 @@ func restGetCommandById(
 			errorconcept.Default.InternalServerError)
 		return
 	}
-	pkg.Encode(cmd, w, loggingClient)
+	pkg.Encode(cmd, w, lc)
 }
 
 func restGetCommandsByName(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -95,13 +95,13 @@ func restGetCommandsByName(
 		errorHandler.Handle(w, err, errorconcept.Common.RetrieveError_StatusInternalServer)
 		return
 	}
-	pkg.Encode(&cmds, w, loggingClient)
+	pkg.Encode(&cmds, w, lc)
 }
 
 func restGetCommandsByDeviceId(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -122,5 +122,5 @@ func restGetCommandsByDeviceId(
 			errorconcept.Default.InternalServerError)
 		return
 	}
-	pkg.Encode(&commands, w, loggingClient)
+	pkg.Encode(&commands, w, lc)
 }

--- a/internal/core/metadata/rest_devicereport.go
+++ b/internal/core/metadata/rest_devicereport.go
@@ -58,7 +58,7 @@ func restGetAllDeviceReports(
 func restAddDeviceReport(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -92,8 +92,8 @@ func restAddDeviceReport(
 	}
 
 	// Notify associates
-	if err := notifyDeviceReportAssociates(dr, http.MethodPost, loggingClient, dbClient); err != nil {
-		loggingClient.Error(err.Error())
+	if err := notifyDeviceReportAssociates(dr, http.MethodPost, lc, dbClient); err != nil {
+		lc.Error(err.Error())
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -103,7 +103,7 @@ func restAddDeviceReport(
 func restUpdateDeviceReport(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -131,7 +131,7 @@ func restUpdateDeviceReport(
 	}
 
 	if err := updateDeviceReportFields(from, &to, w, dbClient, errorHandler); err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
@@ -141,8 +141,8 @@ func restUpdateDeviceReport(
 	}
 
 	// Notify Associates
-	if err := notifyDeviceReportAssociates(to, http.MethodPut, loggingClient, dbClient); err != nil {
-		loggingClient.Error(err.Error())
+	if err := notifyDeviceReportAssociates(to, http.MethodPut, lc, dbClient); err != nil {
+		lc.Error(err.Error())
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -298,7 +298,7 @@ func restGetDeviceReportByDeviceName(
 func restDeleteReportById(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -312,8 +312,8 @@ func restDeleteReportById(
 		return
 	}
 
-	if err := deleteDeviceReport(dr, w, loggingClient, dbClient, errorHandler); err != nil {
-		loggingClient.Error(err.Error())
+	if err := deleteDeviceReport(dr, w, lc, dbClient, errorHandler); err != nil {
+		lc.Error(err.Error())
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -324,7 +324,7 @@ func restDeleteReportById(
 func restDeleteReportByName(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -342,8 +342,8 @@ func restDeleteReportByName(
 		return
 	}
 
-	if err = deleteDeviceReport(dr, w, loggingClient, dbClient, errorHandler); err != nil {
-		loggingClient.Error(err.Error())
+	if err = deleteDeviceReport(dr, w, lc, dbClient, errorHandler); err != nil {
+		lc.Error(err.Error())
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -354,7 +354,7 @@ func restDeleteReportByName(
 func deleteDeviceReport(
 	dr models.DeviceReport,
 	w http.ResponseWriter,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) error {
 
@@ -364,7 +364,7 @@ func deleteDeviceReport(
 	}
 
 	// Notify Associates
-	if err := notifyDeviceReportAssociates(dr, http.MethodDelete, loggingClient, dbClient); err != nil {
+	if err := notifyDeviceReportAssociates(dr, http.MethodDelete, lc, dbClient); err != nil {
 		return err
 	}
 
@@ -375,7 +375,7 @@ func deleteDeviceReport(
 func notifyDeviceReportAssociates(
 	dr models.DeviceReport,
 	action string,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) error {
 
 	// Get the device of the report
@@ -391,7 +391,7 @@ func notifyDeviceReportAssociates(
 	}
 
 	// Notify the associating device services
-	if err = notifyAssociates([]models.DeviceService{ds}, dr.Id, action, models.REPORT, loggingClient); err != nil {
+	if err = notifyAssociates([]models.DeviceService{ds}, dr.Id, action, models.REPORT, lc); err != nil {
 		return err
 	}
 

--- a/internal/core/metadata/rest_provisionwatcher.go
+++ b/internal/core/metadata/rest_provisionwatcher.go
@@ -56,7 +56,7 @@ func restGetProvisionWatchers(
 func restDeleteProvisionWatcherById(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -70,7 +70,7 @@ func restDeleteProvisionWatcherById(
 		return
 	}
 
-	err = deleteProvisionWatcher(pw, w, loggingClient, dbClient, errorHandler)
+	err = deleteProvisionWatcher(pw, w, lc, dbClient, errorHandler)
 	if err != nil {
 		errorHandler.Handle(w, err, errorconcept.ProvisionWatcher.DeleteError_StatusInternalServer)
 		return
@@ -82,7 +82,7 @@ func restDeleteProvisionWatcherById(
 func restDeleteProvisionWatcherByName(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -104,8 +104,8 @@ func restDeleteProvisionWatcherByName(
 		return
 	}
 
-	if err = deleteProvisionWatcher(pw, w, loggingClient, dbClient, errorHandler); err != nil {
-		loggingClient.Error("Problem deleting provision watcher: " + err.Error())
+	if err = deleteProvisionWatcher(pw, w, lc, dbClient, errorHandler); err != nil {
+		lc.Error("Problem deleting provision watcher: " + err.Error())
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -117,7 +117,7 @@ func restDeleteProvisionWatcherByName(
 func deleteProvisionWatcher(
 	pw models.ProvisionWatcher,
 	w http.ResponseWriter,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) error {
 
@@ -129,9 +129,9 @@ func deleteProvisionWatcher(
 	if err := notifyProvisionWatcherAssociates(
 		pw,
 		http.MethodDelete,
-		loggingClient,
+		lc,
 		dbClient); err != nil {
-		loggingClient.Error("Problem notifying associated device services to provision watcher: " + err.Error())
+		lc.Error("Problem notifying associated device services to provision watcher: " + err.Error())
 	}
 
 	return nil
@@ -329,7 +329,7 @@ func restGetProvisionWatchersByIdentifier(
 func restAddProvisionWatcher(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -401,8 +401,8 @@ func restAddProvisionWatcher(
 	}
 
 	// Notify Associates
-	if err = notifyProvisionWatcherAssociates(pw, http.MethodPost, loggingClient, dbClient); err != nil {
-		loggingClient.Error(
+	if err = notifyProvisionWatcherAssociates(pw, http.MethodPost, lc, dbClient); err != nil {
+		lc.Error(
 			"Problem with notifying associating device services for the provision watcher: " + err.Error())
 	}
 
@@ -416,7 +416,7 @@ func restAddProvisionWatcher(
 func restUpdateProvisionWatcher(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	errorHandler errorconcept.ErrorHandler) {
 
@@ -443,7 +443,7 @@ func restUpdateProvisionWatcher(
 	}
 
 	if err := updateProvisionWatcherFields(from, &to, w, dbClient, errorHandler); err != nil {
-		loggingClient.Error("Problem updating provision watcher: " + err.Error())
+		lc.Error("Problem updating provision watcher: " + err.Error())
 		return
 	}
 
@@ -453,8 +453,8 @@ func restUpdateProvisionWatcher(
 	}
 
 	// Notify Associates
-	if err := notifyProvisionWatcherAssociates(to, http.MethodPut, loggingClient, dbClient); err != nil {
-		loggingClient.Error("Problem notifying associated device services for provision watcher: " + err.Error())
+	if err := notifyProvisionWatcherAssociates(to, http.MethodPut, lc, dbClient); err != nil {
+		lc.Error("Problem notifying associated device services for provision watcher: " + err.Error())
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
@@ -496,7 +496,7 @@ func updateProvisionWatcherFields(
 func notifyProvisionWatcherAssociates(
 	pw models.ProvisionWatcher,
 	action string,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) error {
 
 	// Get the device service for the provision watcher
@@ -506,7 +506,7 @@ func notifyProvisionWatcherAssociates(
 	}
 
 	// Notify the service
-	err = notifyAssociates([]models.DeviceService{ds}, pw.Id, action, models.PROVISIONWATCHER, loggingClient)
+	err = notifyAssociates([]models.DeviceService{ds}, pw.Id, action, models.PROVISIONWATCHER, lc)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/db/redis/client.go
+++ b/internal/pkg/db/redis/client.go
@@ -59,7 +59,7 @@ func NewCoreDataClient(config db.Configuration, logger logger.LoggingClient) (*C
 }
 
 // Return a pointer to the Redis client
-func NewClient(config db.Configuration, loggingClient logger.LoggingClient) (*Client, error) {
+func NewClient(config db.Configuration, lc logger.LoggingClient) (*Client, error) {
 	once.Do(func() {
 		connectionString := fmt.Sprintf("%s:%d", config.Host, config.Port)
 		opts := []redis.DialOption{
@@ -95,7 +95,7 @@ func NewClient(config db.Configuration, loggingClient logger.LoggingClient) (*Cl
 				Dial:    dialFunc,
 			},
 			BatchSize:     batchSize,
-			loggingClient: loggingClient,
+			loggingClient: lc,
 		}
 	})
 	return currClient, nil

--- a/internal/pkg/telemetry/telemetry.go
+++ b/internal/pkg/telemetry/telemetry.go
@@ -82,8 +82,8 @@ func cpuUsageAverage() {
 // and is intended to supersede the existing StartCpuUsageAverage() function when the new bootstrap package is used
 // by all of the core services.
 func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
-	loggingClient := container.LoggingClientFrom(dic.Get)
-	loggingClient.Info("Telemetry starting")
+	lc := container.LoggingClientFrom(dic.Get)
+	lc.Info("Telemetry starting")
 
 	wg.Add(1)
 	go func() {
@@ -95,7 +95,7 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 			for seconds := 30; seconds > 0; seconds-- {
 				select {
 				case <-ctx.Done():
-					loggingClient.Info("Telemetry stopped")
+					lc.Info("Telemetry stopped")
 					return
 				default:
 					time.Sleep(time.Second)

--- a/internal/security/fileprovider/init.go
+++ b/internal/security/fileprovider/init.go
@@ -36,35 +36,35 @@ import (
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
 func Handler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	cfg := container.ConfigurationFrom(dic.Get)
-	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 
 	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
 	tokenProvider := authtokenloader.NewAuthTokenLoader(fileOpener)
 
 	var req internal.HttpCaller
 	if caFilePath := cfg.SecretService.CaFilePath; caFilePath != "" {
-		loggingClient.Info("using certificate verification for secret store connection")
+		lc.Info("using certificate verification for secret store connection")
 		caReader, err := fileOpener.OpenFileReader(caFilePath, os.O_RDONLY, 0400)
 		if err != nil {
-			loggingClient.Error(fmt.Sprintf("failed to load CA certificate: %s", err.Error()))
+			lc.Error(fmt.Sprintf("failed to load CA certificate: %s", err.Error()))
 			return false
 		}
-		req = secretstoreclient.NewRequestor(loggingClient).WithTLS(caReader, cfg.SecretService.ServerName)
+		req = secretstoreclient.NewRequestor(lc).WithTLS(caReader, cfg.SecretService.ServerName)
 	} else {
-		loggingClient.Info("bypassing certificate verification for secret store connection")
-		req = secretstoreclient.NewRequestor(loggingClient).Insecure()
+		lc.Info("bypassing certificate verification for secret store connection")
+		req = secretstoreclient.NewRequestor(lc).Insecure()
 	}
 	vaultScheme := cfg.SecretService.Scheme
 	vaultHost := fmt.Sprintf("%s:%v", cfg.SecretService.Server, cfg.SecretService.Port)
-	vaultClient := secretstoreclient.NewSecretStoreClient(loggingClient, req, vaultScheme, vaultHost)
+	vaultClient := secretstoreclient.NewSecretStoreClient(lc, req, vaultScheme, vaultHost)
 
-	fileProvider := NewTokenProvider(loggingClient, fileOpener, tokenProvider, vaultClient)
+	fileProvider := NewTokenProvider(lc, fileOpener, tokenProvider, vaultClient)
 
 	fileProvider.SetConfiguration(cfg.SecretService, cfg.TokenFileProvider)
 	err := fileProvider.Run()
 
 	if err != nil {
-		loggingClient.Error(fmt.Sprintf("error occurred generating tokens: %s", err.Error()))
+		lc.Error(fmt.Sprintf("error occurred generating tokens: %s", err.Error()))
 	}
 
 	return false // Tell bootstrap.Run() to exit wait loop and terminate

--- a/internal/security/proxy/certs.go
+++ b/internal/security/proxy/certs.go
@@ -45,13 +45,13 @@ func NewCertificateLoader(
 	certPath string,
 	tokenPath string,
 	secretServiceBaseUrl string,
-	loggingClient logger.LoggingClient) CertificateLoader {
+	lc logger.LoggingClient) CertificateLoader {
 
 	return certificate{
 		client:               r,
 		certPath:             certPath,
 		tokenPath:            tokenPath,
-		loggingClient:        loggingClient,
+		loggingClient:        lc,
 		secretServiceBaseUrl: secretServiceBaseUrl,
 	}
 }

--- a/internal/security/proxy/consumer.go
+++ b/internal/security/proxy/consumer.go
@@ -43,13 +43,13 @@ type Consumer struct {
 func NewConsumer(
 	name string,
 	r internal.HttpCaller,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	configuration *config.ConfigurationStruct) Consumer {
 
 	return Consumer{
 		name:          name,
 		client:        r,
-		loggingClient: loggingClient,
+		loggingClient: lc,
 		configuration: configuration,
 	}
 }

--- a/internal/security/proxy/init.go
+++ b/internal/security/proxy/init.go
@@ -57,14 +57,14 @@ func NewBootstrapHandler(
 	}
 }
 
-func (b *Bootstrap) errorAndHalt(loggingClient logger.LoggingClient, message string) {
-	loggingClient.Error(message)
+func (b *Bootstrap) errorAndHalt(lc logger.LoggingClient, message string) {
+	lc.Error(message)
 	os.Exit(1)
 }
 
-func (b *Bootstrap) haltIfError(loggingClient logger.LoggingClient, err error) {
+func (b *Bootstrap) haltIfError(lc logger.LoggingClient, err error) {
 	if err != nil {
-		b.errorAndHalt(loggingClient, err.Error())
+		b.errorAndHalt(lc, err.Error())
 	}
 }
 
@@ -75,64 +75,64 @@ func (b *Bootstrap) Handler(
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 
-	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 
 	req := NewRequestor(
 		b.insecureSkipVerify,
 		configuration.Writable.RequestTimeout,
 		configuration.SecretService.CACertPath,
-		loggingClient)
+		lc)
 	if req == nil {
 		os.Exit(1)
 	}
 
-	s := NewService(req, loggingClient, configuration)
-	b.haltIfError(loggingClient, s.CheckProxyServiceStatus())
+	s := NewService(req, lc, configuration)
+	b.haltIfError(lc, s.CheckProxyServiceStatus())
 
 	if b.initNeeded {
 		if b.resetNeeded {
-			b.errorAndHalt(loggingClient, "can't run initialization and reset at the same time for security service")
+			b.errorAndHalt(lc, "can't run initialization and reset at the same time for security service")
 		}
 
 		b.haltIfError(
-			loggingClient,
+			lc,
 			s.Init(
 				NewCertificateLoader(
 					req,
 					configuration.SecretService.CertPath,
 					configuration.SecretService.TokenPath,
 					configuration.SecretService.GetSecretSvcBaseURL(),
-					loggingClient,
+					lc,
 				),
 			),
 		) // Where the Service init is called
 	} else if b.resetNeeded {
-		b.haltIfError(loggingClient, s.ResetProxy())
+		b.haltIfError(lc, s.ResetProxy())
 	}
 
 	if b.userTobeCreated != "" && b.userOfGroup != "" {
-		c := NewConsumer(b.userTobeCreated, req, loggingClient, configuration)
-		b.haltIfError(loggingClient, c.Create(EdgeXKong))
-		b.haltIfError(loggingClient, c.AssociateWithGroup(b.userOfGroup))
+		c := NewConsumer(b.userTobeCreated, req, lc, configuration)
+		b.haltIfError(lc, c.Create(EdgeXKong))
+		b.haltIfError(lc, c.AssociateWithGroup(b.userOfGroup))
 
 		t, err := c.CreateToken()
 		if err != nil {
-			b.errorAndHalt(loggingClient, fmt.Sprintf("failed to create access token for edgex service due to error %s", err.Error()))
+			b.errorAndHalt(lc, fmt.Sprintf("failed to create access token for edgex service due to error %s", err.Error()))
 		}
 
 		fmt.Println(fmt.Sprintf("the access token for user %s is: %s. Please keep the token for accessing edgex services", b.userTobeCreated, t))
 
 		file, err := os.Create(configuration.KongAuth.OutputPath)
-		b.haltIfError(loggingClient, err)
+		b.haltIfError(lc, err)
 
 		utp := &UserTokenPair{User: b.userTobeCreated, Token: t}
-		b.haltIfError(loggingClient, utp.Save(file))
+		b.haltIfError(lc, utp.Save(file))
 	}
 
 	if b.userToBeDeleted != "" {
-		t := NewConsumer(b.userToBeDeleted, req, loggingClient, configuration)
-		b.haltIfError(loggingClient, t.Delete())
+		t := NewConsumer(b.userToBeDeleted, req, lc, configuration)
+		b.haltIfError(lc, t.Delete())
 	}
 
 	return false

--- a/internal/security/proxy/requestor.go
+++ b/internal/security/proxy/requestor.go
@@ -31,7 +31,7 @@ func NewRequestor(
 	skipVerify bool,
 	timeoutInSecond int,
 	caCertPath string,
-	loggingClient logger.LoggingClient) internal.HttpCaller {
+	lc logger.LoggingClient) internal.HttpCaller {
 
 	var tr *http.Transport
 	if skipVerify {
@@ -41,10 +41,10 @@ func NewRequestor(
 	} else {
 		caCert, err := ioutil.ReadFile(caCertPath)
 		if err != nil {
-			loggingClient.Error("failed to load rootCA certificate.")
+			lc.Error("failed to load rootCA certificate.")
 			return nil
 		}
-		loggingClient.Info("successfully loaded rootCA certificate.")
+		lc.Info("successfully loaded rootCA certificate.")
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 

--- a/internal/security/proxy/resource.go
+++ b/internal/security/proxy/resource.go
@@ -38,13 +38,13 @@ func NewResource(
 	name string,
 	r internal.HttpCaller,
 	kongProxyBaseUrl string,
-	loggingClient logger.LoggingClient) *Resource {
+	lc logger.LoggingClient) *Resource {
 
 	return &Resource{
 		name:             name,
 		client:           r,
 		kongProxyBaseUrl: kongProxyBaseUrl,
-		loggingClient:    loggingClient,
+		loggingClient:    lc,
 	}
 }
 

--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -56,12 +56,12 @@ type Service struct {
 
 func NewService(
 	r internal.HttpCaller,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	configuration *config.ConfigurationStruct) Service {
 
 	return Service{
 		client:        r,
-		loggingClient: loggingClient,
+		loggingClient: lc,
 		configuration: configuration,
 	}
 }

--- a/internal/security/secrets/command/cache/cache.go
+++ b/internal/security/secrets/command/cache/cache.go
@@ -40,12 +40,12 @@ type Command struct {
 }
 
 func NewCommand(
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	configuration *config.ConfigurationStruct,
 	generate *generate.Command) (*Command, *flag.FlagSet) {
 
 	return &Command{
-		loggingClient: loggingClient,
+		loggingClient: lc,
 		configuration: configuration,
 		generate:      generate,
 	}, flag.NewFlagSet(CommandName, flag.ExitOnError)

--- a/internal/security/secrets/command/generate/generate.go
+++ b/internal/security/secrets/command/generate/generate.go
@@ -48,11 +48,11 @@ type Command struct {
 }
 
 func NewCommand(
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	configuration *config.ConfigurationStruct) (*Command, *flag.FlagSet) {
 
 	return &Command{
-		loggingClient: loggingClient,
+		loggingClient: lc,
 		configuration: configuration,
 	}, flag.NewFlagSet(CommandName, flag.ExitOnError)
 }

--- a/internal/security/secrets/command/import/import.go
+++ b/internal/security/secrets/command/import/import.go
@@ -35,11 +35,11 @@ type Command struct {
 }
 
 func NewCommand(
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	configuration *config.ConfigurationStruct) (*Command, *flag.FlagSet) {
 
 	return &Command{
-		loggingClient: loggingClient,
+		loggingClient: lc,
 		configuration: configuration,
 	}, flag.NewFlagSet(CommandName, flag.ExitOnError)
 }

--- a/internal/security/secrets/command/legacy/legacy.go
+++ b/internal/security/secrets/command/legacy/legacy.go
@@ -31,9 +31,9 @@ type Command struct {
 	loggingClient logger.LoggingClient
 }
 
-func NewCommand(loggingClient logger.LoggingClient) (*Command, *flag.FlagSet) {
+func NewCommand(lc logger.LoggingClient) (*Command, *flag.FlagSet) {
 	command := Command{
-		loggingClient: loggingClient,
+		loggingClient: lc,
 	}
 	flags := flag.NewFlagSet(CommandName, flag.ExitOnError)
 	flags.StringVar(&command.configFile, "config", "", "specify JSON configuration file: /path/to/file.json")

--- a/internal/security/secrets/directory/directory.go
+++ b/internal/security/secrets/directory/directory.go
@@ -27,9 +27,9 @@ type handler struct {
 	loggingClient logger.LoggingClient
 }
 
-func NewHandler(loggingClient logger.LoggingClient) contract.DirectoryHandler {
+func NewHandler(lc logger.LoggingClient) contract.DirectoryHandler {
 	return handler{
-		loggingClient: loggingClient,
+		loggingClient: lc,
 	}
 }
 

--- a/internal/security/secrets/helper/helper.go
+++ b/internal/security/secrets/helper/helper.go
@@ -109,7 +109,7 @@ func IsDirEmpty(dir string) (empty bool, err error) {
 	return empty, err
 }
 
-func CopyDir(srcDir, destDir string, loggingClient logger.LoggingClient) error {
+func CopyDir(srcDir, destDir string, lc logger.LoggingClient) error {
 	srcFileInfo, statErr := os.Stat(srcDir)
 	if statErr != nil {
 		return statErr
@@ -128,11 +128,11 @@ func CopyDir(srcDir, destDir string, loggingClient logger.LoggingClient) error {
 		destFilePath := filepath.Join(destDir, fileDesc.Name())
 
 		if fileDesc.IsDir() {
-			if err := CopyDir(srcFilePath, destFilePath, loggingClient); err != nil {
+			if err := CopyDir(srcFilePath, destFilePath, lc); err != nil {
 				return err
 			}
 		} else {
-			loggingClient.Debug(fmt.Sprintf("copying srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath))
+			lc.Debug(fmt.Sprintf("copying srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath))
 			if _, copyErr := CopyFile(srcFilePath, destFilePath); copyErr != nil {
 				return copyErr
 			}
@@ -143,8 +143,8 @@ func CopyDir(srcDir, destDir string, loggingClient logger.LoggingClient) error {
 	return nil
 }
 
-func Deploy(srcDir, destDir string, loggingClient logger.LoggingClient) error {
-	if err := CopyDir(srcDir, destDir, loggingClient); err != nil {
+func Deploy(srcDir, destDir string, lc logger.LoggingClient) error {
+	if err := CopyDir(srcDir, destDir, lc); err != nil {
 		return err
 	}
 	return markComplete(destDir)
@@ -318,14 +318,14 @@ func GetDeployDir(configuration *config.ConfigurationStruct) (string, error) {
 }
 
 // GenTLSAssets generates the TLS assets based on the JSON configuration file
-func GenTLSAssets(jsonConfig string, loggingClient logger.LoggingClient) error {
+func GenTLSAssets(jsonConfig string, lc logger.LoggingClient) error {
 	// Read the Json x509 file and unmarshall content into struct type X509Config
 	x509Config, err := x509.NewX509Config(jsonConfig)
 	if err != nil {
 		return err
 	}
 
-	directoryHandler := directory.NewHandler(loggingClient)
+	directoryHandler := directory.NewHandler(lc)
 	if directoryHandler == nil {
 		return errors.New("h.loggingClient is nil")
 	}
@@ -335,7 +335,7 @@ func GenTLSAssets(jsonConfig string, loggingClient logger.LoggingClient) error {
 		return err
 	}
 
-	rootCA, err := certificates.NewCertificateGenerator(certificates.RootCertificate, seed, certificates.NewFileWriter(), loggingClient)
+	rootCA, err := certificates.NewCertificateGenerator(certificates.RootCertificate, seed, certificates.NewFileWriter(), lc)
 	if err != nil {
 		return err
 	}
@@ -345,7 +345,7 @@ func GenTLSAssets(jsonConfig string, loggingClient logger.LoggingClient) error {
 		return err
 	}
 
-	tlsCert, err := certificates.NewCertificateGenerator(certificates.TLSCertificate, seed, certificates.NewFileWriter(), loggingClient)
+	tlsCert, err := certificates.NewCertificateGenerator(certificates.TLSCertificate, seed, certificates.NewFileWriter(), lc)
 	if err != nil {
 		return err
 	}

--- a/internal/security/secrets/init.go
+++ b/internal/security/secrets/init.go
@@ -47,7 +47,7 @@ func (b *Bootstrap) Handler(
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 
-	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 
 	var command contract.Command
@@ -56,35 +56,35 @@ func (b *Bootstrap) Handler(
 	commandName := flag.Args()[0]
 	switch commandName {
 	case legacy.CommandName:
-		command, flagSet = legacy.NewCommand(loggingClient)
+		command, flagSet = legacy.NewCommand(lc)
 	case generate.CommandName:
-		command, flagSet = generate.NewCommand(loggingClient, configuration)
+		command, flagSet = generate.NewCommand(lc, configuration)
 	case cache.CommandName:
-		generateCommand, _ := generate.NewCommand(loggingClient, configuration)
-		command, flagSet = cache.NewCommand(loggingClient, configuration, generateCommand)
+		generateCommand, _ := generate.NewCommand(lc, configuration)
+		command, flagSet = cache.NewCommand(lc, configuration, generateCommand)
 	case _import.CommandName:
-		command, flagSet = _import.NewCommand(loggingClient, configuration)
+		command, flagSet = _import.NewCommand(lc, configuration)
 	default:
-		loggingClient.Error(fmt.Sprintf("unsupported subcommand %s", commandName))
+		lc.Error(fmt.Sprintf("unsupported subcommand %s", commandName))
 		b.exitStatusCode = contract.StatusCodeNoOptionSelected
 		return false
 	}
 
 	if err := flagSet.Parse(flag.Args()[1:]); err != nil {
-		loggingClient.Error(fmt.Sprintf("error parsing subcommand %s: %v", commandName, err))
+		lc.Error(fmt.Sprintf("error parsing subcommand %s: %v", commandName, err))
 		b.exitStatusCode = contract.StatusCodeExitWithError
 		return false
 	}
 
 	if len(flagSet.Args()) > 0 {
-		loggingClient.Error(fmt.Sprintf("subcommand %s doesn't use any args", commandName))
+		lc.Error(fmt.Sprintf("subcommand %s doesn't use any args", commandName))
 		b.exitStatusCode = contract.StatusCodeExitWithError
 		return false
 	}
 
 	exitStatusCode, err := command.Execute()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 	}
 	b.exitStatusCode = exitStatusCode
 	return false

--- a/internal/security/secretstore/certs.go
+++ b/internal/security/secretstore/certs.go
@@ -59,14 +59,14 @@ func NewCerts(
 	certPath string,
 	tokenPath string,
 	secretServiceBaseURL string,
-	loggingClient logger.LoggingClient) Certs {
+	lc logger.LoggingClient) Certs {
 
 	return Certs{
 		client:               caller,
 		certPath:             certPath,
 		tokenPath:            tokenPath,
 		secretServiceBaseURL: secretServiceBaseURL,
-		loggingClient:        loggingClient,
+		loggingClient:        lc,
 	}
 }
 

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -54,7 +54,7 @@ func (b *Bootstrap) Handler(
 	dic *di.Container) bool {
 
 	configuration := container.ConfigurationFrom(dic.Get)
-	loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 
 	//step 1: boot up secretstore general steps same as other EdgeX microservice
 
@@ -63,22 +63,22 @@ func (b *Bootstrap) Handler(
 
 	var req internal.HttpCaller
 	if caFilePath := configuration.SecretService.CaFilePath; caFilePath != "" {
-		loggingClient.Info("using certificate verification for secret store connection")
+		lc.Info("using certificate verification for secret store connection")
 		caReader, err := fileOpener.OpenFileReader(caFilePath, os.O_RDONLY, 0400)
 		if err != nil {
-			loggingClient.Error(fmt.Sprintf("failed to load CA certificate: %s", err.Error()))
+			lc.Error(fmt.Sprintf("failed to load CA certificate: %s", err.Error()))
 			return false
 		}
-		req = secretstoreclient.NewRequestor(loggingClient).WithTLS(caReader, configuration.SecretService.ServerName)
+		req = secretstoreclient.NewRequestor(lc).WithTLS(caReader, configuration.SecretService.ServerName)
 	} else {
-		loggingClient.Info("bypassing certificate verification for secret store connection")
-		req = secretstoreclient.NewRequestor(loggingClient).Insecure()
+		lc.Info("bypassing certificate verification for secret store connection")
+		req = secretstoreclient.NewRequestor(lc).Insecure()
 	}
 
 	vaultScheme := configuration.SecretService.Scheme
 	vaultHost := fmt.Sprintf("%s:%v", configuration.SecretService.Server, configuration.SecretService.Port)
 	intervalDuration := time.Duration(b.vaultInterval) * time.Second
-	vc := secretstoreclient.NewSecretStoreClient(loggingClient, req, vaultScheme, vaultHost)
+	vc := secretstoreclient.NewSecretStoreClient(lc, req, vaultScheme, vaultHost)
 
 	//step 3: initialize and unseal Vault
 	path := configuration.SecretService.TokenFolderPath
@@ -89,7 +89,7 @@ func (b *Bootstrap) Handler(
 		func() {
 			tokenFile, err := os.OpenFile(absPath, os.O_CREATE|os.O_RDWR, 0600)
 			if err != nil {
-				loggingClient.Error(fmt.Sprintf("unable to open token file at %s with error: %s", absPath, err.Error()))
+				lc.Error(fmt.Sprintf("unable to open token file at %s with error: %s", absPath, err.Error()))
 				os.Exit(1)
 			}
 			defer tokenFile.Close()
@@ -97,13 +97,13 @@ func (b *Bootstrap) Handler(
 
 			switch sCode {
 			case http.StatusOK:
-				loggingClient.Info(fmt.Sprintf("vault is initialized and unsealed (status code: %d)", sCode))
+				lc.Info(fmt.Sprintf("vault is initialized and unsealed (status code: %d)", sCode))
 				shouldContinue = false
 			case http.StatusTooManyRequests:
-				loggingClient.Error(fmt.Sprintf("vault is unsealed and in standby mode (Status Code: %d)", sCode))
+				lc.Error(fmt.Sprintf("vault is unsealed and in standby mode (Status Code: %d)", sCode))
 				shouldContinue = false
 			case http.StatusNotImplemented:
-				loggingClient.Info(fmt.Sprintf("vault is not initialized (status code: %d). Starting initialisation and unseal phases", sCode))
+				lc.Info(fmt.Sprintf("vault is not initialized (status code: %d). Starting initialisation and unseal phases", sCode))
 				_, err := vc.Init(configuration.SecretService, tokenFile)
 				if err == nil {
 					tokenFile.Seek(0, 0) // Read starting at beginning
@@ -113,22 +113,22 @@ func (b *Bootstrap) Handler(
 					}
 				}
 			case http.StatusServiceUnavailable:
-				loggingClient.Info(fmt.Sprintf("vault is sealed (status code: %d). Starting unseal phase", sCode))
+				lc.Info(fmt.Sprintf("vault is sealed (status code: %d). Starting unseal phase", sCode))
 				_, err := vc.Unseal(configuration.SecretService, tokenFile)
 				if err == nil {
 					shouldContinue = false
 				}
 			default:
 				if sCode == 0 {
-					loggingClient.Error(fmt.Sprintf("vault is in an unknown state. No Status code available"))
+					lc.Error(fmt.Sprintf("vault is in an unknown state. No Status code available"))
 				} else {
-					loggingClient.Error(fmt.Sprintf("vault is in an unknown state. Status code: %d", sCode))
+					lc.Error(fmt.Sprintf("vault is in an unknown state. Status code: %d", sCode))
 				}
 			}
 		}()
 
 		if shouldContinue {
-			loggingClient.Info(fmt.Sprintf("trying Vault init/unseal again in %d seconds", b.vaultInterval))
+			lc.Info(fmt.Sprintf("trying Vault init/unseal again in %d seconds", b.vaultInterval))
 			time.Sleep(intervalDuration)
 		}
 	}
@@ -155,47 +155,47 @@ func (b *Bootstrap) Handler(
 	<-healthOkCh
 
 	//Step 4: Launch token handler
-	tokenProvider := NewTokenProvider(ctx, loggingClient, ExecWrapper{})
+	tokenProvider := NewTokenProvider(ctx, lc, ExecWrapper{})
 	if configuration.SecretService.TokenProvider != "" {
 		if err := tokenProvider.SetConfiguration(configuration.SecretService); err != nil {
-			loggingClient.Error(fmt.Sprintf("failed to configure token provider: %s", err.Error()))
+			lc.Error(fmt.Sprintf("failed to configure token provider: %s", err.Error()))
 			os.Exit(1)
 		}
 		if err := tokenProvider.Launch(); err != nil {
-			loggingClient.Error(fmt.Sprintf("token provider failed: %s", err.Error()))
+			lc.Error(fmt.Sprintf("token provider failed: %s", err.Error()))
 			os.Exit(1)
 		}
 	} else {
-		loggingClient.Info("no token provider configured")
+		lc.Info("no token provider configured")
 	}
 
 	// credential creation
 	gk := NewGokeyGenerator(absPath)
-	loggingClient.Warn("WARNING: The gokey generator is a reference implementation for credential generation and the underlying libraries not been reviewed for cryptographic security. The user is encouraged to perform their own security investigation before deployment.")
-	cred := NewCred(req, absPath, gk, configuration.SecretService.GetSecretSvcBaseURL(), loggingClient)
+	lc.Warn("WARNING: The gokey generator is a reference implementation for credential generation and the underlying libraries not been reviewed for cryptographic security. The user is encouraged to perform their own security investigation before deployment.")
+	cred := NewCred(req, absPath, gk, configuration.SecretService.GetSecretSvcBaseURL(), lc)
 
 	// Detour: Create secrets engine if not there already
 	vaultToken, err := GetAccessToken(absPath)
 	if err != nil {
-		loggingClient.Error(fmt.Sprintf("failed to reload root token: %s", err.Error()))
+		lc.Error(fmt.Sprintf("failed to reload root token: %s", err.Error()))
 		os.Exit(1)
 	}
 	// Note: trailing slash on secret/ is required.
 	installed, err := vc.CheckSecretEngineInstalled(vaultToken, "secret/", "kv")
 	if err != nil {
-		loggingClient.Error(fmt.Sprintf("failed call to check if kv secrets engine is installed: %s", err.Error()))
+		lc.Error(fmt.Sprintf("failed call to check if kv secrets engine is installed: %s", err.Error()))
 		os.Exit(1)
 	}
 	if !installed {
-		loggingClient.Info("enabling KV secrets engine for the first time...")
+		lc.Info("enabling KV secrets engine for the first time...")
 		// Enable KV version 1 at /v1/secret path (/v1 prefix supplied by Vault)
 		_, err := vc.EnableKVSecretEngine(vaultToken, "secret", "1")
 		if err != nil {
-			loggingClient.Error(fmt.Sprintf("failed call to enable KV secrets engine: %s", err.Error()))
+			lc.Error(fmt.Sprintf("failed call to enable KV secrets engine: %s", err.Error()))
 			os.Exit(1)
 		}
 	} else {
-		loggingClient.Info("KV secrets engine already enabled...")
+		lc.Info("KV secrets engine already enabled...")
 	}
 
 	// continue credential creation
@@ -204,7 +204,7 @@ func (b *Bootstrap) Handler(
 		// generate credentials
 		password, err := cred.GeneratePassword(dbname)
 		if err != nil {
-			loggingClient.Error(fmt.Sprintf("failed to generate credential pair for service %s", service))
+			lc.Error(fmt.Sprintf("failed to generate credential pair for service %s", service))
 			os.Exit(1)
 		}
 		pair := UserPasswordPair{
@@ -217,17 +217,17 @@ func (b *Bootstrap) Handler(
 			servicePath := fmt.Sprintf("/v1/secret/edgex/%s/mongodb", service)
 			existing, err := cred.AlreadyInStore(servicePath)
 			if err != nil {
-				loggingClient.Error(err.Error())
+				lc.Error(err.Error())
 				os.Exit(1)
 			}
 			if !existing {
 				err = cred.UploadToStore(&pair, servicePath)
 				if err != nil {
-					loggingClient.Error(fmt.Sprintf("failed to upload credential pair for db %s on path %s", dbname, servicePath))
+					lc.Error(fmt.Sprintf("failed to upload credential pair for db %s on path %s", dbname, servicePath))
 					os.Exit(1)
 				}
 			} else {
-				loggingClient.Info(fmt.Sprintf("credentials for %s already present at path %s", dbname, servicePath))
+				lc.Info(fmt.Sprintf("credentials for %s already present at path %s", dbname, servicePath))
 			}
 		}
 
@@ -235,48 +235,48 @@ func (b *Bootstrap) Handler(
 		// add credentials to mongo path if they're not already there
 		existing, err := cred.AlreadyInStore(mongoPath)
 		if err != nil {
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			os.Exit(1)
 		}
 		if !existing {
 			err = cred.UploadToStore(&pair, mongoPath)
 			if err != nil {
-				loggingClient.Error(fmt.Sprintf("failed to upload credential pair for db %s on path %s", dbname, mongoPath))
+				lc.Error(fmt.Sprintf("failed to upload credential pair for db %s on path %s", dbname, mongoPath))
 				os.Exit(1)
 			}
 		} else {
-			loggingClient.Info(fmt.Sprintf("credentials for %s already present at path %s", dbname, mongoPath))
+			lc.Info(fmt.Sprintf("credentials for %s already present at path %s", dbname, mongoPath))
 		}
 	}
 
-	cert := NewCerts(req, configuration.SecretService.CertPath, absPath, configuration.SecretService.GetSecretSvcBaseURL(), loggingClient)
+	cert := NewCerts(req, configuration.SecretService.CertPath, absPath, configuration.SecretService.GetSecretSvcBaseURL(), lc)
 	existing, err := cert.AlreadyinStore()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		os.Exit(1)
 	}
 
 	if existing == true {
-		loggingClient.Info("proxy certificate pair are in the secret store already, skip uploading")
+		lc.Info("proxy certificate pair are in the secret store already, skip uploading")
 		return false
 	}
 
-	loggingClient.Info("proxy certificate pair are not in the secret store yet, uploading them")
+	lc.Info("proxy certificate pair are not in the secret store yet, uploading them")
 	cp, err := cert.ReadFrom(configuration.SecretService.CertFilePath, configuration.SecretService.KeyFilePath)
 	if err != nil {
-		loggingClient.Error("failed to get certificate pair from volume")
+		lc.Error("failed to get certificate pair from volume")
 		os.Exit(1)
 	}
 
-	loggingClient.Info("proxy certificate pair are loaded from volume successfully, will upload to secret store")
+	lc.Info("proxy certificate pair are loaded from volume successfully, will upload to secret store")
 
 	err = cert.UploadToStore(cp)
 	if err != nil {
-		loggingClient.Error("failed to upload the proxy cert pair into the secret store")
-		loggingClient.Error(err.Error())
+		lc.Error("failed to upload the proxy cert pair into the secret store")
+		lc.Error(err.Error())
 		os.Exit(1)
 	}
 
-	loggingClient.Info("proxy certificate pair are uploaded to secret store successfully, Vault init done successfully")
+	lc.Info("proxy certificate pair are uploaded to secret store successfully, Vault init done successfully")
 	return false
 }

--- a/internal/security/secretstore/password.go
+++ b/internal/security/secretstore/password.go
@@ -84,14 +84,14 @@ func NewCred(
 	tpath string,
 	generator CredentialGenerator,
 	secretServiceBaseURL string,
-	loggingClient logger.LoggingClient) Cred {
+	lc logger.LoggingClient) Cred {
 
 	return Cred{
 		client:               caller,
 		tokenPath:            tpath,
 		generator:            generator,
 		secretServiceBaseURL: secretServiceBaseURL,
-		loggingClient:        loggingClient,
+		loggingClient:        lc,
 	}
 }
 

--- a/internal/security/secretstore/tokenprovider.go
+++ b/internal/security/secretstore/tokenprovider.go
@@ -59,9 +59,9 @@ type TokenProvider struct {
 }
 
 // NewTokenProvider creates a new TokenProvider
-func NewTokenProvider(ctx context.Context, loggingClient logger.LoggingClient, execRunner ExecRunner) *TokenProvider {
+func NewTokenProvider(ctx context.Context, lc logger.LoggingClient, execRunner ExecRunner) *TokenProvider {
 	return &TokenProvider{
-		loggingClient: loggingClient,
+		loggingClient: lc,
 		ctx:           ctx,
 		execRunner:    execRunner,
 	}

--- a/internal/support/logging/init.go
+++ b/internal/support/logging/init.go
@@ -67,7 +67,7 @@ func (s ServiceInit) BootstrapHandler(
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 
-	loggingClient := logging.FactoryToStdout(s.serviceKey)
+	lc := logging.FactoryToStdout(s.serviceKey)
 	configuration := container.ConfigurationFrom(dic.Get)
 
 	// get database credentials.
@@ -79,7 +79,7 @@ func (s ServiceInit) BootstrapHandler(
 		if err == nil {
 			break
 		}
-		loggingClient.Warn(fmt.Sprintf("couldn't retrieve database credentials: %v", err.Error()))
+		lc.Warn(fmt.Sprintf("couldn't retrieve database credentials: %v", err.Error()))
 		startupTimer.SleepForInterval()
 	}
 
@@ -91,7 +91,7 @@ func (s ServiceInit) BootstrapHandler(
 		if err == nil {
 			break
 		}
-		loggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
+		lc.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
 		startupTimer.SleepForInterval()
 	}
 
@@ -101,14 +101,14 @@ func (s ServiceInit) BootstrapHandler(
 
 	dic.Update(di.ServiceConstructorMap{
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
-			return loggingClient
+			return lc
 		},
 		container.PersistenceInterfaceName: func(get di.Get) interface{} {
 			return persistenceClient
 		},
 	})
 
-	loggingClient.Info("Database connected")
+	lc.Info("Database connected")
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -117,7 +117,7 @@ func (s ServiceInit) BootstrapHandler(
 		for {
 			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
 			if s.server.IsRunning() == false {
-				loggingClient.Info("Database disconnecting")
+				lc.Info("Database disconnecting")
 				persistenceClient.CloseSession()
 				break
 			}

--- a/internal/support/notifications/cleanup.go
+++ b/internal/support/notifications/cleanup.go
@@ -30,21 +30,21 @@ import (
 func cleanupHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
 		defer r.Body.Close()
 	}
 
-	loggingClient.Info("Cleaning up of notifications and transmissions")
-	cleanupHandlerCloser(w, dbClient.Cleanup(), loggingClient)
+	lc.Info("Cleaning up of notifications and transmissions")
+	cleanupHandlerCloser(w, dbClient.Cleanup(), lc)
 }
 
 func cleanupAgeHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -55,18 +55,18 @@ func cleanupAgeHandler(
 	// Problem converting age
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the age to an integer")
+		lc.Error("Error converting the age to an integer")
 		return
 	}
 
-	loggingClient.Info("Cleaning up of notifications and transmissions")
-	cleanupHandlerCloser(w, dbClient.CleanupOld(age), loggingClient)
+	lc.Info("Cleaning up of notifications and transmissions")
+	cleanupHandlerCloser(w, dbClient.CleanupOld(age), lc)
 }
 
-func cleanupHandlerCloser(w http.ResponseWriter, err error, loggingClient logger.LoggingClient) {
+func cleanupHandlerCloser(w http.ResponseWriter, err error, lc logger.LoggingClient) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 

--- a/internal/support/notifications/distribution_coordinator.go
+++ b/internal/support/notifications/distribution_coordinator.go
@@ -25,52 +25,52 @@ import (
 
 func distribute(
 	n models.Notification,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) error {
 
-	loggingClient.Debug("DistributionCoordinator start distributing notification: " + n.Slug)
+	lc.Debug("DistributionCoordinator start distributing notification: " + n.Slug)
 	var categories []string
 	categories = append(categories, string(n.Category))
 	subs, err := dbClient.GetSubscriptionByCategoriesLabels(categories, n.Labels)
 	if err != nil {
-		loggingClient.Error("Unable to get subscriptions to distribute notification:" + n.Slug)
+		lc.Error("Unable to get subscriptions to distribute notification:" + n.Slug)
 		return err
 	}
 	for _, sub := range subs {
-		send(n, sub, loggingClient, dbClient, config)
+		send(n, sub, lc, dbClient, config)
 	}
 	return nil
 }
 
 func resend(
 	t models.Transmission,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
-	loggingClient.Debug("Resending transmission: " + t.ID + " for: " + t.Notification.Slug)
-	resendViaChannel(t, loggingClient, dbClient, config)
+	lc.Debug("Resending transmission: " + t.ID + " for: " + t.Notification.Slug)
+	resendViaChannel(t, lc, dbClient, config)
 }
 
 func send(
 	n models.Notification,
 	s models.Subscription,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
 	for _, ch := range s.Channels {
-		sendViaChannel(n, ch, s.Receiver, loggingClient, dbClient, config)
+		sendViaChannel(n, ch, s.Receiver, lc, dbClient, config)
 	}
 }
 
 func criticalSeverityResend(
 	t models.Transmission,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
-	loggingClient.Info("Critical severity resend scheduler is triggered.")
-	resend(t, loggingClient, dbClient, config)
+	lc.Info("Critical severity resend scheduler is triggered.")
+	resend(t, lc, dbClient, config)
 }

--- a/internal/support/notifications/escalating_service.go
+++ b/internal/support/notifications/escalating_service.go
@@ -25,26 +25,26 @@ import (
 
 func escalate(
 	t models.Transmission,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
-	loggingClient.Warn("Escalating transmission: " + t.ID + ", for: " + t.Notification.Slug)
+	lc.Warn("Escalating transmission: " + t.ID + ", for: " + t.Notification.Slug)
 
 	var err error
 	s, err := dbClient.GetSubscriptionBySlug(ESCALATIONSUBSCRIPTIONSLUG)
 	if err != nil {
-		loggingClient.Error("Unable to find Escalation subscriber to send escalation notice for " + t.ID)
+		lc.Error("Unable to find Escalation subscriber to send escalation notice for " + t.ID)
 		return
 	}
 
 	n, err := createEscalatedNotification(t, dbClient)
 	if err != nil {
-		loggingClient.Error("Unable to create new escalating notice to send escalation notice for " + t.ID)
+		lc.Error("Unable to create new escalating notice to send escalation notice for " + t.ID)
 		return
 	}
 
-	send(n, s, loggingClient, dbClient, config)
+	send(n, s, lc, dbClient, config)
 }
 
 func createEscalatedNotification(

--- a/internal/support/notifications/normal_distribution.go
+++ b/internal/support/notifications/normal_distribution.go
@@ -25,15 +25,15 @@ import (
 
 func distributeAndMark(
 	n models.Notification,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) error {
 
-	go distribute(n, loggingClient, dbClient, config)
+	go distribute(n, lc, dbClient, config)
 
 	err := dbClient.MarkNotificationProcessed(n)
 	if err != nil {
-		loggingClient.Error("Trouble updating notification to Processed for: " + n.Slug)
+		lc.Error("Trouble updating notification to Processed for: " + n.Slug)
 		return err
 	}
 	return nil

--- a/internal/support/notifications/rest_notification.go
+++ b/internal/support/notifications/rest_notification.go
@@ -37,7 +37,7 @@ import (
 func notificationHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
@@ -51,33 +51,33 @@ func notificationHandler(
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error decoding notification: " + err.Error())
+		lc.Error("Error decoding notification: " + err.Error())
 		return
 	}
 
-	loggingClient.Info("Posting Notification: " + n.String())
+	lc.Info("Posting Notification: " + n.String())
 	n.Status = models.NotificationsStatus(models.New)
 	n.ID, err = dbClient.AddNotification(n)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusConflict)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
 	if n.Severity == models.NotificationsSeverity(models.Critical) {
-		loggingClient.Info("Critical severity scheduler is triggered for: " + n.Slug)
+		lc.Info("Critical severity scheduler is triggered for: " + n.Slug)
 		n, err = dbClient.GetNotificationById(n.ID)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			return
 		}
 
-		err := distributeAndMark(n, loggingClient, dbClient, config)
+		err := distributeAndMark(n, lc, dbClient, config)
 		if err != nil {
 			return
 		}
-		loggingClient.Info("Critical severity scheduler has completed for: " + n.Slug)
+		lc.Info("Critical severity scheduler has completed for: " + n.Slug)
 	}
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -89,7 +89,7 @@ func notificationHandler(
 func restGetNotificationBySlug(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -102,7 +102,7 @@ func restGetNotificationBySlug(
 	op := notification.NewSlugExecutor(dbClient, slug)
 	result, err := op.Execute()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		switch err.(type) {
 		case errors.ErrNotificationNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -113,13 +113,13 @@ func restGetNotificationBySlug(
 		return
 	}
 
-	pkg.Encode(result, w, loggingClient)
+	pkg.Encode(result, w, lc)
 }
 
 func restDeleteNotificationBySlug(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -129,12 +129,12 @@ func restDeleteNotificationBySlug(
 	vars := mux.Vars(r)
 	slug := vars["slug"]
 
-	loggingClient.Info("Deleting notification (and associated transmissions) by slug: " + slug)
+	lc.Info("Deleting notification (and associated transmissions) by slug: " + slug)
 
 	op := notification.NewDeleteBySlugExecutor(dbClient, slug)
 	err := op.Execute()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		switch err.(type) {
 		case errors.ErrNotificationNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -153,7 +153,7 @@ func restDeleteNotificationBySlug(
 func restGetNotificationByID(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -165,7 +165,7 @@ func restGetNotificationByID(
 	op := notification.NewIdExecutor(dbClient, id)
 	result, err := op.Execute()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		switch err.(type) {
 		case errors.ErrNotificationNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -175,13 +175,13 @@ func restGetNotificationByID(
 		}
 		return
 	}
-	pkg.Encode(result, w, loggingClient)
+	pkg.Encode(result, w, lc)
 }
 
 func restDeleteNotificationByID(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -191,13 +191,13 @@ func restDeleteNotificationByID(
 	vars := mux.Vars(r)
 	id := vars["id"]
 
-	loggingClient.Info("Deleting notification (and associated transmissions): " + id)
+	lc.Info("Deleting notification (and associated transmissions): " + id)
 
 	op := notification.NewDeleteByIDExecutor(dbClient, id)
 	err := op.Execute()
 
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		switch err.(type) {
 		case errors.ErrNotificationNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -214,7 +214,7 @@ func restDeleteNotificationByID(
 func restDeleteNotificationsByAge(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -225,15 +225,15 @@ func restDeleteNotificationsByAge(
 	age, err := strconv.Atoi(vars["age"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the age to an integer")
+		lc.Error("Error converting the age to an integer")
 		return
 	}
-	loggingClient.Info("Deleting old notifications (and associated transmissions): " + vars["age"])
+	lc.Info("Deleting old notifications (and associated transmissions): " + vars["age"])
 	op := notification.NewDeleteByAgeExecutor(dbClient, age)
 	err = op.Execute()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -244,7 +244,7 @@ func restDeleteNotificationsByAge(
 func restGetNotificationsBySender(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
@@ -256,12 +256,12 @@ func restGetNotificationsBySender(
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
 	// Check the length
-	if err = checkMaxLimit(limitNum, loggingClient, config); err != nil {
+	if err = checkMaxLimit(limitNum, lc, config); err != nil {
 		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
@@ -274,17 +274,17 @@ func restGetNotificationsBySender(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(results, w, loggingClient)
+	pkg.Encode(results, w, lc)
 }
 
 func restNotificationByStartEnd(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
@@ -296,24 +296,24 @@ func restNotificationByStartEnd(
 	start, err := strconv.ParseInt(vars["start"], 10, 64)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the start to an integer")
+		lc.Error("Error converting the start to an integer")
 		return
 	}
 	end, err := strconv.ParseInt(vars["end"], 10, 64)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the end to an integer")
+		lc.Error("Error converting the end to an integer")
 		return
 	}
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
 	// Check the length
-	if err = checkMaxLimit(limitNum, loggingClient, config); err != nil {
+	if err = checkMaxLimit(limitNum, lc, config); err != nil {
 		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
@@ -326,17 +326,17 @@ func restNotificationByStartEnd(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(results, w, loggingClient)
+	pkg.Encode(results, w, lc)
 }
 
 func restNotificationByStart(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
@@ -347,18 +347,18 @@ func restNotificationByStart(
 	start, err := strconv.ParseInt(vars["start"], 10, 64)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the start to an integer")
+		lc.Error("Error converting the start to an integer")
 		return
 	}
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
 	// Check the length
-	if err = checkMaxLimit(limitNum, loggingClient, config); err != nil {
+	if err = checkMaxLimit(limitNum, lc, config); err != nil {
 		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
@@ -371,17 +371,17 @@ func restNotificationByStart(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(results, w, loggingClient)
+	pkg.Encode(results, w, lc)
 }
 
 func restNotificationByEnd(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
@@ -393,18 +393,18 @@ func restNotificationByEnd(
 	end, err := strconv.ParseInt(vars["end"], 10, 64)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the end to an integer")
+		lc.Error("Error converting the end to an integer")
 		return
 	}
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
 	// Check the length
-	if err = checkMaxLimit(limitNum, loggingClient, config); err != nil {
+	if err = checkMaxLimit(limitNum, lc, config); err != nil {
 		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
@@ -417,17 +417,17 @@ func restNotificationByEnd(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(results, w, loggingClient)
+	pkg.Encode(results, w, lc)
 }
 
 func restNotificationsByLabels(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
@@ -439,12 +439,12 @@ func restNotificationsByLabels(
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
 	// Check the length
-	if err = checkMaxLimit(limitNum, loggingClient, config); err != nil {
+	if err = checkMaxLimit(limitNum, lc, config); err != nil {
 		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
@@ -459,17 +459,17 @@ func restNotificationsByLabels(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(results, w, loggingClient)
+	pkg.Encode(results, w, lc)
 }
 
 func restNotificationsNew(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	config notificationsConfig.ConfigurationStruct) {
 
@@ -481,12 +481,12 @@ func restNotificationsNew(
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
 	// Check the length
-	if err = checkMaxLimit(limitNum, loggingClient, config); err != nil {
+	if err = checkMaxLimit(limitNum, lc, config); err != nil {
 		http.Error(w, ExceededMaxResultCount, http.StatusRequestEntityTooLarge)
 		return
 	}
@@ -499,9 +499,9 @@ func restNotificationsNew(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(n, w, loggingClient)
+	pkg.Encode(n, w, lc)
 }

--- a/internal/support/notifications/rest_subscription.go
+++ b/internal/support/notifications/rest_subscription.go
@@ -36,7 +36,7 @@ import (
 func restGetSubscriptions(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -45,17 +45,17 @@ func restGetSubscriptions(
 
 	subscriptions, err := dbClient.GetSubscriptions()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
-	pkg.Encode(subscriptions, w, loggingClient)
+	pkg.Encode(subscriptions, w, lc)
 }
 
 func restAddSubscription(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -68,7 +68,7 @@ func restAddSubscription(
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error decoding subscription: " + err.Error())
+		lc.Error("Error decoding subscription: " + err.Error())
 		return
 	}
 
@@ -76,16 +76,16 @@ func restAddSubscription(
 	err = validateEmailAddresses(s)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	loggingClient.Info("Posting Subscription: " + s.String())
+	lc.Info("Posting Subscription: " + s.String())
 	op := subscription.NewAddExecutor(dbClient, s)
 	err = op.Execute()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusConflict)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
@@ -96,7 +96,7 @@ func restAddSubscription(
 func restUpdateSubscription(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -114,7 +114,7 @@ func restUpdateSubscription(
 	err = validateEmailAddresses(s)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
@@ -126,17 +126,17 @@ func restUpdateSubscription(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	} else {
 		s.ID = s2.ID
 	}
 
-	loggingClient.Info("Updating subscription by slug: " + slug)
+	lc.Info("Updating subscription by slug: " + slug)
 
 	if err = dbClient.UpdateSubscription(s); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -147,7 +147,7 @@ func restUpdateSubscription(
 func restGetSubscriptionByID(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -159,7 +159,7 @@ func restGetSubscriptionByID(
 	op := subscription.NewIdExecutor(dbClient, id)
 	s, err := op.Execute()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		switch err.(type) {
 		case errors.ErrSubscriptionNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -168,13 +168,13 @@ func restGetSubscriptionByID(
 		}
 		return
 	}
-	pkg.Encode(s, w, loggingClient)
+	pkg.Encode(s, w, lc)
 }
 
 func restDeleteSubscriptionByID(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -183,7 +183,7 @@ func restDeleteSubscriptionByID(
 
 	vars := mux.Vars(r)
 	id := vars["id"]
-	loggingClient.Info("Deleting subscription: " + id)
+	lc.Info("Deleting subscription: " + id)
 
 	op := subscription.NewDeleteByIDExecutor(dbClient, id)
 	err := op.Execute()
@@ -203,7 +203,7 @@ func restDeleteSubscriptionByID(
 func restGetSubscriptionBySlug(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -223,17 +223,17 @@ func restGetSubscriptionBySlug(
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(s, w, loggingClient)
+	pkg.Encode(s, w, lc)
 }
 
 func restDeleteSubscriptionBySlug(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -243,7 +243,7 @@ func restDeleteSubscriptionBySlug(
 	vars := mux.Vars(r)
 	slug := vars["slug"]
 
-	loggingClient.Info("Deleting subscription by slug: " + slug)
+	lc.Info("Deleting subscription by slug: " + slug)
 
 	op := subscription.NewDeleteBySlugExecutor(dbClient, slug)
 	err := op.Execute()
@@ -254,7 +254,7 @@ func restDeleteSubscriptionBySlug(
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
@@ -265,7 +265,7 @@ func restDeleteSubscriptionBySlug(
 func restGetSubscriptionsByCategories(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -282,17 +282,17 @@ func restGetSubscriptionsByCategories(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(s, w, loggingClient)
+	pkg.Encode(s, w, lc)
 }
 
 func subscriptionsByLabelsHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -310,18 +310,18 @@ func subscriptionsByLabelsHandler(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(s, w, loggingClient)
+	pkg.Encode(s, w, lc)
 
 }
 
 func subscriptionsByCategoriesLabelsHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -340,11 +340,11 @@ func subscriptionsByCategoriesLabelsHandler(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(s, w, loggingClient)
+	pkg.Encode(s, w, lc)
 
 }
 
@@ -373,7 +373,7 @@ func validateEmailAddresses(s models.Subscription) error {
 func subscriptionsByReceiverHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -389,9 +389,9 @@ func subscriptionsByReceiverHandler(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
-	pkg.Encode(s, w, loggingClient)
+	pkg.Encode(s, w, lc)
 
 }

--- a/internal/support/notifications/rest_transmission.go
+++ b/internal/support/notifications/rest_transmission.go
@@ -35,7 +35,7 @@ import (
 func transmissionHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -49,15 +49,15 @@ func transmissionHandler(
 	// Problem Decoding Transmission
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error decoding transmission: " + err.Error())
+		lc.Error("Error decoding transmission: " + err.Error())
 		return
 	}
 
-	loggingClient.Info("Posting Transmission: " + t.String())
+	lc.Info("Posting Transmission: " + t.String())
 	id, err := dbClient.AddTransmission(t)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
@@ -69,7 +69,7 @@ func transmissionHandler(
 func transmissionBySlugHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -80,7 +80,7 @@ func transmissionBySlugHandler(
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
@@ -91,18 +91,18 @@ func transmissionBySlugHandler(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(t, w, loggingClient)
+	pkg.Encode(t, w, lc)
 
 }
 
 func transmissionBySlugAndStartEndHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -114,19 +114,19 @@ func transmissionBySlugAndStartEndHandler(
 	start, err := strconv.ParseInt(vars["start"], 10, 64)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error(fmt.Sprintf("failed to parse start %s %s", vars["start"], err.Error()))
+		lc.Error(fmt.Sprintf("failed to parse start %s %s", vars["start"], err.Error()))
 		return
 	}
 	end, err := strconv.ParseInt(vars["end"], 10, 64)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error(fmt.Sprintf("failed to parse end %s %s", vars["end"], err.Error()))
+		lc.Error(fmt.Sprintf("failed to parse end %s %s", vars["end"], err.Error()))
 		return
 	}
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error(fmt.Sprintf("failed to parse limit %s %s", vars["limit"], err.Error()))
+		lc.Error(fmt.Sprintf("failed to parse limit %s %s", vars["limit"], err.Error()))
 		return
 	}
 
@@ -137,18 +137,18 @@ func transmissionBySlugAndStartEndHandler(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(t, w, loggingClient)
+	pkg.Encode(t, w, lc)
 
 }
 
 func transmissionByStartEndHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -160,19 +160,19 @@ func transmissionByStartEndHandler(
 	// Problem converting start
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the start to an integer")
+		lc.Error("Error converting the start to an integer")
 		return
 	}
 	end, err := strconv.ParseInt(vars["end"], 10, 64)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the end to an integer")
+		lc.Error("Error converting the end to an integer")
 		return
 	}
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
@@ -183,18 +183,18 @@ func transmissionByStartEndHandler(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(t, w, loggingClient)
+	pkg.Encode(t, w, lc)
 
 }
 
 func transmissionByStartHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -205,13 +205,13 @@ func transmissionByStartHandler(
 	// Problem converting start
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the start to an integer")
+		lc.Error("Error converting the start to an integer")
 		return
 	}
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
@@ -222,18 +222,18 @@ func transmissionByStartHandler(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(t, w, loggingClient)
+	pkg.Encode(t, w, lc)
 
 }
 
 func transmissionByEndHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -245,13 +245,13 @@ func transmissionByEndHandler(
 	// Problem converting start
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the end to an integer")
+		lc.Error("Error converting the end to an integer")
 		return
 	}
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
@@ -262,37 +262,37 @@ func transmissionByEndHandler(
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(t, w, loggingClient)
+	pkg.Encode(t, w, lc)
 
 }
 
 func transmissionByEscalatedHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	transmissionByStatusHandler(w, r, models.Trxescalated, loggingClient, dbClient)
+	transmissionByStatusHandler(w, r, models.Trxescalated, lc, dbClient)
 }
 
 func transmissionByFailedHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	transmissionByStatusHandler(w, r, models.Failed, loggingClient, dbClient)
+	transmissionByStatusHandler(w, r, models.Failed, lc, dbClient)
 }
 
 func transmissionByStatusHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	status models.TransmissionStatus,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -303,7 +303,7 @@ func transmissionByStatusHandler(
 	limitNum, err := strconv.Atoi(vars["limit"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting limit to integer: " + err.Error())
+		lc.Error("Error converting limit to integer: " + err.Error())
 		return
 	}
 
@@ -317,55 +317,55 @@ func transmissionByStatusHandler(
 			} else {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			return
 		}
 
-		pkg.Encode(t, w, loggingClient)
+		pkg.Encode(t, w, lc)
 	}
 }
 
 func transmissionByAgeSentHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	transmissionByAgeStatusHandler(w, r, models.Sent, loggingClient, dbClient)
+	transmissionByAgeStatusHandler(w, r, models.Sent, lc, dbClient)
 }
 
 func transmissionByAgeEscalatedHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	transmissionByAgeStatusHandler(w, r, models.Trxescalated, loggingClient, dbClient)
+	transmissionByAgeStatusHandler(w, r, models.Trxescalated, lc, dbClient)
 }
 
 func transmissionByAgeAcknowledgedHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	transmissionByAgeStatusHandler(w, r, models.Acknowledged, loggingClient, dbClient)
+	transmissionByAgeStatusHandler(w, r, models.Acknowledged, lc, dbClient)
 }
 
 func transmissionByAgeFailedHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
-	transmissionByAgeStatusHandler(w, r, models.Failed, loggingClient, dbClient)
+	transmissionByAgeStatusHandler(w, r, models.Failed, lc, dbClient)
 }
 
 func transmissionByAgeStatusHandler(
 	w http.ResponseWriter,
 	r *http.Request,
 	status models.TransmissionStatus,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -377,14 +377,14 @@ func transmissionByAgeStatusHandler(
 	// Problem converting age
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error("Error converting the age to an integer")
+		lc.Error("Error converting the age to an integer")
 		return
 	}
 
 	err = dbClient.DeleteTransmission(age, status)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)

--- a/internal/support/notifications/utils.go
+++ b/internal/support/notifications/utils.go
@@ -44,9 +44,9 @@ func printBody(r io.ReadCloser) {
 	fmt.Println(bodyString)
 }
 
-func checkMaxLimit(limit int, loggingClient logger.LoggingClient, config notificationsConfig.ConfigurationStruct) error {
+func checkMaxLimit(limit int, lc logger.LoggingClient, config notificationsConfig.ConfigurationStruct) error {
 	if limit > config.Service.MaxResultCount {
-		loggingClient.Error(ExceededMaxResultCount)
+		lc.Error(ExceededMaxResultCount)
 		return errors.NewErrLimitExceeded(limit)
 	}
 

--- a/internal/support/scheduler/interval_action.go
+++ b/internal/support/scheduler/interval_action.go
@@ -310,8 +310,8 @@ func deleteIntervalAction(intervalAction contract.IntervalAction, dbClient inter
 	return nil
 }
 
-func scrubAllInteralActions(loggingClient logger.LoggingClient, dbClient interfaces.DBClient) (int, error) {
-	loggingClient.Info("Scrubbing All IntervalAction(s).")
+func scrubAllInteralActions(lc logger.LoggingClient, dbClient interfaces.DBClient) (int, error) {
+	lc.Info("Scrubbing All IntervalAction(s).")
 
 	count, err := dbClient.ScrubAllIntervalActions()
 	if err != nil {

--- a/internal/support/scheduler/rest_interval.go
+++ b/internal/support/scheduler/rest_interval.go
@@ -36,7 +36,7 @@ import (
 func restGetIntervals(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	configuration *config.ConfigurationStruct) {
 
@@ -47,17 +47,17 @@ func restGetIntervals(
 	op := interval.NewAllExecutor(dbClient, configuration.Service.MaxResultCount)
 	intervals, err := op.Execute()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	pkg.Encode(intervals, w, loggingClient)
+	pkg.Encode(intervals, w, lc)
 }
 
 func restUpdateInterval(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	scClient interfaces.SchedulerQueueClient) {
 
@@ -72,11 +72,11 @@ func restUpdateInterval(
 	// Problem decoding
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error decoding the interval: " + err.Error())
+		lc.Error("Error decoding the interval: " + err.Error())
 		return
 	}
 
-	loggingClient.Info("Updating Interval: " + from.ID)
+	lc.Info("Updating Interval: " + from.ID)
 	op := interval.NewUpdateExecutor(dbClient, scClient, from)
 	err = op.Execute()
 	if err != nil {
@@ -92,7 +92,7 @@ func restUpdateInterval(
 		default:
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
@@ -104,7 +104,7 @@ func restUpdateInterval(
 func restAddInterval(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	scClient interfaces.SchedulerQueueClient) {
 
@@ -117,10 +117,10 @@ func restAddInterval(
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error decoding interval" + err.Error())
+		lc.Error("Error decoding interval" + err.Error())
 		return
 	}
-	loggingClient.Info("Posting new Interval: " + intervalObj.String())
+	lc.Info("Posting new Interval: " + intervalObj.String())
 
 	op := interval.NewAddExecutor(dbClient, scClient, intervalObj)
 	newId, err := op.Execute()
@@ -131,7 +131,7 @@ func restAddInterval(
 		default:
 			http.Error(w, t.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
@@ -142,7 +142,7 @@ func restAddInterval(
 func restGetIntervalByID(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -154,14 +154,14 @@ func restGetIntervalByID(
 	id, err := url.QueryUnescape(vars["id"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error un-escaping the value id: " + err.Error())
+		lc.Error("Error un-escaping the value id: " + err.Error())
 		return
 	}
 
 	op := interval.NewIdExecutor(dbClient, id)
 	result, err := op.Execute()
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		switch err.(type) {
 		case errors.ErrIntervalNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -171,13 +171,13 @@ func restGetIntervalByID(
 		}
 		return
 	}
-	pkg.Encode(result, w, loggingClient)
+	pkg.Encode(result, w, lc)
 }
 
 func restDeleteIntervalByID(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	scClient interfaces.SchedulerQueueClient) {
 
@@ -190,7 +190,7 @@ func restDeleteIntervalByID(
 	id, err := url.QueryUnescape(vars["id"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error un-escaping the value id: " + err.Error())
+		lc.Error("Error un-escaping the value id: " + err.Error())
 		return
 	}
 
@@ -198,7 +198,7 @@ func restDeleteIntervalByID(
 	err = op.Execute()
 
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		switch err.(type) {
 		case errors.ErrIntervalNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -215,7 +215,7 @@ func restDeleteIntervalByID(
 func restGetIntervalByName(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	defer r.Body.Close()
@@ -226,7 +226,7 @@ func restGetIntervalByName(
 	// Issues un-escaping
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error un-escaping the value name: " + err.Error())
+		lc.Error("Error un-escaping the value name: " + err.Error())
 		return
 	}
 
@@ -241,18 +241,18 @@ func restGetIntervalByName(
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
-	pkg.Encode(result, w, loggingClient)
+	pkg.Encode(result, w, lc)
 
 }
 
 func restDeleteIntervalByName(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	scClient interfaces.SchedulerQueueClient) {
 
@@ -264,7 +264,7 @@ func restDeleteIntervalByName(
 	// Issues un-escaping
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error un-escaping the value name: " + err.Error())
+		lc.Error("Error un-escaping the value name: " + err.Error())
 		return
 	}
 	op := interval.NewDeleteByNameExecutor(dbClient, scClient, name)
@@ -295,11 +295,11 @@ func restDeleteIntervalByName(
 func restScrubAllIntervals(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	defer r.Body.Close()
-	loggingClient.Info("Scrubbing All Interval(s) and IntervalAction(s).")
+	lc.Info("Scrubbing All Interval(s) and IntervalAction(s).")
 	op := interval.NewScrubExecutor(dbClient)
 	count, err := op.Execute()
 	if err != nil {

--- a/internal/support/scheduler/rest_intervalaction.go
+++ b/internal/support/scheduler/rest_intervalaction.go
@@ -36,7 +36,7 @@ import (
 func restGetIntervalAction(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	configuration *config.ConfigurationStruct) {
 
@@ -47,7 +47,7 @@ func restGetIntervalAction(
 	intervalActions, err := op.Execute()
 
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		switch err.(type) {
 		case errors.ErrLimitExceeded:
 			http.Error(w, "Exceeded max limit", http.StatusRequestEntityTooLarge)
@@ -56,13 +56,13 @@ func restGetIntervalAction(
 		}
 		return
 	}
-	pkg.Encode(intervalActions, w, loggingClient)
+	pkg.Encode(intervalActions, w, lc)
 }
 
 func restAddIntervalAction(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	scClient interfaces.SchedulerQueueClient) {
 
@@ -77,7 +77,7 @@ func restAddIntervalAction(
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	loggingClient.Info("posting new intervalAction: " + intervalAction.String())
+	lc.Info("posting new intervalAction: " + intervalAction.String())
 
 	op := intervalaction.NewAddExecutor(dbClient, scClient, intervalAction)
 	newId, err := op.Execute()
@@ -90,7 +90,7 @@ func restAddIntervalAction(
 		default:
 			http.Error(w, t.Error(), http.StatusInternalServerError)
 		}
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
@@ -109,7 +109,7 @@ api/v1/interval
 func intervalActionHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	scClient interfaces.SchedulerQueueClient,
 	configuration *config.ConfigurationStruct) {
@@ -122,11 +122,11 @@ func intervalActionHandler(
 	case http.MethodGet:
 		intervalActions, err := getIntervalActions(configuration.Service.MaxResultCount, dbClient)
 		if err != nil {
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		pkg.Encode(intervalActions, w, loggingClient)
+		pkg.Encode(intervalActions, w, lc)
 		break
 		// Post a new IntervalAction
 	case http.MethodPost:
@@ -136,10 +136,10 @@ func intervalActionHandler(
 
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
-			loggingClient.Error("error decoding intervalAction" + err.Error())
+			lc.Error("error decoding intervalAction" + err.Error())
 			return
 		}
-		loggingClient.Info("posting new intervalAction: " + intervalAction.String())
+		lc.Info("posting new intervalAction: " + intervalAction.String())
 
 		newId, err := addNewIntervalAction(intervalAction, dbClient, scClient)
 		if err != nil {
@@ -153,7 +153,7 @@ func intervalActionHandler(
 			default:
 				http.Error(w, t.Error(), http.StatusInternalServerError)
 			}
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			return
 		}
 
@@ -168,11 +168,11 @@ func intervalActionHandler(
 		// Problem decoding
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
-			loggingClient.Error("Error decoding the intervalAction: " + err.Error())
+			lc.Error("Error decoding the intervalAction: " + err.Error())
 			return
 		}
 
-		loggingClient.Info("Updating IntervalAction: " + from.ID)
+		lc.Info("Updating IntervalAction: " + from.ID)
 		err = updateIntervalAction(from, dbClient, scClient)
 		if err != nil {
 			switch t := err.(type) {
@@ -191,7 +191,7 @@ func intervalActionHandler(
 			default:
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			}
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			return
 		}
 
@@ -210,7 +210,7 @@ api/v1/interval
 func intervalActionByIdHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	scClient interfaces.SchedulerQueueClient) {
 
@@ -223,7 +223,7 @@ func intervalActionByIdHandler(
 	id, err := url.QueryUnescape(vars["id"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error un-escaping the value interval id: " + err.Error())
+		lc.Error("Error un-escaping the value interval id: " + err.Error())
 		return
 	}
 
@@ -237,10 +237,10 @@ func intervalActionByIdHandler(
 			default:
 				http.Error(w, x.Error(), http.StatusInternalServerError)
 			}
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			return
 		}
-		pkg.Encode(intervalAction, w, loggingClient)
+		pkg.Encode(intervalAction, w, lc)
 		// Post a new Interval Action
 	case http.MethodDelete:
 		if err = deleteIntervalActionById(id, dbClient, scClient); err != nil {
@@ -268,7 +268,7 @@ api/v1/interval
 func intervalActionByNameHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	scClient interfaces.SchedulerQueueClient) {
 
@@ -281,7 +281,7 @@ func intervalActionByNameHandler(
 	name, err := url.QueryUnescape(vars["name"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error un-escaping the value name: " + err.Error())
+		lc.Error("Error un-escaping the value name: " + err.Error())
 		return
 	}
 
@@ -295,10 +295,10 @@ func intervalActionByNameHandler(
 			default:
 				http.Error(w, x.Error(), http.StatusInternalServerError)
 			}
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			return
 		}
-		pkg.Encode(intervalAction, w, loggingClient)
+		pkg.Encode(intervalAction, w, lc)
 		// Post a new Interval Action
 	case http.MethodDelete:
 		if err = deleteIntervalActionByName(name, dbClient, scClient); err != nil {
@@ -326,7 +326,7 @@ api/v1/interval
 func intervalActionByTargetHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 	if r.Body != nil {
 		defer r.Body.Close()
@@ -339,7 +339,7 @@ func intervalActionByTargetHandler(
 	// Issues un-escaping
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error un-escaping the value descriptor name: " + err.Error())
+		lc.Error("Error un-escaping the value descriptor name: " + err.Error())
 		return
 	}
 
@@ -347,11 +347,11 @@ func intervalActionByTargetHandler(
 	case http.MethodGet:
 		intervalActions, err := getIntervalActionsByTarget(target, dbClient)
 		if err != nil {
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		pkg.Encode(intervalActions, w, loggingClient)
+		pkg.Encode(intervalActions, w, lc)
 		break
 	}
 }
@@ -365,7 +365,7 @@ api/v1/interval
 func intervalActionByIntervalHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	if r.Body != nil {
@@ -379,7 +379,7 @@ func intervalActionByIntervalHandler(
 	// Issues un-escaping
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("Error un-escaping the value interval name: " + err.Error())
+		lc.Error("Error un-escaping the value interval name: " + err.Error())
 		return
 	}
 
@@ -387,11 +387,11 @@ func intervalActionByIntervalHandler(
 	case http.MethodGet:
 		intervalActions, err := getIntervalActionsByInterval(interval, dbClient)
 		if err != nil {
-			loggingClient.Error(err.Error())
+			lc.Error(err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		pkg.Encode(intervalActions, w, loggingClient)
+		pkg.Encode(intervalActions, w, lc)
 		break
 	}
 }
@@ -400,14 +400,14 @@ func intervalActionByIntervalHandler(
 func scrubIntervalActionsHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	dbClient interfaces.DBClient) {
 
 	defer r.Body.Close()
 
 	switch r.Method {
 	case http.MethodDelete:
-		count, err := scrubAllInteralActions(loggingClient, dbClient)
+		count, err := scrubAllInteralActions(lc, dbClient)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/support/scheduler/schedulecontext.go
+++ b/internal/support/scheduler/schedulecontext.go
@@ -26,7 +26,7 @@ type IntervalContext struct {
 	MarkedDeleted      bool
 }
 
-func (sc *IntervalContext) Reset(interval models.Interval, loggingClient logger.LoggingClient) {
+func (sc *IntervalContext) Reset(interval models.Interval, lc logger.LoggingClient) {
 	if sc.Interval != (models.Interval{}) && sc.Interval.Name != interval.Name {
 		// if interval name has changed, we should clear the old actions map(here just renew one)
 		sc.IntervalActionsMap = make(map[string]models.IntervalAction)
@@ -48,7 +48,7 @@ func (sc *IntervalContext) Reset(interval models.Interval, loggingClient logger.
 	} else {
 		t, err := time.Parse(TIMELAYOUT, sc.Interval.Start)
 		if err != nil {
-			loggingClient.Error("parse time error, the original time string is : " + sc.Interval.Start)
+			lc.Error("parse time error, the original time string is : " + sc.Interval.Start)
 		}
 
 		sc.StartTime = t
@@ -60,7 +60,7 @@ func (sc *IntervalContext) Reset(interval models.Interval, loggingClient logger.
 	} else {
 		t, err := time.Parse(TIMELAYOUT, sc.Interval.End)
 		if err != nil {
-			loggingClient.Error("parse time error, the original time string is : " + sc.Interval.End)
+			lc.Error("parse time error, the original time string is : " + sc.Interval.End)
 		}
 
 		sc.EndTime = t
@@ -71,7 +71,7 @@ func (sc *IntervalContext) Reset(interval models.Interval, loggingClient logger.
 	if !sc.Interval.RunOnce {
 		frequency, err := parseFrequency(sc.Interval.Frequency)
 		if err != nil {
-			loggingClient.Error("interval parse frequency error  %v", err.Error())
+			lc.Error("interval parse frequency error  %v", err.Error())
 		}
 		sc.Frequency = frequency
 	}

--- a/internal/support/scheduler/schedulercontext_test.go
+++ b/internal/support/scheduler/schedulercontext_test.go
@@ -61,11 +61,11 @@ func TestRet(t *testing.T) {
 		RunOnce:   TestIntervalRunOnce,
 	}
 
-	loggingClient := logger.NewMockClient()
+	lc := logger.NewMockClient()
 
 	// init reset
 	testIntervalContext := IntervalContext{}
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 
 	if testInterval.Name != testIntervalContext.Interval.Name {
 		t.Fatalf(TestUnexpectedMsgFormatStr, testIntervalContext.Interval.Name, testInterval.Name)
@@ -77,7 +77,7 @@ func TestRet(t *testing.T) {
 
 	// run times, current and max iteration
 	testInterval.RunOnce = false
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 
 	if testIntervalContext.MaxIterations != 0 {
 		t.Fatalf(TestUnexpectedMsgFormatStrForIntVal, testIntervalContext.MaxIterations, 0)
@@ -93,7 +93,7 @@ func TestRet(t *testing.T) {
 	}
 
 	testInterval.Start = "20180101T010101"
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 
 	if testIntervalContext.StartTime.Year() != 2018 {
 		t.Fatalf(TestUnexpectedMsgFormatStrForIntVal, testIntervalContext.StartTime.Year(), 2018)
@@ -105,7 +105,7 @@ func TestRet(t *testing.T) {
 	}
 
 	testInterval.End = "20170101T010101"
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 
 	if testIntervalContext.EndTime.Year() != 2017 {
 		t.Fatalf(TestUnexpectedMsgFormatStrForIntVal, testIntervalContext.EndTime.Year(), 2017)
@@ -117,7 +117,7 @@ func TestRet(t *testing.T) {
 	}
 
 	testInterval.Frequency = "60s"
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 	if testIntervalContext.Frequency.Seconds() != 60 {
 		t.Fatalf(TestUnexpectedMsgFormatStrForFloatVal, testIntervalContext.Frequency.Seconds(), 60.0)
 	}
@@ -127,7 +127,7 @@ func TestRet(t *testing.T) {
 	testInterval.End = ""
 	testInterval.RunOnce = true
 
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 
 	// next time
 	if testIntervalContext.StartTime != testIntervalContext.NextTime {
@@ -139,7 +139,7 @@ func TestRet(t *testing.T) {
 	}
 
 	testInterval.RunOnce = false
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 
 	if testIntervalContext.StartTime.Unix() > testIntervalContext.NextTime.Unix() {
 		t.Error(TestUnexpectedMsg)
@@ -147,7 +147,7 @@ func TestRet(t *testing.T) {
 
 	testInterval.Start = "20180101T010101"
 	testInterval.Frequency = "24h"
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 
 	if testIntervalContext.StartTime.Unix() > testIntervalContext.NextTime.Unix() {
 		t.Error(TestUnexpectedMsg)
@@ -169,11 +169,11 @@ func TestIsComplete(t *testing.T) {
 		RunOnce:   true,
 	}
 
-	loggingClient := logger.NewMockClient()
+	lc := logger.NewMockClient()
 
 	// init reset
 	testIntervalContext := IntervalContext{}
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 
 	if !testIntervalContext.IsComplete() {
 		t.Fatalf(TestUnexpectedMsgFormatStrForBoolVal, testIntervalContext.IsComplete(), true)
@@ -182,7 +182,7 @@ func TestIsComplete(t *testing.T) {
 	testInterval.Start = "20180101T010101"
 	testInterval.Frequency = "24h"
 	testInterval.RunOnce = false
-	testIntervalContext.Reset(testInterval, loggingClient)
+	testIntervalContext.Reset(testInterval, lc)
 
 	if testIntervalContext.IsComplete() {
 		t.Fatalf(TestUnexpectedMsgFormatStrForBoolVal, testIntervalContext.IsComplete(), false)

--- a/internal/system/agent/direct/metrics.go
+++ b/internal/system/agent/direct/metrics.go
@@ -48,13 +48,13 @@ type metrics struct {
 
 // NewMetrics is a factory function that returns an initialized metrics receiver struct.
 func NewMetrics(
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	genClients *agentClients.General,
 	registryClient registry.Client,
 	serviceProtocol string) *metrics {
 
 	return &metrics{
-		loggingClient:   loggingClient,
+		loggingClient:   lc,
 		genClients:      genClients,
 		registryClient:  registryClient,
 		serviceProtocol: serviceProtocol,

--- a/internal/system/agent/executor/metrics.go
+++ b/internal/system/agent/executor/metrics.go
@@ -33,10 +33,10 @@ type metrics struct {
 }
 
 // NewMetrics is a factory function that returns an initialized metrics receiver struct.
-func NewMetrics(executor interfaces.CommandExecutor, loggingClient logger.LoggingClient, executorPath string) *metrics {
+func NewMetrics(executor interfaces.CommandExecutor, lc logger.LoggingClient, executorPath string) *metrics {
 	return &metrics{
 		executor:      executor,
-		loggingClient: loggingClient,
+		loggingClient: lc,
 		executorPath:  executorPath,
 	}
 }

--- a/internal/system/agent/executor/metrics_test.go
+++ b/internal/system/agent/executor/metrics_test.go
@@ -47,7 +47,7 @@ func TestMetricsGetWithServices(t *testing.T) {
 		service2Result = "[{\"result\":\"bar\"}]"
 	)
 
-	loggingClient := logger.NewMockClient()
+	lc := logger.NewMockClient()
 	expectedError := errors.New("expectedError")
 	tests := []struct {
 		name           string
@@ -58,7 +58,7 @@ func TestMetricsGetWithServices(t *testing.T) {
 		{
 			"one service with no error",
 			[]string{service1Name},
-			[]interface{}{response.Process(service1Result, loggingClient)},
+			[]interface{}{response.Process(service1Result, lc)},
 			map[string]stubCall{
 				service1Name: {[]string{executorPath, service1Name, system.Metrics}, service1Result, nil},
 			},
@@ -75,8 +75,8 @@ func TestMetricsGetWithServices(t *testing.T) {
 			"two services with no errors",
 			[]string{service1Name, service2Name},
 			[]interface{}{
-				response.Process(service1Result, loggingClient),
-				response.Process(service2Result, loggingClient),
+				response.Process(service1Result, lc),
+				response.Process(service2Result, lc),
 			},
 			map[string]stubCall{
 				service1Name: {[]string{executorPath, service1Name, system.Metrics}, service1Result, nil},
@@ -88,7 +88,7 @@ func TestMetricsGetWithServices(t *testing.T) {
 			[]string{service1Name, service2Name},
 			[]interface{}{
 				system.Failure(service1Name, system.Metrics, UnknownExecutorType, expectedError.Error()),
-				response.Process(service2Result, loggingClient),
+				response.Process(service2Result, lc),
 			},
 			map[string]stubCall{
 				service1Name: {[]string{executorPath, service1Name, system.Metrics}, "", expectedError},
@@ -99,7 +99,7 @@ func TestMetricsGetWithServices(t *testing.T) {
 			"two services with second returning error",
 			[]string{service1Name, service2Name},
 			[]interface{}{
-				response.Process(service1Result, loggingClient),
+				response.Process(service1Result, lc),
 				system.Failure(service2Name, system.Metrics, UnknownExecutorType, expectedError.Error()),
 			},
 			map[string]stubCall{
@@ -124,7 +124,7 @@ func TestMetricsGetWithServices(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			executor := NewStub(test.executorCalls)
-			sut := NewMetrics(executor.CommandExecutor, loggingClient, executorPath)
+			sut := NewMetrics(executor.CommandExecutor, lc, executorPath)
 
 			result := sut.Get(context.Background(), test.services)
 

--- a/internal/system/agent/executor/operation.go
+++ b/internal/system/agent/executor/operation.go
@@ -33,12 +33,12 @@ type operations struct {
 // NewOperations is a factory function that returns an initialized operations receiver struct.
 func NewOperations(
 	executor interfaces.CommandExecutor,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	executorPath string) *operations {
 
 	return &operations{
 		executor:      executor,
-		loggingClient: loggingClient,
+		loggingClient: lc,
 		executorPath:  executorPath,
 	}
 }

--- a/internal/system/agent/executor/operation_test.go
+++ b/internal/system/agent/executor/operation_test.go
@@ -47,7 +47,7 @@ func TestOperationDoWithServices(t *testing.T) {
 		service2Result = "[{\"result\":\"bar\"}]"
 	)
 
-	loggingClient := logger.NewMockClient()
+	lc := logger.NewMockClient()
 	expectedError := errors.New("expectedError")
 	tests := []struct {
 		name           string
@@ -58,7 +58,7 @@ func TestOperationDoWithServices(t *testing.T) {
 		{
 			"one service with no error",
 			[]string{service1Name},
-			[]interface{}{response.Process(service1Result, loggingClient)},
+			[]interface{}{response.Process(service1Result, lc)},
 			map[string]stubCall{
 				service1Name: {[]string{executorPath, service1Name, operation}, service1Result, nil},
 			},
@@ -75,8 +75,8 @@ func TestOperationDoWithServices(t *testing.T) {
 			"two services with no errors",
 			[]string{service1Name, service2Name},
 			[]interface{}{
-				response.Process(service1Result, loggingClient),
-				response.Process(service2Result, loggingClient),
+				response.Process(service1Result, lc),
+				response.Process(service2Result, lc),
 			},
 			map[string]stubCall{
 				service1Name: {[]string{executorPath, service1Name, operation}, service1Result, nil},
@@ -88,7 +88,7 @@ func TestOperationDoWithServices(t *testing.T) {
 			[]string{service1Name, service2Name},
 			[]interface{}{
 				system.Failure(service1Name, operation, UnknownExecutorType, expectedError.Error()),
-				response.Process(service2Result, loggingClient),
+				response.Process(service2Result, lc),
 			},
 			map[string]stubCall{
 				service1Name: {[]string{executorPath, service1Name, operation}, "", expectedError},
@@ -99,7 +99,7 @@ func TestOperationDoWithServices(t *testing.T) {
 			"two services with second returning error",
 			[]string{service1Name, service2Name},
 			[]interface{}{
-				response.Process(service1Result, loggingClient),
+				response.Process(service1Result, lc),
 				system.Failure(service2Name, operation, UnknownExecutorType, expectedError.Error()),
 			},
 			map[string]stubCall{
@@ -124,7 +124,7 @@ func TestOperationDoWithServices(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			executor := NewStub(test.executorCalls)
-			sut := NewOperations(executor.CommandExecutor, loggingClient, executorPath)
+			sut := NewOperations(executor.CommandExecutor, lc, executorPath)
 
 			result := sut.Do(test.services, operation)
 

--- a/internal/system/agent/getconfig/executor.go
+++ b/internal/system/agent/getconfig/executor.go
@@ -44,13 +44,13 @@ type executor struct {
 func NewExecutor(
 	genClients *agentClients.General,
 	registryClient registry.Client,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	serviceProtocol string) *executor {
 
 	return &executor{
 		genClients:      genClients,
 		registryClient:  registryClient,
-		loggingClient:   loggingClient,
+		loggingClient:   lc,
 		serviceProtocol: serviceProtocol,
 	}
 }

--- a/internal/system/agent/getconfig/get.go
+++ b/internal/system/agent/getconfig/get.go
@@ -43,10 +43,10 @@ type get struct {
 }
 
 // New is a factory function that returns an initialized get struct.
-func New(executor GetExecutor, loggingClient logger.LoggingClient) *get {
+func New(executor GetExecutor, lc logger.LoggingClient) *get {
 	return &get{
 		executor:      executor,
-		loggingClient: loggingClient,
+		loggingClient: lc,
 	}
 }
 

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -45,8 +45,8 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 	case direct.MetricsMechanism:
 	case executor.MetricsMechanism:
 	default:
-		loggingClient := bootstrapContainer.LoggingClientFrom(dic.Get)
-		loggingClient.Error("the requested metrics mechanism is not supported")
+		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+		lc.Error("the requested metrics mechanism is not supported")
 		return false
 	}
 

--- a/internal/system/agent/response/process.go
+++ b/internal/system/agent/response/process.go
@@ -21,11 +21,11 @@ import (
 )
 
 // Process converts a response string (assumed to contain JSON) to a map.
-func Process(response string, loggingClient logger.LoggingClient) map[string]interface{} {
+func Process(response string, lc logger.LoggingClient) map[string]interface{} {
 	rsp := make(map[string]interface{})
 	err := json.Unmarshal([]byte(response), &rsp)
 	if err != nil {
-		loggingClient.Error("error unmarshalling response from JSON: %v", err.Error())
+		lc.Error("error unmarshalling response from JSON: %v", err.Error())
 	}
 	return rsp
 }

--- a/internal/system/agent/response/process_test.go
+++ b/internal/system/agent/response/process_test.go
@@ -34,7 +34,7 @@ func TestProcess(t *testing.T) {
 			"bool":   true,
 		}
 	}
-	loggingClient := logger.NewMockClient()
+	lc := logger.NewMockClient()
 	tests := []struct {
 		name           string
 		response       string
@@ -53,7 +53,7 @@ func TestProcess(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expectedResult, Process(test.response, loggingClient))
+			assert.Equal(t, test.expectedResult, Process(test.response, lc))
 		})
 	}
 }

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -92,20 +92,20 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 func metricsHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	metricsImpl interfaces.Metrics) {
 
-	loggingClient.Debug("retrieved service names")
+	lc.Debug("retrieved service names")
 
 	vars := mux.Vars(r)
-	pkg.Encode(metricsImpl.Get(r.Context(), strings.Split(vars["services"], ",")), w, loggingClient)
+	pkg.Encode(metricsImpl.Get(r.Context(), strings.Split(vars["services"], ",")), w, lc)
 }
 
 // operationHandler implements a controller to execute a start/stop/restart operation request.
 func operationHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	operationsImpl interfaces.Operations) {
 
 	defer func() { _ = r.Body.Close() }()
@@ -113,78 +113,78 @@ func operationHandler(
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
 	o := models.Operation{}
 	if err = o.UnmarshalJSON(b); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("error during decoding: %s", err.Error())
+		lc.Error("error during decoding: %s", err.Error())
 		return
 	}
 
 	if len(o.Services) == 0 || len(o.Action) == 0 {
 		const errorMessage = "incorrect or malformed body was passed in with the request"
 		http.Error(w, errorMessage, http.StatusBadRequest)
-		loggingClient.Error(errorMessage)
+		lc.Error(errorMessage)
 		return
 	}
 
-	pkg.Encode(operationsImpl.Do(o.Services, o.Action), w, loggingClient)
+	pkg.Encode(operationsImpl.Do(o.Services, o.Action), w, lc)
 }
 
 // getConfigHandler implements a controller to execute a get configuration request.
 func getConfigHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 
 	getConfigImpl interfaces.GetConfig) {
 	vars := mux.Vars(r)
-	loggingClient.Debug("retrieved service names")
+	lc.Debug("retrieved service names")
 
-	pkg.Encode(getConfigImpl.Do(r.Context(), strings.Split(vars["services"], ",")), w, loggingClient)
+	pkg.Encode(getConfigImpl.Do(r.Context(), strings.Split(vars["services"], ",")), w, lc)
 }
 
 // setConfigHandler implements a controller to execute a set configuration request.
 func setConfigHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	setConfigImpl interfaces.SetConfig) {
 
 	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
-	loggingClient.Debug("retrieved service names")
+	lc.Debug("retrieved service names")
 
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return
 	}
 
 	sc := requests.SetConfigRequest{}
 	if err = sc.UnmarshalJSON(b); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		loggingClient.Error("error during decoding")
+		lc.Error("error during decoding")
 		return
 	}
 
-	pkg.Encode(setConfigImpl.Do(strings.Split(vars["services"], ","), sc), w, loggingClient)
+	pkg.Encode(setConfigImpl.Do(strings.Split(vars["services"], ","), sc), w, lc)
 }
 
 // healthHandler implements a controller to execute a get health status request.
 func healthHandler(
 	w http.ResponseWriter,
 	r *http.Request,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	registryClient registry.Client) {
 
 	vars := mux.Vars(r)
-	loggingClient.Debug("health status data requested")
+	lc.Debug("health status data requested")
 
 	list := vars["services"]
 	var services []string
@@ -192,9 +192,9 @@ func healthHandler(
 
 	send, err := getHealth(services, registryClient)
 	if err != nil {
-		loggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	pkg.Encode(send, w, loggingClient)
+	pkg.Encode(send, w, lc)
 }

--- a/internal/system/agent/setconfig/executor.go
+++ b/internal/system/agent/setconfig/executor.go
@@ -35,9 +35,9 @@ type executor struct {
 }
 
 // NewExecutor is a factory function that returns an initialized executor struct.
-func NewExecutor(loggingClient logger.LoggingClient, configuration *config.ConfigurationStruct) *executor {
+func NewExecutor(lc logger.LoggingClient, configuration *config.ConfigurationStruct) *executor {
 	return &executor{
-		loggingClient: loggingClient,
+		loggingClient: lc,
 		configuration: configuration,
 	}
 }


### PR DESCRIPTION
Fix #2072

Rename loggingClient names which are not referring to the LoggingClient
global variable. These changes were applied to all instance variables,
method signatures, and tests. expect for structs with an instance field
named `loggingClient`, for sake of readability.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>