### PR TITLE
Handling empty IDs in the Mongo metadata driver

### DIFF
--- a/internal/pkg/db/mongo/metadata.go
+++ b/internal/pkg/db/mongo/metadata.go
@@ -17,12 +17,14 @@ package mongo
 import (
 	"errors"
 	"fmt"
-	types "github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo/models"
+
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+
+	types "github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo/models"
 )
 
 /* ----------------------Device Report --------------------------*/
@@ -108,6 +110,15 @@ func (mc MongoClient) AddDeviceReport(d contract.DeviceReport) (string, error) {
 }
 
 func (mc MongoClient) UpdateDeviceReport(dr contract.DeviceReport) error {
+	if dr.Id == "" {
+		byName, err := mc.GetDeviceReportByName(dr.Name)
+		if err != nil {
+			return err
+		}
+
+		dr = byName
+	}
+
 	var mapped models.DeviceReport
 	id, err := mapped.FromContract(dr)
 	if err != nil {
@@ -156,6 +167,15 @@ func (mc MongoClient) AddDevice(d contract.Device, commands []contract.Command) 
 }
 
 func (mc MongoClient) UpdateDevice(d contract.Device) error {
+	if d.Id == "" {
+		byName, err := mc.GetDeviceByName(d.Name)
+		if err != nil {
+			return err
+		}
+
+		d = byName
+	}
+
 	var mapped models.Device
 	id, err := mapped.FromContract(d, mc, mc, mc)
 	if err != nil {
@@ -380,6 +400,15 @@ func (mc MongoClient) AddDeviceProfile(dp contract.DeviceProfile) (string, error
 }
 
 func (mc MongoClient) UpdateDeviceProfile(dp contract.DeviceProfile) error {
+	if dp.Id == "" {
+		byName, err := mc.GetDeviceProfileByName(dp.Name)
+		if err != nil {
+			return err
+		}
+
+		dp = byName
+	}
+
 	var mapped models.DeviceProfile
 	id, err := mapped.FromContract(dp)
 	if err != nil {
@@ -424,6 +453,15 @@ func (mc MongoClient) AddressableToDBRef(a models.Addressable) (dbRef mgo.DBRef,
 }
 
 func (mc MongoClient) UpdateAddressable(a contract.Addressable) error {
+	if a.Id == "" {
+		byName, err := mc.GetAddressableByName(a.Name)
+		if err != nil {
+			return err
+		}
+
+		a = byName
+	}
+
 	var mapped models.Addressable
 	id, err := mapped.FromContract(a)
 	if err != nil {
@@ -690,6 +728,15 @@ func (mc MongoClient) AddDeviceService(ds contract.DeviceService) (string, error
 }
 
 func (mc MongoClient) UpdateDeviceService(ds contract.DeviceService) error {
+	if ds.Id == "" {
+		byName, err := mc.GetDeviceServiceByName(ds.Name)
+		if err != nil {
+			return err
+		}
+
+		ds = byName
+	}
+
 	var mapped models.DeviceService
 	id, err := mapped.FromContract(ds, mc)
 	if err != nil {
@@ -874,6 +921,33 @@ func (mc MongoClient) AddProvisionWatcher(pw contract.ProvisionWatcher) (string,
 }
 
 func (mc MongoClient) UpdateProvisionWatcher(pw contract.ProvisionWatcher) error {
+	if pw.Id == "" {
+		byName, err := mc.GetProvisionWatcherByName(pw.Name)
+		if err != nil {
+			return err
+		}
+
+		pw = byName
+	}
+
+	if pw.Profile.Id == "" {
+		byName, err := mc.GetDeviceProfileByName(pw.Profile.Name)
+		if err != nil {
+			return err
+		}
+
+		pw.Profile = byName
+	}
+
+	if pw.Service.Id == "" {
+		byName, err := mc.GetDeviceServiceByName(pw.Service.Name)
+		if err != nil {
+			return err
+		}
+
+		pw.Service = byName
+	}
+
 	var mapped models.ProvisionWatcher
 	id, err := mapped.FromContract(pw, mc, mc, mc)
 	if err != nil {

--- a/internal/pkg/db/mongo/models/provisionwatcher.go
+++ b/internal/pkg/db/mongo/models/provisionwatcher.go
@@ -74,7 +74,12 @@ func (pw *ProvisionWatcher) ToContract(dpt deviceProfileTransform, dst deviceSer
 	return
 }
 
-func (pw *ProvisionWatcher) FromContract(from contract.ProvisionWatcher, dpt deviceProfileTransform, dst deviceServiceTransform, at addressableTransform) (id string, err error) {
+func (pw *ProvisionWatcher) FromContract(
+	from contract.ProvisionWatcher,
+	dpt deviceProfileTransform,
+	dst deviceServiceTransform,
+	at addressableTransform) (id string, err error) {
+
 	pw.Id, pw.Uuid, err = fromContractId(from.Id)
 	if err != nil {
 		return

--- a/internal/pkg/errorconcept/provision_watcher.go
+++ b/internal/pkg/errorconcept/provision_watcher.go
@@ -30,6 +30,7 @@ type provisionWatcherErrorConcept struct {
 	DeviceProfileNotFound_StatusNotFound provisionWatcherDeviceProfileNotFound_StatusNotFound
 	DeviceServiceNotFound_StatusConflict provisionWatcherDeviceServiceNotFound_StatusConflict
 	DeviceServiceNotFound_StatusNotFound provisionWatcherDeviceServiceNotFound_StatusNotFound
+	InvalidID                            provisionWatcherInvalidId
 	NameCollision                        provisionWatcherNameCollision
 	NotFoundById                         provisionWatcherNotFoundById
 	NotFoundByName                       provisionWatcherNotFoundByName
@@ -133,6 +134,20 @@ func (r provisionWatcherNotFoundByName) isA(err error) bool {
 
 func (r provisionWatcherNotFoundByName) message(err error) string {
 	return "Provision Watcher not found: " + err.Error()
+}
+
+type provisionWatcherInvalidId struct{}
+
+func (r provisionWatcherInvalidId) httpErrorCode() int {
+	return http.StatusNotFound
+}
+
+func (r provisionWatcherInvalidId) isA(err error) bool {
+	return err == db.ErrInvalidObjectId
+}
+
+func (r provisionWatcherInvalidId) message(err error) string {
+	return db.ErrInvalidObjectId.Error()
 }
 
 type provisionWatcherNameCollision struct{}


### PR DESCRIPTION
#1723  PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
This PR attempts to address an issue where if an object presented to the Mongo metadata driver for update did not have an ID (but was a valid object in the database) instead of automatically performing a lookup by ID, the driver would generate a new ID and then throw an error because no updated could be performed on the new ID.

Issue Number: Fixes #2464


## What is the new behavior?
This has been corrected, and now when no ID is present on the update request, the driver will first do a lookup by name to attempt to match the update request to an existing object.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Are there any specific instructions or things that should be known prior to reviewing?
To verify, run the metadata blackbox tests using Mongo.