### PR TITLE
Fix core-command response when handling a CBOR result.

### DIFF
--- a/internal/core/command/device_test.go
+++ b/internal/core/command/device_test.go
@@ -15,138 +15,172 @@
 package command
 
 import (
-	"context"
 	goErrors "errors"
 	"net/http"
 	"net/url"
 	"testing"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
-	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/command/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/interfaces/mocks"
 	mdMocks "github.com/edgexfoundry/edgex-go/internal/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 var (
-	status400 = "400"
-	status404 = "404"
-	status500 = "500"
-	status423 = "423"
-
-	mismatch = "d200-c200-mismatch"
-	d200c404 = "d200-c404"
-	d200c500 = "d200-c500"
-
-	TestCommandId = "TestCommandID"
+	ExistingDeviceID                       = "existing device id"
+	DeviceIDWithAssociatedInvalidObjectID  = "device id with associated invalid object id"
+	NonExistentDeviceID                    = "non existent device id"
+	DeviceIDResultingInInternalServerError = "device id resulting in internal server error"
+	DeviceIDForLockedResource              = "device id for locked resource"
+	MismatchedDeviceID                     = "mismatched device id"
+	DeviceIDd200c404                       = "device id d200-c404"
+	DeviceIDd200c500                       = "device id d200-c500"
+	DeviceIDd200c200                       = "device id d200-c200"
+	TestCommandID                          = "test command id"
+	TestDeviceID                           = "test device id"
 )
 
+func createTestDeviceWithPathUrl(commandID string, deviceID string) models.Device {
+
+	return models.Device{
+		AdminState: models.Unlocked,
+		Service: models.DeviceService{
+			Addressable: models.Addressable{
+				Path: "/api/v1/device/" + deviceID + "/command/" + commandID}}}
+}
+
+func createDeviceRequestWithPathParameters(
+	sampleDevice models.Device,
+	params map[string]string) *http.Request {
+
+	req, _ := http.NewRequest(http.MethodGet, cmdURI, nil)
+	req.URL.Path = sampleDevice.Service.Addressable.Path
+
+	return mux.SetURLVars(req, params)
+}
+
 // commandByDeviceID
-func TestExecuteGETCommandByDeviceIdAndCommandId(t *testing.T) {
+func TestExecuteGETCommandByDeviceIDAndCommandID(t *testing.T) {
 	tests := []struct {
 		name        string
-		deviceId    string
-		commandId   string
+		status      string
+		request     *http.Request
 		expectedErr error
 	}{
 		{
-			"Device-InvalidObjectId",
-			status400,
-			TestCommandId,
+			"device with invalid object id",
+			DeviceIDWithAssociatedInvalidObjectID,
+			createDeviceRequestWithPathParameters(
+				createTestDeviceWithPathUrl(TestCommandID, DeviceIDWithAssociatedInvalidObjectID),
+				map[string]string{ID: DeviceIDWithAssociatedInvalidObjectID, COMMANDID: TestCommandID}),
 			types.NewErrServiceClient(400, []byte("Invalid object ID")),
 		},
 		{
-			"Device-NotFound",
-			status404,
-			TestCommandId,
+			"device not found",
+			NonExistentDeviceID,
+			createDeviceRequestWithPathParameters(
+				createTestDeviceWithPathUrl(TestCommandID, NonExistentDeviceID),
+				map[string]string{ID: NonExistentDeviceID, COMMANDID: TestCommandID}),
 			types.NewErrServiceClient(http.StatusNotFound, []byte{}),
 		},
 		{
-			"Device-InternalServerErr",
-			status500,
-			TestCommandId,
+			"device resulting in internal server error",
+			DeviceIDResultingInInternalServerError,
+			createDeviceRequestWithPathParameters(
+				createTestDeviceWithPathUrl(TestCommandID, DeviceIDResultingInInternalServerError),
+				map[string]string{ID: DeviceIDResultingInInternalServerError, COMMANDID: TestCommandID}),
 			goErrors.New("unexpected error"),
 		},
 		{
-			"Device-Locked",
-			status423,
-			TestCommandId,
+			"device was locked",
+			DeviceIDForLockedResource,
+			createDeviceRequestWithPathParameters(
+				createTestDeviceWithPathUrl(TestCommandID, DeviceIDForLockedResource),
+				map[string]string{ID: DeviceIDForLockedResource, COMMANDID: TestCommandID}),
 			errors.NewErrDeviceLocked(""),
 		},
 		{
-			"Command-NotFound",
-			d200c404,
-			status400,
+			"command was not found",
+			DeviceIDd200c404,
+			createDeviceRequestWithPathParameters(
+				createTestDeviceWithPathUrl(TestCommandID, DeviceIDd200c404),
+				map[string]string{ID: DeviceIDd200c404, COMMANDID: DeviceIDWithAssociatedInvalidObjectID}),
 			db.ErrNotFound,
 		},
 		{
-			"Command-InternalServerErr",
-			d200c500,
-			status500,
+			"command could not be handled",
+			DeviceIDd200c500,
+			createDeviceRequestWithPathParameters(
+				createTestDeviceWithPathUrl(TestCommandID, DeviceIDd200c500),
+				map[string]string{ID: DeviceIDd200c500, COMMANDID: DeviceIDResultingInInternalServerError}),
 			goErrors.New("unexpected error"),
 		},
 		{
-			"Command-NotBelongToDevice",
-			mismatch,
-			mismatch,
-			errors.NewErrCommandNotAssociatedWithDevice(TestCommandId, mismatch),
-		},
-		{
-			"Command-500URLCannotBeParsed",
-			"d200c200",
-			"200",
+			"command did not belong to device",
+			MismatchedDeviceID,
+			createDeviceRequestWithPathParameters(
+				createTestDeviceWithPathUrl(TestCommandID, MismatchedDeviceID),
+				map[string]string{ID: MismatchedDeviceID, COMMANDID: TestCommandID}),
+			errors.NewErrCommandNotAssociatedWithDevice(TestCommandID, MismatchedDeviceID),
+		}, {
+			"command could not be parsed",
+			DeviceIDd200c200,
+			createDeviceRequestWithPathParameters(
+				createTestDeviceWithPathUrl(ExistingDeviceID, DeviceIDd200c200),
+				map[string]string{ID: DeviceIDd200c200, COMMANDID: ExistingDeviceID}),
 			&url.Error{Op: "parse", URL: "://:0?", Err: goErrors.New("missing protocol scheme")},
 		},
 	}
+	httpCaller := createMockHttpCaller()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, actualErr := executeCommandByDeviceID(
-				context.Background(),
-				tt.deviceId,
-				TestCommandId,
+			_, _, actualErr := executeCommandByDeviceID(
+				tt.request,
 				"",
-				"",
-				false,
 				logger.NewMockClient(),
 				newMockDBClient(),
-				newMockDeviceClient())
+				newMockDeviceClient(),
+				httpCaller)
 			if actualErr == nil {
 				t.Fatal("expected error")
 			}
-			if tt.expectedErr.Error() != actualErr.Error() {
-				t.Fatalf("error value mismatch -- expected %v got %v", tt.expectedErr, actualErr)
-			}
+			require.Equal(t, tt.expectedErr.Error(), actualErr.Error())
 		})
 	}
 }
 
 func newMockDeviceClient() *mdMocks.DeviceClient {
 	client := mdMocks.DeviceClient{}
-	client.On("Device", context.Background(), status404).Return(contract.Device{}, types.NewErrServiceClient(http.StatusNotFound, []byte{}))
-	client.On("Device", context.Background(), status400).Return(contract.Device{}, types.NewErrServiceClient(400, []byte("Invalid object ID")))
-	client.On("Device", context.Background(), status500).Return(contract.Device{}, goErrors.New("unexpected error"))
-	client.On("Device", context.Background(), status423).Return(contract.Device{Id: status423, AdminState: "LOCKED"}, nil)
-	client.On("Device", context.Background(), d200c404).Return(contract.Device{Id: status400}, nil)
-	client.On("Device", context.Background(), d200c500).Return(contract.Device{Id: status500}, nil)
-	client.On("Device", context.Background(), mismatch).Return(contract.Device{Id: mismatch}, nil)
-
-	client.On("Device", context.Background(), "d200c200").Return(contract.Device{Id: TestDeviceId}, nil)
+	client.On("Device", mock.Anything, DeviceIDWithAssociatedInvalidObjectID).Return(contract.Device{}, types.NewErrServiceClient(400, []byte("Invalid object ID")))
+	client.On("Device", mock.Anything, NonExistentDeviceID).Return(contract.Device{}, types.NewErrServiceClient(http.StatusNotFound, []byte{}))
+	client.On("Device", mock.Anything, DeviceIDResultingInInternalServerError).Return(contract.Device{}, goErrors.New("unexpected error"))
+	client.On("Device", mock.Anything, DeviceIDForLockedResource).Return(contract.Device{Id: DeviceIDForLockedResource, AdminState: "LOCKED"}, nil)
+	client.On("Device", mock.Anything, DeviceIDd200c404).Return(contract.Device{Id: DeviceIDWithAssociatedInvalidObjectID}, nil)
+	client.On("Device", mock.Anything, DeviceIDd200c500).Return(contract.Device{Id: DeviceIDResultingInInternalServerError}, nil)
+	client.On("Device", mock.Anything, MismatchedDeviceID).Return(contract.Device{Id: MismatchedDeviceID}, nil)
+	client.On("Device", mock.Anything, TestDeviceID).Return(contract.Device{Id: TestDeviceID}, nil)
+	client.On("Device", mock.Anything, DeviceIDd200c200).Return(contract.Device{Id: DeviceIDd200c200}, nil)
 	return &client
 }
 
 func newMockDBClient() interfaces.DBClient {
 	dbMock := &mocks.DBClient{}
-	dbMock.On("GetCommandsByDeviceId", status400).Return(nil, db.ErrNotFound)
-	dbMock.On("GetCommandsByDeviceId", status500).Return(nil, goErrors.New("unexpected error"))
-	dbMock.On("GetCommandsByDeviceId", mismatch).Return([]models.Command{{Id: "dummy"}}, nil)
-
-	dbMock.On("GetCommandsByDeviceId", TestDeviceId).Return([]models.Command{{Id: TestCommandId}}, nil)
-
+	dbMock.On("GetCommandsByDeviceId", DeviceIDWithAssociatedInvalidObjectID).Return(nil, db.ErrNotFound)
+	dbMock.On("GetCommandsByDeviceId", DeviceIDResultingInInternalServerError).Return(nil, goErrors.New("unexpected error"))
+	dbMock.On("GetCommandsByDeviceId", MismatchedDeviceID).Return([]models.Command{{Id: "dummy"}}, nil)
+	dbMock.On("GetCommandsByDeviceId", TestDeviceID).Return([]models.Command{{Id: TestCommandID}}, nil)
+	dbMock.On("GetCommandsByDeviceId", ExistingDeviceID).Return([]models.Command{{Id: ExistingDeviceID}}, nil)
+	dbMock.On("GetCommandsByDeviceId", DeviceIDd200c200).Return([]models.Command{{Id: ExistingDeviceID}}, nil)
 	return dbMock
 }

--- a/internal/core/command/errors/types.go
+++ b/internal/core/command/errors/types.go
@@ -26,3 +26,36 @@ func (e ErrCommandNotAssociatedWithDevice) Error() string {
 func NewErrCommandNotAssociatedWithDevice(commandID string, deviceID string) error {
 	return ErrCommandNotAssociatedWithDevice{commandID, deviceID}
 }
+
+// ErrExtractingInfoFromRequest is a struct that serves as the value
+// receiver for Error as defined for NewErrExtractingInfoFromRequest
+type ErrExtractingInfoFromRequest struct {
+}
+
+// Error returns a meaningful string message describing error details.
+func (e ErrExtractingInfoFromRequest) Error() string {
+	return fmt.Sprintf("error extracting command id and device id.")
+}
+
+// NewErrExtractingInfoFromRequest returns the relevant, properly-
+// constructed error type.
+func NewErrExtractingInfoFromRequest() error {
+	return ErrExtractingInfoFromRequest{}
+}
+
+// ErrBadRequest is a struct that serves as the value receiver
+// for Error as defined for NewErrParsingOriginalRequest
+type ErrBadRequest struct {
+	value string
+}
+
+// Error returns a meaningful string message describing error details.
+func (e ErrBadRequest) Error() string {
+	return fmt.Sprintf("error in parsing related to '%s'", e.value)
+}
+
+// NewErrParsingOriginalRequest returns the relevant, properly-
+// constructed error type.
+func NewErrParsingOriginalRequest(invalid string) error {
+	return ErrBadRequest{value: invalid}
+}

--- a/internal/core/command/interfaces.go
+++ b/internal/core/command/interfaces.go
@@ -14,7 +14,9 @@
 
 package command
 
+import "net/http"
+
 // Executor interface used to execute commands
 type Executor interface {
-	Execute() (string, int, error)
+	Execute() (deviceServiceResponse *http.Response, failure error)
 }

--- a/internal/core/command/restDevice_test.go
+++ b/internal/core/command/restDevice_test.go
@@ -1,0 +1,432 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/core/command/config"
+	"github.com/edgexfoundry/edgex-go/internal/core/command/interfaces"
+	commandMocks "github.com/edgexfoundry/edgex-go/internal/core/command/interfaces/mocks"
+	"github.com/edgexfoundry/edgex-go/internal/mocks"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
+
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/config"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var knownDeviceName = "Test Device"
+var unknownDeviceName = "?"
+var cmdURI = clients.ApiBase + "/" + DEVICE
+var deviceId = "b3445cc6-87df-48f4-b8b0-587dc8a4e1c2"
+var deviceName = ""
+var TestCommandId = "TestCommandID"
+var testTimestamps = models.Timestamps{Created: 123, Modified: 123, Origin: 123}
+var exampleCommand = models.Command{
+	Timestamps: testTimestamps,
+	Id:         TestCommandId,
+	Name:       "testName",
+}
+
+var unlockedDevice = models.Device{
+	Id:         deviceId,
+	Name:       deviceName,
+	AdminState: models.Unlocked,
+	Service: models.DeviceService{
+		Addressable: models.Addressable{Protocol: "http", Address: "localhost",
+			Port: 8080}}}
+var lockedDevice = models.Device{
+	Id:         deviceId,
+	Name:       NAME,
+	AdminState: models.Locked,
+	Service: models.DeviceService{
+		Addressable: models.Addressable{Protocol: "http", Address: "localhost",
+			Port: 8080}}}
+
+type mockOutline struct {
+	methodName string
+	arg        []interface{}
+	ret        []interface{}
+}
+
+func TestRestGetCommandsByDeviceName(t *testing.T) {
+	tests := []struct {
+		name           string
+		dcMock         *mocks.DeviceClient
+		dbMock         interfaces.DBClient
+		request        *http.Request
+		expectedErr    error
+		expectedStatus int
+	}{
+		{
+			"ok json content type in header",
+			createMockUnlockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodGet,
+				clients.ContentTypeJSON,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusOK,
+		},
+		{
+			"ok cbor content type in header",
+			createMockUnlockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodGet,
+				clients.ContentTypeCBOR,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusOK,
+		},
+		{
+			"no device for requested name",
+			createMockUnlockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{unknownDeviceName}, []interface{}{models.DeviceService{}, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{}, db.ErrNotFound}},
+			}),
+			createGetCommandRequest(),
+			nil,
+			http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			rr := httptest.NewRecorder()
+			var loggerMock = logger.NewMockClient()
+			configuration := config.ConfigurationStruct{
+				Service: bootstrapConfig.ServiceInfo{MaxResultCount: 1},
+			}
+			restGetCommandsByDeviceName(
+				rr,
+				tt.request,
+				tt.dbMock,
+				tt.dcMock,
+				&configuration,
+				errorconcept.NewErrorHandler(loggerMock))
+			response := rr.Result()
+			require.Equal(t, tt.expectedStatus, response.StatusCode)
+		})
+	}
+}
+
+func TestRestPutDeviceCommandByCommandID(t *testing.T) {
+	tests := []struct {
+		name           string
+		dcMock         *mocks.DeviceClient
+		dbMock         interfaces.DBClient
+		request        *http.Request
+		expectedErr    error
+		expectedStatus int
+	}{
+		{
+			"ok json content type in header",
+			createMockUnlockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodPut,
+				clients.ContentTypeJSON,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusOK,
+		},
+		{
+			"ok cbor content type in header",
+			createMockUnlockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodPut,
+				clients.ContentTypeCBOR,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusOK,
+		},
+
+		{
+			"device was locked with json content type in header",
+			createMockLockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodPut,
+				clients.ContentTypeJSON,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusLocked,
+		},
+		{
+			"device was locked with cbor content type in header",
+			createMockLockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodPut,
+				clients.ContentTypeCBOR,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusLocked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			rr := httptest.NewRecorder()
+			var loggerMock = logger.NewMockClient()
+			httpCaller := createMockHttpCaller()
+			restPutDeviceCommandByCommandID(
+				rr,
+				tt.request,
+				loggerMock,
+				tt.dbMock,
+				tt.dcMock,
+				errorconcept.NewErrorHandler(loggerMock),
+				httpCaller)
+			response := rr.Result()
+			require.Equal(t, tt.expectedStatus, response.StatusCode)
+		})
+	}
+}
+
+func TestRestGetDeviceCommandByCommandID(t *testing.T) {
+	tests := []struct {
+		name           string
+		dcMock         *mocks.DeviceClient
+		dbMock         interfaces.DBClient
+		request        *http.Request
+		expectedErr    error
+		expectedStatus int
+	}{
+		{
+			"ok json content type in header",
+			createMockUnlockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodGet,
+				clients.ContentTypeJSON,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusOK,
+		},
+		{
+			"ok cbor content type in header",
+			createMockUnlockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodGet,
+				clients.ContentTypeCBOR,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusOK,
+		},
+		{
+			"device was locked with json content type in header",
+			createMockLockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodGet,
+				clients.ContentTypeJSON,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusLocked,
+		},
+		{
+			"device was locked with cbor content type in header",
+			createMockLockedDeviceCommandClient(deviceId),
+			createMockWithOutlines([]mockOutline{
+				{"GetCommandsByName", []interface{}{knownDeviceName}, []interface{}{nil, nil}},
+				{"GetCommandsByDeviceId", []interface{}{deviceId}, []interface{}{[]models.Command{exampleCommand}, nil}},
+			}),
+			createRequestWithPathParameters(
+				http.MethodGet,
+				clients.ContentTypeCBOR,
+				map[string]string{ID: deviceId, COMMANDID: TestCommandId},
+				createTestDeviceWithPathUrl(TestCommandId, deviceId),
+				exampleCommand),
+			nil,
+			http.StatusLocked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			rr := httptest.NewRecorder()
+			var loggerMock = logger.NewMockClient()
+			httpCaller := createMockHttpCaller()
+			restGetDeviceCommandByCommandID(
+				rr,
+				tt.request,
+				loggerMock,
+				tt.dbMock,
+				tt.dcMock,
+				errorconcept.NewErrorHandler(loggerMock),
+				httpCaller)
+			response := rr.Result()
+			require.Equal(t, tt.expectedStatus, response.StatusCode)
+		})
+	}
+}
+
+func createMockWithOutlines(outlines []mockOutline) interfaces.DBClient {
+	dbMock := commandMocks.DBClient{}
+
+	for _, o := range outlines {
+		dbMock.On(o.methodName, o.arg...).Return(o.ret...)
+	}
+	return &dbMock
+}
+
+// An HttpCaller which returns a normal response when a mocked request is executed.
+type NormalMockHttpCaller struct{}
+
+// MockNormalBody is a body that will return...
+type MockNormalBody struct{}
+
+// Read returns ...
+func (MockNormalBody) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+func (MockNormalBody) ReadFrom(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+// Close implementation is not required
+func (MockNormalBody) Close() error {
+	panic("implement me")
+}
+
+func (NormalMockHttpCaller) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       MockNormalBody{},
+	}, nil
+}
+
+func createMockHttpCaller() internal.HttpCaller {
+	reqBody := ioutil.NopCloser(bytes.NewReader([]byte(exampleCommand.String())))
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       reqBody,
+	}
+
+	req := &mocks.HttpCaller{}
+	req.On("Do", mock.Anything).Return(resp, nil)
+	return req
+}
+
+func createMockUnlockedDeviceCommandClient(deviceId string) *mocks.DeviceClient {
+	client := &mocks.DeviceClient{}
+	client.On("DeviceForName", mock.Anything, knownDeviceName).Return(unlockedDevice, nil)
+	client.On("DeviceForName", mock.Anything, unknownDeviceName).Return(unlockedDevice, db.ErrNotFound)
+	client.On("DeviceForName", mock.Anything, "").Return(unlockedDevice, nil)
+	client.On("Device", mock.Anything, deviceId).Return(unlockedDevice, nil)
+	client.On("Device", mock.Anything, "").Return(unlockedDevice, nil)
+	client.On("Device", mock.Anything, "").Return(unlockedDevice, nil)
+	return client
+}
+
+func createMockLockedDeviceCommandClient(deviceId string) *mocks.DeviceClient {
+	client := &mocks.DeviceClient{}
+	client.On("DeviceForName", mock.Anything, knownDeviceName).Return(lockedDevice, nil)
+	client.On("DeviceForName", mock.Anything, unknownDeviceName).Return(lockedDevice, db.ErrNotFound)
+	client.On("DeviceForName", mock.Anything, "").Return(lockedDevice, nil)
+	client.On("Device", mock.Anything, deviceId).Return(lockedDevice, nil)
+	client.On("Device", mock.Anything, "").Return(lockedDevice, nil)
+	client.On("Device", mock.Anything, "").Return(lockedDevice, nil)
+	return client
+}
+
+func createGetCommandRequest() *http.Request {
+	return httptest.NewRequest(http.MethodGet, cmdURI, nil)
+}
+
+func createRequestWithPathParameters(
+	httpMethod string,
+	contentType string,
+	params map[string]string,
+	sampleDevice models.Device,
+	cmd models.Command) *http.Request {
+
+	cmdBody, _ := json.Marshal(cmd)
+	req, _ := http.NewRequest(httpMethod, cmdURI, strings.NewReader(string(cmdBody)))
+	req.Header.Set(clients.ContentType, contentType)
+	req.URL.Path = sampleDevice.Service.Addressable.Path
+	req.Context()
+
+	return mux.SetURLVars(req, params)
+}

--- a/internal/core/command/rest_device.go
+++ b/internal/core/command/rest_device.go
@@ -19,69 +19,67 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
-	"github.com/gorilla/mux"
-
+	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/config"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/errorconcept"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+
+	"github.com/gorilla/mux"
 )
 
 func restGetDeviceCommandByCommandID(
 	w http.ResponseWriter,
-	r *http.Request,
+	originalRequest *http.Request,
 	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	httpCaller internal.HttpCaller) {
 
-	issueDeviceCommand(w, r, false, lc, dbClient, deviceClient, httpErrorHandler)
+	issueDeviceCommand(w, originalRequest, lc, dbClient, deviceClient, httpErrorHandler, httpCaller)
 }
 
 func restPutDeviceCommandByCommandID(
 	w http.ResponseWriter,
-	r *http.Request,
+	originalRequest *http.Request,
 	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	httpCaller internal.HttpCaller) {
 
-	issueDeviceCommand(w, r, true, lc, dbClient, deviceClient, httpErrorHandler)
+	issueDeviceCommand(w, originalRequest, lc, dbClient, deviceClient, httpErrorHandler, httpCaller)
 }
 
 func issueDeviceCommand(
 	w http.ResponseWriter,
-	r *http.Request,
-	isPutCommand bool,
+	originalRequest *http.Request,
 	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	httpCaller internal.HttpCaller) {
 
-	defer r.Body.Close()
+	defer originalRequest.Body.Close()
 
-	vars := mux.Vars(r)
-	did := vars[ID]
-	cid := vars[COMMANDID]
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := ioutil.ReadAll(originalRequest.Body)
 	if b == nil && err != nil {
 		lc.Error(err.Error())
 		return
 	}
 
-	ctx := r.Context()
-	body, err := executeCommandByDeviceID(
-		ctx,
-		did,
-		cid,
+	deviceServiceResponse, deviceServiceResponseBody, err := executeCommandByDeviceID(
+		originalRequest,
 		string(b),
-		r.URL.RawQuery,
-		isPutCommand,
 		lc,
 		dbClient,
-		deviceClient)
+		deviceClient,
+		httpCaller)
+
 	if err != nil {
 		httpErrorHandler.HandleManyVariants(
 			w,
@@ -96,65 +94,81 @@ func issueDeviceCommand(
 		return
 	}
 
-	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	// Extract the headers from the device service's response, so
+	// we can propagate it to functions upward in the call chain.
+	headers := map[string]string{"Content-Type": ""}
+	m := make(map[string][]string)
+	m = deviceServiceResponse.Header
+	for name, values := range m {
+		for _, value := range values {
+			headers[name] = value
+		}
+	}
+
+	// Set the returned header Content-type based on header Content-type received in
+	// the Device Service request (No need to inspect it).
+	w.Header().Set(clients.ContentType, headers[clients.ContentType])
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(body))
+	w.Write([]byte(deviceServiceResponseBody))
 }
 
 func restGetDeviceCommandByNames(
 	w http.ResponseWriter,
-	r *http.Request,
+	originalRequest *http.Request,
 	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	httpCaller internal.HttpCaller) {
 
-	issueDeviceCommandByNames(w, r, false, lc, dbClient, deviceClient, httpErrorHandler)
+	issueDeviceCommandByNames(w, originalRequest, lc, dbClient, deviceClient, httpErrorHandler, httpCaller)
 }
 
 func restPutDeviceCommandByNames(
 	w http.ResponseWriter,
-	r *http.Request,
+	originalRequest *http.Request,
 	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	httpCaller internal.HttpCaller) {
 
-	issueDeviceCommandByNames(w, r, true, lc, dbClient, deviceClient, httpErrorHandler)
+	issueDeviceCommandByNames(w, originalRequest, lc, dbClient, deviceClient, httpErrorHandler, httpCaller)
 }
 
 func issueDeviceCommandByNames(
 	w http.ResponseWriter,
-	r *http.Request,
-	isPutCommand bool,
+	originalRequest *http.Request,
 	lc logger.LoggingClient,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
-	httpErrorHandler errorconcept.ErrorHandler) {
+	httpErrorHandler errorconcept.ErrorHandler,
+	httpCaller internal.HttpCaller) {
 
-	defer r.Body.Close()
+	defer originalRequest.Body.Close()
 
-	vars := mux.Vars(r)
+	vars := mux.Vars(originalRequest)
 	dn := vars[NAME]
 	cn := vars[COMMANDNAME]
 
-	ctx := r.Context()
+	ctx := originalRequest.Context()
 
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := ioutil.ReadAll(originalRequest.Body)
 	if b == nil && err != nil {
 		httpErrorHandler.Handle(w, err, errorconcept.Common.InvalidRequest_StatusBadRequest)
 		return
 	}
-	body, err := executeCommandByName(
+
+	deviceServiceResponse, deviceServiceResponseBody, err := executeCommandByName(
+		originalRequest,
 		ctx,
 		dn,
 		cn,
 		string(b),
-		r.URL.RawQuery,
-		isPutCommand,
 		lc,
 		dbClient,
-		deviceClient)
+		deviceClient,
+		httpCaller)
 
 	if err != nil {
 		httpErrorHandler.HandleManyVariants(
@@ -169,22 +183,35 @@ func issueDeviceCommandByNames(
 		return
 	}
 
-	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	// Extract the headers from the device service's response, so
+	// we can propagate it to functions upward in the call chain.
+	headers := map[string]string{"Content-Type": ""}
+	m := make(map[string][]string)
+	m = deviceServiceResponse.Header
+	for name, values := range m {
+		for _, value := range values {
+			headers[name] = value
+		}
+	}
+
+	// Set the returned header Content-type based on header Content-type received in
+	// the Device Service request (No need to inspect it).
+	w.Header().Set(clients.ContentType, headers[clients.ContentType])
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(body))
+	w.Write([]byte(deviceServiceResponseBody))
 }
 
 func restGetCommandsByDeviceID(
 	w http.ResponseWriter,
-	r *http.Request,
+	originalRequest *http.Request,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
 	configuration *config.ConfigurationStruct,
 	httpErrorHandler errorconcept.ErrorHandler) {
 
-	vars := mux.Vars(r)
+	vars := mux.Vars(originalRequest)
 	did := vars[ID]
-	ctx := r.Context()
+	ctx := originalRequest.Context()
 	device, err := getCommandsByDeviceID(ctx, did, dbClient, deviceClient, configuration)
 	if err != nil {
 		httpErrorHandler.HandleManyVariants(
@@ -206,15 +233,15 @@ func restGetCommandsByDeviceID(
 
 func restGetCommandsByDeviceName(
 	w http.ResponseWriter,
-	r *http.Request,
+	originalRequest *http.Request,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
 	configuration *config.ConfigurationStruct,
 	httpErrorHandler errorconcept.ErrorHandler) {
 
-	vars := mux.Vars(r)
+	vars := mux.Vars(originalRequest)
 	dn := vars[NAME]
-	ctx := r.Context()
+	ctx := originalRequest.Context()
 	devices, err := getCommandsByDeviceName(ctx, dn, dbClient, deviceClient, configuration)
 	if err != nil {
 		httpErrorHandler.HandleManyVariants(
@@ -228,20 +255,19 @@ func restGetCommandsByDeviceName(
 		return
 	}
 
-	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(&devices)
 }
 
 func restGetAllCommands(
 	w http.ResponseWriter,
-	r *http.Request,
+	originalRequest *http.Request,
 	dbClient interfaces.DBClient,
 	deviceClient metadata.DeviceClient,
 	configuration *config.ConfigurationStruct,
 	httpErrorHandler errorconcept.ErrorHandler) {
 
-	ctx := r.Context()
+	ctx := originalRequest.Context()
 	devices, err := getAllCommands(ctx, dbClient, deviceClient, configuration)
 	if err != nil {
 		httpErrorHandler.HandleManyVariants(

--- a/internal/core/command/router.go
+++ b/internal/core/command/router.go
@@ -103,7 +103,8 @@ func loadDeviceRoutes(b *mux.Router, dic *di.Container) {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				commandContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				&http.Client{})
 		}).Methods(http.MethodGet)
 	d.HandleFunc(
 		"/{"+ID+"}/"+COMMAND+"/{"+COMMANDID+"}",
@@ -114,8 +115,19 @@ func loadDeviceRoutes(b *mux.Router, dic *di.Container) {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				commandContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				&http.Client{})
 		}).Methods(http.MethodPut)
+	// In the block of code above, as well as in the one that follows below,
+	// there are two references each to http.Client. Putting them into the
+	// DI container(dic) and retrieving the value like we do for other components
+	// would bring about further consistency in the code base. But the concern
+	// then would be the creation of a race condition because we can only have a
+	// single http.Client instance in the dic. In turn, every invocation of this
+	// REST handler would be served by a different goroutine. This would create
+	// a situation where each one of them would use the same http.Client instance,
+	// resulting in state divergence, misalignment. So the decision is to not
+	// put this into the DI container(dic).
 
 	// /api/<version>/device/name
 	dn := d.PathPrefix("/" + NAME).Subrouter()
@@ -129,7 +141,8 @@ func loadDeviceRoutes(b *mux.Router, dic *di.Container) {
 				container.DBClientFrom(dic.Get),
 				commandContainer.MetadataDeviceClientFrom(dic.Get),
 				commandContainer.ConfigurationFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+			)
 		}).Methods(http.MethodGet)
 	dn.HandleFunc(
 		"/{"+NAME+"}/"+COMMAND+"/{"+COMMANDNAME+"}",
@@ -140,7 +153,8 @@ func loadDeviceRoutes(b *mux.Router, dic *di.Container) {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				commandContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				&http.Client{})
 		}).Methods(http.MethodGet)
 	dn.HandleFunc(
 		"/{"+NAME+"}/"+COMMAND+"/{"+COMMANDNAME+"}",
@@ -151,6 +165,7 @@ func loadDeviceRoutes(b *mux.Router, dic *di.Container) {
 				bootstrapContainer.LoggingClientFrom(dic.Get),
 				container.DBClientFrom(dic.Get),
 				commandContainer.MetadataDeviceClientFrom(dic.Get),
-				errorContainer.ErrorHandlerFrom(dic.Get))
+				errorContainer.ErrorHandlerFrom(dic.Get),
+				&http.Client{})
 		}).Methods(http.MethodPut)
 }

--- a/internal/core/command/test_utils.go
+++ b/internal/core/command/test_utils.go
@@ -1,0 +1,18 @@
+package command
+
+import (
+	"net/http"
+	"strings"
+)
+
+// newRequestWithHeaders accepts httpMethod and outlines, which is a map[string]string,
+// and, by looping over the entries in outlines, populates the HTTP headers of the
+// http.Request, which is returned from this function.
+func newRequestWithHeaders(outlines map[string]string, httpMethod string) *http.Request {
+	req, _ := http.NewRequest(httpMethod, "/", strings.NewReader("Test body"))
+	for k, v := range outlines {
+		req.Header.Set(k, v)
+	}
+
+	return req
+}

--- a/internal/core/command/types.go
+++ b/internal/core/command/types.go
@@ -15,16 +15,13 @@
 package command
 
 import (
-	"bytes"
 	"net/http"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
-
-// DefaultErrorCode the default value used when an error has occurred and no response code was received.
-const DefaultErrorCode = 0
 
 // serviceCommand type which encapsulates command information to be sent to the command service.
 type serviceCommand struct {
@@ -34,23 +31,18 @@ type serviceCommand struct {
 	logger.LoggingClient
 }
 
-// Execute sends the command to the command service
-func (sc serviceCommand) Execute() (string, int, error) {
+// Execute sends the command to the core-command service and gets a deviceServiceResponse back,
+// which it then returns, along with other parameters.
+func (sc serviceCommand) Execute() (deviceServiceResponse *http.Response, failure error) {
+
 	sc.LoggingClient.Debug("Issuing" + sc.Request.Method + " command to: " + sc.Request.URL.String())
-	resp, reqErr := sc.HttpCaller.Do(sc.Request)
+	deviceServiceResponse, reqErr := sc.HttpCaller.Do(sc.Request)
 	if reqErr != nil {
 		sc.LoggingClient.Error(reqErr.Error())
-		return "", http.StatusInternalServerError, reqErr
-
+		return nil, reqErr
 	}
 
-	buf := new(bytes.Buffer)
-	_, readErr := buf.ReadFrom(resp.Body)
-
-	if readErr != nil {
-		return "", DefaultErrorCode, readErr
-	}
-	return buf.String(), resp.StatusCode, nil
+	return deviceServiceResponse, nil
 }
 
 func newServiceCommand(

--- a/internal/core/command/utils.go
+++ b/internal/core/command/utils.go
@@ -1,0 +1,43 @@
+package command
+
+import (
+	"context"
+	"github.com/edgexfoundry/edgex-go/internal/core/command/errors"
+	"net/http"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+// propagatedHeader is a slice containing request headers that we want to propagate. It is
+// used by the function addHeadersToRequest, which is responsible for adding the headers
+// by iterating over the slice, adding any header values contained in this slice.
+var propagatedHeader = []string{clients.ContentType}
+
+// addHeadersToRequest populates deviceServiceRequest with matching headers from
+// originalRequest to retain information that can be used by the device service.
+func addHeadersToRequest(
+	originalRequest *http.Request,
+	deviceServiceProxiedRequest *http.Request,
+	context context.Context) error {
+
+	if originalRequest == nil {
+		return errors.NewErrParsingOriginalRequest("header")
+	}
+
+	for _, headerName := range propagatedHeader {
+		originalHeader := originalRequest.Header.Get(headerName)
+		if originalHeader != "" {
+			deviceServiceProxiedRequest.Header.Set(headerName, originalHeader)
+		}
+	}
+
+	// Also populate deviceServiceProxiedRequest with clients.CorrelationHeader value
+	// from originalRequest (via the context.Value() part of the request) since
+	// inclusion of a Correlation ID (in deviceServiceProxiedRequest) is a requirement.
+	correlationID := context.Value(clients.CorrelationHeader)
+	if correlationID != nil {
+		deviceServiceProxiedRequest.Header.Set(clients.CorrelationHeader, correlationID.(string))
+	}
+
+	return nil
+}


### PR DESCRIPTION
- This is the second (thought first in sequence of being reviewed) of two `PR`s that will address https://github.com/edgexfoundry/edgex-go/issues/2272 ("Response of issueDeviceCommand is not providing CBOR Content-Type header"). 
- The second `PR` (in `device-sdk-go`) was previously submitted, with [details on sequencing here](https://github.com/edgexfoundry/device-sdk-go/pull/464#issuecomment-598815862).
- `Blackbox Integration tests` were run, to validate the updates per this `PR` (Results are provided in the comment below).
- The set of steps used for testing are provided in the comment below.
- Immediately after submitting this `PR`, on realizing that we would be better served by marking this as a `Draft PR`, I sought to reclassify this as a `Draft PR`, but don't see an option to do so - The thinking here is that as we work through the best approach to resolving a challenge that was encountered (and related details into that insight below) during the work done per this `PR`.
- The insight referred to above is thanks entirely to @tsconn23: The handling of `PUT` and `GET` is done significantly down a deeply nested call to functions (as follows) and we may be better served by making them (i.e. `PUT` and `GET`) first class citizens by creating a type abstraction for them, which can be tapped into at a much higher level in the call chain, enabling the request and client to be assembled higher up the chain:
```
github.com/edgexfoundry/edgex-go/internal/core/command.serviceCommand.Execute at types.go:47
github.com/edgexfoundry/edgex-go/internal/core/command.executeCommandByDevice at device.go:128
github.com/edgexfoundry/edgex-go/internal/core/command.executeCommandByDeviceID at device.go:72
github.com/edgexfoundry/edgex-go/internal/core/command.issueDeviceCommand at restDevice.go:79
github.com/edgexfoundry/edgex-go/internal/core/command.restGetDeviceCommandByCommandID at restDevice.go:42
github.com/edgexfoundry/edgex-go/internal/core/command.TestRestGetDeviceCommandByCommandID.func1 at restDevice_test.go:272
```