### PR TITLE
Race condition when initializing external clients using bootstrap

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -10,7 +10,7 @@ Port = 48082
 Protocol = 'http'
 MaxResultCount = 50000
 StartupMsg = 'This is the Core Command Microservice'
-Timeout = 5000
+Timeout = 45000
 
 [Registry]
 Host = 'localhost'

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -49,6 +49,13 @@ func NewBootstrap(router *mux.Router) *Bootstrap {
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
 	loadRestRoutes(b.router, dic)
 
+	// TODO: there is an outstanding known issue (https://github.com/edgexfoundry/edgex-go/issues/2462)
+	// 		that could be seemingly be solved by moving from JIT initialization of these external clients to static
+	// 		init on startup, like registryClient and configuration are initialized.
+	// 		Doing so would cover over the symptoms of the bug, but the root problem of server processing taking longer
+	// 		than the configured client time out would still be present.
+	// 		Until that problem is addressed by larger architectural changes, if you are experiencing a bug similar to
+	//		https://github.com/edgexfoundry/edgex-go/issues/2421, the correct fix is to bump up the client timeout.
 	registryClient := bootstrapContainer.RegistryFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)

--- a/internal/core/command/rest_device.go
+++ b/internal/core/command/rest_device.go
@@ -201,7 +201,7 @@ func restGetCommandsByDeviceID(
 
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(&device)
+	_ = json.NewEncoder(w).Encode(&device)
 }
 
 func restGetCommandsByDeviceName(
@@ -230,7 +230,7 @@ func restGetCommandsByDeviceName(
 
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(&devices)
+	_ = json.NewEncoder(w).Encode(&devices)
 }
 
 func restGetAllCommands(
@@ -257,5 +257,5 @@ func restGetAllCommands(
 
 	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(devices)
+	_ = json.NewEncoder(w).Encode(devices)
 }

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -48,6 +48,13 @@ func NewBootstrap(router *mux.Router) *Bootstrap {
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
 	loadRestRoutes(b.router, dic)
 
+	// TODO: there is an outstanding known issue (https://github.com/edgexfoundry/edgex-go/issues/2462)
+	// 		that could be seemingly be solved by moving from JIT initialization of these external clients to static
+	// 		init on startup, like registryClient and configuration are initialized.
+	// 		Doing so would cover over the symptoms of the bug, but the root problem of server processing taking longer
+	// 		than the configured client time out would still be present.
+	// 		Until that problem is addressed by larger architectural changes, if you are experiencing a bug similar to
+	//		https://github.com/edgexfoundry/edgex-go/issues/2421, the correct fix is to bump up the client timeout.
 	configuration := container.ConfigurationFrom(dic.Get)
 	registryClient := bootstrapContainer.RegistryFrom(dic.Get)
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
A race occurs during bootstrap external client initialization between the bootstrap handler and the bootstrap registry component. If the external client is initialized JIT, the registry variable will no longer contain valid data. On subsequent calls, the registry variable is updated and execution proceeds as normal.

Issue Number: Fixes #2421 


## What is the new behavior?
The external client is initialized before the bootstrap update code and the race does not occur.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Are there any specific instructions or things that should be known prior to reviewing?
To verify:

Repro the bug on master:
Run (in order) consul, redis, config-seed, core-data, core-metadata, core-command. Ensure the core services are configured for consul usage and not local configuration. Make the following curl command: `curl http://localhost:48082/api/v1/device` .

Checkout this PR code, follow the steps above, and ensure that device data is returned.

## Other information
[The system management agent contains code that is very similar to the problematic code identified in this PR in command and metadata. I do not have the familiarity with the SMA to say if it is going to be an issue there.](https://github.com/edgexfoundry/edgex-go/blob/master/internal/system/agent/init.go#L68-L107)