### PR TITLE
snapcraft.yaml: fix builtin fuji device services

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -313,9 +313,11 @@ apps:
       - core-data
       - core-metadata
       - support-logging
-    command: bin/device-random -confdir $SNAP_DATA/config/device-random -profile res --registry $CONSUL_ADDR
+    command: bin/device-random $CONF_ARG $PROFILE_ARG $REGISTRY_ARG
     environment:
-      CONSUL_ADDR: "consul://localhost:8500"
+      CONF_ARG: "--confdir=$SNAP_DATA/config/device-random"
+      PROFILE_ARG: "--profile=res"
+      REGISTRY_ARG: "--registry=consul://localhost:8500"
     daemon: simple
     plugs: [network, network-bind]
   device-virtual:
@@ -327,9 +329,11 @@ apps:
       - core-data
       - core-metadata
       - support-logging
-    command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual -profile res --registry $CONSUL_ADDR
+    command: bin/device-virtual $CONF_ARG $PROFILE_ARG $REGISTRY_ARG
     environment:
-      CONSUL_ADDR: "consul://localhost:8500"
+      CONF_ARG: "--confdir=$SNAP_DATA/config/device-virtual"
+      PROFILE_ARG: "--profile=res"
+      REGISTRY_ARG: "--registry=consul://localhost:8500"
     daemon: simple
     plugs: [network, network-bind]
   app-service-configurable:
@@ -1185,7 +1189,7 @@ parts:
   device-virtual-go:
     source: https://github.com/edgexfoundry/device-virtual-go.git
     source-depth: 1
-    source-branch: fuji
+    source-tag: v1.1.1
     plugin: make
     after: [go]
     override-build: |
@@ -1217,7 +1221,7 @@ parts:
   device-random:
     source: https://github.com/edgexfoundry/device-random.git
     source-depth: 1
-    source-branch: fuji
+    source-tag: v1.1.1
     plugin: make
     after: [go]
     override-build: |


### PR DESCRIPTION
A recent change to device-sdk-go introduced new command-line
changes which break the device services (-random, and -virtual)
included by default in the snap. Both of these device services
were being built from the fuji branch instead of from a source
tag, which also contributed to this breakage. This commit updates
the command-line arguments for both, and also sets a git-tag to
be used for both instead of the fuji branch.

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2366

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

_- [ ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide_

The commit doesn't follow the guidelines because the given wiki page doesn't include any guidelines for commit messages!

- [**NA**] Tests for the changes have been added (for bug fixes / features)
- [**NA**] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:
Updates the snap packaging

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:
https://github.com/edgexfoundry/edgex-go/issues/2366

**Note** - see the issue for test instructions.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
