### PR TITLE
Add Jenkinsfile for posting API files to SwaggerHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,23 @@
+#!/usr/bin/env groovy
+
+def OASVERSION = '3.0.0'
+def ISPRIVATE = true
+def OWNER = 'EdgeXFoundry1'
+def APIVERSION = ''
+def APIFOLDER = ''
+node {
+    stage ('Checkout') {
+        checkout scm
+    }
+
+    withCredentials([string(credentialsId: 'swaggerhub-api-key', variable: 'APIKEY')]) {
+        APIVERSION = '1.1.1'
+        APIFOLDER = 'v1.1.1'
+        sh "sh toSwaggerHub.sh ${APIKEY} ${APIFOLDER} ${APIVERSION} ${OASVERSION} ${ISPRIVATE} ${OWNER}"
+    }
+    withCredentials([string(credentialsId: 'swaggerhub-api-key', variable: 'APIKEY')]) {
+        APIVERSION = '2.0.0'
+        APIFOLDER = 'v2'
+        sh "sh toSwaggerHub.sh ${APIKEY} ${APIFOLDER} ${APIVERSION} ${OASVERSION} ${ISPRIVATE} ${OWNER}"
+    }
+}

--- a/Jenkinsfile.sandbox
+++ b/Jenkinsfile.sandbox
@@ -1,0 +1,23 @@
+#!/usr/bin/env groovy
+
+def OASVERSION = '3.0.0'
+def ISPRIVATE = true
+def OWNER = 'EdgeXFoundry1'
+def APIVERSION = ''
+def APIFOLDER = ''
+node {
+    stage ('Checkout') {
+        checkout scm
+    }
+
+    withCredentials([string(credentialsId: 'swaggerhub-api-key', variable: 'APIKEY')]) {
+        APIVERSION = '1.1.1'
+        APIFOLDER = 'v1.1.1'
+        sh "sh toSwaggerHub.sh ${APIKEY} ${APIFOLDER} ${APIVERSION} ${OASVERSION} ${ISPRIVATE} ${OWNER}"
+    }
+    withCredentials([string(credentialsId: 'swaggerhub-api-key', variable: 'APIKEY')]) {
+        APIVERSION = '2.0.0'
+        APIFOLDER = 'v2'
+        sh "sh toSwaggerHub.sh ${APIKEY} ${APIFOLDER} ${APIVERSION} ${OASVERSION} ${ISPRIVATE} ${OWNER}"
+    }
+}

--- a/toSwaggerHub.sh
+++ b/toSwaggerHub.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+apiKey=$1
+apiFolder=$2
+apiVersion=$3
+oasVersion=$4
+isPrivate=$5
+owner=$6
+apiPath="api/openapi/"${apiFolder}
+
+for file in ${apiPath}/*.yaml; do
+    apiName="$(echo $file | cut -d "/" -f 4 | cut -d "." -f 1)"
+    echo "API_Name:"$apiName
+    apiContent="$(cat ${apiPath}/${apiName}.yaml)"
+    
+    curl -X POST "https://api.swaggerhub.com/apis/${owner}/${apiName}?isPrivate=${isPrivate}&version=${apiVersion}&oas=${oasVersion}&force=true" -H "accept:application/json" -H "Authorization:${apiKey}" -H "Content-Type:application/yaml" -d "${apiContent}"
+done


### PR DESCRIPTION
1. Add Jenkinsfile and toSwaggerHub.sh for posting the API files to SwaggerHub.
2. The Jenkinsfile.sandbox is for the validation in Jenkins Sandbox.
3. This job needs to add SwaggerHub credential in Jenkins. I will send a request from LF help desk.
4. This PR depends on  PR #2329 and can't be merged before it.
Fix #2330 
Signed-off-by: Cherry Wang <cherry@iotechsys.com>