### PR TITLE
Persist new properties on Readings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.21
 	github.com/edgexfoundry/go-mod-configuration v0.0.0
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.51
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.52
 	github.com/edgexfoundry/go-mod-messaging v0.1.14
 	github.com/edgexfoundry/go-mod-registry v0.1.17
 	github.com/edgexfoundry/go-mod-secrets v0.0.17

--- a/internal/pkg/db/mongo/models/reading.go
+++ b/internal/pkg/db/mongo/models/reading.go
@@ -26,15 +26,18 @@ type readingTransform interface {
 }
 
 type Reading struct {
-	Created  int64         `bson:"created"`
-	Modified int64         `bson:"modified"`
-	Origin   int64         `bson:"origin"`
-	Id       bson.ObjectId `bson:"_id,omitempty"`
-	Uuid     string        `bson:"uuid"`
-	Pushed   int64         `bson:"pushed"` // When the data was pushed out of EdgeX (0 - not pushed yet)
-	Device   string        `bson:"device"`
-	Name     string        `bson:"name"`
-	Value    string        `bson:"value"` // Device sensor data value
+	Created       int64         `bson:"created"`
+	Modified      int64         `bson:"modified"`
+	Origin        int64         `bson:"origin"`
+	Id            bson.ObjectId `bson:"_id,omitempty"`
+	Uuid          string        `bson:"uuid"`
+	Pushed        int64         `bson:"pushed"` // When the data was pushed out of EdgeX (0 - not pushed yet)
+	Device        string        `bson:"device"`
+	Name          string        `bson:"name"`
+	Value         string        `bson:"value"` // Device sensor data value
+	ValueType     string        `bson:"valueType"`
+	MediaType     string        `bson:"mediaType"`
+	FloatEncoding string        `bson:"floatEncoding"`
 }
 
 func (r *Reading) ToContract() (c contract.Reading) {
@@ -52,6 +55,9 @@ func (r *Reading) ToContract() (c contract.Reading) {
 	c.Device = r.Device
 	c.Name = r.Name
 	c.Value = r.Value
+	c.ValueType = r.ValueType
+	c.MediaType = r.MediaType
+	c.FloatEncoding = r.FloatEncoding
 
 	return c
 }
@@ -69,6 +75,9 @@ func (r *Reading) FromContract(from contract.Reading) (id string, err error) {
 	r.Device = from.Device
 	r.Name = from.Name
 	r.Value = from.Value
+	r.ValueType = from.ValueType
+	r.MediaType = from.MediaType
+	r.FloatEncoding = from.FloatEncoding
 
 	id = toContractId(r.Id, r.Uuid)
 	return


### PR DESCRIPTION
Persist ValueType, MediaType, FloatEncoding Properties on Readings.

Fixes #2425.  Redis DB Client implementation uses `json.Marshal()`
to store Readings, so no change is required.

To verify functionality, run against a local database (both mongo
and redis) and use the following curl command:

```curl --location --request POST 'http://localhost:48080/api/v1/reading' \
--header 'Content-Type: application/json' \
--data-raw '{
 "name": "foo",
 "value": "3.14159",
 "mediaType": "some type",
 "floatEncoding": "ieee16.4",
 "valueType": "Float64"
}'
```

Then GET on the same url and ensure the three new fields are
there as expected.

Signed-off-by: Daniel Harms <jdharms@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The fields on Reading added in https://github.com/edgexfoundry/go-mod-core-contracts/pull/223 aren't persisted upon Reading creation. 

Issue Number: #2425 

## What is the new behavior?

These fields are now properly persisted.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No