### PR TITLE
Increase http.Server timeout value to make allowance for the ARM64 build.

### DIFF
--- a/cmd/sys-mgmt-agent/res/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/configuration.toml
@@ -24,7 +24,7 @@ Port = 48090
 Protocol = 'http'
 MaxResultCount = 50000
 StartupMsg = 'This is the System Management Agent Service'
-Timeout = 10000
+Timeout = 20000
 FormatSpecifier = '%(\\d+\\$)?([-#+ 0(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])'
 
 [Registry]

--- a/cmd/sys-mgmt-agent/res/docker/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/docker/configuration.toml
@@ -24,7 +24,7 @@ Port = 48090
 Protocol = 'http'
 MaxResultCount = 50000
 StartupMsg = 'This is the System Management Agent Service'
-Timeout = 10000
+Timeout = 20000
 FormatSpecifier = '%(\\d+\\$)?([-#+ 0(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])'
 
 [Registry]


### PR DESCRIPTION
Fix the issue related to the SMA operation "restart" (as tested by Blackbox scripts) wherein the said operation fails on `ARM64 builds` (but continues to pass on `UBUNTU builds` and not an issue there). Further details in [Issue-384](https://github.com/edgexfoundry/blackbox-testing/issues/384).