### PR TITLE
Provision Watcher REST API Audit: Update Endpoint

### DIFF
--- a/internal/core/metadata/errors/types.go
+++ b/internal/core/metadata/errors/types.go
@@ -165,3 +165,21 @@ func NewErrEmptyFile(fileType string) ErrEmptyFile {
 		fileType: fileType,
 	}
 }
+
+type ErrNameCollision struct {
+	name   string
+	fromID string
+	toID   string
+}
+
+func (e ErrNameCollision) Error() string {
+	return fmt.Sprintf("%s is used by two provision watchers: %s and %s", e.name, e.fromID, e.toID)
+}
+
+func NewErrNameCollision(name, fromID, toID string) ErrNameCollision {
+	return ErrNameCollision{
+		name:   name,
+		fromID: fromID,
+		toID:   toID,
+	}
+}

--- a/internal/pkg/errorconcept/provision_watcher.go
+++ b/internal/pkg/errorconcept/provision_watcher.go
@@ -148,7 +148,7 @@ func (r provisionWatcherDuplicate) httpErrorCode() int {
 }
 
 func (r provisionWatcherDuplicate) isA(err error) bool {
-	return err != db.ErrNotFound && r.currentId != r.newId
+	return err == nil && r.currentId == r.newId
 }
 
 func (r provisionWatcherDuplicate) message(err error) string {

--- a/internal/pkg/errorconcept/provision_watcher.go
+++ b/internal/pkg/errorconcept/provision_watcher.go
@@ -17,6 +17,7 @@ package errorconcept
 import (
 	"net/http"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 )
 
@@ -29,6 +30,7 @@ type provisionWatcherErrorConcept struct {
 	DeviceProfileNotFound_StatusNotFound provisionWatcherDeviceProfileNotFound_StatusNotFound
 	DeviceServiceNotFound_StatusConflict provisionWatcherDeviceServiceNotFound_StatusConflict
 	DeviceServiceNotFound_StatusNotFound provisionWatcherDeviceServiceNotFound_StatusNotFound
+	NameCollision                        provisionWatcherNameCollision
 	NotFoundById                         provisionWatcherNotFoundById
 	NotFoundByName                       provisionWatcherNotFoundByName
 	NotUnique                            provisionWatcherNotUnique
@@ -133,26 +135,19 @@ func (r provisionWatcherNotFoundByName) message(err error) string {
 	return "Provision Watcher not found: " + err.Error()
 }
 
-// NewProvisionWatcherDuplicateErrorConcept instantiates a new error concept for a given set of ids
-func NewProvisionWatcherDuplicateErrorConcept(currentId string, newId string) provisionWatcherDuplicate {
-	return provisionWatcherDuplicate{currentId: currentId, newId: newId}
-}
+type provisionWatcherNameCollision struct{}
 
-type provisionWatcherDuplicate struct {
-	currentId string
-	newId     string
-}
-
-func (r provisionWatcherDuplicate) httpErrorCode() int {
+func (r provisionWatcherNameCollision) httpErrorCode() int {
 	return http.StatusConflict
 }
 
-func (r provisionWatcherDuplicate) isA(err error) bool {
-	return err == nil && r.currentId == r.newId
+func (r provisionWatcherNameCollision) isA(err error) bool {
+	_, isA := err.(errors.ErrNameCollision)
+	return isA
 }
 
-func (r provisionWatcherDuplicate) message(err error) string {
-	return "Duplicate name for the provision watcher"
+func (r provisionWatcherNameCollision) message(err error) string {
+	return err.Error()
 }
 
 type provisionWatcherNotUnique struct{}


### PR DESCRIPTION
Signed-off-by: Brandon Forster <me@brandonforster.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [X] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, the provision watcher update code will never correctly detect duplicate entries and throws the wrong errors.

Issue Number: Fixes #2411


## What is the new behavior?
The update code correctly detects duplicate entries and throws the correct status codes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Are there any specific instructions or things that should be known prior to reviewing?

Additional blackbox tests are needed; provision watcher error coverage is very poor.

## Other information