### PR TITLE
getObjectsByValueSorted in Redis: removed indeterminism and fixed sorting issue

### DIFF
--- a/internal/pkg/db/redis/queries.go
+++ b/internal/pkg/db/redis/queries.go
@@ -293,7 +293,7 @@ func getObjectsByValuesSorted(conn redis.Conn, limit int, vals ...string) ([][]b
 		return nil, err
 	}
 
-	ids, err := redis.Values(conn.Do("ZRANGE", cacheSet, 0, -1))
+	ids, err := redis.Values(conn.Do("ZREVRANGE", cacheSet, 0, -1))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #2374
Fixes #2394 

Signed-off-by: Brandon Forster <me@brandonforster.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #2374


## What is the new behavior?
 A unique temporary key is generated every time `getObjectsByValuesSorted` is invoked, and the result of `ZINTERSTORE` is stored in a cache set indexed to that key. This set is deleted at the end of every call to the function.


To verify:

1. Start core-data. Start redis. Start some method of inspection on your Redis DB. I use a program called `redis-browser.` Clear your database with `redis-cli FLUSHDB`.

2. Make the following request to core-data:
```
curl --location --request POST 'http://localhost:48080/api/v1/reading' \
--header 'Content-Type: application/json' \
--data-raw '{
	"origin":14718063666192,
	"device":"livingroomthermostat",
	"name":"co2",
	"value":"1"
}'
```
Make that request a few times, each time you make the request change the `value` field to some other number.

3. Make the following request to core-data:
```
curl --location --request GET 'http://localhost:48080/api/v1/reading/name/co2/device/livingroomthermostat2/100' \
--header 'Content-Type: application/json'
```
Ensure that the response is sorted in descending order according to creation date

4. Using the redis inspection tool of choice, ensure that there are no keys in the database that were not added in step 2.
