### PR TITLE
snap: replace gosu with local drop-user cmd

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -153,7 +153,7 @@ mkdir -p "$SNAP_DATA/postgresql"
 chown -R snap_daemon:snap_daemon "$SNAP_DATA/postgresql" 
 
 # setup the postgres data directory
-gosu snap_daemon "$SNAP/usr/lib/postgresql/10/bin/initdb" -D "$SNAP_DATA/postgresql/10/main"
+drop "$SNAP/usr/lib/postgresql/10/bin/initdb" -D "$SNAP_DATA/postgresql/10/main"
 
 # ensure the sockets dir exists and is properly owned
 mkdir -p "$SNAP_COMMON/sockets"
@@ -168,7 +168,7 @@ snapctl start "$SNAP_NAME.postgres"
 # trying to do this because we have to wait for postgres to start up
 iter_num=0
 MAX_POSTGRES_INIT_ITERATIONS=10
-until gosu snap_daemon "$SNAP/bin/perl5lib-launch.sh" "$SNAP/usr/bin/createuser" kong; do
+until drop "$SNAP/bin/perl5lib-launch.sh" "$SNAP/usr/bin/createuser" kong; do
     sleep 1
     iter_num=$(( iter_num + 1 ))
     if [ $iter_num -gt $MAX_POSTGRES_INIT_ITERATIONS ]; then
@@ -177,7 +177,7 @@ until gosu snap_daemon "$SNAP/bin/perl5lib-launch.sh" "$SNAP/usr/bin/createuser"
     fi
 done
 iter_num=0
-until gosu snap_daemon "$SNAP/bin/perl5lib-launch.sh" "$SNAP/usr/bin/createdb" kong; do
+until drop "$SNAP/bin/perl5lib-launch.sh" "$SNAP/usr/bin/createdb" kong; do
     sleep 1
     iter_num=$(( iter_num + 1 ))
     if [ $iter_num -gt $MAX_POSTGRES_INIT_ITERATIONS ]; then

--- a/snap/local/parts/drop-user/Makefile
+++ b/snap/local/parts/drop-user/Makefile
@@ -1,0 +1,22 @@
+#
+# apt-get install build-essential
+# make clean
+# make
+# make install
+
+CFLAGS += -g -O0 -Wall -Wstrict-prototypes
+
+# snapcraft will copy anything from here
+INSTALL_DIR := ${SNAPCRAFT_PART_INSTALL}
+
+all: drop
+
+drop:
+	${CC} ${CFLAGS} ${LDFLAGS} drop.c -o $@ -ldl
+
+install: drop
+	mkdir -p ${INSTALL_DIR}
+	cp -f drop ${INSTALL_DIR}/drop
+
+clean:
+	rm -f ./drop

--- a/snap/local/parts/drop-user/drop.c
+++ b/snap/local/parts/drop-user/drop.c
@@ -1,0 +1,89 @@
+/* -*- Mode: C; indent-tabs-mode: nil; tab-width: 4 -*-
+ *
+ * Copyright (C) 2020 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <err.h>
+#include <errno.h>
+#include <pwd.h>
+#include <grp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+/* This code is based on example code published on launchpad:
+ *
+ * - https://git.launchpad.net/~jdstrand/+git/test-setgroups
+ *
+ * The Fuji snap originally used gosu command to run postgres commands as the
+ * 'snap_daemon' user, but as gosu doesn't support the extrausers passwd db
+ * extension used on Ubuntu Core, the snap couldn't be installed on a Core system.
+*/
+
+static int (*original_setgroups) (size_t, const gid_t[]);
+
+int main(int argc, char *argv[])
+{
+	char **cmdargv;
+	char *user = "snap_daemon";
+
+	if (argc < 2) {
+	  printf("Usage: %s command [args]\n", argv[0]);
+	  exit(0);
+	}
+
+	cmdargv = &argv[1];
+
+	original_setgroups = dlsym(RTLD_NEXT, "setgroups");
+	if (!original_setgroups) {
+		fprintf(stderr, "could not find setgroups in libc; %s", dlerror());
+		return -1;
+	}
+
+	/* Convert our username to a passwd entry */
+	struct passwd *pwd = getpwnam(user);
+	if (pwd == NULL) {
+		printf("'%s' not found\n", user);
+		exit(EXIT_FAILURE);
+	}
+
+	/* Drop supplementary groups first if can, using portable method
+	 * (should fail without LD_PRELOAD)
+	 */
+	if (geteuid() == 0 && original_setgroups(0, NULL) < 0) {
+		perror("setgroups");
+		goto fail;
+	}
+
+	/* Drop gid after supplementary groups */
+	if (setgid(pwd->pw_gid) < 0) {
+		perror("setgid");
+		goto fail;
+	}
+
+	/* Drop uid after gid */
+	if (setuid(pwd->pw_uid) < 0) {
+		perror("setuid");
+		goto fail;
+	}
+
+	execvp(cmdargv[0], cmdargv);
+	err(1, "%s", cmdargv[0]);
+	exit (1);
+
+ fail:
+	exit(EXIT_FAILURE);
+}

--- a/snap/local/runtime-helpers/bin/gosu-snap_daemon.sh
+++ b/snap/local/runtime-helpers/bin/gosu-snap_daemon.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-
-gosu snap_daemon "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,7 +101,7 @@ apps:
       CONFIG_ARG: config_file=$SNAP_DATA/etc/postgresql/10/main/postgresql.conf
       SNAPCRAFT_PRELOAD_REDIRECT_ONLY_SHM: 1
     command-chain:
-      - bin/gosu-snap_daemon.sh
+      - bin/drop
       - bin/snapcraft-preload
     plugs:
       - network
@@ -398,7 +398,7 @@ apps:
       - bin/perl5lib-launch.sh
       # createuser should be run as the snap_daemon user, which is the user
       # who is initially created as a role with postgres
-      - bin/gosu-snap_daemon.sh
+      - bin/drop
     plugs: [home, removable-media, network]
   psql-any:
     adapter: full
@@ -422,7 +422,7 @@ apps:
       - bin/perl5lib-launch.sh
       # createuser should be run as the snap_daemon user, which is the user
       # who is initially created as a role with postgres
-      - bin/gosu-snap_daemon.sh
+      - bin/drop
     plugs: [home, removable-media, network]
   createdb:
     adapter: full
@@ -435,7 +435,7 @@ apps:
       - bin/perl5lib-launch.sh
       # createdb should be run as the snap_daemon user, which is the user
       # who is initially created as a role with postgres
-      - bin/gosu-snap_daemon.sh
+      - bin/drop
     plugs: [home, removable-media, network]
 
 parts:
@@ -493,15 +493,13 @@ parts:
     stage-packages:
       - to amd64:
           - lib32stdc++6
-  gosu:
-    source: https://github.com/tianon/gosu.git
-    source-tag: "1.11"
-    plugin: go
-    go-importpath: github.com/tianon/gosu
-    build-snaps: []
-    after: [go]
-    build-environment:
-      - CGO_ENABLED: "0"
+  drop-user:
+    source: snap/local/parts/drop-user
+    plugin: make
+    build-packages:
+    - build-essential
+    organize:
+      drop: bin/drop
   postgres:
     plugin: nil
     source: snap/local/build-helpers


### PR DESCRIPTION
The gosu commnand doesn't support libnss-extrausers
as used on Ubuntu Core, so the snap install fails
on an Ubuntu Core system when gosu is used to start
postgres.

This commit replaces gosu with a local C part which is
now used to run postgres and its applications as the
'snap_daemon' user.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2356

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information