### PR TITLE
delete notification by id should return 404 if doesn't exist

### DIFF
--- a/internal/pkg/db/redis/notifications.go
+++ b/internal/pkg/db/redis/notifications.go
@@ -70,7 +70,7 @@ func (c Client) GetNotificationById(id string) (notification contract.Notificati
 
 	err = getObjectById(conn, id, unmarshalObject, &notification)
 	if err != nil {
-		return notification, err
+		return contract.Notification{}, err
 	}
 	return notification, nil
 }
@@ -232,7 +232,7 @@ func (c Client) DeleteNotificationById(id string) error {
 
 	n, err := c.GetNotificationById(id)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	err = c.deleteTransmissionBySlug(conn, n.Slug)


### PR DESCRIPTION
Fixes #2414

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently attempting to delete a Notification which doesn't exist by ID will result in a 200 response code.

Issue Number:

#2414 


## What is the new behavior?
Attempting to delete a Notification which doesn't exist will result in a 404 response.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information