### PR TITLE
Implementation for adding addtional Vault tokens from the environment variable

### DIFF
--- a/internal/security/fileprovider/tokenconfig.go
+++ b/internal/security/fileprovider/tokenconfig.go
@@ -45,9 +45,16 @@ Example config file
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
+)
+
+const (
+	addSecretstoreTokensEnvKey = "ADD_SECRETSTORE_TOKENS"
 )
 
 type TokenConfFile map[string]ServiceKey
@@ -79,4 +86,91 @@ func LoadTokenConfig(fileOpener fileioperformer.FileIoPerformer, path string, to
 	}
 
 	return nil
+}
+
+// GetTokenConfigFromEnv function gets a list of token service keys
+// from environment variable and populates the default configuration with
+// default token parameters and policies
+// the function returns a TokenConfFile map instance and error if any
+// if the environment variable is not present or the value of that is empty
+// then it will return empty map
+// if the value for the list is not well-formed, not comma-separated
+// then it will return an error
+func GetTokenConfigFromEnv() (TokenConfFile, error) {
+	emptyTokenConfig := make(TokenConfFile)
+
+	addTokenList := os.Getenv(addSecretstoreTokensEnvKey)
+	if strings.TrimSpace(addTokenList) == "" {
+		return emptyTokenConfig, nil
+	}
+
+	// the list of service names is comma-separated
+	tokenConfigFromEnv := make(TokenConfFile)
+	serviceNameList := strings.Split(addTokenList, ",")
+	// regex for valid service name as key
+	// the service name eventually becomes part of the URL to Vault's API call
+	// Based upon the RFC 3986: https://tools.ietf.org/html/rfc3986#page-12,
+	// the following characters are reserved characters for URI's and thus NOT allowed:
+	// gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+	// sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+	// backslash (\) also is not allowed due to being as a delimiter for URI directory in Windows
+	// percent symbol (%) also is not allowed due to being used to encode the reserved characters in URI
+	// and the regular alphanumeric characters like A to Z, a to z, 0 to 9, underscore (_),
+	// -, ~, ^,  {, }, |, <, >, . are allowed.
+	// and the the length of the name is upto 512 characters
+	serviceNameRegx := regexp.MustCompile(`^[\w. \~\^\-\|\<\>\{\}]{1,512}$`)
+
+	for _, name := range serviceNameList {
+		serviceName := strings.TrimSpace(name)
+		if serviceName == "" {
+			// skipping the empty name cases, ie. treating it as non-existent service
+			continue
+		}
+
+		if !serviceNameRegx.MatchString(serviceName) {
+			return emptyTokenConfig, fmt.Errorf("invalid service name: %s as key from environment variable", serviceName)
+		}
+
+		// with default service configuration
+		tokenConfigFromEnv[serviceName] = ServiceKey{
+			UseDefaults: true,
+		}
+	}
+
+	return tokenConfigFromEnv, nil
+}
+
+// mergeWith function takes another TokenConfFile and merges with the current one
+// to return a new TokenConfFile.
+// The merging is based on the key of TokenConfFile's map
+// if the key of another has already been existing on the current one,
+// then the former (ie. from another) will replaces the latter (ie. from tf).
+func (tf TokenConfFile) mergeWith(another TokenConfFile) TokenConfFile {
+	if len(another) == 0 {
+		// nothing to be merged, return itself
+		return tf
+	}
+
+	if len(tf) == 0 {
+		// itself is empty, just use another
+		return another
+	}
+
+	// deep copy the tf first
+	mergedMap := make(TokenConfFile)
+	for k, v := range tf {
+		mergedMap[k] = v
+	}
+
+	for key, value := range another {
+		mergedMap[key] = value
+	}
+
+	return mergedMap
+}
+
+// keyExists function returns true if the input key exists in the TokenConfFile map
+func (tf TokenConfFile) keyExists(key string) bool {
+	_, exists := tf[key]
+	return exists
 }


### PR DESCRIPTION
 - security-file-token-provider now can take the environment variable,
     ADD_SECRETSTORE_TOKENS that takes a comma-separated list of additional service keys
     for which to create tokens.
 - The tokens create with the default token parameters and policies.
 - Unit tests refactored to reduce some duplicate codes

Fix: #2266

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The current security-token-file-provider can only take the pre-configured services from the TOML configuration file and it is asked for adding additional service token on the fly from the environment variable.

Issue Number: #2266 


## What is the new behavior?
With this PR, the additional Vault tokens can be created via the environment variable `ADD_SECRETSTORE_TOKENS`.  This suits the need for application function related services, which is more dynamic configured.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information
To test this locally, do the following steps:
1. Clone this branch
2. Build the docker image of `security_secretstore_setup` via make from the base of this repo: 
```
$ make docker_security_secretstore_setup
```
It should produce the docker image: edgexfoundry/docker-edgex-security-secretstore-setup-go:master-dev
3. Modify the docker-compose-nexus-mongo.yml from the developer-script to use the built docker image from local and add the entry in the environment section of `vault-worker` like this example:
```yml
vault-worker:
    #image: nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:master
    image: edgexfoundry/docker-edgex-security-secretstore-setup-go:master-dev
    container_name: edgex-vault-worker
    hostname: edgex-vault-worker
    environment:
      - "SECRETSTORE_SETUP_DONE_FLAG=/tmp/edgex/secrets/edgex-consul/.secretstore-setup-done"
      - "ADD_SECRETSTORE_TOKENS=test-env-add-service"
    networks:
      edgex-network:
        aliases:
            - edgex-vault-worker


```
Here we are adding `test-env-add-service` as an additional or extra service for creating Vault token of it.
4. Run docker-compose up of `vault-worker`  eg.:
```sh
$ docker-compose -f docker-compose-nexus-mongo.yml up vault-worker
edgex-files is up-to-date
edgex-secrets-setup is up-to-date
edgex-core-consul is up-to-date
edgex-vault is up-to-date
Recreating edgex-vault-worker ... done
Attaching to edgex-vault-worker
edgex-vault-worker        | Clearing secretstore-setup completion flag
edgex-vault-worker        | creating /vault/config/assets
edgex-vault-worker        | + exec /consul/scripts/health security-secrets-setup
edgex-vault-worker        | starting vault-worker...
edgex-vault-worker        | passing
edgex-vault-worker        | Initializing secret store
edgex-vault-worker        | level=INFO ts=2020-03-25T23:23:09.456239697Z app=edgex-security-secretstore-setup source=file.go:60 msg="Loaded configuration from ./res/configuration.toml"
edgex-vault-worker        | Creating directory: /logs
edgex-vault-worker        | level=INFO ts=2020-03-25T23:23:09.456365624Z app=edgex-security-secretstore-setup source=init.go:67 msg="using certificate verification for secret store connection"
edgex-vault-worker        | level=INFO ts=2020-03-25T23:23:09.460556844Z app=edgex-security-secretstore-setup source=requestor.go:63 msg="successful loading the rootCA certificate."
edgex-vault-worker        | level=INFO ts=2020-03-25T23:23:09.50545955Z app=edgex-security-secretstore-setup source=common.go:97 msg="successfully made request to health check"
edgex-vault-worker        | level=INFO ts=2020-03-25T23:23:09.50704265Z app=edgex-security-secretstore-setup source=vault.go:64 msg="vault health check HTTP status: StatusCode: 200"
<.... Omit due to lengthy printout ...>
edgex-vault-worker        | Executing custom command: 
edgex-vault-worker        | Signaling secretstore-setup completion
edgex-vault-worker        | Waiting for termination signal
```
5. Inspect the `/tmp/edgex/secrets` directory, and it should create a new directory for that named service from the environment variable. ie. `test-env-add-service` like this:
```sh
$ sudo ls -al /tmp/edgex/secrets/test-env-add-service
total 12
drwx------  2 root root 4096 Mar 25 16:23 .
drwxr-xr-x 21 root root 4096 Mar 25 16:23 ..
-rw-------  1 root root  515 Mar 25 16:23 secrets-token.json
```
6. Compose down if needed: 
```
docker-compose -f docker-compose-nexus-mongo.yml down -v
```
