### PR TITLE
Notifications not distributing for normal severity (Fuji).

### DIFF
--- a/internal/support/notifications/rest_notification.go
+++ b/internal/support/notifications/rest_notification.go
@@ -53,21 +53,19 @@ func notificationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if n.Severity == models.NotificationsSeverity(models.Critical) {
-		LoggingClient.Info("Critical severity scheduler is triggered for: " + n.Slug)
-		n, err = dbClient.GetNotificationById(n.ID)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			LoggingClient.Error(err.Error())
-			return
-		}
-
-		err := distributeAndMark(n)
-		if err != nil {
-			return
-		}
-		LoggingClient.Info("Critical severity scheduler has completed for: " + n.Slug)
+	LoggingClient.Debug("The scheduler is triggered for: " + n.Slug)
+	n, err = dbClient.GetNotificationById(n.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		LoggingClient.Error(err.Error())
+		return
 	}
+
+	err = distributeAndMark(n)
+	if err != nil {
+		return
+	}
+	LoggingClient.Debug("The scheduler has completed for: " + n.Slug)
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
- This PR will address the following bug: https://github.com/edgexfoundry/edgex-go/issues/2328.
- The aforementioned bug has _already_ been fixed, and that feature branch then merged into `master` branch via: https://github.com/edgexfoundry/edgex-go/pull/2347
- Details of functional testing (mentioned above) are [documented in detail here](https://github.com/edgexfoundry/edgex-go/pull/2347#issuecomment-587564977).
- Functionally tested this by creating a _NORMAL_ notification and confirming that it is now processed immediately. Then proceeded to creating a _CRITICAL_ notification and confirming that it is also processed immediately. 
- In addition (per the ask to [revise the docs content accordingly](https://github.com/edgexfoundry/edgex-go/issues/2328#issuecomment-581975741)), a PR has been created (https://github.com/edgexfoundry/edgex-docs/pull/88) in the `edgex-docs` repo, similar to how this has been done in the past (for e.g. per https://github.com/edgexfoundry/edgex-docs/pull/63).