### PR TITLE
Enable edgex-proxy to use per-service token instead of root token.

### DIFF
--- a/cmd/security-proxy-setup/res/docker/configuration.toml
+++ b/cmd/security-proxy-setup/res/docker/configuration.toml
@@ -46,7 +46,7 @@ Server = "edgex-vault"
 Port = 8200
 HealthCheckPath = "v1/sys/health"
 CertPath = "v1/secret/edgex/pki/tls/edgex-kong"
-TokenPath = "/vault/config/assets/resp-init.json"
+TokenPath = "/tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json"
 CACertPath = "/tmp/edgex/secrets/ca/ca.pem"
 SNIS = ["edgex-kong"]
 

--- a/internal/security/proxy/certs.go
+++ b/internal/security/proxy/certs.go
@@ -19,12 +19,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/security/authtokenloader"
+	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
@@ -65,10 +66,6 @@ type CertPair struct {
 	Key  string `json:"key,omitempty"`
 }
 
-type auth struct {
-	Token string `json:"root_token"`
-}
-
 func (cs certificate) Load() (*CertPair, error) {
 	t, err := cs.getAccessToken(cs.tokenPath)
 	if err != nil {
@@ -86,14 +83,10 @@ func (cs certificate) Load() (*CertPair, error) {
 }
 
 func (cs certificate) getAccessToken(filename string) (string, error) {
-	a := auth{}
-	raw, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return a.Token, err
-	}
-
-	err = json.Unmarshal(raw, &a)
-	return a.Token, err
+	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
+	tokenLoader := authtokenloader.NewAuthTokenLoader(fileOpener)
+	t, err := tokenLoader.Load(filename)
+	return t, err
 }
 
 func (cs certificate) retrieve(t string) (*CertPair, error) {


### PR DESCRIPTION
Add dependency on auth token loader so that it can read service
tokens or root tokens interchangably.  Configure docker version of
configuration.toml to use per-service token.

Fixes #1930 

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>