### PR TITLE
Update to support Golang-based acceptance testing

### DIFF
--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -14,70 +14,14 @@
 package main
 
 import (
-	"flag"
+	"context"
 
-	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata"
-	"github.com/edgexfoundry/edgex-go/internal/core/metadata/config"
-	"github.com/edgexfoundry/edgex-go/internal/core/metadata/container"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
-
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
-	"github.com/edgexfoundry/go-mod-bootstrap/di"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 
 	"github.com/gorilla/mux"
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
-
-	var useRegistry bool
-	var configDir, profileDir string
-
-	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
-	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
-	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
-	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
-
-	flag.Usage = usage.HelpCallback
-	flag.Parse()
-
-	configuration := &config.ConfigurationStruct{}
-	dic := di.NewContainer(di.ServiceConstructorMap{
-		container.ConfigurationName: func(get di.Get) interface{} {
-			return configuration
-		},
-	})
-
-	router := mux.NewRouter()
-	httpServer := httpserver.NewBootstrap(router)
-
-	bootstrap.Run(
-		configDir,
-		profileDir,
-		internal.ConfigFileName,
-		useRegistry,
-		clients.CoreMetaDataServiceKey,
-		configuration,
-		startupTimer,
-		dic,
-		[]interfaces.BootstrapHandler{
-			secret.NewSecret().BootstrapHandler,
-			database.NewDatabase(httpServer, configuration).BootstrapHandler,
-			metadata.NewBootstrap(router).BootstrapHandler,
-			telemetry.BootstrapHandler,
-			httpServer.BootstrapHandler,
-			message.NewBootstrap(clients.CoreMetaDataServiceKey, edgex.Version).BootstrapHandler,
-		})
+	ctx, cancel := context.WithCancel(context.Background())
+	metadata.Main(ctx, cancel, mux.NewRouter(), nil)
 }

--- a/cmd/security-file-token-provider/main.go
+++ b/cmd/security-file-token-provider/main.go
@@ -16,55 +16,14 @@
 package main
 
 import (
-	"flag"
+	"context"
 
-	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
-	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
-	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/container"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
-	"github.com/edgexfoundry/go-mod-bootstrap/di"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/gorilla/mux"
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
-
-	var configDir, profileDir string
-	var useRegistry bool
-
-	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
-	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
-	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
-	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
-
-	flag.Usage = usage.HelpCallbackSecurityFileTokenProvider
-	flag.Parse()
-
-	configuration := &config.ConfigurationStruct{}
-	dic := di.NewContainer(di.ServiceConstructorMap{
-		container.ConfigurationName: func(get di.Get) interface{} {
-			return configuration
-		},
-	})
-
-	bootstrap.Run(
-		configDir,
-		profileDir,
-		internal.ConfigFileName,
-		useRegistry,
-		clients.SecurityFileTokenProviderServiceKey,
-		configuration,
-		startupTimer,
-		dic,
-		[]interfaces.BootstrapHandler{
-			fileprovider.BootstrapHandler,
-		},
-	)
+	ctx, cancel := context.WithCancel(context.Background())
+	fileprovider.Main(ctx, cancel, mux.NewRouter(), nil)
 }

--- a/cmd/security-secrets-setup/main_test.go
+++ b/cmd/security-secrets-setup/main_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -25,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edgexfoundry/edgex-go/internal/security/secrets"
 	"github.com/edgexfoundry/edgex-go/internal/security/secrets/command/generate"
 	"github.com/edgexfoundry/edgex-go/internal/security/secrets/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/secrets/contract"
@@ -35,8 +37,9 @@ import (
 
 func TestMainWithNoOption(t *testing.T) {
 	defer (setupTest([]string{"cmd"}))()
+	ctx, cancel := context.WithCancel(context.Background())
 
-	configuration, exitStatusCode := wrappedMain()
+	configuration, exitStatusCode := secrets.Main(ctx, cancel)
 
 	removeTestDirectories(configuration)
 	assert.Equal(t, contract.StatusCodeExitNormal, exitStatusCode)
@@ -44,8 +47,9 @@ func TestMainWithNoOption(t *testing.T) {
 
 func TestMainWithConfigFileOption(t *testing.T) {
 	defer (setupTest([]string{"cmd", "legacy", "-config", "./res/pkisetup-vault.json"}))()
+	ctx, cancel := context.WithCancel(context.Background())
 
-	configuration, exitStatusCode := wrappedMain()
+	configuration, exitStatusCode := secrets.Main(ctx, cancel)
 
 	removeTestDirectories(configuration)
 	assert.Equal(t, contract.StatusCodeExitNormal, exitStatusCode)
@@ -60,8 +64,9 @@ func TestMainWithConfigFileOption(t *testing.T) {
 
 func TestConfigFileOptionError(t *testing.T) {
 	defer (setupTest([]string{"cmd", "legacy", "-config", "./non-exist/cert.json"}))()
+	ctx, cancel := context.WithCancel(context.Background())
 
-	configuration, exitStatusCode := wrappedMain()
+	configuration, exitStatusCode := secrets.Main(ctx, cancel)
 
 	removeTestDirectories(configuration)
 	assert.Equal(t, contract.StatusCodeExitWithError, exitStatusCode)
@@ -74,8 +79,9 @@ func TestMainWithGenerateOption(t *testing.T) {
 	if err := helper.CreateDirectoryIfNotExists(d); err != nil {
 		assert.Fail(t, "unable to create deploy directory")
 	}
+	ctx, cancel := context.WithCancel(context.Background())
 
-	configuration, exitStatusCode := wrappedMain()
+	configuration, exitStatusCode := secrets.Main(ctx, cancel)
 
 	removeTestDirectories(configuration)
 	assert.Equal(t, contract.StatusCodeExitNormal, exitStatusCode)
@@ -83,8 +89,9 @@ func TestMainWithGenerateOption(t *testing.T) {
 
 func TestMainUnsupportedArgument(t *testing.T) {
 	defer (setupTest([]string{"cmd", "unsupported"}))()
+	ctx, cancel := context.WithCancel(context.Background())
 
-	configuration, exitStatusCode := wrappedMain()
+	configuration, exitStatusCode := secrets.Main(ctx, cancel)
 
 	removeTestDirectories(configuration)
 	assert.Equal(t, contract.StatusCodeNoOptionSelected, exitStatusCode)
@@ -92,8 +99,9 @@ func TestMainUnsupportedArgument(t *testing.T) {
 
 func TestMainVerifyMultipleSubcommands(t *testing.T) {
 	defer (setupTest([]string{"cmd", "generate", "legacy"}))()
+	ctx, cancel := context.WithCancel(context.Background())
 
-	configuration, exitStatusCode := wrappedMain()
+	configuration, exitStatusCode := secrets.Main(ctx, cancel)
 
 	removeTestDirectories(configuration)
 	assert.Equal(t, contract.StatusCodeExitWithError, exitStatusCode)
@@ -101,8 +109,9 @@ func TestMainVerifyMultipleSubcommands(t *testing.T) {
 
 func TestMainLegacySubcommandWithExtraArgs(t *testing.T) {
 	defer (setupTest([]string{"cmd", "legacy", "-c", "./res/pkisetup-vault.json", "extra"}))()
+	ctx, cancel := context.WithCancel(context.Background())
 
-	configuration, exitStatusCode := wrappedMain()
+	configuration, exitStatusCode := secrets.Main(ctx, cancel)
 
 	removeTestDirectories(configuration)
 	assert.Equal(t, contract.StatusCodeExitWithError, exitStatusCode)
@@ -120,8 +129,9 @@ func TestMainWithCacheOption(t *testing.T) {
 	if err := helper.CreateDirectoryIfNotExists(d); err != nil {
 		assert.Fail(t, "unable to create cache directory")
 	}
+	ctx, cancel := context.WithCancel(context.Background())
 
-	configuration, exitStatusCode := wrappedMain()
+	configuration, exitStatusCode := secrets.Main(ctx, cancel)
 
 	removeTestDirectories(configuration)
 	assert.Equal(t, contract.StatusCodeExitNormal, exitStatusCode)
@@ -147,8 +157,9 @@ func TestMainWithImportOption(t *testing.T) {
 	}
 	d, _ = filepath.Abs("./cachetest")
 	writeTestFileToCacheDir(t, d) // must match SecretsSetup.CacheDir value in configuration.toml
+	ctx, cancel := context.WithCancel(context.Background())
 
-	configuration, exitStatusCode := wrappedMain()
+	configuration, exitStatusCode := secrets.Main(ctx, cancel)
 
 	removeTestDirectories(configuration)
 	assert.Equal(t, contract.StatusCodeExitNormal, exitStatusCode)

--- a/cmd/support-logging/main.go
+++ b/cmd/support-logging/main.go
@@ -9,68 +9,14 @@
 package main
 
 import (
-	"flag"
+	"context"
 
-	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/logging"
-	"github.com/edgexfoundry/edgex-go/internal/support/logging/config"
-	"github.com/edgexfoundry/edgex-go/internal/support/logging/container"
-
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
-	"github.com/edgexfoundry/go-mod-bootstrap/di"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 
 	"github.com/gorilla/mux"
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
-
-	var useRegistry bool
-	var configDir, profileDir string
-
-	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
-	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
-	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
-	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
-
-	flag.Usage = usage.HelpCallback
-	flag.Parse()
-
-	configuration := &config.ConfigurationStruct{}
-	dic := di.NewContainer(di.ServiceConstructorMap{
-		container.ConfigurationName: func(get di.Get) interface{} {
-			return configuration
-		},
-	})
-
-	router := mux.NewRouter()
-	httpServer := httpserver.NewBootstrap(router)
-
-	bootstrap.Run(
-		configDir,
-		profileDir,
-		internal.ConfigFileName,
-		useRegistry,
-		clients.SupportLoggingServiceKey,
-		configuration,
-		startupTimer,
-		dic,
-		[]interfaces.BootstrapHandler{
-			secret.NewSecret().BootstrapHandler,
-			logging.NewServiceInit(router, httpServer, clients.SupportLoggingServiceKey).BootstrapHandler,
-			telemetry.BootstrapHandler,
-			httpServer.BootstrapHandler,
-			message.NewBootstrap(clients.SupportLoggingServiceKey, edgex.Version).BootstrapHandler,
-		})
+	ctx, cancel := context.WithCancel(context.Background())
+	logging.Main(ctx, cancel, mux.NewRouter(), nil)
 }

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -21,69 +21,14 @@
 package main
 
 import (
-	"flag"
+	"context"
 
-	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications"
-	notificationsConfig "github.com/edgexfoundry/edgex-go/internal/support/notifications/config"
-	"github.com/edgexfoundry/edgex-go/internal/support/notifications/container"
-
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
-	"github.com/edgexfoundry/go-mod-bootstrap/di"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 
 	"github.com/gorilla/mux"
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
-
-	var useRegistry bool
-	var configDir, profileDir string
-
-	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
-	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
-	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
-	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
-	flag.Usage = usage.HelpCallback
-	flag.Parse()
-
-	configuration := &notificationsConfig.ConfigurationStruct{}
-	dic := di.NewContainer(di.ServiceConstructorMap{
-		container.ConfigurationName: func(get di.Get) interface{} {
-			return configuration
-		},
-	})
-
-	router := mux.NewRouter()
-	httpServer := httpserver.NewBootstrap(router)
-
-	bootstrap.Run(
-		configDir,
-		profileDir,
-		internal.ConfigFileName,
-		useRegistry,
-		clients.SupportNotificationsServiceKey,
-		configuration,
-		startupTimer,
-		dic,
-		[]interfaces.BootstrapHandler{
-			secret.NewSecret().BootstrapHandler,
-			database.NewDatabase(httpServer, configuration).BootstrapHandler,
-			notifications.NewBootstrap(router).BootstrapHandler,
-			telemetry.BootstrapHandler,
-			httpServer.BootstrapHandler,
-			message.NewBootstrap(clients.SupportNotificationsServiceKey, edgex.Version).BootstrapHandler,
-		})
+	ctx, cancel := context.WithCancel(context.Background())
+	notifications.Main(ctx, cancel, mux.NewRouter(), nil)
 }

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -15,69 +15,14 @@
 package main
 
 import (
-	"flag"
+	"context"
 
-	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler"
-	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/config"
-	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
-
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
-	"github.com/edgexfoundry/go-mod-bootstrap/di"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 
 	"github.com/gorilla/mux"
 )
 
 func main() {
-	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
-	var useRegistry bool
-	var configDir, profileDir string
-
-	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
-	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
-	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
-	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
-
-	flag.Usage = usage.HelpCallback
-	flag.Parse()
-
-	configuration := &config.ConfigurationStruct{}
-	dic := di.NewContainer(di.ServiceConstructorMap{
-		container.ConfigurationName: func(get di.Get) interface{} {
-			return configuration
-		},
-	})
-
-	router := mux.NewRouter()
-	httpServer := httpserver.NewBootstrap(router)
-
-	bootstrap.Run(
-		configDir,
-		profileDir,
-		internal.ConfigFileName,
-		useRegistry,
-		clients.SupportSchedulerServiceKey,
-		configuration,
-		startupTimer,
-		dic,
-		[]interfaces.BootstrapHandler{
-			secret.NewSecret().BootstrapHandler,
-			database.NewDatabase(httpServer, configuration).BootstrapHandler,
-			scheduler.NewBootstrap(router).BootstrapHandler,
-			telemetry.BootstrapHandler,
-			httpServer.BootstrapHandler,
-			message.NewBootstrap(clients.SupportSchedulerServiceKey, edgex.Version).BootstrapHandler,
-		})
+	ctx, cancel := context.WithCancel(context.Background())
+	scheduler.Main(ctx, cancel, mux.NewRouter(), nil)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/edgexfoundry/go-mod-bootstrap v0.0.7
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.8
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.37
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package command
+
+import (
+	"context"
+	"flag"
+
+	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/core/command/config"
+	container "github.com/edgexfoundry/edgex-go/internal/core/command/container"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/testing"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/gorilla/mux"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router, readyStream chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	var useRegistry bool
+	var configDir, profileDir string
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+	flag.Usage = usage.HelpCallback
+	flag.Parse()
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	httpServer := httpserver.NewBootstrap(router)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.CoreCommandServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			secret.NewSecret().BootstrapHandler,
+			database.NewDatabase(httpServer, configuration, readyStream != nil).BootstrapHandler,
+			NewBootstrap(router).BootstrapHandler,
+			telemetry.BootstrapHandler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.CoreCommandServiceKey, edgex.Version).BootstrapHandler,
+			testing.NewBootstrap(httpServer, readyStream).BootstrapHandler,
+		})
+
+	// code here!
+}

--- a/internal/core/data/main.go
+++ b/internal/core/data/main.go
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright 2017 Dell Inc.
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package data
+
+import (
+	"context"
+	"flag"
+
+	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
+	dataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/container"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/testing"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/gorilla/mux"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router, readyStream chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	var useRegistry bool
+	var profileDir, configDir string
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallback
+	flag.Parse()
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		dataContainer.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	httpServer := httpserver.NewBootstrap(router)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.CoreDataServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			secret.NewSecret().BootstrapHandler,
+			database.NewDatabaseForCoreData(httpServer, configuration, readyStream != nil).BootstrapHandler,
+			NewBootstrap(router).BootstrapHandler,
+			telemetry.BootstrapHandler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.CoreDataServiceKey, edgex.Version).BootstrapHandler,
+			testing.NewBootstrap(httpServer, readyStream).BootstrapHandler,
+		},
+	)
+}

--- a/internal/core/metadata/main.go
+++ b/internal/core/metadata/main.go
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package metadata
+
+import (
+	"context"
+	"flag"
+
+	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/config"
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/container"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/testing"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/gorilla/mux"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router, readyStream chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	var useRegistry bool
+	var configDir, profileDir string
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallback
+	flag.Parse()
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	httpServer := httpserver.NewBootstrap(router)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.CoreMetaDataServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			secret.NewSecret().BootstrapHandler,
+			database.NewDatabase(httpServer, configuration, readyStream != nil).BootstrapHandler,
+			NewBootstrap(router).BootstrapHandler,
+			telemetry.BootstrapHandler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.CoreMetaDataServiceKey, edgex.Version).BootstrapHandler,
+			testing.NewBootstrap(httpServer, readyStream).BootstrapHandler,
+		})
+}

--- a/internal/pkg/acceptance/sut.go
+++ b/internal/pkg/acceptance/sut.go
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package acceptance
+
+import (
+	"context"
+	"flag"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+const ENV_NO_SECURITY = "EDGEX_SECURITY_SECRET_STORE=false"
+
+// MainFunc defines the signature of the function used to start a service.
+type MainFunc func(ctx context.Context, cancel context.CancelFunc, router *mux.Router, readyStream chan<- bool)
+
+// NewSUT implements the generic code to start a service within a separate goRoutine within the Golang test runner
+// context.
+func NewSUT(
+	t *testing.T,
+	env []string,
+	args []string,
+	mainFunc MainFunc) (context.CancelFunc, *sync.WaitGroup, *mux.Router) {
+
+	setEnv := func(env []string) {
+		os.Clearenv()
+		for k := range env {
+			kv := strings.Split(env[k], "=")
+			_ = os.Setenv(kv[0], kv[1])
+		}
+	}
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+
+	router := mux.NewRouter()
+	stream := make(chan bool, 1)
+
+	wg.Add(1)
+	go func() {
+		origArgs := os.Args
+		origEnv := os.Environ()
+
+		os.Args = args
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+		setEnv(env)
+
+		mainFunc(ctx, cancel, router, stream)
+
+		stream <- false
+		close(stream)
+
+		setEnv(origEnv)
+		os.Args = origArgs
+		wg.Done()
+	}()
+
+	result := <-stream
+	if result == false {
+		wg.Wait()
+		assert.FailNow(t, "unable to start")
+	}
+	return cancel, &wg, router
+}

--- a/internal/pkg/db/memory/addressables.go
+++ b/internal/pkg/db/memory/addressables.go
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) GetAddressables() ([]contract.Addressable, error) {
+	return []contract.Addressable{}, nil
+}
+
+func (c *Client) UpdateAddressable(a contract.Addressable) error {
+	return nil
+}
+
+func (c *Client) GetAddressableById(id string) (contract.Addressable, error) {
+	return contract.Addressable{}, nil
+}
+
+func (c *Client) AddAddressable(a contract.Addressable) (string, error) {
+	return "", nil
+}
+
+func (c *Client) GetAddressableByName(n string) (contract.Addressable, error) {
+	return contract.Addressable{}, nil
+}
+
+func (c *Client) GetAddressablesByTopic(t string) ([]contract.Addressable, error) {
+	return []contract.Addressable{}, nil
+}
+
+func (c *Client) GetAddressablesByPort(p int) ([]contract.Addressable, error) {
+	return []contract.Addressable{}, nil
+}
+
+func (c *Client) GetAddressablesByPublisher(p string) ([]contract.Addressable, error) {
+	return []contract.Addressable{}, nil
+}
+
+func (c *Client) GetAddressablesByAddress(add string) ([]contract.Addressable, error) {
+	return []contract.Addressable{}, nil
+}
+
+func (c *Client) DeleteAddressableById(id string) error {
+	return nil
+}

--- a/internal/pkg/db/memory/commands.go
+++ b/internal/pkg/db/memory/commands.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019 Dell Inc.
+ * Copyright 2020 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,24 +10,28 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- *
- * @author: Alain Pulluelo, ForgeRock AS
- * @author: Tingyu Zeng, Dell
- * @author: Daniel Harms, Dell
- *
  *******************************************************************************/
 
-package main
+package memory
 
-import (
-	"context"
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
-	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
+func (c *Client) GetAllCommands() ([]contract.Command, error) {
+	return []contract.Command{}, nil
+}
 
-	"github.com/gorilla/mux"
-)
+func (c *Client) GetCommandById(id string) (contract.Command, error) {
+	return contract.Command{}, nil
+}
 
-func main() {
-	ctx, cancel := context.WithCancel(context.Background())
-	secretstore.Main(ctx, cancel, mux.NewRouter(), nil)
+func (c *Client) GetCommandsByName(n string) ([]contract.Command, error) {
+	return []contract.Command{}, nil
+}
+
+func (c *Client) GetCommandsByDeviceId(did string) ([]contract.Command, error) {
+	return []contract.Command{}, nil
+}
+
+func (c *Client) GetCommandByNameAndDeviceId(cname string, did string) (contract.Command, error) {
+	return contract.Command{}, nil
 }

--- a/internal/pkg/db/memory/deviceprofiles.go
+++ b/internal/pkg/db/memory/deviceprofiles.go
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) GetAllDeviceProfiles() ([]contract.DeviceProfile, error) {
+	return []contract.DeviceProfile{}, nil
+}
+
+func (c *Client) GetDeviceProfileById(id string) (contract.DeviceProfile, error) {
+	return contract.DeviceProfile{}, nil
+}
+
+func (c *Client) GetDeviceProfilesByModel(model string) ([]contract.DeviceProfile, error) {
+	return []contract.DeviceProfile{}, nil
+}
+
+func (c *Client) GetDeviceProfilesWithLabel(l string) ([]contract.DeviceProfile, error) {
+	return []contract.DeviceProfile{}, nil
+}
+
+func (c *Client) GetDeviceProfilesByManufacturerModel(man string, mod string) ([]contract.DeviceProfile, error) {
+	return []contract.DeviceProfile{}, nil
+}
+
+func (c *Client) GetDeviceProfilesByManufacturer(man string) ([]contract.DeviceProfile, error) {
+	return []contract.DeviceProfile{}, nil
+}
+
+func (c *Client) GetDeviceProfileByName(n string) (contract.DeviceProfile, error) {
+	return contract.DeviceProfile{}, nil
+}
+
+func (c *Client) AddDeviceProfile(dp contract.DeviceProfile) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateDeviceProfile(dp contract.DeviceProfile) error {
+	return nil
+}
+
+func (c *Client) DeleteDeviceProfileById(id string) error {
+	return nil
+}

--- a/internal/pkg/db/memory/devicereports.go
+++ b/internal/pkg/db/memory/devicereports.go
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) GetAllDeviceReports() ([]contract.DeviceReport, error) {
+	return []contract.DeviceReport{}, nil
+}
+
+func (c *Client) GetDeviceReportByName(n string) (contract.DeviceReport, error) {
+	return contract.DeviceReport{}, nil
+}
+
+func (c *Client) GetDeviceReportByDeviceName(n string) ([]contract.DeviceReport, error) {
+	return []contract.DeviceReport{}, nil
+}
+
+func (c *Client) GetDeviceReportById(id string) (contract.DeviceReport, error) {
+	return contract.DeviceReport{}, nil
+}
+
+func (c *Client) GetDeviceReportsByAction(n string) ([]contract.DeviceReport, error) {
+	return []contract.DeviceReport{}, nil
+}
+
+func (c *Client) AddDeviceReport(d contract.DeviceReport) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateDeviceReport(dr contract.DeviceReport) error {
+	return nil
+}
+
+func (c *Client) DeleteDeviceReportById(id string) error {
+	return nil
+}

--- a/internal/pkg/db/memory/devices.go
+++ b/internal/pkg/db/memory/devices.go
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) GetAllDevices() ([]contract.Device, error) {
+	return []contract.Device{}, nil
+}
+
+func (c *Client) AddDevice(d contract.Device, commands []contract.Command) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateDevice(d contract.Device) error {
+	return nil
+}
+
+func (c *Client) DeleteDeviceById(id string) error {
+	return nil
+}
+
+func (c *Client) GetDevicesByProfileId(id string) ([]contract.Device, error) {
+	return []contract.Device{}, nil
+}
+
+func (c *Client) GetDeviceById(id string) (contract.Device, error) {
+	return contract.Device{}, nil
+}
+
+func (c *Client) GetDeviceByName(n string) (contract.Device, error) {
+	return contract.Device{}, nil
+}
+
+func (c *Client) GetDevicesByServiceId(id string) ([]contract.Device, error) {
+	return []contract.Device{}, nil
+}
+
+func (c *Client) GetDevicesWithLabel(l string) ([]contract.Device, error) {
+	return []contract.Device{}, nil
+}

--- a/internal/pkg/db/memory/deviceservices.go
+++ b/internal/pkg/db/memory/deviceservices.go
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) GetDeviceServiceByName(n string) (contract.DeviceService, error) {
+	return contract.DeviceService{}, nil
+}
+
+func (c *Client) GetDeviceServiceById(id string) (contract.DeviceService, error) {
+	return contract.DeviceService{}, nil
+}
+
+func (c *Client) GetAllDeviceServices() ([]contract.DeviceService, error) {
+	return []contract.DeviceService{}, nil
+}
+
+func (c *Client) GetDeviceServicesByAddressableId(id string) ([]contract.DeviceService, error) {
+	return []contract.DeviceService{}, nil
+}
+
+func (c *Client) GetDeviceServicesWithLabel(l string) ([]contract.DeviceService, error) {
+	return []contract.DeviceService{}, nil
+}
+
+func (c *Client) AddDeviceService(ds contract.DeviceService) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateDeviceService(ds contract.DeviceService) error {
+	return nil
+}
+
+func (c *Client) DeleteDeviceServiceById(id string) error {
+	return nil
+}

--- a/internal/pkg/db/memory/events.go
+++ b/internal/pkg/db/memory/events.go
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import (
+	correlation "github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+func (c *Client) Events() ([]contract.Event, error) {
+	return []contract.Event{}, nil
+}
+
+func (c *Client) EventsWithLimit(limit int) ([]contract.Event, error) {
+	return []contract.Event{}, nil
+}
+
+func (c *Client) AddEvent(e correlation.Event) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateEvent(e correlation.Event) error {
+	return nil
+}
+
+func (c *Client) EventById(id string) (contract.Event, error) {
+	return contract.Event{}, nil
+}
+
+func (c *Client) EventsByChecksum(checksum string) ([]contract.Event, error) {
+	return []contract.Event{}, nil
+}
+
+func (c *Client) EventCount() (int, error) {
+	return 0, nil
+}
+
+func (c *Client) EventCountByDeviceId(id string) (int, error) {
+	return 0, nil
+}
+
+func (c *Client) DeleteEventById(id string) error {
+	return nil
+}
+
+func (c *Client) DeleteEventsByDevice(deviceId string) (int, error) {
+	return 0, nil
+}
+
+func (c *Client) EventsForDeviceLimit(id string, limit int) ([]contract.Event, error) {
+	return []contract.Event{}, nil
+}
+
+func (c *Client) EventsForDevice(id string) ([]contract.Event, error) {
+	return []contract.Event{}, nil
+}
+
+func (c *Client) EventsByCreationTime(startTime, endTime int64, limit int) ([]contract.Event, error) {
+	return []contract.Event{}, nil
+}
+
+func (c *Client) EventsOlderThanAge(age int64) ([]contract.Event, error) {
+	return []contract.Event{}, nil
+}
+
+func (c *Client) EventsPushed() ([]contract.Event, error) {
+	return []contract.Event{}, nil
+}
+
+func (c *Client) ScrubAllEvents() error {
+	return nil
+}

--- a/internal/pkg/db/memory/factory.go
+++ b/internal/pkg/db/memory/factory.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019 Dell Inc.
+ * Copyright 2020 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,24 +10,14 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- *
- * @author: Alain Pulluelo, ForgeRock AS
- * @author: Tingyu Zeng, Dell
- * @author: Daniel Harms, Dell
- *
  *******************************************************************************/
 
-package main
+package memory
 
-import (
-	"context"
+type Client struct{}
 
-	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
-
-	"github.com/gorilla/mux"
-)
-
-func main() {
-	ctx, cancel := context.WithCancel(context.Background())
-	secretstore.Main(ctx, cancel, mux.NewRouter(), nil)
+func NewClient() *Client {
+	panic("Memory Client must be implemented before usage.")
 }
+
+func (c *Client) CloseSession() {}

--- a/internal/pkg/db/memory/intervals.go
+++ b/internal/pkg/db/memory/intervals.go
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) Intervals() ([]contract.Interval, error) {
+	return []contract.Interval{}, nil
+}
+
+func (c *Client) IntervalsWithLimit(limit int) ([]contract.Interval, error) {
+	return []contract.Interval{}, nil
+}
+
+func (c *Client) IntervalByName(name string) (contract.Interval, error) {
+	return contract.Interval{}, nil
+}
+
+func (c *Client) IntervalById(id string) (contract.Interval, error) {
+	return contract.Interval{}, nil
+}
+
+func (c *Client) AddInterval(interval contract.Interval) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateInterval(interval contract.Interval) error {
+	return nil
+}
+
+func (c *Client) DeleteIntervalById(id string) error {
+	return nil
+}
+
+func (c *Client) IntervalActions() ([]contract.IntervalAction, error) {
+	return []contract.IntervalAction{}, nil
+}
+
+func (c *Client) IntervalActionsWithLimit(limit int) ([]contract.IntervalAction, error) {
+	return []contract.IntervalAction{}, nil
+}
+
+func (c *Client) IntervalActionsByIntervalName(name string) ([]contract.IntervalAction, error) {
+	return []contract.IntervalAction{}, nil
+}
+
+func (c *Client) IntervalActionsByTarget(name string) ([]contract.IntervalAction, error) {
+	return []contract.IntervalAction{}, nil
+}
+
+func (c *Client) IntervalActionById(id string) (contract.IntervalAction, error) {
+	return contract.IntervalAction{}, nil
+}
+
+func (c *Client) IntervalActionByName(name string) (contract.IntervalAction, error) {
+	return contract.IntervalAction{}, nil
+}
+
+func (c *Client) AddIntervalAction(action contract.IntervalAction) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateIntervalAction(action contract.IntervalAction) error {
+	return nil
+}
+
+func (c *Client) DeleteIntervalActionById(id string) error {
+	return nil
+}
+
+func (c *Client) ScrubAllIntervalActions() (int, error) {
+	return 0, nil
+}
+
+func (c *Client) ScrubAllIntervals() (int, error) {
+	return 0, nil
+}

--- a/internal/pkg/db/memory/notifications.go
+++ b/internal/pkg/db/memory/notifications.go
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) GetNotifications() ([]contract.Notification, error) {
+	return []contract.Notification{}, nil
+}
+
+func (c *Client) GetNotificationById(id string) (contract.Notification, error) {
+	return contract.Notification{}, nil
+}
+
+func (c *Client) GetNotificationBySlug(slug string) (contract.Notification, error) {
+	return contract.Notification{}, nil
+}
+
+func (c *Client) GetNotificationBySender(sender string, limit int) ([]contract.Notification, error) {
+	return []contract.Notification{}, nil
+}
+
+func (c *Client) GetNotificationsByLabels(labels []string, limit int) ([]contract.Notification, error) {
+	return []contract.Notification{}, nil
+}
+
+func (c *Client) GetNotificationsByStartEnd(start int64, end int64, limit int) ([]contract.Notification, error) {
+	return []contract.Notification{}, nil
+}
+
+func (c *Client) GetNotificationsByStart(start int64, limit int) ([]contract.Notification, error) {
+	return []contract.Notification{}, nil
+}
+
+func (c *Client) GetNotificationsByEnd(end int64, limit int) ([]contract.Notification, error) {
+	return []contract.Notification{}, nil
+}
+
+func (c *Client) GetNewNotifications(limit int) ([]contract.Notification, error) {
+	return []contract.Notification{}, nil
+}
+
+func (c *Client) GetNewNormalNotifications(limit int) ([]contract.Notification, error) {
+	return []contract.Notification{}, nil
+}
+
+func (c *Client) AddNotification(n contract.Notification) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateNotification(n contract.Notification) error {
+	return nil
+}
+
+func (c *Client) MarkNotificationProcessed(n contract.Notification) error {
+	return nil
+}
+
+func (c *Client) DeleteNotificationById(id string) error {
+	return nil
+}
+
+func (c *Client) DeleteNotificationBySlug(slug string) error {
+	return nil
+}
+
+func (c *Client) DeleteNotificationsOld(age int) error {
+	return nil
+}

--- a/internal/pkg/db/memory/provisionwatchers.go
+++ b/internal/pkg/db/memory/provisionwatchers.go
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) GetAllProvisionWatchers() (pw []contract.ProvisionWatcher, err error) {
+	return []contract.ProvisionWatcher{}, nil
+}
+
+func (c *Client) GetProvisionWatcherByName(n string) (pw contract.ProvisionWatcher, err error) {
+	return contract.ProvisionWatcher{}, nil
+}
+
+func (c *Client) GetProvisionWatchersByIdentifier(k string, v string) (pw []contract.ProvisionWatcher, err error) {
+	return []contract.ProvisionWatcher{}, nil
+}
+
+func (c *Client) GetProvisionWatchersByServiceId(id string) (pw []contract.ProvisionWatcher, err error) {
+	return []contract.ProvisionWatcher{}, nil
+}
+
+func (c *Client) GetProvisionWatchersByProfileId(id string) (pw []contract.ProvisionWatcher, err error) {
+	return []contract.ProvisionWatcher{}, nil
+}
+
+func (c *Client) GetProvisionWatcherById(id string) (pw contract.ProvisionWatcher, err error) {
+	return contract.ProvisionWatcher{}, nil
+}
+
+func (c *Client) AddProvisionWatcher(pw contract.ProvisionWatcher) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateProvisionWatcher(pw contract.ProvisionWatcher) error {
+	return nil
+}
+
+func (c *Client) DeleteProvisionWatcherById(id string) error {
+	return nil
+}

--- a/internal/pkg/db/memory/readings.go
+++ b/internal/pkg/db/memory/readings.go
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) Readings() ([]contract.Reading, error) {
+	return []contract.Reading{}, nil
+}
+
+func (c *Client) AddReading(r contract.Reading) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateReading(r contract.Reading) error {
+	return nil
+}
+
+func (c *Client) ReadingById(id string) (contract.Reading, error) {
+	return contract.Reading{}, nil
+}
+
+func (c *Client) ReadingCount() (int, error) {
+	return 0, nil
+}
+
+func (c *Client) DeleteReadingById(id string) error {
+	return nil
+}
+
+func (c *Client) DeleteReadingsByDevice(deviceId string) error {
+	return nil
+}
+
+func (c *Client) ReadingsByDevice(id string, limit int) ([]contract.Reading, error) {
+	return []contract.Reading{}, nil
+}
+
+func (c *Client) ReadingsByValueDescriptor(name string, limit int) ([]contract.Reading, error) {
+	return []contract.Reading{}, nil
+}
+
+func (c *Client) ReadingsByValueDescriptorNames(names []string, limit int) ([]contract.Reading, error) {
+	return []contract.Reading{}, nil
+}
+
+func (c *Client) ReadingsByCreationTime(start, end int64, limit int) ([]contract.Reading, error) {
+	return []contract.Reading{}, nil
+}
+
+func (c *Client) ReadingsByDeviceAndValueDescriptor(deviceId, valueDescriptor string, limit int) ([]contract.Reading, error) {
+	return []contract.Reading{}, nil
+}

--- a/internal/pkg/db/memory/scrub.go
+++ b/internal/pkg/db/memory/scrub.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019 Dell Inc.
+ * Copyright 2020 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,24 +10,18 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- *
- * @author: Alain Pulluelo, ForgeRock AS
- * @author: Tingyu Zeng, Dell
- * @author: Daniel Harms, Dell
- *
  *******************************************************************************/
 
-package main
+package memory
 
-import (
-	"context"
+func (c *Client) ScrubMetadata() error {
+	return nil
+}
 
-	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
+func (c *Client) Cleanup() error {
+	return nil
+}
 
-	"github.com/gorilla/mux"
-)
-
-func main() {
-	ctx, cancel := context.WithCancel(context.Background())
-	secretstore.Main(ctx, cancel, mux.NewRouter(), nil)
+func (c *Client) CleanupOld(age int) error {
+	return nil
 }

--- a/internal/pkg/db/memory/subscriptions.go
+++ b/internal/pkg/db/memory/subscriptions.go
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) GetSubscriptionBySlug(slug string) (contract.Subscription, error) {
+	return contract.Subscription{}, nil
+}
+
+func (c *Client) GetSubscriptionByCategories(categories []string) ([]contract.Subscription, error) {
+	return []contract.Subscription{}, nil
+}
+
+func (c *Client) GetSubscriptionByLabels(labels []string) ([]contract.Subscription, error) {
+	return []contract.Subscription{}, nil
+}
+
+func (c *Client) GetSubscriptionByCategoriesLabels(categories []string, labels []string) ([]contract.Subscription, error) {
+	return []contract.Subscription{}, nil
+}
+
+func (c *Client) GetSubscriptionByReceiver(receiver string) ([]contract.Subscription, error) {
+	return []contract.Subscription{}, nil
+}
+
+func (c *Client) GetSubscriptionById(id string) (contract.Subscription, error) {
+	return contract.Subscription{}, nil
+}
+
+func (c *Client) DeleteSubscriptionById(id string) error {
+	return nil
+}
+
+func (c *Client) AddSubscription(sub contract.Subscription) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateSubscription(sub contract.Subscription) error {
+	return nil
+}
+
+func (c *Client) DeleteSubscriptionBySlug(slug string) error {
+	return nil
+}
+
+func (c *Client) GetSubscriptions() ([]contract.Subscription, error) {
+	return []contract.Subscription{}, nil
+}

--- a/internal/pkg/db/memory/transmissions.go
+++ b/internal/pkg/db/memory/transmissions.go
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) AddTransmission(t contract.Transmission) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateTransmission(t contract.Transmission) error {
+	return nil
+}
+
+func (c *Client) DeleteTransmission(age int64, status contract.TransmissionStatus) error {
+	return nil
+}
+
+func (c *Client) GetTransmissionById(id string) (contract.Transmission, error) {
+	return contract.Transmission{}, nil
+}
+
+func (c *Client) GetTransmissionsByNotificationSlug(slug string, limit int) ([]contract.Transmission, error) {
+	return []contract.Transmission{}, nil
+}
+
+func (c *Client) GetTransmissionsByNotificationSlugAndStartEnd(slug string, start int64, end int64, limit int) ([]contract.Transmission, error) {
+	return []contract.Transmission{}, nil
+}
+
+func (c *Client) GetTransmissionsByStartEnd(start int64, end int64, limit int) ([]contract.Transmission, error) {
+	return []contract.Transmission{}, nil
+}
+
+func (c *Client) GetTransmissionsByStart(start int64, limit int) ([]contract.Transmission, error) {
+	return []contract.Transmission{}, nil
+}
+
+func (c *Client) GetTransmissionsByEnd(end int64, limit int) ([]contract.Transmission, error) {
+	return []contract.Transmission{}, nil
+}
+
+func (c *Client) GetTransmissionsByStatus(limit int, status contract.TransmissionStatus) ([]contract.Transmission, error) {
+	return []contract.Transmission{}, nil
+}

--- a/internal/pkg/db/memory/valuedescriptors.go
+++ b/internal/pkg/db/memory/valuedescriptors.go
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+func (c *Client) ValueDescriptors() ([]contract.ValueDescriptor, error) {
+	return []contract.ValueDescriptor{}, nil
+}
+
+func (c *Client) AddValueDescriptor(v contract.ValueDescriptor) (string, error) {
+	return "", nil
+}
+
+func (c *Client) UpdateValueDescriptor(cvd contract.ValueDescriptor) error {
+	return nil
+}
+
+func (c *Client) DeleteValueDescriptorById(id string) error {
+	return nil
+}
+
+func (c *Client) ValueDescriptorByName(name string) (contract.ValueDescriptor, error) {
+	return contract.ValueDescriptor{}, nil
+}
+
+func (c *Client) ValueDescriptorsByName(names []string) ([]contract.ValueDescriptor, error) {
+	return []contract.ValueDescriptor{}, nil
+}
+
+func (c *Client) ValueDescriptorById(id string) (contract.ValueDescriptor, error) {
+	return contract.ValueDescriptor{}, nil
+}
+
+func (c *Client) ValueDescriptorsByUomLabel(uomLabel string) ([]contract.ValueDescriptor, error) {
+	return []contract.ValueDescriptor{}, nil
+}
+
+func (c *Client) ValueDescriptorsByLabel(label string) ([]contract.ValueDescriptor, error) {
+	return []contract.ValueDescriptor{}, nil
+}
+
+func (c *Client) ValueDescriptorsByType(t string) ([]contract.ValueDescriptor, error) {
+	return []contract.ValueDescriptor{}, nil
+}
+
+func (c *Client) ScrubAllValueDescriptors() error {
+	return nil
+}

--- a/internal/security/fileprovider/main.go
+++ b/internal/security/fileprovider/main.go
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package fileprovider
+
+import (
+	"context"
+	"flag"
+	"github.com/gorilla/mux"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, _ *mux.Router, _ chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	var configDir, profileDir string
+	var useRegistry bool
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallbackSecurityFileTokenProvider
+	flag.Parse()
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SecurityFileTokenProviderServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			BootstrapHandler,
+		},
+	)
+}

--- a/internal/security/proxy/main.go
+++ b/internal/security/proxy/main.go
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author: Tingyu Zeng, Dell
+ *******************************************************************************/
+
+package proxy
+
+import (
+	"context"
+	"flag"
+	"github.com/gorilla/mux"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/proxy/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, _ *mux.Router, _ chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	if len(os.Args) < 2 {
+		usage.HelpCallbackSecurityProxy()
+	}
+	var initNeeded bool
+	var insecureSkipVerify bool
+	var resetNeeded bool
+	var configDir, profileDir string
+	var userTobeCreated string
+	var userOfGroup string
+	var userToBeDeleted string
+	var useRegistry bool
+
+	flag.BoolVar(&insecureSkipVerify, "insecureSkipVerify", false, "skip server side SSL verification, mainly for self-signed cert")
+	flag.BoolVar(&initNeeded, "init", false, "run init procedure for security service.")
+	flag.BoolVar(&resetNeeded, "reset", false, "reset reverse proxy by removing all services/routes/consumers")
+	flag.StringVar(&userTobeCreated, "useradd", "", "user that needs to be added to consume the edgex services")
+	flag.StringVar(&userOfGroup, "group", "user", "group that the user belongs to. By default it is in user group")
+	flag.StringVar(&userToBeDeleted, "userdel", "", "user that needs to be deleted from the edgex services")
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallbackSecurityProxy
+	flag.Parse()
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SecurityProxySetupServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			NewBootstrap(
+				insecureSkipVerify,
+				initNeeded,
+				resetNeeded,
+				userTobeCreated,
+				userOfGroup,
+				userToBeDeleted).BootstrapHandler,
+		},
+	)
+}

--- a/internal/security/secrets/main.go
+++ b/internal/security/secrets/main.go
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ * Copyright 2019 Intel Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package secrets
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/edgex-go/internal/security/secrets/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secrets/container"
+	"github.com/edgexfoundry/edgex-go/internal/security/secrets/contract"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc) (*config.ConfigurationStruct, int) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	var configDir string
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+	flag.Usage = usage.HelpCallbackSecuritySetup
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Println("Please specify subcommand for " + clients.SecuritySecretsSetupServiceKey)
+		flag.Usage()
+		return nil, contract.StatusCodeExitNormal
+	}
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	serviceHandler := NewBootstrap()
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		bootstrap.EmptyProfileDir,
+		internal.ConfigFileName,
+		bootstrap.DoNotUseRegistry,
+		clients.SecuritySecretsSetupServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			serviceHandler.BootstrapHandler,
+		},
+	)
+	return configuration, serviceHandler.ExitStatusCode()
+}

--- a/internal/security/secretstore/main.go
+++ b/internal/security/secretstore/main.go
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @author: Alain Pulluelo, ForgeRock AS
+ * @author: Tingyu Zeng, Dell
+ * @author: Daniel Harms, Dell
+ *
+ *******************************************************************************/
+
+package secretstore
+
+import (
+	"context"
+	"flag"
+	"github.com/gorilla/mux"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, _ *mux.Router, _ chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	if len(os.Args) < 2 {
+		usage.HelpCallbackSecuritySecretStore()
+	}
+
+	var insecureSkipVerify bool
+	var vaultInterval int
+	var configDir, profileDir string
+	var useRegistry bool
+
+	flag.BoolVar(&insecureSkipVerify, "insecureSkipVerify", false, "skip server side SSL verification, mainly for self-signed cert")
+	flag.IntVar(&vaultInterval, "vaultInterval", 30, "time to wait between checking Vault status in seconds.")
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallbackSecuritySecretStore
+	flag.Parse()
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SecuritySecretStoreSetupServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			NewBootstrap(insecureSkipVerify, vaultInterval).BootstrapHandler,
+		},
+	)
+}

--- a/internal/support/logging/main.go
+++ b/internal/support/logging/main.go
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2018
+// Cavium
+// Mainflux
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package logging
+
+import (
+	"context"
+	"flag"
+
+	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/edgex-go/internal/support/logging/config"
+	"github.com/edgexfoundry/edgex-go/internal/support/logging/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/testing"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/gorilla/mux"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router, readyStream chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	var useRegistry bool
+	var configDir, profileDir string
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallback
+	flag.Parse()
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	httpServer := httpserver.NewBootstrap(router)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SupportLoggingServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			secret.NewSecret().BootstrapHandler,
+			NewServiceInit(router, httpServer, clients.SupportLoggingServiceKey).BootstrapHandler,
+			telemetry.BootstrapHandler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.SupportLoggingServiceKey, edgex.Version).BootstrapHandler,
+			testing.NewBootstrap(httpServer, readyStream).BootstrapHandler,
+		})
+}

--- a/internal/support/notifications/main.go
+++ b/internal/support/notifications/main.go
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright 2017 Dell Inc.
+ * Copyright 2018 Dell Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * @microservice: support-notifications
+ * @author: Jim White, Dell Technologies
+ * @version: 0.5.0
+ *******************************************************************************/
+
+// main is the central entry point for the application and calls all the startup logic.
+package notifications
+
+import (
+	"context"
+	"flag"
+
+	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	notificationsConfig "github.com/edgexfoundry/edgex-go/internal/support/notifications/config"
+	"github.com/edgexfoundry/edgex-go/internal/support/notifications/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/testing"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/gorilla/mux"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router, readyStream chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	var useRegistry bool
+	var configDir, profileDir string
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+	flag.Usage = usage.HelpCallback
+	flag.Parse()
+
+	configuration := &notificationsConfig.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	httpServer := httpserver.NewBootstrap(router)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SupportNotificationsServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			secret.NewSecret().BootstrapHandler,
+			database.NewDatabase(httpServer, configuration, readyStream != nil).BootstrapHandler,
+			NewBootstrap(router).BootstrapHandler,
+			telemetry.BootstrapHandler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.SupportNotificationsServiceKey, edgex.Version).BootstrapHandler,
+			testing.NewBootstrap(httpServer, readyStream).BootstrapHandler,
+		})
+}

--- a/internal/support/scheduler/main.go
+++ b/internal/support/scheduler/main.go
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package scheduler
+
+import (
+	"context"
+	"flag"
+
+	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/config"
+	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/testing"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/gorilla/mux"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router, readyStream chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+	var useRegistry bool
+	var configDir, profileDir string
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use Registry.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use Registry.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallback
+	flag.Parse()
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	httpServer := httpserver.NewBootstrap(router)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SupportSchedulerServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			secret.NewSecret().BootstrapHandler,
+			database.NewDatabase(httpServer, configuration, readyStream != nil).BootstrapHandler,
+			NewBootstrap(router).BootstrapHandler,
+			telemetry.BootstrapHandler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.SupportSchedulerServiceKey, edgex.Version).BootstrapHandler,
+			testing.NewBootstrap(httpServer, readyStream).BootstrapHandler,
+		})
+}

--- a/internal/system/agent/main.go
+++ b/internal/system/agent/main.go
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright 2017 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package agent
+
+import (
+	"context"
+	"flag"
+
+	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/usage"
+	agentConfig "github.com/edgexfoundry/edgex-go/internal/system/agent/config"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/httpserver"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/message"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/testing"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/gorilla/mux"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router, readyStream chan<- bool) {
+	startupTimer := startup.NewStartUpTimer(internal.BootRetrySecondsDefault, internal.BootTimeoutSecondsDefault)
+
+	var useRegistry bool
+	var configDir, profileDir string
+
+	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use registry service.")
+	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry service.")
+	flag.StringVar(&profileDir, "profile", "", "Specify a profile other than default.")
+	flag.StringVar(&profileDir, "p", "", "Specify a profile other than default.")
+	flag.StringVar(&configDir, "confdir", "", "Specify local configuration directory")
+
+	flag.Usage = usage.HelpCallback
+	flag.Parse()
+
+	configuration := &agentConfig.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	httpServer := httpserver.NewBootstrap(router)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		configDir,
+		profileDir,
+		internal.ConfigFileName,
+		useRegistry,
+		clients.SystemManagementAgentServiceKey,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			NewBootstrap(router).BootstrapHandler,
+			httpServer.BootstrapHandler,
+			message.NewBootstrap(clients.SystemManagementAgentServiceKey, edgex.Version).BootstrapHandler,
+			testing.NewBootstrap(httpServer, readyStream).BootstrapHandler,
+		})
+}


### PR DESCRIPTION
As proposed in December QA/Testing WG call and demonstrated in
edgexfoundry/edgex-go@master...michaelestrin:testing-poc

Update services to use new Run() method signature. Shift main.go
functionality into individual service-specific packages. Create
skeleton for memory-based persistence implementation.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2273
Signed-off-by: Michael Estrin <m.estrin@dell.com>