### PR TITLE
Update OpenAPI Docs for V2 API -- Ping, Metrics, Version, Configuration

### DIFF
--- a/api/openapi/v2/core-command.yaml
+++ b/api/openapi/v2/core-command.yaml
@@ -95,7 +95,12 @@ components:
         - $ref: '#/components/schemas/BaseResponse'
       description: "A response type for returning a generic error to the caller."
       type: object
-    GetConfigurationResponse:
+    ConfigRequest:
+      description: "A request associated with the /config endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
+    ConfigResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
       description: "Provides a response containing the configuration for the targeted service."
@@ -138,6 +143,11 @@ components:
       required:
       - device
       - command
+    MetricsRequest:
+      description: "A request associated with the /metrics endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     MetricsResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -173,6 +183,11 @@ components:
       - memSys
       - memTotalAlloc
       - cpuBusyAvg
+    PingRequest:
+      description: "A request associated with the /ping endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     PingResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -236,6 +251,11 @@ components:
         - strategy
         - type
         - version
+    VersionRequest:
+      description: "A request associated with the /version endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     VersionResponse:
       description: "A response returned from the /version endpoint whose purpose is to report out the latest version supported by the service."
       allOf:
@@ -340,28 +360,6 @@ paths:
                   anyOf:
                     - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/IssueCommandResponse'
-  /config:
-    get:
-      summary: "Returns the current configuration of the service."
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
   /device/id/{deviceid}/command/{commandid}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -631,9 +629,64 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ErrorResponse'
+  /config:
+    post:
+      summary: "Returns the current configuration of the service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/ConfigRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/ConfigRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ConfigResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /metrics:
-    get:
+    post:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/MetricsRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/MetricsRequest'
       responses:
         '200':
           description: "OK"
@@ -644,8 +697,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MetricsResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/MetricsResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -654,8 +720,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /ping:
-    get:
+    post:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PingRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/PingRequest'
       responses:
         '200':
           description: "OK"
@@ -666,8 +742,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PingResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/PingResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -676,8 +765,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /version:
-    get:
+    post:
       summary: "A simple 'version' endpoint that will return the current version of the service"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/VersionRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/VersionRequest'
       responses:
         '200':
           description: "OK"
@@ -688,8 +787,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/VersionResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'

--- a/api/openapi/v2/core-data.yaml
+++ b/api/openapi/v2/core-data.yaml
@@ -167,7 +167,12 @@ components:
       properties:
         event:
           $ref: '#/components/schemas/Event'
-    GetConfigurationResponse:
+    ConfigRequest:
+      description: "A request associated with the /config endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
+    ConfigResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
       description: "Provides a response containing the configuration for the targeted service."
@@ -178,6 +183,11 @@ components:
           type: string
       required:
       - config
+    MetricsRequest:
+      description: "A request associated with the /metrics endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     MetricsResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -213,6 +223,11 @@ components:
       - memSys
       - memTotalAlloc
       - cpuBusyAvg
+    PingRequest:
+      description: "A request associated with the /ping endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     PingResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -382,6 +397,11 @@ components:
         uomLabel:
           description: "A custom unit-of-measure label"
           type: string
+    VersionRequest:
+      description: "A request associated with the /version endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     VersionResponse:
       description: "A response returned from the /version endpoint whose purpose is to report out the latest version supported by the service."
       allOf:
@@ -457,28 +477,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ResponseEnvelope'
-  /config:
-    get:
-      summary: "Returns the current configuration of the service."
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
   /event:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -932,50 +930,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /metrics:
-    get:
-      summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MetricsResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-  /ping:
-    get:
-      summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PingResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
   /reading/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1246,9 +1200,154 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ErrorResponse'
+  /config:
+    post:
+      summary: "Returns the current configuration of the service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/ConfigRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/ConfigRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ConfigResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /metrics:
+    post:
+      summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/MetricsRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/MetricsRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/MetricsResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /ping:
+    post:
+      summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PingRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/PingRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PingResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/PingResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /version:
-    get:
+    post:
       summary: "A simple 'version' endpoint that will return the current version of the service"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/VersionRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/VersionRequest'
       responses:
         '200':
           description: "OK"
@@ -1259,8 +1358,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/VersionResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'

--- a/api/openapi/v2/core-metadata.yaml
+++ b/api/openapi/v2/core-metadata.yaml
@@ -422,7 +422,12 @@ components:
         - $ref: '#/components/schemas/BaseResponse'
       description: "A response type for returning a generic error to the caller."
       type: object
-    GetConfigurationResponse:
+    ConfigRequest:
+      description: "A request associated with the /config endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
+    ConfigResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
       description: "Provides a response containing the configuration for the targeted service."
@@ -433,6 +438,11 @@ components:
           type: string
       required:
       - config
+    MetricsRequest:
+      description: "A request associated with the /metrics endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     MetricsResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -468,6 +478,11 @@ components:
       - memSys
       - memTotalAlloc
       - cpuBusyAvg
+    PingRequest:
+      description: "A request associated with the /ping endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     PingResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -772,6 +787,11 @@ components:
           format: uuid
       required:
         - id
+    VersionRequest:
+      description: "A request associated with the /version endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     VersionResponse:
       description: "A response returned from the /version endpoint whose purpose is to report out the latest version supported by the service."
       allOf:
@@ -1152,28 +1172,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ResponseEnvelope'
-  /config:
-    get:
-      summary: "Returns the current configuration of the service."
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
   /device:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -2415,9 +2413,64 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /config:
+    post:
+      summary: "Returns the current configuration of the service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/ConfigRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/ConfigRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ConfigResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /metrics:
-    get:
+    post:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/MetricsRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/MetricsRequest'
       responses:
         '200':
           description: "OK"
@@ -2428,8 +2481,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MetricsResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/MetricsResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -2438,8 +2504,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /ping:
-    get:
+    post:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PingRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/PingRequest'
       responses:
         '200':
           description: "OK"
@@ -2450,8 +2526,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PingResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/PingResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -2460,8 +2549,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /version:
-    get:
+    post:
       summary: "A simple 'version' endpoint that will return the current version of the service"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/VersionRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/VersionRequest'
       responses:
         '200':
           description: "OK"
@@ -2472,8 +2571,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/VersionResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'

--- a/api/openapi/v2/support-logging.yaml
+++ b/api/openapi/v2/support-logging.yaml
@@ -44,7 +44,12 @@ components:
         - $ref: '#/components/schemas/BaseResponse'
       description: "A response type for returning a generic error to the caller."
       type: object
-    GetConfigurationResponse:
+    ConfigRequest:
+      description: "A request associated with the /config endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
+    ConfigResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
       description: "Provides a response containing the configuration for the targeted service."
@@ -90,6 +95,11 @@ components:
           $ref: '#/components/schemas/LogEntry'
       required:
       - entry
+    MetricsRequest:
+      description: "A request associated with the /metrics endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     MetricsResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -125,6 +135,11 @@ components:
       - memSys
       - memTotalAlloc
       - cpuBusyAvg
+    PingRequest:
+      description: "A request associated with the /ping endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     PingResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -188,6 +203,11 @@ components:
         - strategy
         - type
         - version
+    VersionRequest:
+      description: "A request associated with the /version endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     VersionResponse:
       description: "A response returned from the /version endpoint whose purpose is to report out the latest version supported by the service."
       allOf:
@@ -301,28 +321,6 @@ paths:
                   anyOf:
                     - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/ResponseEnvelope'
-  /config:
-    get:
-      summary: "Returns the current configuration of the service."
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
   /logs:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -493,9 +491,64 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /config:
+    post:
+      summary: "Returns the current configuration of the service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/ConfigRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/ConfigRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ConfigResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /metrics:
-    get:
+    post:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/MetricsRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/MetricsRequest'
       responses:
         '200':
           description: "OK"
@@ -506,8 +559,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MetricsResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/MetricsResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -516,8 +582,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /ping:
-    get:
+    post:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PingRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/PingRequest'
       responses:
         '200':
           description: "OK"
@@ -528,8 +604,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PingResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/PingResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -538,8 +627,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /version:
-    get:
+    post:
       summary: "A simple 'version' endpoint that will return the current version of the service"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/VersionRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/VersionRequest'
       responses:
         '200':
           description: "OK"
@@ -550,8 +649,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/VersionResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'

--- a/api/openapi/v2/support-notifications.yaml
+++ b/api/openapi/v2/support-notifications.yaml
@@ -154,7 +154,12 @@ components:
         - $ref: '#/components/schemas/BaseResponse'
       description: "A response type for returning a generic error to the caller."
       type: object
-    GetConfigurationResponse:
+    ConfigRequest:
+      description: "A request associated with the /config endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
+    ConfigResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
       description: "Provides a response containing the configuration for the targeted service."
@@ -165,6 +170,11 @@ components:
           type: string
       required:
       - config
+    MetricsRequest:
+      description: "A request associated with the /metrics endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     MetricsResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -249,6 +259,11 @@ components:
       properties:
         notification:
           $ref: '#/components/schemas/Notification'
+    PingRequest:
+      description: "A request associated with the /ping endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     PingResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -455,6 +470,11 @@ components:
         id:
           type: string
           format: uuid
+    VersionRequest:
+      description: "A request associated with the /version endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     VersionResponse:
       description: "A response returned from the /version endpoint whose purpose is to report out the latest version supported by the service."
       allOf:
@@ -569,28 +589,6 @@ paths:
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-  /config:
-    get:
-      summary: "Returns the current configuration of the service."
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -940,50 +938,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ErrorResponse'
-  /metrics:
-    get:
-      summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MetricsResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-  /ping:
-    get:
-      summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PingResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
   /subscription:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1565,9 +1519,154 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /config:
+    post:
+      summary: "Returns the current configuration of the service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/ConfigRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/ConfigRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ConfigResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /metrics:
+    post:
+      summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/MetricsRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/MetricsRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/MetricsResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /ping:
+    post:
+      summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PingRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/PingRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PingResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/PingResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /version:
-    get:
+    post:
       summary: "A simple 'version' endpoint that will return the current version of the service"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/VersionRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/VersionRequest'
       responses:
         '200':
           description: "OK"
@@ -1578,8 +1677,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/VersionResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'

--- a/api/openapi/v2/support-scheduler.yaml
+++ b/api/openapi/v2/support-scheduler.yaml
@@ -137,7 +137,12 @@ components:
         - $ref: '#/components/schemas/BaseResponse'
       description: "A response type for returning a generic error to the caller."
       type: object
-    GetConfigurationResponse:
+    ConfigRequest:
+      description: "A request associated with the /config endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
+    ConfigResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
       description: "Provides a response containing the configuration for the targeted service."
@@ -247,6 +252,11 @@ components:
       properties:
         interval:
           $ref: '#/components/schemas/Interval'
+    MetricsRequest:
+      description: "A request associated with the /metrics endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     MetricsResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -282,6 +292,11 @@ components:
       - memSys
       - memTotalAlloc
       - cpuBusyAvg
+    PingRequest:
+      description: "A request associated with the /ping endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     PingResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
@@ -444,6 +459,11 @@ components:
         id:
           type: string
           format: uuid
+    VersionRequest:
+      description: "A request associated with the /version endpoint."
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      type: object
     VersionResponse:
       description: "A response returned from the /version endpoint whose purpose is to report out the latest version supported by the service."
       allOf:
@@ -521,28 +541,6 @@ paths:
                   anyOf:
                     - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/ResponseEnvelope'
-  /config:
-    get:
-      summary: "Returns the current configuration of the service."
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
   /interval:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1061,9 +1059,64 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /config:
+    post:
+      summary: "Returns the current configuration of the service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/ConfigRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/ConfigRequest'
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ConfigResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /metrics:
-    get:
+    post:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/MetricsRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/MetricsRequest'
       responses:
         '200':
           description: "OK"
@@ -1074,8 +1127,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MetricsResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/MetricsResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -1084,8 +1150,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /ping:
-    get:
+    post:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PingRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/PingRequest'
       responses:
         '200':
           description: "OK"
@@ -1096,8 +1172,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PingResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/PingResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -1106,8 +1195,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /version:
-    get:
+    post:
       summary: "A simple 'version' endpoint that will return the current version of the service"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/VersionRequest'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/VersionRequest'
       responses:
         '200':
           description: "OK"
@@ -1118,8 +1217,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionResponse'
-        '500':
-          description: "An unexpected error occurred on the server"
+        '207':
+          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/VersionResponse'
+        '400':
+          description: "Bad request"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -1127,4 +1239,3 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-      


### PR DESCRIPTION
Support for /ping, /metrics, /version, and /config endpoints is currently
specified for the HTTP GET method. That method is cachable. These are not
resource retrievals that should be cached; they are commands. Update to
specify support via the HTTP POST method.

Add a corresponding request DTO for each of these endpoints.

Update to support single and array of use-case requests and responses 
for these endpoints.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2321
Signed-off-by: Michael Estrin <m.estrin@dell.com>