### PR TITLE
Update Core/Security/Support/SMA Service Dockerfiles for Go 1.13.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ on the snap, including how to install it, please refer to [EdgeX snap](https://g
 
 #### Go
 
-- The current targeted version of the Go language runtime for release artifacts is v1.12.x
-- The minimum supported version of the Go language runtime is v1.11.x (currently v1.11.13)
+- The current targeted version of the Go language runtime for release artifacts is v1.13.x
+- The minimum supported version of the Go language runtime is v1.13.x (currently v1.13)
 
 #### pkg-config
 

--- a/cmd/config-seed/Dockerfile
+++ b/cmd/config-seed/Dockerfile
@@ -16,7 +16,7 @@
 ###############################################################################
 
 # Docker image for building EdgeX Foundry Config Seed
-FROM golang:1.12-alpine AS build-env
+FROM golang:1.13-alpine AS build-env
 
 # environment variables
 ENV GO111MODULE=on

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # Docker image for Golang Core Data micro service 
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/security-proxy-setup/Dockerfile
+++ b/cmd/security-proxy-setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 

--- a/cmd/security-secrets-setup/Dockerfile
+++ b/cmd/security-secrets-setup/Dockerfile
@@ -25,7 +25,7 @@
 #  ----------------------------------------------------------------------------------
 
 # Docker image for building EdgeX Foundry Config Seed
-FROM golang:1.12-alpine AS build-env
+FROM golang:1.13-alpine AS build-env
 
 # environment variables
 ENV GO111MODULE=on

--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 

--- a/cmd/support-logging/Dockerfile
+++ b/cmd/support-logging/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/cmd/sys-mgmt-agent/Dockerfile
+++ b/cmd/sys-mgmt-agent/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.12-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/edgexfoundry/edgex-go

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.8
 )
 
-go 1.12
+go 1.13


### PR DESCRIPTION
Fix #2341 
- After making the updates to the Dockerfiles, as well as to go.mod, I built the Docker images and made sure the Docker containers are launched properly. Also did a sanity check by hitting the `ping` endpoint each of all services for the correct response.