### PR TITLE
Send notifications of any severity when they are received.

### DIFF
--- a/internal/support/notifications/rest_notification.go
+++ b/internal/support/notifications/rest_notification.go
@@ -64,21 +64,19 @@ func notificationHandler(
 		return
 	}
 
-	if n.Severity == models.NotificationsSeverity(models.Critical) {
-		lc.Info("Critical severity scheduler is triggered for: " + n.Slug)
-		n, err = dbClient.GetNotificationById(n.ID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			lc.Error(err.Error())
-			return
-		}
-
-		err := distributeAndMark(n, lc, dbClient, config)
-		if err != nil {
-			return
-		}
-		lc.Info("Critical severity scheduler has completed for: " + n.Slug)
+	lc.Debug("The scheduler is triggered for: " + n.Slug)
+	n, err = dbClient.GetNotificationById(n.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		lc.Error(err.Error())
+		return
 	}
+
+	err = distributeAndMark(n, lc, dbClient, config)
+	if err != nil {
+		return
+	}
+	lc.Debug("The scheduler has completed for: " + n.Slug)
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusAccepted)

--- a/internal/support/notifications/rest_notification_test.go
+++ b/internal/support/notifications/rest_notification_test.go
@@ -15,6 +15,8 @@
 package notifications
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -29,6 +31,7 @@ import (
 
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/config"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
@@ -48,6 +51,11 @@ var TestInvalidAge = "invalid age"
 var TestSender = "System Management"
 var TestStart int64 = 1564758450
 var TestEnd int64 = 1564758650
+var notificationId = "526c5c28-7a21-48a8-90f6-8009400441f4"
+var invalidNotificationId = "..."
+var badNotificationId = "11111111-7a21-48a8-90f6-8009400441f4"
+var notificationServiceURI = clients.ApiBase + "/" + NOTIFICATIONSERVICE
+var testError = errors.New("some error")
 
 var TestLabels = []string{
 	"test_label",
@@ -57,6 +65,10 @@ var TestLabels = []string{
 var TestCategories = []string{
 	"test_category",
 }
+
+const (
+	NOTIFICATIONSERVICE = "notification"
+)
 
 func TestGetNotificationById(t *testing.T) {
 	tests := []struct {
@@ -252,6 +264,139 @@ func createNotifications(howMany int) []contract.Notification {
 		})
 	}
 	return notifications
+}
+
+func createNotificationBySeverityLevel(severityLevel string) contract.Notification {
+	var notification contract.Notification
+
+	switch severityLevel {
+	case contract.Critical:
+		notification = contract.Notification{
+			ID:       notificationId,
+			Slug:     "notice-critical-123",
+			Sender:   "Sender A",
+			Category: "SECURITY",
+			Severity: contract.Critical,
+			Content:  "Hello, Notification!",
+			Status:   "NEW",
+			Labels: []string{
+				"first-label",
+				"second-label",
+			},
+		}
+	case contract.Normal:
+		notification = contract.Notification{
+			ID:       notificationId,
+			Slug:     "notice-normal-123",
+			Sender:   "Sender B",
+			Category: "SECURITY",
+			Severity: contract.Normal,
+			Content:  "Hello, Notification!",
+			Status:   "NEW",
+			Labels: []string{
+				"first-label",
+				"second-label",
+			},
+		}
+	default:
+		//	...
+	}
+
+	return notification
+}
+
+func createInvalidNotification() contract.Notification {
+	var notification contract.Notification
+
+	notification = contract.Notification{
+		ID:       invalidNotificationId,
+		Slug:     "...",
+		Sender:   "...",
+		Category: "...",
+		Severity: contract.Critical,
+		Content:  "...",
+		Status:   "...",
+		Labels: []string{
+			"...",
+			"...",
+		},
+	}
+	return notification
+}
+
+func createInvalidCategoriesAndLabelsNotification() contract.Notification {
+	var notification contract.Notification
+
+	notification = contract.Notification{
+		ID:       notificationId,
+		Slug:     "notice-critical-123",
+		Sender:   "Sender A",
+		Category: "...",
+		Severity: contract.Critical,
+		Content:  "Hello, Notification!",
+		Status:   "NEW",
+		Labels: []string{
+			"first-bad-label",
+			"second-bad-label",
+		},
+	}
+	return notification
+}
+
+func createBadNotification() contract.Notification {
+	var notification contract.Notification
+
+	notification = contract.Notification{
+		ID:       badNotificationId,
+		Slug:     "notice-normal-123",
+		Sender:   "Sender B",
+		Category: "SECURITY",
+		Severity: contract.Critical,
+		Content:  "Hello, Notification!",
+		Status:   "NEW",
+		Labels: []string{
+			"first-label",
+			"second-label",
+		},
+	}
+	return notification
+}
+
+// This function serves to update the unexported isValidated field (in "go-mod-core-contracts"),
+// which can only be done by marshalling and unmarshalling to JSON.
+func validateNotification(notification *contract.Notification) contract.Notification {
+	b, _ := json.Marshal(notification)
+	_ = notification.UnmarshalJSON(b)
+	return *notification
+}
+
+func createNotificationHandlerRequestWithBody(
+	httpMethod string,
+	notification contract.Notification,
+	pathParams map[string]string) *http.Request {
+
+	// if your JSON marshalling fails you've got bigger problems
+	body, _ := json.Marshal(notification)
+
+	req := httptest.NewRequest(httpMethod, notificationServiceURI, bytes.NewReader(body))
+
+	return mux.SetURLVars(req, pathParams)
+}
+
+type mockOutline struct {
+	methodName string
+	arg        []interface{}
+	ret        []interface{}
+}
+
+func createMockWithOutlines(outlines []mockOutline) interfaces.DBClient {
+	dbMock := mocks.DBClient{}
+
+	for _, o := range outlines {
+		dbMock.On(o.methodName, o.arg...).Return(o.ret...)
+	}
+
+	return &dbMock
 }
 
 func TestDeleteNotificationById(t *testing.T) {
@@ -735,6 +880,135 @@ func TestGetNotificationsNewest(t *testing.T) {
 			if response.StatusCode != tt.expectedStatus {
 				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
 
+				return
+			}
+		})
+	}
+}
+
+func TestNotificationHandler(t *testing.T) {
+
+	notificationNormal := createNotificationBySeverityLevel(contract.Normal)
+	notificationCritical := createNotificationBySeverityLevel(contract.Critical)
+	notificationInvalid := createInvalidNotification()
+	notificationBad := createBadNotification()
+	notificationInvalidCategoriesAndLabels := createInvalidCategoriesAndLabelsNotification()
+
+	var categories []string
+	categories = append(categories, string(notificationNormal.Category))
+	var labels = []string{"first-label", "second-label"}
+
+	var badCategories []string
+	badCategories = append(badCategories, string(notificationInvalidCategoriesAndLabels.Category))
+	var badLabels = []string{"first-bad-label", "second-bad-label"}
+
+	tests := []struct {
+		name           string
+		request        *http.Request
+		dbMock         interfaces.DBClient
+		expectedStatus int
+	}{
+		{
+			"ok normal notification",
+			createNotificationHandlerRequestWithBody(http.MethodPost, notificationNormal, nil),
+			createMockWithOutlines([]mockOutline{
+				{"AddNotification", []interface{}{validateNotification(&notificationNormal)}, []interface{}{notificationId, nil}},
+				{"GetNotificationById", []interface{}{notificationId}, []interface{}{notificationNormal, nil}},
+				{"GetSubscriptionByCategoriesLabels", []interface{}{categories, labels}, []interface{}{[]contract.Subscription{}, nil}},
+				{"MarkNotificationProcessed", []interface{}{validateNotification(&notificationNormal)}, []interface{}{nil}},
+			}),
+			http.StatusAccepted,
+		},
+		{
+			"ok critical notification",
+			createNotificationHandlerRequestWithBody(http.MethodPost, notificationCritical, nil),
+			createMockWithOutlines([]mockOutline{
+				{"AddNotification", []interface{}{validateNotification(&notificationCritical)}, []interface{}{notificationId, nil}},
+				{"GetNotificationById", []interface{}{notificationId}, []interface{}{notificationCritical, nil}},
+				{"GetSubscriptionByCategoriesLabels", []interface{}{categories, labels}, []interface{}{[]contract.Subscription{}, nil}},
+				{"MarkNotificationProcessed", []interface{}{validateNotification(&notificationCritical)}, []interface{}{nil}},
+			}),
+			http.StatusAccepted,
+		},
+		{
+			"notification validation error",
+			createNotificationHandlerRequestWithBody(http.MethodPost, notificationInvalid, nil),
+			createMockWithOutlines([]mockOutline{
+				{"AddNotification", []interface{}{validateNotification(&notificationInvalid)}, []interface{}{notificationId, nil}},
+				{"GetNotificationById", []interface{}{invalidNotificationId}, []interface{}{notificationInvalid, nil}},
+				{"GetSubscriptionByCategoriesLabels", []interface{}{categories, labels}, []interface{}{[]contract.Subscription{}, nil}},
+				{"MarkNotificationProcessed", []interface{}{validateNotification(&notificationInvalid)}, []interface{}{nil}},
+			}),
+			http.StatusBadRequest,
+		},
+		{
+			"add notification error",
+			createNotificationHandlerRequestWithBody(http.MethodPost, notificationCritical, nil),
+			createMockWithOutlines([]mockOutline{
+				{"AddNotification", []interface{}{validateNotification(&notificationCritical)}, []interface{}{invalidNotificationId, testError}},
+				{"GetNotificationById", []interface{}{notificationId}, []interface{}{notificationCritical, nil}},
+				{"GetSubscriptionByCategoriesLabels", []interface{}{categories, labels}, []interface{}{[]contract.Subscription{}, nil}},
+				{"MarkNotificationProcessed", []interface{}{validateNotification(&notificationCritical)}, []interface{}{nil}},
+			}),
+			http.StatusConflict,
+		},
+		{
+			"get notification error",
+			createNotificationHandlerRequestWithBody(http.MethodPost, notificationCritical, nil),
+			createMockWithOutlines([]mockOutline{
+				{"AddNotification", []interface{}{validateNotification(&notificationCritical)}, []interface{}{notificationId, nil}},
+				{"GetNotificationById", []interface{}{notificationId}, []interface{}{notificationBad, testError}},
+				{"GetSubscriptionByCategoriesLabels", []interface{}{categories, labels}, []interface{}{[]contract.Subscription{}, nil}},
+				{"MarkNotificationProcessed", []interface{}{validateNotification(&notificationCritical)}, []interface{}{nil}},
+			}),
+			http.StatusInternalServerError,
+		},
+		{
+			"distribute and mark notification ok",
+			createNotificationHandlerRequestWithBody(http.MethodPost, notificationCritical, nil),
+			createMockWithOutlines([]mockOutline{
+				{"AddNotification", []interface{}{validateNotification(&notificationCritical)}, []interface{}{notificationId, nil}},
+				{"GetNotificationById", []interface{}{notificationId}, []interface{}{notificationCritical, nil}},
+				{"GetSubscriptionByCategoriesLabels", []interface{}{categories, labels}, []interface{}{[]contract.Subscription{}, nil}},
+				{"MarkNotificationProcessed", []interface{}{validateNotification(&notificationCritical)}, []interface{}{nil}},
+			}),
+			http.StatusAccepted,
+		},
+		{
+			"distribute and mark notification processed",
+			createNotificationHandlerRequestWithBody(http.MethodPost, notificationCritical, nil),
+			createMockWithOutlines([]mockOutline{
+				{"AddNotification", []interface{}{validateNotification(&notificationCritical)}, []interface{}{notificationId, nil}},
+				{"GetNotificationById", []interface{}{notificationId}, []interface{}{notificationCritical, nil}},
+				{"GetSubscriptionByCategoriesLabels", []interface{}{categories, labels}, []interface{}{[]contract.Subscription{}, testError}},
+				{"MarkNotificationProcessed", []interface{}{validateNotification(&notificationCritical)}, []interface{}{testError}},
+			}),
+			http.StatusOK,
+		},
+		{
+			"distribute and mark notification error",
+			createNotificationHandlerRequestWithBody(http.MethodPost, notificationInvalidCategoriesAndLabels, nil),
+			createMockWithOutlines([]mockOutline{
+				{"AddNotification", []interface{}{validateNotification(&notificationInvalidCategoriesAndLabels)}, []interface{}{notificationId, nil}},
+				{"GetNotificationById", []interface{}{notificationId}, []interface{}{notificationInvalidCategoriesAndLabels, nil}},
+				{"GetSubscriptionByCategoriesLabels", []interface{}{badCategories, badLabels}, []interface{}{[]contract.Subscription{}, testError}},
+				{"MarkNotificationProcessed", []interface{}{validateNotification(&notificationInvalidCategoriesAndLabels)}, []interface{}{testError}},
+			}),
+			http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			notificationHandler(rr,
+				tt.request,
+				logger.NewMockClient(),
+				tt.dbMock,
+				notificationsConfig.ConfigurationStruct{Service: bootstrapConfig.ServiceInfo{MaxResultCount: 5}})
+			response := rr.Result()
+			if response.StatusCode != tt.expectedStatus {
+				t.Errorf("status code mismatch -- expected %v got %v", tt.expectedStatus, response.StatusCode)
 				return
 			}
 		})


### PR DESCRIPTION
- This PR will address https://github.com/edgexfoundry/edgex-go/issues/2328.
- Functionally tested this by creating a _NORMAL_ notification and confirming that it is now processed immediately. Then proceeded to creating a _CRITICAL_ notification and confirming that it is also processed immediately. 
- In addition (per the ask to [revise the docs content accordingly](https://github.com/edgexfoundry/edgex-go/issues/2328#issuecomment-581975741)), a PR has been created (https://github.com/edgexfoundry/edgex-docs/pull/88) in the `edgex-docs` repo, similar to how this has been done in the past (for e.g. per https://github.com/edgexfoundry/edgex-docs/pull/63).



