### PR TITLE
Add In-Memory DB Implementation for Addressable

### DIFF
--- a/internal/pkg/db/memory/addressables.go
+++ b/internal/pkg/db/memory/addressables.go
@@ -14,44 +14,189 @@
 
 package memory
 
-import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+import (
+	"github.com/google/uuid"
 
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+// GetAddressables retrieves all the stored addressables.
 func (c *Client) GetAddressables() ([]contract.Addressable, error) {
-	return []contract.Addressable{}, nil
+	// Locking is handled in the getAllAddressables method as it is the one performing the read operation.
+	return c.getAllAddressables(), nil
 }
 
+// UpdateAddressable updates the value stored for the provided addressable. If no addressable exists then an error is
+// returned.
 func (c *Client) UpdateAddressable(a contract.Addressable) error {
+	c.addressableStore.addressableMapMutex.Lock()
+	defer c.addressableStore.addressableMapMutex.Unlock()
+
+	_, isPresent := c.addressableStore.addressableMap[a.Id]
+	if !isPresent {
+		return db.ErrNotFound
+	}
+
+	c.addressableStore.addressableMap[a.Id] = a
 	return nil
 }
 
+// GetAddressableById retrieves the addressable with the associated ID. If no matching addressable exists then an error
+// is returned.
 func (c *Client) GetAddressableById(id string) (contract.Addressable, error) {
-	return contract.Addressable{}, nil
+	c.addressableStore.addressableMapMutex.RLock()
+	defer c.addressableStore.addressableMapMutex.RUnlock()
+
+	addressable, isPresent := c.addressableStore.addressableMap[id]
+	if !isPresent {
+		return contract.Addressable{}, db.ErrNotFound
+	}
+
+	return addressable, nil
 }
 
+// AddAddressable stores the new addressable. If an addressable with a matching ID is already stored then an error is
+// returned.
 func (c *Client) AddAddressable(a contract.Addressable) (string, error) {
-	return "", nil
+	c.addressableStore.addressableMapMutex.Lock()
+	defer c.addressableStore.addressableMapMutex.Unlock()
+
+	_, isPresent := c.addressableStore.addressableMap[a.Id]
+	if isPresent {
+		return "", db.ErrNotUnique
+	}
+
+	_, err := uuid.Parse(a.Id)
+	if err != nil {
+		a.Id = uuid.New().String()
+	}
+
+	c.addressableStore.addressableMap[a.Id] = a
+	return a.Id, nil
 }
 
+// GetAddressableByName retrieves the addressables which match the provided name. If no matching addressable exists then
+// an error is returned.
 func (c *Client) GetAddressableByName(n string) (contract.Addressable, error) {
-	return contract.Addressable{}, nil
+	c.addressableStore.addressableMapMutex.RLock()
+	defer c.addressableStore.addressableMapMutex.RUnlock()
+
+	for _, addressable := range c.addressableStore.addressableMap {
+		if addressable.Name == n {
+			return addressable, nil
+		}
+	}
+	return contract.Addressable{}, db.ErrNotFound
 }
 
+// GetAddressablesByTopic retrieves the addressables which match the provided Topic. If no matching addressable exists
+// then an error is returned.
 func (c *Client) GetAddressablesByTopic(t string) ([]contract.Addressable, error) {
-	return []contract.Addressable{}, nil
+	c.addressableStore.addressableMapMutex.RLock()
+	defer c.addressableStore.addressableMapMutex.RUnlock()
+
+	matchingAddressables := make([]contract.Addressable, 0)
+	for _, addressable := range c.addressableStore.addressableMap {
+		if addressable.Topic == t {
+			matchingAddressables = append(matchingAddressables, addressable)
+		}
+	}
+
+	if len(matchingAddressables) > 0 {
+		return matchingAddressables, nil
+	}
+
+	return matchingAddressables, db.ErrNotFound
 }
 
+// GetAddressablesByPort retrieves the addressables which match the provided Port. If no matching addressable exists
+// then an error is returned.
 func (c *Client) GetAddressablesByPort(p int) ([]contract.Addressable, error) {
-	return []contract.Addressable{}, nil
+	c.addressableStore.addressableMapMutex.RLock()
+	defer c.addressableStore.addressableMapMutex.RUnlock()
+
+	matchingAddressables := make([]contract.Addressable, 0)
+	for _, addressable := range c.addressableStore.addressableMap {
+		if addressable.Port == p {
+			matchingAddressables = append(matchingAddressables, addressable)
+		}
+	}
+
+	if len(matchingAddressables) > 0 {
+		return matchingAddressables, nil
+	}
+
+	return matchingAddressables, db.ErrNotFound
 }
 
+// GetAddressablesByPublisher retrieves the addressables which match the provided Publisher. If no matching addressable
+// exists then an error is returned.
 func (c *Client) GetAddressablesByPublisher(p string) ([]contract.Addressable, error) {
-	return []contract.Addressable{}, nil
+	c.addressableStore.addressableMapMutex.RLock()
+	defer c.addressableStore.addressableMapMutex.RUnlock()
+
+	matchingAddressables := make([]contract.Addressable, 0)
+	for _, addressable := range c.addressableStore.addressableMap {
+		if addressable.Publisher == p {
+			matchingAddressables = append(matchingAddressables, addressable)
+		}
+	}
+
+	if len(matchingAddressables) > 0 {
+		return matchingAddressables, nil
+	}
+
+	return matchingAddressables, db.ErrNotFound
 }
 
+// GetAddressablesByAddress retrieves the addressables which match the provided Address. If no matching addressable
+// exists then an error is returned.
 func (c *Client) GetAddressablesByAddress(add string) ([]contract.Addressable, error) {
-	return []contract.Addressable{}, nil
+	c.addressableStore.addressableMapMutex.RLock()
+	defer c.addressableStore.addressableMapMutex.RUnlock()
+
+	matchingAddressables := make([]contract.Addressable, 0)
+	for _, addressable := range c.addressableStore.addressableMap {
+		if addressable.Address == add {
+			matchingAddressables = append(matchingAddressables, addressable)
+		}
+	}
+
+	if len(matchingAddressables) > 0 {
+		return matchingAddressables, nil
+	}
+
+	return matchingAddressables, db.ErrNotFound
 }
 
+// DeleteAddressableById removes the addressable with the associated ID from memory. If no matching addressable exists
+// then an error is returned.
 func (c *Client) DeleteAddressableById(id string) error {
+	c.addressableStore.addressableMapMutex.Lock()
+	defer c.addressableStore.addressableMapMutex.Unlock()
+
+	_, isPresent := c.addressableStore.addressableMap[id]
+	if !isPresent {
+		return db.ErrNotFound
+	}
+
+	delete(c.addressableStore.addressableMap, id)
 	return nil
+}
+
+// getAllAddressables retrieves all the persisted addressables and returns them in a slice.
+//
+// NOTE: Acquires a read lock when invoked.
+func (c *Client) getAllAddressables() []contract.Addressable {
+	c.addressableStore.addressableMapMutex.RLock()
+	defer c.addressableStore.addressableMapMutex.RUnlock()
+
+	addressables := make([]contract.Addressable, 0)
+	for _, value := range c.addressableStore.addressableMap {
+		addressables = append(addressables, value)
+	}
+
+	return addressables
 }

--- a/internal/pkg/db/memory/addressables_test.go
+++ b/internal/pkg/db/memory/addressables_test.go
@@ -1,0 +1,737 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package memory
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/google/uuid"
+)
+
+// allTestAddressables a slice containing all the pre-constructed addressables for testing.
+var allTestAddressables = []contract.Addressable{addressable1, addressable2, addressable3}
+
+// addressable1 is a pre-constructed addressable with unique properties which does not match any other addressable when
+//  invoking functions which can return multiple addressables such as GetAddressablesByPort
+var addressable1 = contract.Addressable{
+	Timestamps: contract.Timestamps{
+		Created:  123,
+		Modified: 456,
+		Origin:   789,
+	},
+	// This is a valid UUID which allows us to ensure that the ID used is not replaced.
+	Id:         "6d40520f-035b-4be9-bacc-152d4f4f37a9",
+	Name:       "FirstAddressable",
+	Protocol:   "tcp",
+	HTTPMethod: "POST",
+	Address:    "0.0.0.0",
+	Port:       8000,
+	Path:       "/",
+	Publisher:  "Mushroom Kingdom",
+	User:       "Yoshi",
+	Password:   "MarioIsGettingHeavy",
+	Topic:      "dinosaur-things",
+}
+
+// addressable2 is a pre-constructed addressable with non-unique properties. The properties which can lead to multiple
+// results when invoking the client, such as GetAddressablesByPort, have matching properties with addressable3. This
+// helps with testing situations where multiple addressables are returned
+var addressable2 = contract.Addressable{
+	Timestamps: contract.Timestamps{
+		Created:  789,
+		Modified: 456,
+		Origin:   123,
+	},
+	// This is a valid UUID which allows us to ensure that the ID used is not replaced.
+	Id:         "1d874125-df04-4718-bd81-b550019b74aa",
+	Name:       "SecondAddressable",
+	Protocol:   "http",
+	HTTPMethod: "GET",
+	Address:    "127.0.0.1",
+	Port:       8080,
+	Path:       "/home",
+	Publisher:  "Nintendo",
+	User:       "Link the hero time",
+	Password:   "RescueZelda",
+	Topic:      "hyrule-events",
+}
+
+// addressable3 is a pre-constructed addressable with non-unique properties. The properties which can lead to multiple
+// results when invoking the client, such as GetAddressablesByPort, have matching properties with addressable2. This
+// helps with testing situations where multiple addressables are returned
+var addressable3 = contract.Addressable{
+	Timestamps: contract.Timestamps{
+		Created:  789,
+		Modified: 456,
+		Origin:   123,
+	},
+	// This is a valid UUID which allows us to ensure that the ID used is not replaced.
+	Id:         "cb7d56ca-527d-448b-91f0-bc27f9891b90",
+	Name:       "ThirdAddressable",
+	Protocol:   "stomp",
+	HTTPMethod: "PUT",
+	Address:    "127.0.0.1",
+	Port:       8080,
+	Path:       "/castle",
+	Publisher:  "Nintendo",
+	User:       "Gannon",
+	Password:   "GetTriforce",
+	Topic:      "hyrule-events",
+}
+
+func TestClient_AddAddressableUUID(t *testing.T) {
+	client := NewClient()
+	generatedId, err := client.AddAddressable(contract.Addressable{})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	// Verify the ID is not blank and is a valid UUID
+	_, err = uuid.Parse(generatedId)
+	if err != nil {
+		t.Errorf("The generated UUID is not valid: %s", generatedId)
+	}
+}
+
+func TestClient_GetAddressables(t *testing.T) {
+
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		want                     []contract.Addressable
+		wantErr                  bool
+	}{
+		{
+			"One Addressable",
+			[]contract.Addressable{addressable1},
+			[]contract.Addressable{addressable1},
+			false,
+		},
+		{
+			"Multiple Addressables",
+			[]contract.Addressable{addressable1, addressable2},
+
+			[]contract.Addressable{addressable1, addressable2},
+			false,
+		},
+		{
+			"No Addressables",
+			[]contract.Addressable{},
+
+			[]contract.Addressable{},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			got, err := c.GetAddressables()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddressables() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && !verifySliceEqualIgnoreOrder(got, tt.want) {
+				t.Errorf("GetAddressables() got = %v, want %v", got, tt.want)
+
+			}
+		})
+	}
+}
+
+func TestClient_UpdateAddressable(t *testing.T) {
+
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		newAddressable           contract.Addressable
+		wantErr                  bool
+		errorType                error
+	}{
+		{
+			"Update existing addressable",
+			allTestAddressables,
+			addressable1,
+			false,
+			nil,
+		},
+		{
+			"Update non-existing addressable",
+			[]contract.Addressable{addressable1},
+			addressable2,
+			true,
+			db.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			err = c.UpdateAddressable(tt.newAddressable)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UpdateAddressable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errorType != nil {
+				if err.Error() != tt.errorType.Error() {
+					t.Errorf("Expected error of '%v', but got an error of  '%v'", tt.errorType, err)
+					return
+				}
+			}
+
+			if !tt.wantErr {
+				want := tt.newAddressable
+				got, err := c.GetAddressableById(tt.newAddressable.Id)
+				if err != nil {
+					t.Errorf("Unexpected error during validation of update: %v", err)
+					return
+				}
+
+				if !reflect.DeepEqual(want, got) {
+					t.Errorf("UpdateAddressable() got = %v, want %v", got, want)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestClient_GetAddressableById(t *testing.T) {
+
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		id                       string
+		want                     contract.Addressable
+		wantErr                  bool
+		errorType                error
+	}{
+		{
+			"Get existing addressable by ID",
+			[]contract.Addressable{addressable1},
+			addressable1.Id,
+			addressable1,
+			false,
+			nil,
+		},
+		{
+			"No matching ID",
+			[]contract.Addressable{addressable1},
+			addressable2.Id,
+			contract.Addressable{},
+			true,
+			db.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			got, err := c.GetAddressableById(tt.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddressableById() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errorType != nil {
+				if err.Error() != tt.errorType.Error() {
+					t.Errorf("Expected error of '%v', but got an error of  '%v'", tt.errorType, err)
+					return
+				}
+			}
+
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAddressableById() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_AddAddressable(t *testing.T) {
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		newAddressable           contract.Addressable
+		want                     string
+		wantErr                  bool
+		errorType                error
+	}{
+		{
+			"Add addressable with unique ID",
+			[]contract.Addressable{addressable1},
+			addressable2,
+			addressable2.Id,
+			false,
+			nil,
+		},
+		{
+			"Add addressable with non-unique ID",
+			[]contract.Addressable{addressable1},
+			addressable1,
+			"",
+			true,
+			db.ErrNotUnique,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			got, err := c.AddAddressable(tt.newAddressable)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddAddressable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errorType != nil {
+				if err.Error() != tt.errorType.Error() {
+					t.Errorf("Expected error of '%v', but got an error of  '%v'", tt.errorType, err)
+					return
+				}
+			}
+
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("AddAddressable() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_GetAddressableByName(t *testing.T) {
+
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		addressableName          string
+		want                     contract.Addressable
+		wantErr                  bool
+		errorType                error
+	}{
+		{
+			"Get matching addressable by name",
+			allTestAddressables,
+			addressable1.Name,
+			addressable1,
+			false,
+			nil,
+		},
+		{
+			"No matching addressable",
+			allTestAddressables,
+			"non-existent name",
+			contract.Addressable{},
+			true,
+			db.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			got, err := c.GetAddressableByName(tt.addressableName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddressableByName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errorType != nil {
+				if err.Error() != tt.errorType.Error() {
+					t.Errorf("Expected error of '%v', but got an error of  '%v'", tt.errorType, err)
+					return
+				}
+			}
+
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAddressableByName() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_GetAddressablesByTopic(t *testing.T) {
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		topic                    string
+		want                     []contract.Addressable
+		wantErr                  bool
+		errorType                error
+	}{
+		{
+			"Get matching addressable by topic",
+			allTestAddressables,
+			addressable1.Topic,
+			[]contract.Addressable{addressable1},
+			false,
+			nil,
+		},
+		{
+			"Get multiple matching addressable by topic",
+			allTestAddressables,
+			addressable2.Topic,
+			[]contract.Addressable{addressable2, addressable3},
+			false,
+			nil,
+		},
+		{
+			"No matching addressable",
+			allTestAddressables,
+			"non-existent topic",
+			nil,
+			true,
+			db.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			got, err := c.GetAddressablesByTopic(tt.topic)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddressablesByTopic() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errorType != nil {
+				if err.Error() != tt.errorType.Error() {
+					t.Errorf("Expected error of '%v', but got an error of  '%v'", tt.errorType, err)
+					return
+				}
+			}
+
+			if !tt.wantErr && !verifySliceEqualIgnoreOrder(got, tt.want) {
+				t.Errorf("GetAddressablesByTopic() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_GetAddressablesByPort(t *testing.T) {
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		port                     int
+		want                     []contract.Addressable
+		wantErr                  bool
+		errorType                error
+	}{
+		{
+			"Get matching addressable by port",
+			allTestAddressables,
+			addressable1.Port,
+			[]contract.Addressable{addressable1},
+			false,
+			nil,
+		},
+		{
+			"Get multiple matching addressable by port",
+			allTestAddressables,
+			addressable2.Port,
+			[]contract.Addressable{addressable2, addressable3},
+			false,
+			nil,
+		},
+		{
+			"No matching addressable",
+			allTestAddressables,
+			999999,
+			nil,
+			true,
+			db.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			got, err := c.GetAddressablesByPort(tt.port)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddressablesByPort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errorType != nil {
+				if err.Error() != tt.errorType.Error() {
+					t.Errorf("Expected error of '%v', but got an error of  '%v'", tt.errorType, err)
+					return
+				}
+			}
+
+			if !tt.wantErr && !verifySliceEqualIgnoreOrder(got, tt.want) {
+				t.Errorf("GetAddressablesByPort() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_GetAddressablesByAddress(t *testing.T) {
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		address                  string
+		want                     []contract.Addressable
+		wantErr                  bool
+		errorType                error
+	}{
+		{
+			"Get matching addressable by address",
+			allTestAddressables,
+			addressable1.Address,
+			[]contract.Addressable{addressable1},
+			false,
+			nil,
+		},
+		{
+			"Get multiple matching addressable by address",
+			allTestAddressables,
+			addressable2.Address,
+			[]contract.Addressable{addressable2, addressable3},
+			false,
+			nil,
+		},
+		{
+			"No matching addressable",
+			allTestAddressables,
+			"non-existent address",
+			nil,
+			true,
+			db.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			got, err := c.GetAddressablesByAddress(tt.address)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddressablesByAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errorType != nil {
+				if err.Error() != tt.errorType.Error() {
+					t.Errorf("Expected error of '%v', but got an error of  '%v'", tt.errorType, err)
+					return
+				}
+			}
+
+			if !tt.wantErr && !verifySliceEqualIgnoreOrder(got, tt.want) {
+				t.Errorf("GetAddressablesByAddress() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_GetAddressablesByPublisher(t *testing.T) {
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		publisher                string
+		want                     []contract.Addressable
+		wantErr                  bool
+		errorType                error
+	}{
+		{
+			"Get matching addressable by publisher",
+			allTestAddressables,
+			addressable1.Publisher,
+			[]contract.Addressable{addressable1},
+			false,
+			nil,
+		},
+		{
+			"Get multiple matching addressable by publisher",
+			allTestAddressables,
+			addressable2.Publisher,
+			[]contract.Addressable{addressable2, addressable3},
+			false,
+			nil,
+		},
+		{
+			"No matching addressable",
+			allTestAddressables,
+			"non-existent publisher",
+			nil,
+			true,
+			db.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			got, err := c.GetAddressablesByPublisher(tt.publisher)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAddressablesByPublisher() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errorType != nil {
+				if err.Error() != tt.errorType.Error() {
+					t.Errorf("Expected error of '%v', but got an error of  '%v'", tt.errorType, err)
+					return
+				}
+			}
+
+			if !tt.wantErr && !verifySliceEqualIgnoreOrder(got, tt.want) {
+				t.Errorf("GetAddressablesByPublisher() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_DeleteAddressableById(t *testing.T) {
+	tests := []struct {
+		name                     string
+		prePopulatedAddressables []contract.Addressable
+		id                       string
+		wantErr                  bool
+		errorType                error
+	}{
+		{
+			"Delete existing addressable",
+			allTestAddressables,
+			addressable1.Id,
+			false,
+			nil,
+		},
+		{
+			"Delete non-existing addressable",
+			allTestAddressables,
+			"non-existing ID",
+			true,
+			db.ErrNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := createAndPopulateClient(tt.prePopulatedAddressables)
+			if err != nil {
+				t.Errorf("Unexpected error during test setup: %v", err)
+				return
+			}
+
+			err = c.DeleteAddressableById(tt.id)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteAddressableById() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errorType != nil {
+				if err.Error() != tt.errorType.Error() {
+					t.Errorf("Expected error of '%v', but got an error of  '%v'", tt.errorType, err)
+					return
+				}
+			}
+
+			if !tt.wantErr {
+				_, err := c.GetAddressableById(tt.id)
+				if err == nil || err.Error() != db.ErrNotFound.Error() {
+					t.Errorf("Expected the Addressable to be deleted but was not.")
+				}
+			}
+		})
+	}
+}
+
+// createAndPopulateClient constructs a new client and loads provided addressables into the underlying datastore.
+func createAndPopulateClient(addressables []contract.Addressable) (*Client, error) {
+	client := NewClient()
+
+	for _, addressable := range addressables {
+		_, err := client.AddAddressable(addressable)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return client, nil
+}
+
+// verifySliceEqualIgnoreOrder verfies the contents of two slices of Addressables are equal ignoring order.
+func verifySliceEqualIgnoreOrder(a, b []contract.Addressable) bool {
+	aLen := len(a)
+	bLen := len(b)
+
+	if aLen != bLen {
+		return false
+	}
+
+	visited := make([]bool, bLen)
+
+	for i := 0; i < aLen; i++ {
+		found := false
+		element := a[i]
+		for j := 0; j < bLen; j++ {
+			if visited[j] {
+				continue
+			}
+			if element == b[j] {
+				visited[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pkg/db/memory/commands.go
+++ b/internal/pkg/db/memory/commands.go
@@ -17,21 +17,21 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) GetAllCommands() ([]contract.Command, error) {
-	return []contract.Command{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetCommandById(id string) (contract.Command, error) {
-	return contract.Command{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetCommandsByName(n string) ([]contract.Command, error) {
-	return []contract.Command{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetCommandsByDeviceId(did string) ([]contract.Command, error) {
-	return []contract.Command{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetCommandByNameAndDeviceId(cname string, did string) (contract.Command, error) {
-	return contract.Command{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/deviceprofiles.go
+++ b/internal/pkg/db/memory/deviceprofiles.go
@@ -17,41 +17,41 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) GetAllDeviceProfiles() ([]contract.DeviceProfile, error) {
-	return []contract.DeviceProfile{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceProfileById(id string) (contract.DeviceProfile, error) {
-	return contract.DeviceProfile{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceProfilesByModel(model string) ([]contract.DeviceProfile, error) {
-	return []contract.DeviceProfile{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceProfilesWithLabel(l string) ([]contract.DeviceProfile, error) {
-	return []contract.DeviceProfile{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceProfilesByManufacturerModel(man string, mod string) ([]contract.DeviceProfile, error) {
-	return []contract.DeviceProfile{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceProfilesByManufacturer(man string) ([]contract.DeviceProfile, error) {
-	return []contract.DeviceProfile{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceProfileByName(n string) (contract.DeviceProfile, error) {
-	return contract.DeviceProfile{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddDeviceProfile(dp contract.DeviceProfile) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateDeviceProfile(dp contract.DeviceProfile) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteDeviceProfileById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/devicereports.go
+++ b/internal/pkg/db/memory/devicereports.go
@@ -17,33 +17,33 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) GetAllDeviceReports() ([]contract.DeviceReport, error) {
-	return []contract.DeviceReport{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceReportByName(n string) (contract.DeviceReport, error) {
-	return contract.DeviceReport{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceReportByDeviceName(n string) ([]contract.DeviceReport, error) {
-	return []contract.DeviceReport{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceReportById(id string) (contract.DeviceReport, error) {
-	return contract.DeviceReport{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceReportsByAction(n string) ([]contract.DeviceReport, error) {
-	return []contract.DeviceReport{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddDeviceReport(d contract.DeviceReport) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateDeviceReport(dr contract.DeviceReport) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteDeviceReportById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/devices.go
+++ b/internal/pkg/db/memory/devices.go
@@ -17,37 +17,37 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) GetAllDevices() ([]contract.Device, error) {
-	return []contract.Device{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddDevice(d contract.Device, commands []contract.Command) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateDevice(d contract.Device) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteDeviceById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDevicesByProfileId(id string) ([]contract.Device, error) {
-	return []contract.Device{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceById(id string) (contract.Device, error) {
-	return contract.Device{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceByName(n string) (contract.Device, error) {
-	return contract.Device{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDevicesByServiceId(id string) ([]contract.Device, error) {
-	return []contract.Device{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDevicesWithLabel(l string) ([]contract.Device, error) {
-	return []contract.Device{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/deviceservices.go
+++ b/internal/pkg/db/memory/deviceservices.go
@@ -17,33 +17,33 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) GetDeviceServiceByName(n string) (contract.DeviceService, error) {
-	return contract.DeviceService{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceServiceById(id string) (contract.DeviceService, error) {
-	return contract.DeviceService{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetAllDeviceServices() ([]contract.DeviceService, error) {
-	return []contract.DeviceService{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceServicesByAddressableId(id string) ([]contract.DeviceService, error) {
-	return []contract.DeviceService{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetDeviceServicesWithLabel(l string) ([]contract.DeviceService, error) {
-	return []contract.DeviceService{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddDeviceService(ds contract.DeviceService) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateDeviceService(ds contract.DeviceService) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteDeviceServiceById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/events.go
+++ b/internal/pkg/db/memory/events.go
@@ -21,65 +21,65 @@ import (
 )
 
 func (c *Client) Events() ([]contract.Event, error) {
-	return []contract.Event{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventsWithLimit(limit int) ([]contract.Event, error) {
-	return []contract.Event{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddEvent(e correlation.Event) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateEvent(e correlation.Event) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventById(id string) (contract.Event, error) {
-	return contract.Event{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventsByChecksum(checksum string) ([]contract.Event, error) {
-	return []contract.Event{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventCount() (int, error) {
-	return 0, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventCountByDeviceId(id string) (int, error) {
-	return 0, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteEventById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteEventsByDevice(deviceId string) (int, error) {
-	return 0, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventsForDeviceLimit(id string, limit int) ([]contract.Event, error) {
-	return []contract.Event{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventsForDevice(id string) ([]contract.Event, error) {
-	return []contract.Event{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventsByCreationTime(startTime, endTime int64, limit int) ([]contract.Event, error) {
-	return []contract.Event{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventsOlderThanAge(age int64) ([]contract.Event, error) {
-	return []contract.Event{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) EventsPushed() ([]contract.Event, error) {
-	return []contract.Event{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ScrubAllEvents() error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/factory_test.go
+++ b/internal/pkg/db/memory/factory_test.go
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Dell Inc.
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,14 +14,13 @@
 
 package memory
 
-func (c *Client) ScrubMetadata() error {
-	panic(UnimplementedMethodPanicMessage)
-}
+import (
+	"testing"
+)
 
-func (c *Client) Cleanup() error {
-	panic(UnimplementedMethodPanicMessage)
-}
-
-func (c *Client) CleanupOld(age int) error {
-	panic(UnimplementedMethodPanicMessage)
+func TestNewClient(t *testing.T) {
+	client := NewClient()
+	if client == nil {
+		t.Errorf("Client is not expected to be nil")
+	}
 }

--- a/internal/pkg/db/memory/intervals.go
+++ b/internal/pkg/db/memory/intervals.go
@@ -17,73 +17,73 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) Intervals() ([]contract.Interval, error) {
-	return []contract.Interval{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) IntervalsWithLimit(limit int) ([]contract.Interval, error) {
-	return []contract.Interval{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) IntervalByName(name string) (contract.Interval, error) {
-	return contract.Interval{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) IntervalById(id string) (contract.Interval, error) {
-	return contract.Interval{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddInterval(interval contract.Interval) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateInterval(interval contract.Interval) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteIntervalById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) IntervalActions() ([]contract.IntervalAction, error) {
-	return []contract.IntervalAction{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) IntervalActionsWithLimit(limit int) ([]contract.IntervalAction, error) {
-	return []contract.IntervalAction{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) IntervalActionsByIntervalName(name string) ([]contract.IntervalAction, error) {
-	return []contract.IntervalAction{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) IntervalActionsByTarget(name string) ([]contract.IntervalAction, error) {
-	return []contract.IntervalAction{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) IntervalActionById(id string) (contract.IntervalAction, error) {
-	return contract.IntervalAction{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) IntervalActionByName(name string) (contract.IntervalAction, error) {
-	return contract.IntervalAction{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddIntervalAction(action contract.IntervalAction) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateIntervalAction(action contract.IntervalAction) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteIntervalActionById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ScrubAllIntervalActions() (int, error) {
-	return 0, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ScrubAllIntervals() (int, error) {
-	return 0, nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/notifications.go
+++ b/internal/pkg/db/memory/notifications.go
@@ -17,65 +17,65 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) GetNotifications() ([]contract.Notification, error) {
-	return []contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetNotificationById(id string) (contract.Notification, error) {
-	return contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetNotificationBySlug(slug string) (contract.Notification, error) {
-	return contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetNotificationBySender(sender string, limit int) ([]contract.Notification, error) {
-	return []contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetNotificationsByLabels(labels []string, limit int) ([]contract.Notification, error) {
-	return []contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetNotificationsByStartEnd(start int64, end int64, limit int) ([]contract.Notification, error) {
-	return []contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetNotificationsByStart(start int64, limit int) ([]contract.Notification, error) {
-	return []contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetNotificationsByEnd(end int64, limit int) ([]contract.Notification, error) {
-	return []contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetNewNotifications(limit int) ([]contract.Notification, error) {
-	return []contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetNewNormalNotifications(limit int) ([]contract.Notification, error) {
-	return []contract.Notification{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddNotification(n contract.Notification) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateNotification(n contract.Notification) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) MarkNotificationProcessed(n contract.Notification) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteNotificationById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteNotificationBySlug(slug string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteNotificationsOld(age int) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/provisionwatchers.go
+++ b/internal/pkg/db/memory/provisionwatchers.go
@@ -17,37 +17,37 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) GetAllProvisionWatchers() (pw []contract.ProvisionWatcher, err error) {
-	return []contract.ProvisionWatcher{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetProvisionWatcherByName(n string) (pw contract.ProvisionWatcher, err error) {
-	return contract.ProvisionWatcher{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetProvisionWatchersByIdentifier(k string, v string) (pw []contract.ProvisionWatcher, err error) {
-	return []contract.ProvisionWatcher{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetProvisionWatchersByServiceId(id string) (pw []contract.ProvisionWatcher, err error) {
-	return []contract.ProvisionWatcher{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetProvisionWatchersByProfileId(id string) (pw []contract.ProvisionWatcher, err error) {
-	return []contract.ProvisionWatcher{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetProvisionWatcherById(id string) (pw contract.ProvisionWatcher, err error) {
-	return contract.ProvisionWatcher{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddProvisionWatcher(pw contract.ProvisionWatcher) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateProvisionWatcher(pw contract.ProvisionWatcher) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteProvisionWatcherById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/readings.go
+++ b/internal/pkg/db/memory/readings.go
@@ -17,49 +17,49 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) Readings() ([]contract.Reading, error) {
-	return []contract.Reading{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddReading(r contract.Reading) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateReading(r contract.Reading) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ReadingById(id string) (contract.Reading, error) {
-	return contract.Reading{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ReadingCount() (int, error) {
-	return 0, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteReadingById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteReadingsByDevice(deviceId string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ReadingsByDevice(id string, limit int) ([]contract.Reading, error) {
-	return []contract.Reading{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ReadingsByValueDescriptor(name string, limit int) ([]contract.Reading, error) {
-	return []contract.Reading{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ReadingsByValueDescriptorNames(names []string, limit int) ([]contract.Reading, error) {
-	return []contract.Reading{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ReadingsByCreationTime(start, end int64, limit int) ([]contract.Reading, error) {
-	return []contract.Reading{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ReadingsByDeviceAndValueDescriptor(deviceId, valueDescriptor string, limit int) ([]contract.Reading, error) {
-	return []contract.Reading{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/subscriptions.go
+++ b/internal/pkg/db/memory/subscriptions.go
@@ -17,45 +17,45 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) GetSubscriptionBySlug(slug string) (contract.Subscription, error) {
-	return contract.Subscription{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetSubscriptionByCategories(categories []string) ([]contract.Subscription, error) {
-	return []contract.Subscription{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetSubscriptionByLabels(labels []string) ([]contract.Subscription, error) {
-	return []contract.Subscription{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetSubscriptionByCategoriesLabels(categories []string, labels []string) ([]contract.Subscription, error) {
-	return []contract.Subscription{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetSubscriptionByReceiver(receiver string) ([]contract.Subscription, error) {
-	return []contract.Subscription{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetSubscriptionById(id string) (contract.Subscription, error) {
-	return contract.Subscription{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteSubscriptionById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddSubscription(sub contract.Subscription) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateSubscription(sub contract.Subscription) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteSubscriptionBySlug(slug string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetSubscriptions() ([]contract.Subscription, error) {
-	return []contract.Subscription{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/transmissions.go
+++ b/internal/pkg/db/memory/transmissions.go
@@ -17,41 +17,41 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) AddTransmission(t contract.Transmission) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateTransmission(t contract.Transmission) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteTransmission(age int64, status contract.TransmissionStatus) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetTransmissionById(id string) (contract.Transmission, error) {
-	return contract.Transmission{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetTransmissionsByNotificationSlug(slug string, limit int) ([]contract.Transmission, error) {
-	return []contract.Transmission{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetTransmissionsByNotificationSlugAndStartEnd(slug string, start int64, end int64, limit int) ([]contract.Transmission, error) {
-	return []contract.Transmission{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetTransmissionsByStartEnd(start int64, end int64, limit int) ([]contract.Transmission, error) {
-	return []contract.Transmission{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetTransmissionsByStart(start int64, limit int) ([]contract.Transmission, error) {
-	return []contract.Transmission{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetTransmissionsByEnd(end int64, limit int) ([]contract.Transmission, error) {
-	return []contract.Transmission{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) GetTransmissionsByStatus(limit int, status contract.TransmissionStatus) ([]contract.Transmission, error) {
-	return []contract.Transmission{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }

--- a/internal/pkg/db/memory/valuedescriptors.go
+++ b/internal/pkg/db/memory/valuedescriptors.go
@@ -17,45 +17,45 @@ package memory
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 func (c *Client) ValueDescriptors() ([]contract.ValueDescriptor, error) {
-	return []contract.ValueDescriptor{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) AddValueDescriptor(v contract.ValueDescriptor) (string, error) {
-	return "", nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) UpdateValueDescriptor(cvd contract.ValueDescriptor) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) DeleteValueDescriptorById(id string) error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ValueDescriptorByName(name string) (contract.ValueDescriptor, error) {
-	return contract.ValueDescriptor{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ValueDescriptorsByName(names []string) ([]contract.ValueDescriptor, error) {
-	return []contract.ValueDescriptor{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ValueDescriptorById(id string) (contract.ValueDescriptor, error) {
-	return contract.ValueDescriptor{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ValueDescriptorsByUomLabel(uomLabel string) ([]contract.ValueDescriptor, error) {
-	return []contract.ValueDescriptor{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ValueDescriptorsByLabel(label string) ([]contract.ValueDescriptor, error) {
-	return []contract.ValueDescriptor{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ValueDescriptorsByType(t string) ([]contract.ValueDescriptor, error) {
-	return []contract.ValueDescriptor{}, nil
+	panic(UnimplementedMethodPanicMessage)
 }
 
 func (c *Client) ScrubAllValueDescriptors() error {
-	return nil
+	panic(UnimplementedMethodPanicMessage)
 }


### PR DESCRIPTION
Fix #2286

Implement previously noop functionality for the memory.Client's methods
for dealing with persisting contract.Addressable types, and
memory.Client constructor.

Update memory.Client methods with noop implementation to panic rather
than return empty data. The reason is that the tests are using the newly
implemented constructor to create instances of the client for easier
maintainability. Previously, we were panicking at the constructor to
protect users from creating an instance of the memory.Client. Now we are
panicking at when an unimplemented method is invoked.

Add tests covering newly added implementation.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>