### PR TITLE
Update go-mod-secrets and go-mod-bootstrap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/edgexfoundry/go-mod-bootstrap v0.0.10
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.11
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.37
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
+	github.com/edgexfoundry/go-mod-secrets v0.0.14
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/uuid v1.1.0

--- a/internal/security/fileprovider/init.go
+++ b/internal/security/fileprovider/init.go
@@ -29,8 +29,9 @@ import (
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
-	"github.com/edgexfoundry/go-mod-bootstrap/security/authtokenloader"
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 )
 
 type Bootstrap struct {

--- a/internal/security/fileprovider/provider.go
+++ b/internal/security/fileprovider/provider.go
@@ -26,10 +26,10 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/security/authtokenloader"
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 )
 
 // permissionable is the subset of the File API that allows setting file permissions

--- a/internal/security/fileprovider/provider_test.go
+++ b/internal/security/fileprovider/provider_test.go
@@ -28,9 +28,12 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
 	. "github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient/mocks"
-	. "github.com/edgexfoundry/go-mod-bootstrap/security/authtokenloader/mocks"
-	. "github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer/mocks"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	. "github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader/mocks"
+	. "github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer/mocks"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/security/fileprovider/tokenconfig.go
+++ b/internal/security/fileprovider/tokenconfig.go
@@ -47,7 +47,7 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 )
 
 type TokenConfFile map[string]ServiceKey

--- a/internal/security/fileprovider/tokenconfig_test.go
+++ b/internal/security/fileprovider/tokenconfig_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer/mocks"
+	. "github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer/mocks"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/security/proxy/certs.go
+++ b/internal/security/proxy/certs.go
@@ -24,9 +24,10 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/security/authtokenloader"
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 )
 
 type CertificateLoader interface {

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -29,12 +29,14 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 )
 
 type Bootstrap struct {

--- a/internal/security/secretstoreclient/requestor.go
+++ b/internal/security/secretstoreclient/requestor.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 )
 
 type HTTPSRequestor interface {

--- a/internal/security/secretstoreclient/roottoken.go
+++ b/internal/security/secretstoreclient/roottoken.go
@@ -25,7 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 )
 
 func (vc *vaultClient) RegenRootToken(vmkReader io.Reader, rootToken *string) (err error) {

--- a/internal/security/secretstoreclient/roottoken_test.go
+++ b/internal/security/secretstoreclient/roottoken_test.go
@@ -25,9 +25,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/security/secretstoreclient/vault.go
+++ b/internal/security/secretstoreclient/vault.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 )
 
 type vaultClient struct {

--- a/internal/security/secretstoreclient/vault_test.go
+++ b/internal/security/secretstoreclient/vault_test.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/security/fileioperformer"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
Fix #2235

Update the versions of go-mod-secrets and go-mod-bootstrap

Update references to 'authtokenloader' and 'fileioperformer' since they
have been moved from go-mod-bootstrap to go-mod-secrets in the versions
now being utilized.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>