### PR TITLE
Turn off root token revokation temporarily until other services updated.

### DIFF
--- a/cmd/security-secretstore-setup/res/docker/configuration.toml
+++ b/cmd/security-secretstore-setup/res/docker/configuration.toml
@@ -38,7 +38,7 @@ tokenprovider = "/security-file-token-provider"
 tokenproviderargs = [ "-confdir", "res-file-token-provider" ]
 tokenprovidertype = "oneshot"
 tokenprovideradmintokenpath = "/run/edgex/secrets/tokenprovider/secrets-token.json"
-revokeroottokens = true
+revokeroottokens = false
 
 [Startup]
 Duration = 30


### PR DESCRIPTION
Root token needs to be temporarily disabled until the following
services are fixed to use non-root tokens:
- edgex-mongo
- edgex-support-logging
- edgex-core-data
- edgex-support-notifications
- edgex-core-metadata
- edgex-core-command
- edgex-support-scheduler

Related issue: #2318 

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>