### PR TITLE
Update the configuration.toml for sys-mgmt-agent to increase the default value for the http.Server timeout..

### DIFF
--- a/cmd/sys-mgmt-agent/res/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/configuration.toml
@@ -24,7 +24,7 @@ Port = 48090
 Protocol = 'http'
 MaxResultCount = 50000
 StartupMsg = 'This is the System Management Agent Service'
-Timeout = 5000
+Timeout = 10000
 FormatSpecifier = '%(\\d+\\$)?([-#+ 0(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])'
 
 [Registry]

--- a/cmd/sys-mgmt-agent/res/docker/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/docker/configuration.toml
@@ -24,7 +24,7 @@ Port = 48090
 Protocol = 'http'
 MaxResultCount = 50000
 StartupMsg = 'This is the System Management Agent Service'
-Timeout = 5000
+Timeout = 10000
 FormatSpecifier = '%(\\d+\\$)?([-#+ 0(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])'
 
 [Registry]


### PR DESCRIPTION
- Fix the issue related to the SMA operation "restart" (via Blackbox scripts). Details in [Issue-372](https://github.com/edgexfoundry/blackbox-testing/issues/372)