### PR TITLE
fix: Blackbox testing failures for docker-compose-nexus-mongo-no-secty.yml

### DIFF
--- a/cmd/support-notifications/res/docker/configuration.toml
+++ b/cmd/support-notifications/res/docker/configuration.toml
@@ -32,9 +32,9 @@ File = '/edgex/logs/edgex-support-notifications.log'
   [Databases.Primary]
   Host = 'edgex-redis'
   Name = 'notifications'
-  Password = ''
+  Password = 'password'
   Port = 6379
-  Username = ''
+  Username = 'notifications'
   Timeout = 5000
   Type = 'redisdb'
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/edgexfoundry/go-mod-bootstrap v0.0.21
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.22
 	github.com/edgexfoundry/go-mod-configuration v0.0.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.52
 	github.com/edgexfoundry/go-mod-messaging v0.1.14


### PR DESCRIPTION
Fixes #2433

Upgrade to latest go-mod-bootstrap to fix issue with deserializing username
and password from consul configuration.  Add missing password to support-
notifications.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Blackbox tests are failing for non-security testing because mongodb was changed to require authentication and the bootstrapping framework due to a bug in 3rd party open source is unable to pull the username and password from .toml configuration that has been reflected into consul into the database credentials.  Thus no service can authenticate to the database, bombing the test suite.

Issue Number: #2433


## What is the new behavior?
Username and password retrieval is fixed.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

See testing instructions in comments below.

## Other information

This PR is failing status checks due to changes that were probably introduced in an upstream python repository (not confirmed).