### PR TITLE
Remove UpdateLastConnected logic in coredata

### DIFF
--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -1,5 +1,4 @@
 [Writable]
-DeviceUpdateLastConnected = false
 MetaDataCheck = false
 PersistData = true
 ServiceUpdateLastConnected = false

--- a/cmd/core-data/res/docker/configuration.toml
+++ b/cmd/core-data/res/docker/configuration.toml
@@ -1,5 +1,4 @@
 [Writable]
-DeviceUpdateLastConnected = false
 MetaDataCheck = false
 PersistData = true
 ServiceUpdateLastConnected = false

--- a/internal/core/data/config/config.go
+++ b/internal/core/data/config/config.go
@@ -33,7 +33,6 @@ type ConfigurationStruct struct {
 }
 
 type WritableInfo struct {
-	DeviceUpdateLastConnected  bool
 	MetaDataCheck              bool
 	PersistData                bool
 	ServiceUpdateLastConnected bool

--- a/internal/core/data/device.go
+++ b/internal/core/data/device.go
@@ -23,45 +23,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 )
 
-// Update when the device was last reported connected
-func updateDeviceLastReportedConnected(
-	device string,
-	lc logger.LoggingClient,
-	mdc metadata.DeviceClient,
-	configuration *config.ConfigurationStruct) {
-	// Config set to skip update last reported
-	if !configuration.Writable.DeviceUpdateLastConnected {
-		lc.Debug("Skipping update of device connected/reported times for:  " + device)
-		return
-	}
-
-	d, err := mdc.CheckForDevice(context.Background(), device)
-	if err != nil {
-		lc.Error("Error getting device " + device + ": " + err.Error())
-		return
-	}
-
-	// Couldn't find device
-	if len(d.Name) == 0 {
-		lc.Error("Error updating device connected/reported times.  Unknown device with identifier of:  " + device)
-		return
-	}
-
-	t := db.MakeTimestamp()
-	// Found device, now update lastReported
-	// Use of context.Background because this function is invoked asynchronously from a channel
-	err = mdc.UpdateLastConnectedByName(context.Background(), d.Name, t)
-	if err != nil {
-		lc.Error("Problems updating last connected value for device: " + d.Name)
-		return
-	}
-	err = mdc.UpdateLastReportedByName(context.Background(), d.Name, t)
-	if err != nil {
-		lc.Error("Problems updating last reported value for device: " + d.Name)
-	}
-	return
-}
-
 // Update when the device service was last reported connected
 func updateDeviceServiceLastReportedConnected(
 	device string,

--- a/internal/core/data/device_test.go
+++ b/internal/core/data/device_test.go
@@ -87,21 +87,13 @@ func handleDomainEvents(bitEvents []bool, chEvents <-chan interface{}, wait *syn
 		select {
 		case evt := <-chEvents:
 			switch evt.(type) {
-			case DeviceLastReported:
-				e := evt.(DeviceLastReported)
-				if e.DeviceName != testDeviceName {
-					t.Errorf("DeviceLastReported name mismatch %s", e.DeviceName)
-					return
-				}
-				bitEvents[0] = true
-				break
 			case DeviceServiceLastReported:
 				e := evt.(DeviceServiceLastReported)
 				if e.DeviceName != testDeviceName {
 					t.Errorf("DeviceLastReported name mismatch %s", e.DeviceName)
 					return
 				}
-				bitEvents[1] = true
+				bitEvents[0] = true
 				break
 			}
 		default:

--- a/internal/core/data/domain_events.go
+++ b/internal/core/data/domain_events.go
@@ -20,11 +20,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 )
 
-// An event indicating that a given device has just reported some data
-type DeviceLastReported struct {
-	DeviceName string
-}
-
 // An event indicating that the service associated with the device that just reported data is alive.
 type DeviceServiceLastReported struct {
 	DeviceName string
@@ -42,10 +37,6 @@ func initEventHandlers(
 			case e, ok := <-chEvents:
 				if ok {
 					switch e.(type) {
-					case DeviceLastReported:
-						dlr := e.(DeviceLastReported)
-						updateDeviceLastReportedConnected(dlr.DeviceName, lc, mdc, configuration)
-						break
 					case DeviceServiceLastReported:
 						dslr := e.(DeviceServiceLastReported)
 						updateDeviceServiceLastReportedConnected(dslr.DeviceName, lc, mdc, msc, configuration)

--- a/internal/core/data/event.go
+++ b/internal/core/data/event.go
@@ -142,7 +142,6 @@ func addNewEvent(
 	}
 
 	putEventOnQueue(e, ctx, lc, msgClient, configuration) // Push event to message bus for App Services to consume
-	chEvents <- DeviceLastReported{e.Device}              // update last reported connected (device)
 	chEvents <- DeviceServiceLastReported{e.Device}       // update last reported connected (device service)
 
 	return e.ID, nil

--- a/internal/core/data/event_test.go
+++ b/internal/core/data/event_test.go
@@ -222,7 +222,7 @@ func TestAddEventWithPersistence(t *testing.T) {
 	chEvents := make(chan interface{}, 10)
 	evt := contract.Event{Device: testDeviceName, Origin: testOrigin, Readings: buildReadings()}
 	// wire up handlers to listen for device events
-	bitEvents := make([]bool, 2)
+	bitEvents := make([]bool, 1)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go handleDomainEvents(bitEvents, chEvents, &wg, t)
@@ -269,7 +269,7 @@ func TestAddEventNoPersistence(t *testing.T) {
 	dbClientMock := newAddEventMockDB(false)
 	evt := contract.Event{Device: testDeviceName, Origin: testOrigin, Readings: buildReadings()}
 	// wire up handlers to listen for device events
-	bitEvents := make([]bool, 2)
+	bitEvents := make([]bool, 1)
 	chEvents := make(chan interface{})
 	wg := sync.WaitGroup{}
 	wg.Add(1)


### PR DESCRIPTION
remove UpdateLastConnected logic in coredata and rename the associated configuration for clarity.
Fix #2280 

Signed-off-by: Chris Hung <chris@iotechsys.com>