### PR TITLE
REPO_ROOT needs to be set to the WORKSPACE location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,7 @@
 
 edgeXGeneric([
     project: 'edgex-go',
-    mavenSettings: ['edgex-go-settings:SETTINGS_FILE', 'edgex-go-codecov-token:CODECOV_TOKEN'],
-    credentials: [ string(credentialsId: 'swaggerhub-api-key', variable: 'APIKEY') ],
+    mavenSettings: ['edgex-go-settings:SETTINGS_FILE', 'edgex-go-codecov-token:CODECOV_TOKEN', 'swaggerhub-api-key:APIKEY'],
     env: [
         GOPATH: '/opt/go-custom/go',
         GO_VERSION: '1.13',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,6 @@ edgeXGeneric([
     env: [
         GOPATH: '/opt/go-custom/go',
         GO_VERSION: '1.13',
-        REPO_ROOT: "/home/jenkins/$BUILD_ID/gopath/src/github.com/edgexfoundry/edgex-go/",
         DEPLOY_TYPE: 'staging'
     ],
     path: [
@@ -31,7 +30,7 @@ edgeXGeneric([
         '*': [
             pre_build: ['shell/install_custom_golang.sh'],
             build: [
-                'make test raml_verify && make build docker',
+                'REPO_ROOT=${WORKSPACE} make test raml_verify && make build docker',
                 'shell/codecov-uploader.sh'
             ]
         ],


### PR DESCRIPTION
Looking at the old JJB job, the REPO_ROOT was just actually set to the WORKSPACE path:

https://github.com/edgexfoundry/ci-management/blob/master/jjb/edgex-templates-go.yaml#L20
https://github.com/edgexfoundry/ci-management/blob/master/jjb/edgex-go/edgex-go.yaml#L14

Those are the same paths. Jenkins exposes an environment variable called `$WORKSPACE` to the build so I updated `REPO_ROOT` to match the `$WORKSPACE` when calling build step and the tests passed.

The reason I have to move the REPO_ROOT out of the `env` section is because of the way that the underlying edgeXGeneric pipeline parses environment variables and the fact that $WORKSPACE is not available until the main build node is allocated.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)

https://jenkins.edgexfoundry.org/sandbox/blue/organizations/jenkins/edgex-go-pr-2285/detail/edgex-go-pr-2285/8/pipeline/110

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No