### PR TITLE
Update OpenAPI Docs for V2 API -- Generic Errors

### DIFF
--- a/api/openapi/v2/core-command.yaml
+++ b/api/openapi/v2/core-command.yaml
@@ -90,21 +90,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Command'
-    ErrorEnvelope:
+    ErrorResponse:
       allOf:
-        - $ref: '#/components/schemas/ResponseEnvelope'
-      description: "A type utilized by the /batch endpoint for returning an error applicable to an individual request."
+        - $ref: '#/components/schemas/BaseResponse'
+      description: "A response type for returning a generic error to the caller."
       type: object
-      properties:
-        message:
-          description: "A field that can contain a free-form message, such as an error message."
-          type: string
-        statusCode:
-          description: "A numeric code signifying the operational status of the response."
-          type: integer
-      required:
-        - message
-        - statusCode
     GetConfigurationResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -320,7 +310,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ResponseEnvelope'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ResponseEnvelope'
   /command:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -345,7 +337,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/IssueCommandResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/IssueCommandResponse'
   /config:
     get:
       summary: "Returns the current configuration of the service."
@@ -367,7 +361,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /device/id/{deviceid}/command/{commandid}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -405,7 +399,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IssueCommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -414,7 +408,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IssueCommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '423':
           description: "The device is locked (AdminState)"
           headers:
@@ -423,7 +417,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IssueCommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -432,7 +426,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IssueCommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     put:
       summary: "Issue the specified write command referenced by the command id to the device/sensor, also referenced by id."
       responses:
@@ -446,7 +440,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/IssueCommandResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/IssueCommandResponse'
   /device/name/{deviceName}/command/{commandName}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -482,7 +478,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IssueCommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -491,7 +487,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IssueCommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '423':
           description: "The device is locked (AdminState)"
           headers:
@@ -500,7 +496,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IssueCommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -509,7 +505,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IssueCommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     put:
       summary: "Issue the specified write command referenced by the command name to the device/sensor, also referenced by name."
       responses:
@@ -523,7 +519,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/IssueCommandResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/IssueCommandResponse'
   /device/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -554,7 +552,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -563,7 +561,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /device/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -593,7 +591,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -602,7 +600,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CommandResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /device/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -632,7 +630,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/CommandResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /metrics:
     get:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
@@ -654,7 +652,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /ping:
     get:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
@@ -676,7 +674,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PingResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /version:
     get:
       summary: "A simple 'version' endpoint that will return the current version of the service"
@@ -698,4 +696,4 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionResponse'
+                $ref: '#/components/schemas/ErrorResponse'

--- a/api/openapi/v2/core-data.yaml
+++ b/api/openapi/v2/core-data.yaml
@@ -114,21 +114,6 @@ components:
             mediaType:
               description: "E.g. MIME Type, indicates what the content type of the binaryValue property is if it's populated."
               type: string
-    ErrorEnvelope:
-      allOf:
-        - $ref: '#/components/schemas/ResponseEnvelope'
-      description: "A type utilized by the /batch endpoint for returning an error applicable to an individual request."
-      type: object
-      properties:
-        message:
-          description: "A field that can contain a free-form message, such as an error message."
-          type: string
-        statusCode:
-          description: "A numeric code signifying the operational status of the response."
-          type: integer
-      required:
-        - message
-        - statusCode
     EventCountResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -169,6 +154,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BaseReading'
+    ErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+      description: "A response type for returning a generic error to the caller."
+      type: object
     EventResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -488,7 +478,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /event:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -513,7 +503,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddEventResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/AddEventResponse'
   /event/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -531,7 +523,7 @@ paths:
             application/json:
               schema:
                 type: array
-                items: 
+                items:
                   $ref: '#/components/schemas/EventResponse'
         '500':
           description: "An unexpected error occurred on the server"
@@ -542,8 +534,8 @@ paths:
             application/json:
               schema:
                 type: array
-                items: 
-                  $ref: '#/components/schemas/EventResponse'
+                items:
+                  $ref: '#/components/schemas/ErrorResponse'
   /event/id/{id}:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -574,7 +566,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -583,7 +575,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Deletes an event by ID"
       responses:
@@ -600,7 +592,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -609,7 +601,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -618,7 +610,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /event/pushed:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -643,7 +635,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UpdateEventPushedByChecksumResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/UpdateEventPushedByChecksumResponse'
   /event/count:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -667,7 +661,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventCountResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /event/count/device/{deviceId}:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -698,7 +692,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventCountResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -707,7 +701,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventCountResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -716,7 +710,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventCountResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /event/device/{deviceId}:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -743,7 +737,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/EventResponse'
+               $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -752,7 +746,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/EventResponse'
+               $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -761,7 +755,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/EventResponse'
+               $ref: '#/components/schemas/ErrorResponse'
   /event/device/{deviceId}/all:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -798,7 +792,7 @@ paths:
               schema:
                 type: array
                 items: 
-                  $ref: '#/components/schemas/EventResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -809,7 +803,7 @@ paths:
               schema:
                 type: array
                 items: 
-                  $ref: '#/components/schemas/EventResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -820,7 +814,7 @@ paths:
               schema:
                 type: array
                 items: 
-                  $ref: '#/components/schemas/EventResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /event/start/{start}/end/{end}:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -862,7 +856,7 @@ paths:
               schema:
                 type: array
                 items: 
-                  $ref: '#/components/schemas/EventResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -873,7 +867,7 @@ paths:
               schema:
                 type: array
                 items: 
-                  $ref: '#/components/schemas/EventResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /event/age/{age}:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -899,7 +893,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -908,7 +902,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -917,7 +911,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /event/scrub:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -937,7 +931,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /metrics:
     get:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
@@ -959,7 +953,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /ping:
     get:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
@@ -981,7 +975,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PingResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /reading/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1017,7 +1011,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ReadingResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /reading/count:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1041,7 +1035,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReadingCountResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /reading/id/{id}:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1072,7 +1066,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReadingResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1081,7 +1075,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReadingResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /reading/device/{deviceId}/all:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1118,7 +1112,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ReadingResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1129,7 +1123,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ReadingResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1140,7 +1134,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ReadingResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /reading/type/{type}:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1176,7 +1170,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SimpleReadingResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1187,7 +1181,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SimpleReadingResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1198,7 +1192,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SimpleReadingResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /reading/start/{start}/end/{end}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1240,7 +1234,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ReadingResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1251,7 +1245,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ReadingResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /version:
     get:
       summary: "A simple 'version' endpoint that will return the current version of the service"
@@ -1273,4 +1267,4 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionResponse'
+                $ref: '#/components/schemas/ErrorResponse'

--- a/api/openapi/v2/core-metadata.yaml
+++ b/api/openapi/v2/core-metadata.yaml
@@ -417,21 +417,11 @@ components:
       properties:
         service:
           $ref: '#/components/schemas/DeviceService'
-    ErrorEnvelope:
+    ErrorResponse:
       allOf:
-        - $ref: '#/components/schemas/ResponseEnvelope'
-      description: "A type utilized by the /batch endpoint for returning an error applicable to an individual request."
+        - $ref: '#/components/schemas/BaseResponse'
+      description: "A response type for returning a generic error to the caller."
       type: object
-      properties:
-        message:
-          description: "A field that can contain a free-form message, such as an error message."
-          type: string
-        statusCode:
-          description: "A numeric code signifying the operational status of the response."
-          type: integer
-      required:
-        - message
-        - statusCode
     GetConfigurationResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -861,7 +851,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddAddressableResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/AddAddressableResponse'
     patch:
       summary: "Allows updates to an existing addressable"
       requestBody:
@@ -883,7 +875,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UpdateAddressableResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/UpdateAddressableResponse'
   /addressable/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -913,7 +907,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddressableResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /addressable/host/{host}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -943,7 +937,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -952,7 +946,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /addressable/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -983,7 +977,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -992,7 +986,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Delete an addressable by ID"
       responses:
@@ -1009,7 +1003,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1018,7 +1012,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /addressable/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1048,7 +1042,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1057,7 +1051,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Delete an addressable by name"
       responses:
@@ -1074,7 +1068,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1083,7 +1077,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddressableResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /addressable/port/{port}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1119,7 +1113,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddressableResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1130,7 +1124,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddressableResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /batch:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1179,7 +1173,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /device:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1204,7 +1198,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddDeviceResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/AddDeviceResponse'
     patch:
       summary: "Allows updates to an existing device"
       requestBody:
@@ -1226,7 +1222,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UpdateDeviceResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/UpdateDeviceResponse'
   /device/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1257,7 +1255,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /device/check/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1284,7 +1282,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/DeviceResponse'
+               $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1293,7 +1291,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/DeviceResponse'
+               $ref: '#/components/schemas/ErrorResponse'
   /device/check/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1319,7 +1317,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/DeviceResponse'
+               $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1328,7 +1326,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/DeviceResponse'
+               $ref: '#/components/schemas/ErrorResponse'
   /device/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1359,7 +1357,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/DeviceResponse'
+               $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1368,7 +1366,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/DeviceResponse'
+               $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Delete a device by ID"
       responses:
@@ -1385,7 +1383,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/DeviceResponse'
+               $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1394,7 +1392,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/DeviceResponse'
+               $ref: '#/components/schemas/ErrorResponse'
   /device/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1424,7 +1422,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1433,7 +1431,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Delete a device by name"
       responses:
@@ -1450,7 +1448,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1459,7 +1457,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /device/profile/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1495,7 +1493,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1506,7 +1504,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /device/profile/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1542,7 +1540,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1553,7 +1551,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /device/service/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1589,7 +1587,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1600,7 +1598,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /device/service/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1636,7 +1634,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1647,7 +1645,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /deviceprofile:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1672,7 +1670,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddDeviceProfileResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/AddDeviceProfileResponse'
     put:
       summary: "Allows updates to an existing device profile"
       requestBody:
@@ -1694,7 +1694,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UpdateDeviceProfileResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/UpdateDeviceProfileResponse'
   /deviceprofile/uploadfile:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1728,7 +1730,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/AddDeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '409':
           description: "Conflict detected. Device name and command names must be universally unique."
           headers:
@@ -1737,7 +1739,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/AddDeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error happened on the server."
           headers:
@@ -1746,7 +1748,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/AddDeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /deviceprofile/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1777,7 +1779,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1788,7 +1790,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /deviceprofile/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1819,7 +1821,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1828,7 +1830,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Delete a device profile by ID. This operation will fail if there are devices actively using the profile."
       responses:
@@ -1845,7 +1847,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1854,7 +1856,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '409':
           description: "The provided request conflicts with existing data"
           headers:
@@ -1863,7 +1865,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1872,7 +1874,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /deviceprofile/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1902,7 +1904,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1911,7 +1913,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Delete a device profile by its unique name. This operation will fail if there are devices actively using the profile."
       responses:
@@ -1928,7 +1930,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1937,7 +1939,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '409':
           description: "The provided request conflicts with existing data"
           headers:
@@ -1946,7 +1948,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1955,7 +1957,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /deviceprofile/manufacturer/{manufacturer}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1991,7 +1993,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2002,7 +2004,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /deviceprofile/manufacturer/{manufacturer}/model/{model}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -2044,7 +2046,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2055,7 +2057,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /deviceprofile/model/{model}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -2091,7 +2093,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2102,7 +2104,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceProfileResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /deviceservice:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -2127,7 +2129,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddDeviceServiceResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/AddDeviceServiceResponse'
     patch:
       summary: "Allows updates to an existing device service"
       requestBody:
@@ -2147,7 +2151,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UpdateDeviceServiceResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/UpdateDeviceServiceResponse'
   /deviceservice/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -2178,7 +2184,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceServiceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2189,7 +2195,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DeviceServiceResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /deviceservice/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -2220,7 +2226,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2229,7 +2235,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Delete a device service by ID"
       responses:
@@ -2246,7 +2252,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2255,7 +2261,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /deviceservice/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -2285,7 +2291,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2294,7 +2300,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Delete a device service by its unique name"
       responses:
@@ -2311,7 +2317,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2320,7 +2326,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /deviceservice/addressable/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -2351,7 +2357,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -2360,7 +2366,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2369,7 +2375,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /deviceservice/addressable/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -2399,7 +2405,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -2408,7 +2414,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /metrics:
     get:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
@@ -2430,7 +2436,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /ping:
     get:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
@@ -2452,7 +2458,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PingResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /version:
     get:
       summary: "A simple 'version' endpoint that will return the current version of the service"
@@ -2474,4 +2480,4 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionResponse'
+                $ref: '#/components/schemas/ErrorResponse'

--- a/api/openapi/v2/support-logging.yaml
+++ b/api/openapi/v2/support-logging.yaml
@@ -39,21 +39,11 @@ components:
       required:
         - requestId
         - statusCode
-    ErrorEnvelope:
+    ErrorResponse:
       allOf:
-        - $ref: '#/components/schemas/ResponseEnvelope'
-      description: "A type utilized by the /batch endpoint for returning an error applicable to an individual request."
+        - $ref: '#/components/schemas/BaseResponse'
+      description: "A response type for returning a generic error to the caller."
       type: object
-      properties:
-        message:
-          description: "A field that can contain a free-form message, such as an error message."
-          type: string
-        statusCode:
-          description: "A numeric code signifying the operational status of the response."
-          type: integer
-      required:
-        - message
-        - statusCode
     GetConfigurationResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -308,7 +298,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ResponseEnvelope'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ResponseEnvelope'
   /config:
     get:
       summary: "Returns the current configuration of the service."
@@ -330,7 +322,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /logs:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -355,7 +347,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WriteLogEntryResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/WriteLogEntryResponse'
   /logs/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -389,7 +383,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/LogEntryResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Allows deletion of log entries matching the specified parameters (levels, keywords, services, etc)"
       responses:
@@ -406,7 +400,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LogEntryResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -415,7 +409,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LogEntryResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /logs/start/{start}/end/{end}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -461,7 +455,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/LogEntryResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -472,7 +466,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/LogEntryResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Allows deletion of log entries within a given time range"
       responses:
@@ -489,7 +483,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LogEntryResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -498,7 +492,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LogEntryResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /metrics:
     get:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
@@ -520,7 +514,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /ping:
     get:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
@@ -542,7 +536,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PingResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /version:
     get:
       summary: "A simple 'version' endpoint that will return the current version of the service"
@@ -564,4 +558,4 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionResponse'
+                $ref: '#/components/schemas/ErrorResponse'

--- a/api/openapi/v2/support-notifications.yaml
+++ b/api/openapi/v2/support-notifications.yaml
@@ -149,21 +149,11 @@ components:
     CleanupResponse:
       allOf:
       - $ref: '#/components/schemas/BaseResponse'
-    ErrorEnvelope:
+    ErrorResponse:
       allOf:
-        - $ref: '#/components/schemas/ResponseEnvelope'
-      description: "A type utilized by the /batch endpoint for returning an error applicable to an individual request."
+        - $ref: '#/components/schemas/BaseResponse'
+      description: "A response type for returning a generic error to the caller."
       type: object
-      properties:
-        message:
-          description: "A field that can contain a free-form message, such as an error message."
-          type: string
-        statusCode:
-          description: "A numeric code signifying the operational status of the response."
-          type: integer
-      required:
-        - message
-        - statusCode
     GetConfigurationResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -539,7 +529,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ResponseEnvelope'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ResponseEnvelope'
   /cleanup:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -559,7 +551,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CleanupResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /cleanup/age/{age}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -585,7 +577,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CleanupResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /config:
     get:
       summary: "Returns the current configuration of the service."
@@ -607,7 +599,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /notification:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -632,7 +624,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddNotificationResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/AddNotificationResponse'
   /notification/start/{start}/end/{end}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -675,7 +669,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NotificationResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -686,7 +680,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NotificationResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /notification/age/{age}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -712,7 +706,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -721,7 +715,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -730,7 +724,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /notification/category/{category}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -766,7 +760,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NotificationResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -777,7 +771,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NotificationResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /notification/label/{label}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -813,7 +807,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NotificationResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -824,7 +818,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NotificationResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /notification/slug/{slug}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -854,7 +848,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -863,7 +857,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Deletes the notification associated with the provided slug (name) and all of its associated transmissions."
       responses:
@@ -880,7 +874,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -889,7 +883,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -898,7 +892,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /notification/status/{status}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -934,7 +928,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NotificationResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -945,7 +939,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/NotificationResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /metrics:
     get:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
@@ -967,7 +961,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /ping:
     get:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
@@ -989,7 +983,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PingResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /subscription:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1014,7 +1008,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddSubscriptionResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/AddSubscriptionResponse'
     patch:
       summary: "Update one or more existing Subscriptions. You might do this in order to add an additional channel if you want another endpoint/person to receive the notification."
       requestBody:
@@ -1036,7 +1032,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UpdateSubscriptionResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/UpdateSubscriptionResponse'
   /subscription/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1066,7 +1064,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SubscriptionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /subscription/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1097,7 +1095,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1106,7 +1104,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Deletes a subscription according to the given ID."
       responses:
@@ -1123,7 +1121,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1132,7 +1130,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1141,7 +1139,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /subscription/category/{category}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1177,7 +1175,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SubscriptionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1188,7 +1186,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SubscriptionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /subscription/label/{label}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1224,7 +1222,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SubscriptionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1235,7 +1233,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SubscriptionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /subscription/receiver/{receiver}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1271,7 +1269,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SubscriptionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1282,7 +1280,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SubscriptionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /subscription/slug/{slug}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1312,7 +1310,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1321,7 +1319,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Deletes a subscription according to the given slug (name)."
       responses:
@@ -1338,7 +1336,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1347,7 +1345,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1356,7 +1354,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /transmission/age/{age}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1382,7 +1380,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TransmissionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1391,7 +1389,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TransmissionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1400,7 +1398,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TransmissionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /transmission/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1430,7 +1428,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TransmissionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /transmission/slug/{slug}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1462,7 +1460,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1471,7 +1469,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /transmission/start/{start}/end/{end}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1514,7 +1512,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TransmissionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1525,7 +1523,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TransmissionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /transmission/status/{status}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1557,7 +1555,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1566,7 +1564,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubscriptionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /version:
     get:
       summary: "A simple 'version' endpoint that will return the current version of the service"
@@ -1588,4 +1586,4 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionResponse'
+                $ref: '#/components/schemas/ErrorResponse'

--- a/api/openapi/v2/support-scheduler.yaml
+++ b/api/openapi/v2/support-scheduler.yaml
@@ -132,21 +132,11 @@ components:
       required:
         - requestId
         - statusCode
-    ErrorEnvelope:
+    ErrorResponse:
       allOf:
-        - $ref: '#/components/schemas/ResponseEnvelope'
-      description: "A type utilized by the /batch endpoint for returning an error applicable to an individual request."
+        - $ref: '#/components/schemas/BaseResponse'
+      description: "A response type for returning a generic error to the caller."
       type: object
-      properties:
-        message:
-          description: "A field that can contain a free-form message, such as an error message."
-          type: string
-        statusCode:
-          description: "A numeric code signifying the operational status of the response."
-          type: integer
-      required:
-        - message
-        - statusCode
     GetConfigurationResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -528,7 +518,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ResponseEnvelope'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/ResponseEnvelope'
   /config:
     get:
       summary: "Returns the current configuration of the service."
@@ -550,7 +542,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetConfigurationResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /interval:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -575,7 +567,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddIntervalResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/AddIntervalResponse'
     patch:
       summary: "Update one or more existing Intervals"
       requestBody:
@@ -597,7 +591,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UpdateIntervalResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/UpdateIntervalResponse'
   /interval/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -627,7 +623,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/IntervalResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /interval/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -658,7 +654,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -667,7 +663,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Deletes an interval according to the specified ID. Associated actions will also be deleted."
       responses:
@@ -684,7 +680,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -693,7 +689,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -702,7 +698,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /interval/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -732,7 +728,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -741,7 +737,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Deletes an interval according to the specified name. Associated actions will also be deleted."
       responses:
@@ -758,7 +754,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -767,7 +763,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -776,7 +772,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /intervalaction:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -801,7 +797,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AddIntervalActionResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/AddIntervalActionResponse'
     patch:
       summary: "Update one or more existing IntervalActions"
       requestBody:
@@ -823,7 +821,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/UpdateIntervalActionResponse'
+                  anyOf:
+                    - $ref: '#/components/schemas/ErrorResponse'
+                    - $ref: '#/components/schemas/UpdateIntervalActionResponse'
   /intervalaction/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -853,7 +853,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/IntervalActionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
   /intervalaction/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -884,7 +884,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -893,7 +893,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Deletes an interval action by ID"
       responses:
@@ -910,7 +910,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -919,7 +919,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -928,7 +928,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /intervalaction/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -958,7 +958,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -967,7 +967,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Deletes an interval action by name"
       responses:
@@ -984,7 +984,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -993,7 +993,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1002,7 +1002,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /intervalaction/target/{target}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1039,7 +1039,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/IntervalActionResponse'
+                  $ref: '#/components/schemas/ErrorResponse'
     delete:
       summary: "Deletes all interval actions associated with the specified target."
       responses:
@@ -1060,7 +1060,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntervalActionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /metrics:
     get:
       summary: "An endpoint that can be used to obtain CPU/Memory usage stats for a given service."
@@ -1082,7 +1082,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /ping:
     get:
       summary: "A simple 'ping' endpoint that can be used as a service healthcheck"
@@ -1104,7 +1104,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PingResponse'
+                $ref: '#/components/schemas/ErrorResponse'
   /version:
     get:
       summary: "A simple 'version' endpoint that will return the current version of the service"
@@ -1126,5 +1126,5 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionResponse'
+                $ref: '#/components/schemas/ErrorResponse'
       


### PR DESCRIPTION
Remove ErrorEnvelope (batch endpoint DTO -- wraps use-case DTO).

Add ErrorResponse (use-case DTO).

Add ErrorResponse to all relevant use-case-request paths.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2323
Signed-off-by: Michael Estrin <m.estrin@dell.com>