### PR TITLE
Fixed Consul initialization in Command bug.

### DIFF
--- a/internal/pkg/endpoint/endpoint.go
+++ b/internal/pkg/endpoint/endpoint.go
@@ -29,14 +29,9 @@ type Endpoint struct {
 
 func (e Endpoint) Monitor(params types.EndpointParams) chan string {
 	ch := make(chan string, 1)
-	ch <- e.fetch(params)
 	go func() {
 		for {
-			url, err := e.buildURL(params)
-			if err != nil {
-				_, _ = fmt.Fprintln(os.Stdout, err.Error())
-			}
-			ch <- url
+			ch <- e.fetch(params)
 			time.Sleep(time.Millisecond * time.Duration(params.Interval))
 		}
 	}()


### PR DESCRIPTION
Fixes #2237

The endpoint monitor was being started just-in-time by the dependency container during the first call to the metadata client instead of starting on service initialization. This caused the first call to the metadata client to always fail with a bad URL.

Reduced code duplication in endpoint.

Signed-off-by: Brandon Forster <brandonforster@gmail.com>