### PR TITLE
Deprivilege token provider and revoke old tokens on startup.

### DIFF
--- a/cmd/security-secretstore-setup/entrypoint.sh
+++ b/cmd/security-secretstore-setup/entrypoint.sh
@@ -36,6 +36,11 @@ until /consul/scripts/consul-svc-healthy.sh security-secrets-setup; do
     sleep 1; 
 done;
 
+echo "Initializing secret store"
 /security-secretstore-setup --vaultInterval=10
 
-exec "$@"
+echo "Executing custom command: $@"
+"$@"
+
+echo "Waiting for termination signal"
+exec tail -f /dev/null

--- a/cmd/security-secretstore-setup/res-file-token-provider/docker/configuration.toml
+++ b/cmd/security-secretstore-setup/res-file-token-provider/docker/configuration.toml
@@ -6,7 +6,7 @@ Port = 8200
 CaFilePath = '/tmp/edgex/secrets/ca/ca.pem'
 
 [TokenFileProvider]
-PrivilegedTokenPath = "/vault/config/assets/resp-init.json"
+PrivilegedTokenPath = "/run/edgex/secrets/tokenprovider/secrets-token.json"
 ConfigFile = "res-file-token-provider/token-config.json"
 OutputDir = "/tmp/edgex/secrets"
 OutputFilename = "secrets-token.json"

--- a/cmd/security-secretstore-setup/res/docker/configuration.toml
+++ b/cmd/security-secretstore-setup/res/docker/configuration.toml
@@ -37,6 +37,8 @@ vaultsecretthreshold = 3
 tokenprovider = "/security-file-token-provider"
 tokenproviderargs = [ "-confdir", "res-file-token-provider" ]
 tokenprovidertype = "oneshot"
+tokenprovideradmintokenpath = "/run/edgex/secrets/tokenprovider/secrets-token.json"
+revokeroottokens = false
 
 [Startup]
 Duration = 30

--- a/internal/security/fileprovider/init.go
+++ b/internal/security/fileprovider/init.go
@@ -33,8 +33,23 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
 )
 
+type Bootstrap struct {
+	exitCode int
+}
+
+func NewBootstrap() *Bootstrap {
+	return &Bootstrap{
+		exitCode: 0,
+	}
+}
+
+// ExitCode returns desired exit code of program
+func (b *Bootstrap) ExitCode() int {
+	return b.exitCode
+}
+
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
-func BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
+func (b *Bootstrap) BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
 	cfg := container.ConfigurationFrom(dic.Get)
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 
@@ -65,6 +80,7 @@ func BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ startup.Timer, dic
 
 	if err != nil {
 		lc.Error(fmt.Sprintf("error occurred generating tokens: %s", err.Error()))
+		b.exitCode = 1
 	}
 
 	return false // Tell bootstrap.Run() to exit wait loop and terminate

--- a/internal/security/fileprovider/main.go
+++ b/internal/security/fileprovider/main.go
@@ -18,6 +18,8 @@ package fileprovider
 import (
 	"context"
 	"flag"
+	"os"
+
 	"github.com/gorilla/mux"
 
 	"github.com/edgexfoundry/edgex-go/internal"
@@ -55,6 +57,8 @@ func Main(ctx context.Context, cancel context.CancelFunc, _ *mux.Router, _ chan<
 		},
 	})
 
+	bootStrapper := NewBootstrap()
+
 	bootstrap.Run(
 		ctx,
 		cancel,
@@ -67,7 +71,9 @@ func Main(ctx context.Context, cancel context.CancelFunc, _ *mux.Router, _ chan<
 		startupTimer,
 		dic,
 		[]interfaces.BootstrapHandler{
-			BootstrapHandler,
+			bootStrapper.BootstrapHandler,
 		},
 	)
+
+	os.Exit(bootStrapper.ExitCode())
 }

--- a/internal/security/secretstore/certs_test.go
+++ b/internal/security/secretstore/certs_test.go
@@ -31,19 +31,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
-func TestGetAccessToken(t *testing.T) {
-	path := "testdata/test-resp-init.json"
-	s, err := GetAccessToken(path)
-	if err != nil {
-		t.Errorf("failed to parse token file")
-		t.Errorf(err.Error())
-	}
-	if s != "test-root-token" {
-		t.Errorf("incorrect token")
-		t.Errorf(s)
-	}
-}
-
 func TestRetrieve(t *testing.T) {
 	certPath := "testCertPath"
 	token := "token"
@@ -86,10 +73,10 @@ func TestRetrieve(t *testing.T) {
 	cs := NewCerts(
 		secretstoreclient.NewRequestor(mockLogger).Insecure(),
 		certPath,
-		"",
+		"token",
 		configuration.SecretService.GetSecretSvcBaseURL(),
 		mockLogger)
-	cp, err := cs.retrieve(token)
+	cp, err := cs.retrieve()
 	if err != nil {
 		t.Errorf("failed to retrieve cert pair")
 		t.Errorf(err.Error())

--- a/internal/security/secretstore/constants.go
+++ b/internal/security/secretstore/constants.go
@@ -18,5 +18,32 @@
 package secretstore
 
 const (
-	VaultToken = "X-Vault-Token"
+	VaultToken             = "X-Vault-Token"
+	TokenCreatorPolicyName = "privileged-token-creator"
+
+	// This is an admin token policy that allow for creation of
+	// per-service tokens and policies
+	TokenCreatorPolicy = `
+path "auth/token/create" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "auth/token/create-orphan" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "auth/token/create/*" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "sys/policies/acl/edgex-service-*"
+{
+  capabilities = ["create", "read", "update", "delete" ]
+}
+
+path "sys/policies/acl"
+{
+  capabilities = ["list"]
+}
+`
 )

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -17,6 +17,7 @@ package secretstore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -25,8 +26,10 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
@@ -98,7 +101,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 				lc.Error(fmt.Sprintf("vault is unsealed and in standby mode (Status Code: %d)", sCode))
 				shouldContinue = false
 			case http.StatusNotImplemented:
-				lc.Info(fmt.Sprintf("vault is not initialized (status code: %d). Starting initialisation and unseal phases", sCode))
+				lc.Info(fmt.Sprintf("vault is not initialized (status code: %d). Starting initialization and unseal phases", sCode))
 				_, err := vc.Init(configuration.SecretService, tokenFile)
 				if err == nil {
 					tokenFile.Seek(0, 0) // Read starting at beginning
@@ -149,6 +152,72 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	// Wait on a StatusOK response from vc.HealthCheck()
 	<-healthOkCh
 
+	// create new root token
+	// defer revoke token
+	// optional: revoke other root token
+	// revoke old tokens
+	// create delegate credential
+	// spawn token provider
+	// create db credentials
+	// upload kong certificate
+	tokenMaintenance := NewTokenMaintenance(lc, vc)
+
+	tokenFile, err := fileOpener.OpenFileReader(absPath, os.O_RDONLY, 0400)
+	if err != nil {
+		lc.Error(fmt.Sprintf("could not read master key shares file %s", err.Error()))
+		os.Exit(1)
+	}
+	tokenFileCloseable := fileioperformer.MakeReadCloser(tokenFile)
+	defer tokenFileCloseable.Close()
+
+	// Create a transient root token from the key shares
+	var rootToken string
+	err = vc.RegenRootToken(tokenFileCloseable, &rootToken)
+	if err != nil {
+		lc.Error(fmt.Sprintf("could not regenerate root token %s", err.Error()))
+		os.Exit(1)
+	}
+	defer func() {
+		// Revoke transient root token at the end of this funciton
+		lc.Info("revoking temporary root token")
+		_, err := vc.RevokeSelf(rootToken)
+		if err != nil {
+			lc.Error(fmt.Sprintf("could not revoke temporary root token %s", err.Error()))
+		}
+	}()
+	lc.Info("generated transient root token")
+
+	// Revoke the other root tokens
+	if configuration.SecretService.RevokeRootTokens {
+		if err = tokenMaintenance.RevokeRootTokens(rootToken); err != nil {
+			lc.Warn(fmt.Sprintf("failed to revoke non-transient root tokens %s", err.Error()))
+		}
+		lc.Info("completed cleanup of old root tokens")
+	} else {
+		lc.Info("not revoking existing root tokens")
+	}
+
+	// Revoke non-root tokens from previous runs
+	err = tokenMaintenance.RevokeNonRootTokens(rootToken)
+	if err != nil {
+		lc.Warn("failed to revoke non-root tokens")
+	}
+	lc.Info("completed cleanup of old admin/service tokens")
+
+	// If configured to do so, create a token issuing token
+	if configuration.SecretService.TokenProviderAdminTokenPath != "" {
+		revokeIssuingTokenFuc, err := makeTokenIssuingToken(lc, configuration, tokenMaintenance, fileOpener, rootToken)
+		if err != nil {
+			lc.Error(fmt.Sprintf("failed to create token issuing token %s", err.Error()))
+			os.Exit(1)
+		}
+		if configuration.SecretService.TokenProviderType == OneShotProvider {
+			// Revoke the admin token at the end of the current function if running a one-shot provider
+			// otherwise assume the token provider will keep its token fresh after this point
+			defer revokeIssuingTokenFuc()
+		}
+	}
+
 	//Step 4: Launch token handler
 	tokenProvider := NewTokenProvider(ctx, lc, ExecWrapper{})
 	if configuration.SecretService.TokenProvider != "" {
@@ -164,34 +233,17 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 		lc.Info("no token provider configured")
 	}
 
-	// credential creation
-	gk := NewGokeyGenerator(absPath)
-	lc.Warn("WARNING: The gokey generator is a reference implementation for credential generation and the underlying libraries not been reviewed for cryptographic security. The user is encouraged to perform their own security investigation before deployment.")
-	cred := NewCred(req, absPath, gk, configuration.SecretService.GetSecretSvcBaseURL(), lc)
+	// Enable KV secret engine
+	err = enableKVSecretsEngine(lc, vc, rootToken)
+	if err != nil {
+		lc.Error(fmt.Sprintf("failed to enable KV secrets engine: %s", err.Error()))
+		os.Exit(1)
+	}
 
-	// Detour: Create secrets engine if not there already
-	vaultToken, err := GetAccessToken(absPath)
-	if err != nil {
-		lc.Error(fmt.Sprintf("failed to reload root token: %s", err.Error()))
-		os.Exit(1)
-	}
-	// Note: trailing slash on secret/ is required.
-	installed, err := vc.CheckSecretEngineInstalled(vaultToken, "secret/", "kv")
-	if err != nil {
-		lc.Error(fmt.Sprintf("failed call to check if kv secrets engine is installed: %s", err.Error()))
-		os.Exit(1)
-	}
-	if !installed {
-		lc.Info("enabling KV secrets engine for the first time...")
-		// Enable KV version 1 at /v1/secret path (/v1 prefix supplied by Vault)
-		_, err := vc.EnableKVSecretEngine(vaultToken, "secret", "1")
-		if err != nil {
-			lc.Error(fmt.Sprintf("failed call to enable KV secrets engine: %s", err.Error()))
-			os.Exit(1)
-		}
-	} else {
-		lc.Info("KV secrets engine already enabled...")
-	}
+	// credential creation
+	gk := NewGokeyGenerator(rootToken)
+	lc.Warn("WARNING: The gokey generator is a reference implementation for credential generation and the underlying libraries not been reviewed for cryptographic security. The user is encouraged to perform their own security investigation before deployment.")
+	cred := NewCred(req, rootToken, gk, configuration.SecretService.GetSecretSvcBaseURL(), lc)
 
 	// continue credential creation
 	for dbname, info := range configuration.Databases {
@@ -244,7 +296,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 		}
 	}
 
-	cert := NewCerts(req, configuration.SecretService.CertPath, absPath, configuration.SecretService.GetSecretSvcBaseURL(), lc)
+	cert := NewCerts(req, configuration.SecretService.CertPath, rootToken, configuration.SecretService.GetSecretSvcBaseURL(), lc)
 	existing, err := cert.AlreadyinStore()
 	if err != nil {
 		lc.Error(err.Error())
@@ -274,4 +326,96 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 
 	lc.Info("proxy certificate pair are uploaded to secret store successfully, Vault init done successfully")
 	return false
+}
+
+func makeTokenIssuingToken(
+	lc logger.LoggingClient,
+	configuration *config.ConfigurationStruct,
+	tokenMaintenance *TokenMaintenance,
+	fileOpener fileioperformer.FileIoPerformer,
+	rootToken string) (RevokeFunc, error) {
+
+	configAdminTokenPath := configuration.SecretService.TokenProviderAdminTokenPath
+	if configAdminTokenPath == "" {
+		err := fmt.Errorf("TokenProviderAdminTokenPath is a required configuration setting")
+		lc.Error(err.Error())
+		return nil, err
+	}
+
+	// Create delegate credential for use by the token provider
+	tokenIssuingToken, revokeIssuingTokenFuc, err := tokenMaintenance.CreateTokenIssuingToken(rootToken)
+	if err != nil {
+		lc.Error(fmt.Sprintf("failed to create token issuing token %s", err.Error()))
+		return nil, err
+	}
+	lc.Info("created token issuing token")
+
+	// Write the token issuing token to disk to pass it to the token provider
+	adminTokenPath, err := filepath.Abs(configAdminTokenPath)
+	if err != nil {
+		lc.Error(fmt.Sprintf("failed to convert to absolute path %s: %s", configAdminTokenPath, err.Error()))
+		revokeIssuingTokenFuc()
+		return nil, err
+	}
+	dirOfAdminToken := filepath.Dir(adminTokenPath)
+	err = fileOpener.MkdirAll(dirOfAdminToken, 0700)
+	if err != nil {
+		lc.Error(fmt.Sprintf("failed to create tokenpath base dir: %s", err.Error()))
+		revokeIssuingTokenFuc()
+		return nil, err
+	}
+	tokenWriter, err := fileOpener.OpenFileWriter(adminTokenPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		lc.Error(fmt.Sprintf("failed to create token issuing file %s: %s", adminTokenPath, err.Error()))
+		revokeIssuingTokenFuc()
+		return nil, err
+	}
+
+	encoder := json.NewEncoder(tokenWriter)
+	if encoder == nil {
+		err := fmt.Errorf("failed to create token encoder")
+		lc.Error(err.Error())
+		tokenWriter.Close()
+		revokeIssuingTokenFuc()
+		return nil, err
+	}
+
+	if err = encoder.Encode(tokenIssuingToken); err != nil {
+		lc.Error(fmt.Sprintf("failed to write token issing token: %s", err.Error()))
+		tokenWriter.Close()
+		revokeIssuingTokenFuc()
+		return nil, err
+	}
+
+	if err = tokenWriter.Close(); err != nil {
+		lc.Error(fmt.Sprintf("failed to close token issuing file: %s", err.Error()))
+		revokeIssuingTokenFuc()
+		return nil, err
+	}
+
+	return revokeIssuingTokenFuc, nil
+}
+
+func enableKVSecretsEngine(
+	lc logger.LoggingClient,
+	vc secretstoreclient.SecretStoreClient,
+	rootToken string) error {
+
+	installed, err := vc.CheckSecretEngineInstalled(rootToken, "secret/", "kv")
+	if err != nil {
+		lc.Error(fmt.Sprintf("failed call to check if kv secrets engine is installed: %s", err.Error()))
+		return err
+	}
+	if !installed {
+		lc.Info("enabling KV secrets engine for the first time...")
+		// Enable KV version 1 at /v1/secret path (/v1 prefix supplied by Vault)
+		_, err := vc.EnableKVSecretEngine(rootToken, "secret", "1")
+		if err != nil {
+			lc.Error(fmt.Sprintf("failed call to enable KV secrets engine: %s", err.Error()))
+			return err
+		}
+	} else {
+		lc.Info("KV secrets engine already enabled...")
+	}
+	return nil
 }

--- a/internal/security/secretstore/password_test.go
+++ b/internal/security/secretstore/password_test.go
@@ -30,9 +30,9 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
-	tokenPath := "testdata/test-resp-init.json"
-	gk := NewGokeyGenerator(tokenPath)
-	cr := NewCred(&http.Client{}, tokenPath, gk, "", logger.MockLogger{})
+	rootToken := "s.Ga5jyNq6kNfRMVQk2LY1j9iu"
+	gk := NewGokeyGenerator(rootToken)
+	cr := NewCred(&http.Client{}, rootToken, gk, "", logger.MockLogger{})
 
 	realm1 := "service1"
 	realm2 := "service2"
@@ -94,11 +94,11 @@ func TestRetrieveCred(t *testing.T) {
 	mockLogger := logger.MockLogger{}
 	cr := NewCred(
 		secretstoreclient.NewRequestor(mockLogger).Insecure(),
-		"",
+		"token",
 		NewGokeyGenerator(""),
 		configuration.SecretService.GetSecretSvcBaseURL(),
 		mockLogger)
-	pair, err := cr.retrieve(token, credPath)
+	pair, err := cr.retrieve(credPath)
 	if err != nil {
 		t.Errorf("failed to retrieve credential pair")
 		t.Errorf(err.Error())

--- a/internal/security/secretstore/tokenmaintenance.go
+++ b/internal/security/secretstore/tokenmaintenance.go
@@ -1,0 +1,189 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package secretstore
+
+/*
+
+High level token maintenance flow is as follows:
+
+1. Recover a root token from keyshares
+2. Revoke all previous non-root tokens
+3. Create new admin token from that root token
+4. Create per-service tokens using admin token
+5. Upload other bootstrapping access with root token (e.g. kong cert, db password)
+6. Revoke all other root tokens (dangerous: breaks backward-compatibility)
+   6a. Go back and retroactively remove root token from resp-init.json
+7. Revoke self
+
+End state is that only admin token and per-service tokens remain.
+For Fuji, the root token in resp-init.json will also remain.
+For Fuji.DOT/Geneva, all root tokens will be revoked.
+
+*/
+
+import (
+	"fmt"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+type RevokeFunc func()
+
+type TokenMaintenance struct {
+	logging      logger.LoggingClient
+	secretClient secretstoreclient.SecretStoreClient
+}
+
+// NewTokenMaintenance creates a new TokenProvider
+func NewTokenMaintenance(logging logger.LoggingClient, secretClient secretstoreclient.SecretStoreClient) *TokenMaintenance {
+	return &TokenMaintenance{
+		logging:      logging,
+		secretClient: secretClient,
+	}
+}
+
+// CreateTokenIssuingToken creates an admin token that
+// allows the holder to create per-service tokens an policies.
+// Requires a root token, returns a function that,
+// if called, with revoke the token
+func (tm *TokenMaintenance) CreateTokenIssuingToken(rootToken string) (map[string]interface{}, RevokeFunc, error) {
+
+	_, err := tm.secretClient.InstallPolicy(rootToken, TokenCreatorPolicyName, TokenCreatorPolicy)
+	if err != nil {
+		tm.logging.Error("failed installation of token-issuing-token policy")
+		return nil, nil, err
+	}
+
+	createTokenParameters := make(map[string]interface{})
+	createTokenParameters["display_name"] = TokenCreatorPolicyName
+	createTokenParameters["no_parent"] = true
+	createTokenParameters["period"] = "1h"
+	createTokenParameters["policies"] = []string{TokenCreatorPolicyName}
+	createTokenParameters["ttl"] = "1h"
+	createTokenResponse := make(map[string]interface{})
+	_, err = tm.secretClient.CreateToken(rootToken, createTokenParameters, &createTokenResponse)
+	if err != nil {
+		tm.logging.Error(fmt.Sprintf("failed creation of token-issuing-token: %s", err.Error()))
+		return nil, nil, err
+	}
+
+	newToken := createTokenResponse["auth"].(map[string]interface{})["client_token"].(string)
+	revokeFunc := func() {
+		tm.logging.Info("revoking token-issuing-token")
+		if _, err2 := tm.secretClient.RevokeSelf(newToken); err2 != nil {
+			tm.logging.Warn("failed revokation of token-issuing-token: %s", err2.Error())
+		}
+	}
+	return createTokenResponse, revokeFunc, nil
+}
+
+// RevokeNonRootTokens revokes non-root tokens that may have been
+// issued in previous EdgeX runs.  Should be called with a high-privileged token.
+func (tm *TokenMaintenance) RevokeNonRootTokens(privilegedToken string) error {
+	// First enumerate all accessors
+	allAccessors := make([]string, 0)
+	_, err := tm.secretClient.ListAccessors(privilegedToken, &allAccessors)
+	if err != nil {
+		return err // secretclient already logged failure
+	}
+
+	var selfMetadata secretstoreclient.TokenMetadata
+	_, err = tm.secretClient.LookupSelf(privilegedToken, &selfMetadata)
+	if err != nil {
+		return err // secretclient already logged failure
+	}
+	selfAccessor := selfMetadata.Accessor
+
+	// Lookup each accessor and figure out which ones are root tokens
+	// add the non-root tokens to the list and also don't add ourself
+	accessorsToRevoke := make([]string, 0)
+	for _, accessor := range allAccessors {
+		if accessor == selfAccessor {
+			continue // don't revoke ourselves
+		}
+		tokenMetadata := secretstoreclient.TokenMetadata{}
+		_, err := tm.secretClient.LookupAccessor(privilegedToken, accessor, &tokenMetadata)
+		if err != nil {
+			return err // secretclient already logged failure
+		}
+		// Search attached policies: flag tokens with root policy attached
+		var hasRootToken bool
+		for _, policy := range tokenMetadata.Policies {
+			if policy == "root" {
+				hasRootToken = true
+				break
+			}
+		}
+		if !hasRootToken {
+			accessorsToRevoke = append(accessorsToRevoke, accessor)
+		}
+	}
+
+	var lastErr error
+
+	// Revoke all the accessors in the above list
+	for _, accessor := range accessorsToRevoke {
+		// Revoke as many as we can despite errors
+		_, err = tm.secretClient.RevokeAccessor(privilegedToken, accessor)
+		if err != nil {
+			lastErr = err
+		}
+	}
+
+	return lastErr // return error if any revoke errored
+}
+
+// RevokeRootTokens revokes any root tokens found in the secret store.
+// Should be called with a high-privileged token.
+func (tm *TokenMaintenance) RevokeRootTokens(privilegedToken string) error {
+	// First enumerate all accessors
+	allAccessors := make([]string, 0)
+	_, err := tm.secretClient.ListAccessors(privilegedToken, &allAccessors)
+	if err != nil {
+		return err // secretclient already logged failure
+	}
+
+	var selfMetadata secretstoreclient.TokenMetadata
+	_, err = tm.secretClient.LookupSelf(privilegedToken, &selfMetadata)
+	if err != nil {
+		return err // secretclient already logged failure
+	}
+	selfAccessor := selfMetadata.Accessor
+
+	// Iterate and revoke any root tokens found that aren't ourselves
+	for _, accessor := range allAccessors {
+		if accessor == selfAccessor {
+			continue // don't revoke ourselves
+		}
+		tokenMetadata := secretstoreclient.TokenMetadata{}
+		_, err := tm.secretClient.LookupAccessor(privilegedToken, accessor, &tokenMetadata)
+		if err != nil {
+			return err // secretclient already logged failure
+		}
+		// Search attached policies: revoke root tokens
+		for _, policy := range tokenMetadata.Policies {
+			if policy == "root" {
+				_, err = tm.secretClient.RevokeAccessor(privilegedToken, accessor)
+				if err != nil {
+					return err // secretclient already logged failure
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/security/secretstore/tokenmaintenance_test.go
+++ b/internal/security/secretstore/tokenmaintenance_test.go
@@ -1,0 +1,156 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package secretstore
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	. "github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient/mocks"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCreateTokenIssuingToken(t *testing.T) {
+	// Arrange
+	logging := logger.MockLogger{}
+	secretClient := &MockSecretStoreClient{}
+	tm := NewTokenMaintenance(logging, secretClient)
+
+	secretClient.On("InstallPolicy", "root-token",
+		TokenCreatorPolicyName, TokenCreatorPolicy).
+		Return(http.StatusNoContent, nil)
+	secretClient.On("CreateToken", "root-token", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			output := make(map[string]interface{})
+			output["auth"] = make(map[string]interface{})
+			output["auth"].(map[string]interface{})["client_token"] = "priv-token"
+			*(args.Get(2)).(*map[string]interface{}) = output
+		}).
+		Return(http.StatusOK, nil)
+	secretClient.On("RevokeSelf", "priv-token").
+		Return(http.StatusNoContent, nil)
+
+	// Act
+	token, revoke, err := tm.CreateTokenIssuingToken("root-token")
+	revoke()
+
+	// Assert
+	assert.Equal(t, "priv-token", token["auth"].(map[string]interface{})["client_token"])
+	assert.Nil(t, err)
+	secretClient.AssertExpectations(t)
+}
+
+func TestRevokeNonRootTokens(t *testing.T) {
+	// Arrange
+	logging := logger.MockLogger{}
+	secretClient := &MockSecretStoreClient{}
+	tm := NewTokenMaintenance(logging, secretClient)
+
+	secretClient.On("ListAccessors", "priv-token", mock.Anything).
+		Run(func(args mock.Arguments) {
+			*(args.Get(1)).(*[]string) = []string{
+				"rootaccessor",
+				"nonrootaccessor",
+				"priv-token-accessor",
+			}
+		}).
+		Return(http.StatusOK, nil)
+	secretClient.On("LookupSelf", "priv-token", mock.Anything).
+		Run(func(args mock.Arguments) {
+			*(args.Get(1)).(*secretstoreclient.TokenMetadata) = secretstoreclient.TokenMetadata{
+				Accessor: "priv-token-accessor",
+			}
+		}).
+		Return(http.StatusOK, nil)
+	secretClient.On("LookupAccessor", "priv-token", "rootaccessor", mock.Anything).
+		Run(func(args mock.Arguments) {
+			*(args.Get(2)).(*secretstoreclient.TokenMetadata) = secretstoreclient.TokenMetadata{
+				Accessor: "rootaccessor",
+				Policies: []string{"root"},
+			}
+		}).
+		Return(http.StatusOK, nil)
+	secretClient.On("LookupAccessor", "priv-token", "nonrootaccessor", mock.Anything).
+		Run(func(args mock.Arguments) {
+			*(args.Get(2)).(*secretstoreclient.TokenMetadata) = secretstoreclient.TokenMetadata{
+				Accessor: "nonrootaccessor",
+			}
+		}).
+		Return(http.StatusOK, nil)
+	secretClient.On("RevokeAccessor", "priv-token", "nonrootaccessor").
+		Return(http.StatusNoContent, nil)
+
+	// Act
+	err := tm.RevokeNonRootTokens("priv-token")
+
+	// Assert
+	assert.Nil(t, err)
+	secretClient.AssertExpectations(t)
+}
+
+func TestRevokeRootTokens(t *testing.T) {
+	// Arrange
+	logging := logger.MockLogger{}
+	secretClient := &MockSecretStoreClient{}
+	tm := NewTokenMaintenance(logging, secretClient)
+
+	secretClient.On("ListAccessors", "priv-token", mock.Anything).
+		Run(func(args mock.Arguments) {
+			*(args.Get(1)).(*[]string) = []string{
+				"rootaccessor",
+				"nonrootaccessor",
+				"priv-token-accessor",
+			}
+		}).
+		Return(http.StatusOK, nil)
+	secretClient.On("LookupSelf", "priv-token", mock.Anything).
+		Run(func(args mock.Arguments) {
+			*(args.Get(1)).(*secretstoreclient.TokenMetadata) = secretstoreclient.TokenMetadata{
+				Accessor: "priv-token-accessor",
+				Policies: []string{"root"}, // Make privileged token a root token for this test
+			}
+		}).
+		Return(http.StatusOK, nil)
+	secretClient.On("LookupAccessor", "priv-token", "rootaccessor", mock.Anything).
+		Run(func(args mock.Arguments) {
+			*(args.Get(2)).(*secretstoreclient.TokenMetadata) = secretstoreclient.TokenMetadata{
+				Accessor: "rootaccessor",
+				Policies: []string{"root"},
+			}
+		}).
+		Return(http.StatusOK, nil)
+	secretClient.On("LookupAccessor", "priv-token", "nonrootaccessor", mock.Anything).
+		Run(func(args mock.Arguments) {
+			*(args.Get(2)).(*secretstoreclient.TokenMetadata) = secretstoreclient.TokenMetadata{
+				Accessor: "nonrootaccessor",
+			}
+		}).
+		Return(http.StatusOK, nil)
+	secretClient.On("RevokeAccessor", "priv-token", "rootaccessor").
+		Return(http.StatusNoContent, nil)
+
+	// Act
+	err := tm.RevokeRootTokens("priv-token")
+
+	// Assert
+	assert.Nil(t, err)
+	secretClient.AssertExpectations(t)
+}

--- a/internal/security/secretstoreclient/types.go
+++ b/internal/security/secretstoreclient/types.go
@@ -21,21 +21,23 @@ import (
 )
 
 type SecretServiceInfo struct {
-	Scheme               string
-	Server               string
-	ServerName           string
-	Port                 int
-	CertPath             string
-	CaFilePath           string
-	CertFilePath         string
-	KeyFilePath          string
-	TokenFolderPath      string
-	TokenFile            string
-	VaultSecretShares    int
-	VaultSecretThreshold int
-	TokenProvider        string
-	TokenProviderArgs    []string
-	TokenProviderType    string
+	Scheme                      string
+	Server                      string
+	ServerName                  string
+	Port                        int
+	CertPath                    string
+	CaFilePath                  string
+	CertFilePath                string
+	KeyFilePath                 string
+	TokenFolderPath             string
+	TokenFile                   string
+	VaultSecretShares           int
+	VaultSecretThreshold        int
+	TokenProvider               string
+	TokenProviderArgs           []string
+	TokenProviderType           string
+	TokenProviderAdminTokenPath string
+	RevokeRootTokens            bool
 }
 
 func (s SecretServiceInfo) GetSecretSvcBaseURL() string {


### PR DESCRIPTION
This commit modifies the back-half of the Vault init/unseal
flow so that the Vault key shares are used to generate a
transient root token when is then used for the remainder
of processing.  The transient root token is used to create
an admin token with the necessary privilege to run
security-file-token-provider with a non-root token.
Moreover, the transient token is also used for seeding
of database passwords and Kong TLS certificates.
Additionally, upon every startup, the existing admin/
service tokens from the previous run are revoked and
replaced with new ones.  The container entrypoint
script is changed to busy-wait at the end of its execution
so that tokens are not inadvertently revoked and replaced
should the container restart as happens during
blackbox testing.

This commit also includes hooks to revoke all root
tokens, including the one from the Vault initialization.
This hook is disabled by default as changes need to be
made to consuming microservices to consume their per-service
Vault tokens prior to enabling this feature.

Fixes #1927 
Fixes #1928 
Related #1929 

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

cc @eno-intel 