### PR TITLE
Create value descriptor when adding the device profile in YAML format

### DIFF
--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -393,8 +393,11 @@ func loadDeviceProfileRoutes(b *mux.Router, dic *di.Container) {
 			restAddProfileByYaml(
 				w,
 				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				metadataContainer.CoreDataValueDescriptorClientFrom(dic.Get),
+				metadataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodPost)
 	dp.HandleFunc(
 		"/"+UPLOAD,
@@ -402,8 +405,11 @@ func loadDeviceProfileRoutes(b *mux.Router, dic *di.Container) {
 			restAddProfileByYamlRaw(
 				w,
 				r,
+				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				metadataContainer.CoreDataValueDescriptorClientFrom(dic.Get),
+				metadataContainer.ConfigurationFrom(dic.Get))
 		}).Methods(http.MethodPost)
 	dp.HandleFunc(
 		"/"+MODEL+"/{"+MODEL+"}",


### PR DESCRIPTION
Fix #2429 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Core metadata service doesn’t create the value descriptor by uploading device profile when EnableValueDescriptorManagement=true and it only works by post the profile in JSON format

Issue Number: #2429 


## What is the new behavior?
Core metadata service should create the value descriptor by uploading the device profile when EnableValueDescriptorManagement is true.
In this commit, Add the missing logic to restAddProfileByYaml and restAddProfileByYamlRaw function.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information