### PR TITLE
Implement Vault root token revokation

### DIFF
--- a/cmd/security-secretstore-setup/res/docker/configuration.toml
+++ b/cmd/security-secretstore-setup/res/docker/configuration.toml
@@ -38,7 +38,7 @@ tokenprovider = "/security-file-token-provider"
 tokenproviderargs = [ "-confdir", "res-file-token-provider" ]
 tokenprovidertype = "oneshot"
 tokenprovideradmintokenpath = "/run/edgex/secrets/tokenprovider/secrets-token.json"
-revokeroottokens = false
+revokeroottokens = true
 
 [Startup]
 Duration = 30

--- a/internal/security/secretstore/init_test.go
+++ b/internal/security/secretstore/init_test.go
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package secretstore
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	. "github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const sampleJSON = `
+{
+	"keys": [
+		"test-keys"
+	],
+	"keys_base64": [
+		"test-keys-base64"
+	],
+	"root_token": "test-root-token"
+}`
+
+func TestLoadInitResponse(t *testing.T) {
+	// Arrange
+	assert := assert.New(t)
+	mockLogger := logger.MockLogger{}
+	fileOpener := &MockFileIoPerformer{}
+	stringReader := strings.NewReader(sampleJSON)
+	fileOpener.On("OpenFileReader", "/foo/bar.baz", os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+	secretConfig := secretstoreclient.SecretServiceInfo{
+		TokenFolderPath: "/foo",
+		TokenFile:       "bar.baz",
+	}
+	initResponse := secretstoreclient.InitResponse{}
+
+	// Act
+	err := loadInitResponse(mockLogger, fileOpener, secretConfig, &initResponse)
+
+	// Assert
+	assert.NoError(err)
+	fileOpener.AssertExpectations(t)
+}
+
+func TestSaveInitResponse(t *testing.T) {
+	// Arrange
+	assert := assert.New(t)
+	mockLogger := logger.MockLogger{}
+	fileOpener := &MockFileIoPerformer{}
+	fileOpener.On("OpenFileWriter", "/foo/bar.baz", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600)).Return(&discardWriterCloser{}, nil)
+	secretConfig := secretstoreclient.SecretServiceInfo{
+		TokenFolderPath: "/foo",
+		TokenFile:       "bar.baz",
+	}
+	initResponse := secretstoreclient.InitResponse{
+		Keys:       []string{"test-key-1"},
+		KeysBase64: []string{"dGVzdC1rZXktMQ=="},
+	}
+
+	// Act
+	err := saveInitResponse(mockLogger, fileOpener, secretConfig, &initResponse)
+
+	// Assert
+	assert.NoError(err)
+	fileOpener.AssertExpectations(t)
+}
+
+//
+// mocks
+//
+
+type discardWriterCloser struct{}
+
+func (wcb *discardWriterCloser) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func (wcb *discardWriterCloser) Close() error {
+	return nil
+}

--- a/internal/security/secretstoreclient/interface.go
+++ b/internal/security/secretstoreclient/interface.go
@@ -16,15 +16,11 @@
 
 package secretstoreclient
 
-import (
-	"io"
-)
-
 // SecretStoreClient is interface to Vault
 type SecretStoreClient interface {
 	HealthCheck() (statusCode int, err error)
-	Init(config SecretServiceInfo, vmkWriter io.Writer) (statusCode int, err error)
-	Unseal(config SecretServiceInfo, vmkReader io.Reader) (statusCode int, err error)
+	Init(secretThreshold int, secretShares int, initResponse *InitResponse) (statusCode int, err error)
+	Unseal(initResponse *InitResponse) (statusCode int, err error)
 	InstallPolicy(token string,
 		policyName string, policyDocument string) (statusCode int, err error)
 	CreateToken(token string,
@@ -34,7 +30,7 @@ type SecretStoreClient interface {
 	LookupAccessor(token string, accessor string, tokenMetadata *TokenMetadata) (statusCode int, err error)
 	LookupSelf(token string, tokenMetadata *TokenMetadata) (statusCode int, err error)
 	RevokeSelf(token string) (statusCode int, err error)
-	RegenRootToken(vmkReader io.Reader, rootToken *string) (err error)
+	RegenRootToken(initResponse *InitResponse, rootToken *string) (err error)
 	CheckSecretEngineInstalled(token string, mountPoint string, engine string) (isInstalled bool, err error)
 	EnableKVSecretEngine(token string, mountPoint string, kvVersion string) (statusCode int, err error)
 }

--- a/internal/security/secretstoreclient/messages.go
+++ b/internal/security/secretstoreclient/messages.go
@@ -27,7 +27,7 @@ type InitRequest struct {
 type InitResponse struct {
 	Keys       []string `json:"keys"`
 	KeysBase64 []string `json:"keys_base64"`
-	RootToken  string   `json:"root_token"`
+	RootToken  string   `json:"root_token,omitempty"`
 }
 
 // UnsealRequest contains a Vault unseal request

--- a/internal/security/secretstoreclient/mocks/mock.go
+++ b/internal/security/secretstoreclient/mocks/mock.go
@@ -17,8 +17,6 @@
 package mocks
 
 import (
-	"io"
-
 	. "github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
 	"github.com/stretchr/testify/mock"
 )
@@ -33,15 +31,15 @@ func (m *MockSecretStoreClient) HealthCheck() (statusCode int, err error) {
 	return arguments.Int(0), arguments.Error(1)
 }
 
-func (m *MockSecretStoreClient) Init(config SecretServiceInfo, vmkWriter io.Writer) (statusCode int, err error) {
+func (m *MockSecretStoreClient) Init(secretThreshold int, secretShares int, initResponse *InitResponse) (statusCode int, err error) {
 	// Boilerplate that returns whatever Mock.On().Returns() is configured for
-	arguments := m.Called(config, vmkWriter)
+	arguments := m.Called(secretThreshold, secretShares, initResponse)
 	return arguments.Int(0), arguments.Error(1)
 }
 
-func (m *MockSecretStoreClient) Unseal(config SecretServiceInfo, vmkReader io.Reader) (statusCode int, err error) {
+func (m *MockSecretStoreClient) Unseal(initResponse *InitResponse) (statusCode int, err error) {
 	// Boilerplate that returns whatever Mock.On().Returns() is configured for
-	arguments := m.Called(config, vmkReader)
+	arguments := m.Called(initResponse)
 	return arguments.Int(0), arguments.Error(1)
 }
 
@@ -87,9 +85,9 @@ func (m *MockSecretStoreClient) RevokeSelf(token string) (statusCode int, err er
 	return arguments.Int(0), arguments.Error(1)
 }
 
-func (m *MockSecretStoreClient) RegenRootToken(vmkReader io.Reader, rootToken *string) (err error) {
+func (m *MockSecretStoreClient) RegenRootToken(initResponse *InitResponse, rootToken *string) (err error) {
 	// Boilerplate that returns whatever Mock.On().Returns() is configured for
-	arguments := m.Called(vmkReader, rootToken)
+	arguments := m.Called(initResponse, rootToken)
 	return arguments.Error(0)
 }
 

--- a/internal/security/secretstoreclient/mocks/mock_test.go
+++ b/internal/security/secretstoreclient/mocks/mock_test.go
@@ -17,7 +17,6 @@
 package mocks
 
 import (
-	"bytes"
 	"net/http"
 	"testing"
 
@@ -43,24 +42,22 @@ func TestMockHealthCheck(t *testing.T) {
 }
 
 func TestMockInit(t *testing.T) {
-	config := SecretServiceInfo{}
-	scratchBuffer := new(bytes.Buffer)
+	var initResp InitResponse
 	mockClient := &MockSecretStoreClient{}
-	mockClient.On("Init", config, scratchBuffer).Return(http.StatusOK, nil)
+	mockClient.On("Init", 1, 2, &initResp).Return(http.StatusOK, nil)
 
-	rc, err := mockClient.Init(config, scratchBuffer)
+	rc, err := mockClient.Init(1, 2, &initResp)
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, rc)
 	mockClient.AssertExpectations(t)
 }
 
 func TestMockUnseal(t *testing.T) {
-	config := SecretServiceInfo{}
-	scratchBuffer := new(bytes.Buffer)
+	var initResponse InitResponse
 	mockClient := &MockSecretStoreClient{}
-	mockClient.On("Unseal", config, scratchBuffer).Return(http.StatusOK, nil)
+	mockClient.On("Unseal", &initResponse).Return(http.StatusOK, nil)
 
-	rc, err := mockClient.Unseal(config, scratchBuffer)
+	rc, err := mockClient.Unseal(&initResponse)
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, rc)
 	mockClient.AssertExpectations(t)
@@ -143,10 +140,11 @@ func TestMockRevokeSelf(t *testing.T) {
 
 func TestMockRegenRootToken(t *testing.T) {
 	mockClient := &MockSecretStoreClient{}
-	mockClient.On("RegenRootToken", mock.Anything, mock.Anything).Return(nil)
+	var initResponse InitResponse
+	mockClient.On("RegenRootToken", &initResponse, mock.Anything).Return(nil)
 
 	var rootToken string
-	err := mockClient.RegenRootToken(nil, &rootToken)
+	err := mockClient.RegenRootToken(&initResponse, &rootToken)
 	assert.NoError(t, err)
 	mockClient.AssertExpectations(t)
 }

--- a/internal/security/secretstoreclient/roottoken_test.go
+++ b/internal/security/secretstoreclient/roottoken_test.go
@@ -20,14 +20,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
-	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -73,14 +69,12 @@ func TestRegenRootToken(t *testing.T) {
 	vc := NewSecretStoreClient(mockLogger, NewRequestor(mockLogger).Insecure(), "https", host)
 
 	// Act
-	config := SecretServiceInfo{
-		TokenFolderPath:   "testdata",
-		TokenFile:         "test-resp-init.json",
-		VaultSecretShares: 1,
+	initResp := InitResponse{
+		// Keys is unused
+		KeysBase64: []string{"dGVzdC1rZXktMQ==", "dGVzdC1rZXktMgo="},
 	}
-	vmkReader, err := fileioperformer.NewDefaultFileIoPerformer().OpenFileReader(filepath.Join(config.TokenFolderPath, config.TokenFile), os.O_RDONLY, 0400)
 	var rootToken string
-	err = vc.RegenRootToken(vmkReader, &rootToken)
+	err := vc.RegenRootToken(&initResp, &rootToken)
 
 	// Assert
 	assert.Nil(err)

--- a/internal/security/secretstoreclient/vault.go
+++ b/internal/security/secretstoreclient/vault.go
@@ -18,9 +18,7 @@
 package secretstoreclient
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -28,8 +26,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-
-	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 )
 
 type vaultClient struct {
@@ -69,12 +65,11 @@ func (vc *vaultClient) HealthCheck() (int, error) {
 	return code, nil
 }
 
-func (vc *vaultClient) Init(config SecretServiceInfo, vmkWriter io.Writer) (statusCode int, err error) {
+func (vc *vaultClient) Init(secretThreshold int, secretShares int, initResponse *InitResponse) (statusCode int, err error) {
 	initRequest := InitRequest{
-		SecretShares:    config.VaultSecretShares,
-		SecretThreshold: config.VaultSecretThreshold,
+		SecretShares:    secretShares,
+		SecretThreshold: secretThreshold,
 	}
-	initResp := InitResponse{}
 
 	vc.logger.Info(fmt.Sprintf("vault init strategy (SSS parameters): shares=%d threshold=%d", initRequest.SecretShares, initRequest.SecretThreshold))
 
@@ -86,26 +81,19 @@ func (vc *vaultClient) Init(config SecretServiceInfo, vmkWriter io.Writer) (stat
 		BodyReader:           nil,
 		OperationDescription: "initialize secret store",
 		ExpectedStatusCode:   http.StatusOK,
-		ResponseObject:       &initResp,
+		ResponseObject:       &initResponse,
 	})
 
-	err = json.NewEncoder(vmkWriter).Encode(initResp) // Write the init response to disk
 	return code, err
 }
 
-func (vc *vaultClient) Unseal(config SecretServiceInfo, vmkReader io.Reader) (int, error) {
+func (vc *vaultClient) Unseal(initResponse *InitResponse) (int, error) {
 	vc.logger.Info(fmt.Sprintf("Vault unsealing Process. Applying key shares."))
-	initResp := InitResponse{}
-	readCloser := fileioperformer.MakeReadCloser(vmkReader)
-	defer readCloser.Close()
 
-	if err := json.NewDecoder(vmkReader).Decode(&initResp); err != nil {
-		vc.logger.Error(fmt.Sprintf("failed to build the JSON structure from the init response body: %s", err.Error()))
-		return 0, err
-	}
+	secretShares := len(initResponse.Keys)
 
 	keyCounter := 1
-	for _, key := range initResp.KeysBase64 {
+	for _, key := range initResponse.KeysBase64 {
 		unsealResponse := UnsealResponse{}
 		code, err := vc.doRequest(commonRequestArgs{
 			AuthToken:            "",
@@ -119,11 +107,11 @@ func (vc *vaultClient) Unseal(config SecretServiceInfo, vmkReader io.Reader) (in
 		})
 
 		if err != nil {
-			vc.logger.Error(fmt.Sprintf("Error applying key share %d/%d: %s", keyCounter, config.VaultSecretShares, err.Error()))
+			vc.logger.Error(fmt.Sprintf("Error applying key share %d/%d: %s", keyCounter, secretShares, err.Error()))
 			return 0, err
 		}
 
-		vc.logger.Info(fmt.Sprintf("Vault key share %d/%d successfully applied.", keyCounter, config.VaultSecretShares))
+		vc.logger.Info(fmt.Sprintf("Vault key share %d/%d successfully applied.", keyCounter, secretShares))
 		if !unsealResponse.Sealed {
 			vc.logger.Info("Vault key share threshold reached. Unsealing complete.")
 			return code, nil


### PR DESCRIPTION
Changes revokeroottokens setting in docker configuration
from false to true and expunges the root token from
resp-init.json when revokeroottokens==true.

To facilitate this change, it is necessary to filter
the Vault /sys/init response so that the root_token
field can be removed.  Minor changes have been made
to SecretStoreClient such that all file IO is done
in secretstore-setup and the SecretStoreClient interfaces
data data structures instead of reader/writer interfaces.

Fixes #1929 

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>