### PR TITLE
Fix Blackbox Testing issue #424

### DIFF
--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -51,7 +51,7 @@ CACertPath = "res/EdgeXFoundryCA/EdgeXFoundryCA.pem"
 SNIS = ["localhost"]
 
 [Clients]
-  [Clients.Coredata]
+  [Clients.CoreData]
   Protocol = "http"
   Host = "localhost"
   Port = 48080

--- a/internal/security/proxy/testdata/configuration.toml
+++ b/internal/security/proxy/testdata/configuration.toml
@@ -51,7 +51,7 @@ CACertPath = "res/EdgeXFoundryCA/EdgeXFoundryCA.pem"
 SNIS = ["edgex-kong"]
 
 [Clients]
-  [Clients.Coredata]
+  [Clients.CoreData]
   Protocol = "http"
   Host = "edgex-core-data"
   Port = 48080


### PR DESCRIPTION
  All other services use that have it use [Clients.CoreData] not [Clients.Coredata]

Case matters... Our global override uses Clients_CoreData

  Changed it to Clients.CoreData everywhere.

  Fixes: https://github.com/edgexfoundry/blackbox-testing/issues/424

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Currently, the configuration toml file uses the case-sensitive service name, Coredata.  It is supposed to use CoreData.

Issue Number: https://github.com/edgexfoundry/blackbox-testing/issues/424


## What is the new behavior?

Change the service name of core data to be CoreData


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information