### PR TITLE
Feature/issue 2031 coredata remove configuration global

### DIFF
--- a/cmd/core-data/toml_test.go
+++ b/cmd/core-data/toml_test.go
@@ -10,12 +10,12 @@ package main
 import (
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/internal/core/data"
+	dataConfig "github.com/edgexfoundry/edgex-go/internal/core/data/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
 
 func TestToml(t *testing.T) {
-	configuration := &data.ConfigurationStruct{}
+	configuration := &dataConfig.ConfigurationStruct{}
 	if err := config.VerifyTomlFiles(configuration); err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/internal/core/data/config/config.go
+++ b/internal/core/data/config/config.go
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright 2018 Dell Inc.
+/********************************************************************************
+ *  Copyright 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package data
+package config
 
 import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"

--- a/internal/core/data/container/config.go
+++ b/internal/core/data/container/config.go
@@ -1,0 +1,29 @@
+/********************************************************************************
+ *  Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package container
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+)
+
+// ConfigurationName contains the name of data's config.ConfigurationStruct implementation in the DIC.
+var ConfigurationName = di.TypeInstanceToName(config.ConfigurationStruct{})
+
+// ConfigurationFrom helper function queries the DIC and returns datas's config.ConfigurationStruct implementation.
+func ConfigurationFrom(get di.Get) *config.ConfigurationStruct {
+	return get(ConfigurationName).(*config.ConfigurationStruct)
+}

--- a/internal/core/data/device.go
+++ b/internal/core/data/device.go
@@ -16,16 +16,22 @@ package data
 import (
 	"context"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
 // Update when the device was last reported connected
-func updateDeviceLastReportedConnected(device string, loggingClient logger.LoggingClient, mdc metadata.DeviceClient) {
+func updateDeviceLastReportedConnected(
+	device string,
+	loggingClient logger.LoggingClient,
+	mdc metadata.DeviceClient,
+	configuration *config.ConfigurationStruct) {
+
 	// Config set to skip update last reported
-	if !Configuration.Writable.DeviceUpdateLastConnected {
+	if !configuration.Writable.DeviceUpdateLastConnected {
 		loggingClient.Debug("Skipping update of device connected/reported times for:  " + device)
 		return
 	}
@@ -62,9 +68,10 @@ func updateDeviceServiceLastReportedConnected(
 	device string,
 	loggingClient logger.LoggingClient,
 	mdc metadata.DeviceClient,
-	msc metadata.DeviceServiceClient) {
+	msc metadata.DeviceServiceClient,
+	configuration *config.ConfigurationStruct) {
 
-	if !Configuration.Writable.ServiceUpdateLastConnected {
+	if !configuration.Writable.ServiceUpdateLastConnected {
 		loggingClient.Debug("Skipping update of device service connected/reported times for:  " + device)
 		return
 	}
@@ -96,8 +103,13 @@ func updateDeviceServiceLastReportedConnected(
 	msc.UpdateLastReported(s.Id, t, context.Background())
 }
 
-func checkDevice(device string, ctx context.Context, mdc metadata.DeviceClient) error {
-	if Configuration.Writable.MetaDataCheck {
+func checkDevice(
+	device string,
+	ctx context.Context,
+	mdc metadata.DeviceClient,
+	configuration *config.ConfigurationStruct) error {
+
+	if configuration.Writable.MetaDataCheck {
 		_, err := mdc.CheckForDevice(device, ctx)
 		if err != nil {
 			return err

--- a/internal/core/data/device_test.go
+++ b/internal/core/data/device_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
@@ -28,7 +29,7 @@ func TestCheckMaxLimit(t *testing.T) {
 
 	testedLimit := math.MinInt32
 
-	expectedNil := checkMaxLimit(testedLimit, logger.NewMockClient())
+	expectedNil := checkMaxLimit(testedLimit, logger.NewMockClient(), &config.ConfigurationStruct{})
 
 	if expectedNil != nil {
 		t.Errorf("Should not exceed limit")
@@ -40,7 +41,7 @@ func TestCheckMaxLimitOverLimit(t *testing.T) {
 
 	testedLimit := math.MaxInt32
 
-	expectedErr := checkMaxLimit(testedLimit, logger.NewMockClient())
+	expectedErr := checkMaxLimit(testedLimit, logger.NewMockClient(), &config.ConfigurationStruct{})
 
 	if expectedErr == nil {
 		t.Errorf("Exceeded limit and should throw error")
@@ -50,7 +51,6 @@ func TestCheckMaxLimitOverLimit(t *testing.T) {
 // Supporting methods
 // Reset() re-initializes dependencies for each test
 func reset() {
-	Configuration = &ConfigurationStruct{}
 	testEvent.ID = testBsonString
 	testEvent.Device = testDeviceName
 	testEvent.Origin = testOrigin

--- a/internal/core/data/domain_events.go
+++ b/internal/core/data/domain_events.go
@@ -14,6 +14,8 @@
 package data
 
 import (
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 )
@@ -32,7 +34,8 @@ func initEventHandlers(
 	loggingClient logger.LoggingClient,
 	chEvents <-chan interface{},
 	mdc metadata.DeviceClient,
-	msc metadata.DeviceServiceClient) {
+	msc metadata.DeviceServiceClient,
+	configuration *config.ConfigurationStruct) {
 
 	go func() {
 		for {
@@ -42,11 +45,11 @@ func initEventHandlers(
 					switch e.(type) {
 					case DeviceLastReported:
 						dlr := e.(DeviceLastReported)
-						updateDeviceLastReportedConnected(dlr.DeviceName, loggingClient, mdc)
+						updateDeviceLastReportedConnected(dlr.DeviceName, loggingClient, mdc, configuration)
 						break
 					case DeviceServiceLastReported:
 						dslr := e.(DeviceServiceLastReported)
-						updateDeviceServiceLastReportedConnected(dslr.DeviceName, loggingClient, mdc, msc)
+						updateDeviceServiceLastReportedConnected(dslr.DeviceName, loggingClient, mdc, msc, configuration)
 						break
 					}
 				} else {

--- a/internal/core/data/io_test.go
+++ b/internal/core/data/io_test.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-
-	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
 )
 
 var TestEvent = contract.Event{
@@ -61,9 +62,12 @@ func TestNewReader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			request := newRequestWithContentType(tt.args.contentType)
-			got := NewRequestReader(request)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewReader() = %v, want %v", got, tt.want)
+			got := NewRequestReader(request, &config.ConfigurationStruct{})
+
+			eet := reflect.TypeOf(tt.want)
+			aet := reflect.TypeOf(got)
+			if !aet.AssignableTo(eet) {
+				t.Errorf("Expected reader of type %v, but got an reader of type %v", eet, aet)
 			}
 		})
 	}
@@ -77,7 +81,7 @@ func TestJsonSerialization(t *testing.T) {
 	r := ioutil.NopCloser(bytes.NewBuffer(data))
 
 	ctx := context.Background()
-	jsonReader := jsonReader{}
+	jsonReader := NewJsonReader()
 	_, err := jsonReader.Read(r, &ctx)
 
 	if err != nil {
@@ -92,7 +96,8 @@ func TestCborSerialization(t *testing.T) {
 	data := event.CBOR()
 	r := ioutil.NopCloser(bytes.NewBuffer(data))
 
-	cborReader := cborReader{}
+	cborReader := NewCborReader(&config.ConfigurationStruct{})
+
 	ctx := context.Background()
 	result, err := cborReader.Read(r, &ctx)
 

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
 	dataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/container"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
@@ -63,7 +64,7 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 	r.HandleFunc(
 		clients.ApiConfigRoute,
 		func(w http.ResponseWriter, _ *http.Request) {
-			pkg.Encode(Configuration, w, bootstrapContainer.LoggingClientFrom(dic.Get))
+			pkg.Encode(dataContainer.ConfigurationFrom(dic.Get), w, bootstrapContainer.LoggingClientFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	// Metrics
@@ -88,7 +89,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				dataContainer.PublisherEventsChannelFrom(dic.Get),
 				dataContainer.MessagingClientFrom(dic.Get),
 				dataContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
 	r.HandleFunc(clients.ApiEventRoute, func(writer http.ResponseWriter, request *http.Request) {
 		eventHandler(
@@ -99,7 +101,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 			dataContainer.PublisherEventsChannelFrom(dic.Get),
 			dataContainer.MessagingClientFrom(dic.Get),
 			dataContainer.MetadataDeviceClientFrom(dic.Get),
-			errorContainer.ErrorHandlerFrom(dic.Get))
+			errorContainer.ErrorHandlerFrom(dic.Get),
+			dataContainer.ConfigurationFrom(dic.Get))
 	}).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
 
 	e := r.PathPrefix(clients.ApiEventRoute).Subrouter()
@@ -145,7 +148,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				container.DBClientFrom(dic.Get),
 				dataContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	e.HandleFunc(
@@ -168,7 +172,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				dataContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodDelete, http.MethodPut)
 
 	e.HandleFunc(
@@ -180,7 +185,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				dataContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodPut)
 
 	e.HandleFunc(
@@ -192,7 +198,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				dataContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 	e.HandleFunc(
 		"/"+DEVICE+"/{"+DEVICEID_PARAM+"}",
@@ -202,7 +209,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				container.DBClientFrom(dic.Get),
 				dataContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodDelete)
 
 	e.HandleFunc(
@@ -224,7 +232,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	// Readings
@@ -237,7 +246,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				dataContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
 
 	rd := r.PathPrefix(clients.ApiReadingRoute).Subrouter()
@@ -284,7 +294,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				dataContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
@@ -295,7 +306,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
@@ -306,7 +318,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
@@ -317,7 +330,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
@@ -328,7 +342,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
@@ -339,7 +354,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	rd.HandleFunc(
@@ -351,7 +367,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				dataContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	// Value descriptors
@@ -363,7 +380,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet, http.MethodPut, http.MethodPost)
 
 	vd := r.PathPrefix(clients.ApiValueDescriptorRoute).Subrouter()
@@ -376,7 +394,8 @@ func LoadRestRoutes(dic *di.Container) *mux.Router {
 				r,
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				dataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodGet)
 
 	vd.HandleFunc(
@@ -502,7 +521,9 @@ func eventCountByDeviceIdHandler(
 	r *http.Request,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
+
 	defer func() { _ = r.Body.Close() }()
 
 	vars := mux.Vars(r)
@@ -515,7 +536,7 @@ func eventCountByDeviceIdHandler(
 	}
 
 	// Check device
-	count, err := countEventsByDevice(id, ctx, dbClient, mdc)
+	count, err := countEventsByDevice(id, ctx, dbClient, mdc, configuration)
 	if err != nil {
 		httpErrorHandler.HandleOneVariant(w,
 			err,
@@ -575,7 +596,8 @@ func eventHandler(
 	chEvents chan<- interface{},
 	msgClient messaging.MessageClient,
 	mdc metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	if r.Body != nil {
 		defer func() { _ = r.Body.Close() }()
@@ -586,7 +608,7 @@ func eventHandler(
 	switch r.Method {
 	// Get all events
 	case http.MethodGet:
-		events, err := getEvents(Configuration.Service.MaxResultCount, dbClient)
+		events, err := getEvents(configuration.Service.MaxResultCount, dbClient)
 		if err != nil {
 			httpErrorHandler.Handle(w, err, errorconcept.Default.InternalServerError)
 			return
@@ -596,7 +618,7 @@ func eventHandler(
 		break
 		// Post a new event
 	case http.MethodPost:
-		reader := NewRequestReader(r)
+		reader := NewRequestReader(r, configuration)
 
 		evt := models.Event{}
 		evt, err := reader.Read(r.Body, &ctx)
@@ -604,7 +626,7 @@ func eventHandler(
 			httpErrorHandler.Handle(w, err, errorconcept.Default.InternalServerError)
 			return
 		}
-		newId, err := addNewEvent(evt, ctx, loggingClient, dbClient, chEvents, msgClient, mdc)
+		newId, err := addNewEvent(evt, ctx, loggingClient, dbClient, chEvents, msgClient, mdc, configuration)
 		if err != nil {
 			httpErrorHandler.HandleManyVariants(
 				w,
@@ -640,7 +662,7 @@ func eventHandler(
 		}
 
 		loggingClient.Info("Updating event: " + from.ID)
-		err = updateEvent(from, ctx, dbClient, mdc)
+		err = updateEvent(from, ctx, dbClient, mdc, configuration)
 		if err != nil {
 			httpErrorHandler.HandleOneVariant(
 				w,
@@ -722,7 +744,8 @@ func getEventByDeviceHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -745,7 +768,7 @@ func getEventByDeviceHandler(
 	}
 
 	// Check device
-	if err := checkDevice(deviceId, ctx, mdc); err != nil {
+	if err := checkDevice(deviceId, ctx, mdc, configuration); err != nil {
 		httpErrorHandler.HandleOneVariant(
 			w,
 			err,
@@ -755,7 +778,7 @@ func getEventByDeviceHandler(
 
 	switch r.Method {
 	case http.MethodGet:
-		err := checkMaxLimit(limitNum, loggingClient)
+		err := checkMaxLimit(limitNum, loggingClient, configuration)
 		if err != nil {
 			httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 			return
@@ -784,7 +807,8 @@ func eventIdHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -803,7 +827,7 @@ func eventIdHandler(
 
 		loggingClient.Info("Updating event: " + id)
 
-		err := updateEventPushDate(id, ctx, dbClient, mdc)
+		err := updateEventPushDate(id, ctx, dbClient, mdc, configuration)
 		if err != nil {
 			httpErrorHandler.HandleOneVariant(w,
 				err,
@@ -846,7 +870,8 @@ func putEventChecksumHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -859,7 +884,7 @@ func putEventChecksumHandler(
 	case http.MethodPut:
 		loggingClient.Debug("Updating event with checksum: " + checksum)
 
-		err := updateEventPushDateByChecksum(checksum, ctx, dbClient, mdc)
+		err := updateEventPushDateByChecksum(checksum, ctx, dbClient, mdc, configuration)
 		if err != nil {
 			httpErrorHandler.HandleOneVariant(
 				w,
@@ -883,7 +908,8 @@ func deleteByDeviceIdHandler(
 	r *http.Request,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -898,7 +924,7 @@ func deleteByDeviceIdHandler(
 	}
 
 	// Check device
-	if err := checkDevice(deviceId, ctx, mdc); err != nil {
+	if err := checkDevice(deviceId, ctx, mdc, configuration); err != nil {
 		httpErrorHandler.HandleOneVariant(
 			w,
 			err,
@@ -931,7 +957,8 @@ func eventByCreationTimeHandler(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -959,7 +986,7 @@ func eventByCreationTimeHandler(
 
 	switch r.Method {
 	case http.MethodGet:
-		err := checkMaxLimit(limit, loggingClient)
+		err := checkMaxLimit(limit, loggingClient, configuration)
 		if err != nil {
 			httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 			return
@@ -1010,7 +1037,8 @@ func readingHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -1018,7 +1046,7 @@ func readingHandler(
 
 	switch r.Method {
 	case http.MethodGet:
-		r, err := getAllReadings(loggingClient, dbClient)
+		r, err := getAllReadings(loggingClient, dbClient, configuration)
 
 		if err != nil {
 			httpErrorHandler.HandleOneVariant(
@@ -1030,7 +1058,7 @@ func readingHandler(
 
 		pkg.Encode(r, w, loggingClient)
 	case http.MethodPost:
-		reading, err := decodeReading(r.Body, loggingClient, dbClient)
+		reading, err := decodeReading(r.Body, loggingClient, dbClient, configuration)
 
 		// Problem decoding
 		if err != nil {
@@ -1047,7 +1075,7 @@ func readingHandler(
 
 		// Check device
 		if reading.Device != "" {
-			if err := checkDevice(reading.Device, ctx, mdc); err != nil {
+			if err := checkDevice(reading.Device, ctx, mdc, configuration); err != nil {
 				httpErrorHandler.HandleOneVariant(
 					w,
 					err,
@@ -1056,7 +1084,7 @@ func readingHandler(
 			}
 		}
 
-		if Configuration.Writable.PersistData {
+		if configuration.Writable.PersistData {
 			id, err := addReading(reading, loggingClient, dbClient)
 			if err != nil {
 				httpErrorHandler.Handle(w, err, errorconcept.Default.InternalServerError)
@@ -1070,7 +1098,7 @@ func readingHandler(
 			pkg.Encode("unsaved", w, loggingClient)
 		}
 	case http.MethodPut:
-		from, err := decodeReading(r.Body, loggingClient, dbClient)
+		from, err := decodeReading(r.Body, loggingClient, dbClient, configuration)
 		// Problem decoding
 		if err != nil {
 			httpErrorHandler.HandleManyVariants(
@@ -1085,7 +1113,7 @@ func readingHandler(
 			return
 		}
 
-		err = updateReading(from, loggingClient, dbClient)
+		err = updateReading(from, loggingClient, dbClient, configuration)
 		if err != nil {
 			httpErrorHandler.HandleManyVariants(
 				w,
@@ -1203,7 +1231,8 @@ func readingByDeviceHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -1225,13 +1254,13 @@ func readingByDeviceHandler(
 
 	switch r.Method {
 	case http.MethodGet:
-		err := checkMaxLimit(limit, loggingClient)
+		err := checkMaxLimit(limit, loggingClient, configuration)
 		if err != nil {
 			httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 			return
 		}
 
-		readings, err := getReadingsByDevice(deviceId, limit, ctx, loggingClient, dbClient, mdc)
+		readings, err := getReadingsByDevice(deviceId, limit, ctx, loggingClient, dbClient, mdc, configuration)
 		if err != nil {
 			httpErrorHandler.HandleOneVariant(
 				w,
@@ -1253,7 +1282,8 @@ func readingbyValueDescriptorHandler(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -1271,7 +1301,7 @@ func readingbyValueDescriptorHandler(
 		return
 	}
 
-	read, err := getReadingsByValueDescriptor(name, limit, loggingClient, dbClient)
+	read, err := getReadingsByValueDescriptor(name, limit, loggingClient, dbClient, configuration)
 	if err != nil {
 		httpErrorHandler.Handle(w, err, errorconcept.Default.InternalServerError)
 		return
@@ -1287,7 +1317,8 @@ func readingByUomLabelHandler(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -1308,7 +1339,7 @@ func readingByUomLabelHandler(
 	}
 
 	// Limit was exceeded
-	err = checkMaxLimit(limit, loggingClient)
+	err = checkMaxLimit(limit, loggingClient, configuration)
 	if err != nil {
 		httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 		return
@@ -1343,7 +1374,8 @@ func readingByLabelHandler(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -1362,7 +1394,7 @@ func readingByLabelHandler(
 	}
 
 	// Limit is too large
-	err = checkMaxLimit(limit, loggingClient)
+	err = checkMaxLimit(limit, loggingClient, configuration)
 	if err != nil {
 		httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 		return
@@ -1396,7 +1428,8 @@ func readingByTypeHandler(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -1415,7 +1448,7 @@ func readingByTypeHandler(
 		return
 	}
 
-	err = checkMaxLimit(limit, loggingClient)
+	err = checkMaxLimit(limit, loggingClient, configuration)
 	if err != nil {
 		httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 		return
@@ -1448,7 +1481,8 @@ func readingByCreationTimeHandler(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -1471,7 +1505,7 @@ func readingByCreationTimeHandler(
 
 	switch r.Method {
 	case http.MethodGet:
-		err = checkMaxLimit(limit, loggingClient)
+		err = checkMaxLimit(limit, loggingClient, configuration)
 		if err != nil {
 			httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 			return
@@ -1496,7 +1530,8 @@ func readingByValueDescriptorAndDeviceHandler(
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	mdc metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -1522,14 +1557,14 @@ func readingByValueDescriptorAndDeviceHandler(
 		return
 	}
 
-	err = checkMaxLimit(limit, loggingClient)
+	err = checkMaxLimit(limit, loggingClient, configuration)
 	if err != nil {
 		httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 		return
 	}
 
 	// Check device
-	if err := checkDevice(device, ctx, mdc); err != nil {
+	if err := checkDevice(device, ctx, mdc, configuration); err != nil {
 		httpErrorHandler.HandleOneVariant(
 			w,
 			err,
@@ -1539,7 +1574,7 @@ func readingByValueDescriptorAndDeviceHandler(
 	}
 
 	// Check for value descriptor
-	if Configuration.Writable.ValidateCheck {
+	if configuration.Writable.ValidateCheck {
 		_, err = getValueDescriptorByName(name, loggingClient, dbClient)
 		if err != nil {
 			httpErrorHandler.HandleOneVariant(
@@ -1569,7 +1604,8 @@ func valueDescriptorHandler(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	defer func() { _ = r.Body.Close() }()
 
@@ -1582,7 +1618,7 @@ func valueDescriptorHandler(
 		}
 
 		// Check the limit
-		err = checkMaxLimit(len(vList), loggingClient)
+		err = checkMaxLimit(len(vList), loggingClient, configuration)
 		if err != nil {
 			httpErrorHandler.Handle(w, err, errorconcept.Common.LimitExceeded)
 			return
@@ -1633,7 +1669,7 @@ func valueDescriptorHandler(
 			return
 		}
 
-		err = updateValueDescriptor(vd, loggingClient, dbClient)
+		err = updateValueDescriptor(vd, loggingClient, dbClient, configuration)
 		if err != nil {
 			httpErrorHandler.HandleManyVariants(
 				w,
@@ -1936,7 +1972,8 @@ func restValueDescriptorsUsageHandler(
 	r *http.Request,
 	loggingClient logger.LoggingClient,
 	dbClient interfaces.DBClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	configuration *config.ConfigurationStruct) {
 
 	qparams, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
@@ -1949,13 +1986,13 @@ func restValueDescriptorsUsageHandler(
 	var op value_descriptor.GetValueDescriptorsExecutor
 	if len(namesFilter) <= 0 {
 		// We are not filtering so get all the value descriptors
-		op = value_descriptor.NewGetValueDescriptorsExecutor(dbClient, loggingClient, Configuration.Service)
+		op = value_descriptor.NewGetValueDescriptorsExecutor(dbClient, loggingClient, configuration.Service)
 	} else {
 		op = value_descriptor.NewGetValueDescriptorsNameExecutor(
 			strings.Split(namesFilter[0], ","),
 			dbClient,
 			loggingClient,
-			Configuration.Service)
+			configuration.Service)
 	}
 
 	vds, err = op.Execute()
@@ -1978,7 +2015,7 @@ func restValueDescriptorsUsageHandler(
 			ValueDescriptorUsageReadLimit,
 			dbClient,
 			loggingClient,
-			Configuration.Service)
+			configuration.Service)
 		r, err := ops.Execute()
 		if err != nil {
 			httpErrorHandler.Handle(w, err, errorconcept.Default.InternalServerError)

--- a/internal/core/data/router_test.go
+++ b/internal/core/data/router_test.go
@@ -27,12 +27,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
 
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/config"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
@@ -176,13 +176,11 @@ func TestRestValueDescriptorsUsageHandler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			Configuration = &ConfigurationStruct{Service: bootstrapConfig.ServiceInfo{MaxResultCount: 10}}
-			defer func() { Configuration = &ConfigurationStruct{} }()
-
-			Configuration.Service = tt.config
+			configuration := &config.ConfigurationStruct{Service: bootstrapConfig.ServiceInfo{MaxResultCount: 10}}
+			configuration.Service = tt.config
 			rr := httptest.NewRecorder()
 			lc := logger.NewMockClient()
-			restValueDescriptorsUsageHandler(rr, tt.request, lc, tt.dbMock, errorconcept.NewErrorHandler(lc))
+			restValueDescriptorsUsageHandler(rr, tt.request, lc, tt.dbMock, errorconcept.NewErrorHandler(lc), configuration)
 			response := rr.Result()
 			b, _ := ioutil.ReadAll(response.Body)
 			var r []map[string]bool

--- a/internal/core/data/utils.go
+++ b/internal/core/data/utils.go
@@ -14,11 +14,13 @@
 package data
 
 import (
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
-	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"io"
 	"io/ioutil"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
 // Printing function purely for debugging purposes
@@ -34,8 +36,8 @@ func printBody(r io.ReadCloser, loggingClient logger.LoggingClient) {
 	loggingClient.Info(bodyString)
 }
 
-func checkMaxLimit(limit int, loggingClient logger.LoggingClient) error {
-	if limit > Configuration.Service.MaxResultCount {
+func checkMaxLimit(limit int, loggingClient logger.LoggingClient, configuration *config.ConfigurationStruct) error {
+	if limit > configuration.Service.MaxResultCount {
 		loggingClient.Error(maxExceededString)
 		return errors.NewErrLimitExceeded(limit)
 	}

--- a/internal/core/data/valuedescriptor.go
+++ b/internal/core/data/valuedescriptor.go
@@ -20,13 +20,14 @@ import (
 	"io"
 	"regexp"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
-	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 const (
@@ -272,7 +273,8 @@ func addValueDescriptor(
 func updateValueDescriptor(
 	from contract.ValueDescriptor,
 	loggingClient logger.LoggingClient,
-	dbClient interfaces.DBClient) error {
+	dbClient interfaces.DBClient,
+	configuration *config.ConfigurationStruct) error {
 
 	to, err := getValueDescriptorById(from.Id, loggingClient, dbClient)
 	if err != nil {
@@ -311,7 +313,7 @@ func updateValueDescriptor(
 	if from.Name != "" {
 		// Check if value descriptor is still in use by readings if the name changes
 		if from.Name != to.Name {
-			r, err := getReadingsByValueDescriptor(to.Name, 10, loggingClient, dbClient) // Arbitrary limit, we're just checking if there are any readings
+			r, err := getReadingsByValueDescriptor(to.Name, 10, loggingClient, dbClient, configuration) // Arbitrary limit, we're just checking if there are any readings
 			if err != nil {
 				loggingClient.Error("Error checking the readings for the value descriptor: " + err.Error())
 				return err


### PR DESCRIPTION
Fix #2031 

Remove the 'Configuration' global variable from coredata and instead use
the DI container to pass a reference to which functions/methods require.
   
Update REST handlers and loadRoutes function to refer to the
configuration provided in the DI container
    
Update tests to work with the changes to production code.
    
Fix test which was incorrectly performing a DeepEqual rather than a type
verification check to ensure the factory was returning the correct type
 of instance.
    
Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>