### PR TITLE
Implement ability to add additional Kong routes

### DIFF
--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -19,12 +19,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
 
 	"github.com/edgexfoundry/edgex-go/internal"
 
@@ -39,6 +42,9 @@ type CertUploadErrorType int
 const (
 	CertExisting  CertUploadErrorType = 0
 	InternalError CertUploadErrorType = 1
+
+	// AddProxyRoutesEnv is the environment variable name for adding the additional Kong routes for app services
+	AddProxyRoutesEnv = "ADD_PROXY_ROUTE"
 )
 
 type CertError struct {
@@ -51,9 +57,11 @@ func (ce *CertError) Error() string {
 }
 
 type Service struct {
-	client        internal.HttpCaller
-	loggingClient logger.LoggingClient
-	configuration *config.ConfigurationStruct
+	client           internal.HttpCaller
+	loggingClient    logger.LoggingClient
+	configuration    *config.ConfigurationStruct
+	additionalRoutes string
+	routes           map[string]*KongRoute
 }
 
 func NewService(
@@ -62,9 +70,11 @@ func NewService(
 	configuration *config.ConfigurationStruct) Service {
 
 	return Service{
-		client:        r,
-		loggingClient: lc,
-		configuration: configuration,
+		client:           r,
+		loggingClient:    lc,
+		configuration:    configuration,
+		additionalRoutes: strings.TrimSpace(os.Getenv(AddProxyRoutesEnv)),
+		routes:           make(map[string]*KongRoute),
 	}
 }
 
@@ -132,7 +142,17 @@ func (s *Service) Init(cp bootstrapConfig.CertKeyPair) error {
 		}
 	}
 
-	for clientName, client := range s.configuration.Clients {
+	addRoutesFromEnv, parseErr := s.parseAdditionalProxyRoutes()
+
+	if parseErr != nil {
+		s.loggingClient.Error(fmt.Sprintf(
+			"failed to parse additional proxy Kong routes from env %s: %s",
+			s.additionalRoutes, parseErr.Error()))
+	}
+
+	mergedClients := s.mergeRoutesWith(addRoutesFromEnv)
+
+	for clientName, client := range mergedClients {
 		serviceParams := &KongService{
 			Name:     strings.ToLower(clientName),
 			Host:     client.Host,
@@ -149,6 +169,7 @@ func (s *Service) Init(cp bootstrapConfig.CertKeyPair) error {
 			Paths: []string{"/" + strings.ToLower(clientName)},
 			Name:  strings.ToLower(clientName),
 		}
+
 		err = s.initKongRoutes(routeParams, strings.ToLower(clientName))
 		if err != nil {
 			return err
@@ -167,6 +188,103 @@ func (s *Service) Init(cp bootstrapConfig.CertKeyPair) error {
 
 	s.loggingClient.Info("finishing initialization for reverse proxy")
 	return nil
+}
+
+// parseAdditionalProxyRoutes is to parse out the value of env AddProxyRoutesEnv
+// into key / value pairs of map [string]bootstrapConfig.ClientInfo
+// where key is service name, and value is the service ClientInfo
+// the env should contain the list of comma separated entries with the format of
+// Name.URL to be considered well-formed
+// Name is used as the key of service name
+// URL should be well-formed as protocol://hostName:portNumber
+// and is parsed into bootstrapConfig.ClientInfo structure if valid
+// returns error if not valid
+func (s *Service) parseAdditionalProxyRoutes() (map[string]bootstrapConfig.ClientInfo, error) {
+	emptyMap := make(map[string]bootstrapConfig.ClientInfo)
+
+	routesFromEnv := strings.Split(s.additionalRoutes, ",")
+
+	additionalClientMap := make(map[string]bootstrapConfig.ClientInfo)
+	for _, rt := range routesFromEnv {
+		route := strings.TrimSpace(rt)
+		// ignore the empty route
+		if route == "" {
+			continue
+		}
+
+		if !strings.Contains(route, ".") {
+			// Invalid syntax for route, it should contain dot (.)
+			return emptyMap, fmt.Errorf(
+				"invalid syntax for defining additional kong route %s, it should contain dot . as separator", route)
+		}
+
+		routePair := strings.Split(route, ".")
+		serviceName := strings.TrimSpace(routePair[0])
+		routeURL := strings.TrimSpace(routePair[1])
+
+		if serviceName == "" {
+			// service name should not be empty
+			return emptyMap, errors.New("service name for kong route should not be empty")
+		}
+
+		// sanity check to validate the well-formness of routeURL
+		// and also parse out the protocol, hostname, and port number if it is good
+		url, err := url.Parse(routeURL)
+		if err != nil {
+			return emptyMap, fmt.Errorf(
+				"malformed route URL for additional kong route %s: %s", routeURL, err.Error())
+		}
+		hostName, port, err := net.SplitHostPort(url.Host)
+		if err != nil {
+			return emptyMap, fmt.Errorf(
+				"malformed host in route URL for additional kong route %s: %s", url.Host, err.Error())
+		}
+		portNum, err := strconv.Atoi(port)
+		if err != nil {
+			return emptyMap, fmt.Errorf(
+				"invalid port, expecting integer as port number for additional kong route %s: %s", port, err.Error())
+		}
+
+		clientInfo := bootstrapConfig.ClientInfo{
+			Protocol: url.Scheme,
+			Host:     hostName,
+			Port:     portNum,
+		}
+
+		additionalClientMap[serviceName] = clientInfo
+	}
+
+	return additionalClientMap, nil
+}
+
+func (s *Service) mergeRoutesWith(additional map[string]bootstrapConfig.ClientInfo) map[string]bootstrapConfig.ClientInfo {
+	// merging ignores the duplicate keys with the current internal map
+
+	if len(additional) == 0 {
+		return s.configuration.Clients
+	}
+
+	if len(s.configuration.Clients) == 0 {
+		return additional
+	}
+
+	merged := make(map[string]bootstrapConfig.ClientInfo)
+	for serviceName, client := range s.configuration.Clients {
+		merged[serviceName] = client
+	}
+
+	for serviceName, client := range additional {
+		_, exists := merged[serviceName]
+		if exists {
+			s.loggingClient.Warn(fmt.Sprintf(
+				"attempting to add additional service name %s that already exists in the config. "+
+					"Ignoring additional", serviceName))
+			continue
+		}
+		merged[serviceName] = client
+	}
+
+	return merged
 }
 
 func (s *Service) postCert(cp bootstrapConfig.CertKeyPair) *CertError {
@@ -225,6 +343,7 @@ func (s *Service) initKongService(service *KongService) error {
 		"protocol": {service.Protocol},
 	}
 	tokens := []string{s.configuration.KongURL.GetProxyBaseURL(), ServicesPath}
+
 	req, err := http.NewRequest(http.MethodPost, strings.Join(tokens, "/"), strings.NewReader(formVals.Encode()))
 	if err != nil {
 		return fmt.Errorf("failed to construct http POST form request: %s %s", service.Name, err.Error())
@@ -261,6 +380,7 @@ func (s *Service) initKongRoutes(r *KongRoute, name string) error {
 		return err
 	}
 	tokens := []string{s.configuration.KongURL.GetProxyBaseURL(), ServicesPath, name, "routes"}
+
 	req, err := http.NewRequest(http.MethodPost, strings.Join(tokens, "/"), strings.NewReader(string(data)))
 	if err != nil {
 		e := fmt.Sprintf("failed to set up routes for %s with error %s", name, err.Error())
@@ -279,6 +399,7 @@ func (s *Service) initKongRoutes(r *KongRoute, name string) error {
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
+		s.routes[name] = r
 		s.loggingClient.Info(fmt.Sprintf("successful to set up route for %s", name))
 		break
 	default:

--- a/internal/security/proxy/service_test.go
+++ b/internal/security/proxy/service_test.go
@@ -20,11 +20,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 
@@ -131,10 +134,77 @@ func TestInit(t *testing.T) {
 
 	mockCertPair := bootstrapConfig.CertKeyPair{Cert: "test-certificate", Key: "test-private-key"}
 	mockLogger := logger.MockLogger{}
-	service := NewService(NewRequestor(true, 10, "", mockLogger), mockLogger, configuration)
-	err = service.Init(mockCertPair)
-	if err != nil {
-		t.Errorf(err.Error())
+
+	origProxyRoutEnv := os.Getenv(AddProxyRoutesEnv)
+	defer func() {
+		_ = os.Setenv(AddProxyRoutesEnv, origProxyRoutEnv)
+	}()
+
+	tests := []struct {
+		name               string
+		proxyRouteEnvValue string
+		expectNumRoutes    int
+	}{
+		{ // the original number of routes is from configuration file
+			name:               "empty env",
+			proxyRouteEnvValue: "",
+			expectNumRoutes:    8,
+		},
+		{
+			name:               "add one unique route",
+			proxyRouteEnvValue: "testService.http://edgex-testService:12345",
+			expectNumRoutes:    9,
+		},
+		{
+			name:               "add two unique routes",
+			proxyRouteEnvValue: "testService1.http://edgex-testService1:12345, testService2.http://edgex-testService2:12346",
+			expectNumRoutes:    10,
+		},
+		{
+			name:               "add one duplicate route",
+			proxyRouteEnvValue: "CoreData.http://edgex-core-data:48080",
+			expectNumRoutes:    8,
+		},
+		{
+			name:               "add one unique, one duplicate route",
+			proxyRouteEnvValue: "testServcie.https://edgex-test-servcie1:12345, CoreData.http://edgex-core-data:48080",
+			expectNumRoutes:    9,
+		},
+		{
+			name:               "add one unique, multiple duplicate routes",
+			proxyRouteEnvValue: "testServcie.https://edgex-test-servcie1:12345, CoreData.http://edgex-core-data:48080, Command.https://edgex-core-command:48082",
+			expectNumRoutes:    9,
+		},
+		// invalid syntax tests:
+		// the bad one is not added into kong route pool
+		{
+			name:               "bad spec without dot . in the definition for route",
+			proxyRouteEnvValue: "testServcie=https://edgex-test-servcie1:12345",
+			expectNumRoutes:    8,
+		},
+		{
+			name:               "bad URL without full quallified URL",
+			proxyRouteEnvValue: "testServcie.edgex-test-servcie1:12345",
+			expectNumRoutes:    8,
+		},
+		{
+			name:               "empty service name",
+			proxyRouteEnvValue: ".https://edgex-test-servcie1:12345",
+			expectNumRoutes:    8,
+		},
+	}
+	for _, tt := range tests {
+		currentTest := tt
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv(AddProxyRoutesEnv, currentTest.proxyRouteEnvValue)
+			service := NewService(NewRequestor(true, 10, "", mockLogger), mockLogger, configuration)
+
+			err = service.Init(mockCertPair)
+
+			require.NoError(t, err)
+
+			assert.Equal(t, currentTest.expectNumRoutes, len(service.routes), "number of Kong routes not the same")
+		})
 	}
 }
 


### PR DESCRIPTION
# Summary
`security-proxy-setup service` now can take an environment variable, `ADD_PROXY_ROUTE`,
that takes a comma-separated list of paired additional service name and URL for which to create Kong routes.
The paired spec. is given like the following:

**\<ServiceName\>.\<RouteURL\>**

where ServiceName is the name of service which requests to create Kong route
and RouteURL is the full qualified URL for the service. eg.: http://edgex-app-service-rules:59807

So for a single service the value would be: "app-service-rules.http://edgex-app-service-rules:59807"

This service info is used to add the service to the routes for Kong.

Fixes: #2473

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

The current Kong routes can only be created and initialized for fixed and statically configured through configuration TOML file specified in `security-proxy-setup` service.  This is not sufficient for application services.  The app services thus need a capability to create or add proxy Kong routes in addition to the existing configuration TOML file.

Issue Number: #2473


## What is the new behavior?

The security-proxy-setup now can take new route to be added from environment variable, `ADD_PROXY_ROUTE` for app services to be used.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
To test this locally, do the following steps:
1. Clone this branch
2. Build the docker image of `security_proxy_setup` via make from the base of this repo: 
```
$ make docker_security_proxy_setup
```
It should produce the docker image: edgexfoundry/docker-edgex-security-proxy-setup-go:master-dev

3. Modify the docker-compose-nexus-mongo.yml from the developer-script to use the built docker image from local and add the entry in the environment section of `edgex-proxy` for `ADD_PROXY_ROUTE`  like this example:
```yml
edgex-proxy:
    #image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:master
    image: nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:master-dev
    container_name: edgex-proxy
    hostname: edgex-proxy
    entrypoint: >
      /bin/sh -c 
      "until /consul/scripts/consul-svc-healthy.sh kong; do sleep 1; done;
      until /consul/scripts/consul-svc-healthy.sh security-secretstore-setup; do sleep 1; done;
      /edgex/security-proxy-setup --init=true"
    networks:
      edgex-network:
        aliases:
            - edgex-proxy
    environment:
      <<: *common-variables
      ADD_PROXY_ROUTE: "app-service-rules.http://edgex-app-service-configurable-rules:48100"
      KongURL_Server: kong
      SecretService_Server: edgex-vault
      SecretService_TokenPath: /tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json
      SecretService_CACertPath: /tmp/edgex/secrets/ca/ca.pem
      SecretService_SNIS: "edgex-kong"
      Logging_EnableRemote: "false"
      Logging_File: "/tmp/security-proxy-setup.log"

```
Here we are adding `app-service-rules.http://edgex-app-service-configurable-rules:48100` as an additional or extra service for Kong proxy route.

4. Run docker-compose up of `edgex-proxy`  eg.:
```sh
$ docker-compose -f docker-compose-nexus-mongo.yml up edgex-proxy
Creating network "compose-files_edgex-network" with driver "bridge"
Creating network "compose-files_default" with the default driver
Creating kong-db     ... done
Creating edgex-files ... done
Creating edgex-core-consul   ... done
Creating edgex-secrets-setup ... done
Creating kong-migrations     ... done
Creating edgex-vault         ... done
Creating edgex-vault-worker  ... done
Creating kong                ... done
Creating edgex-proxy         ... done
Attaching to edgex-proxy
edgex-proxy               | + exec /consul/scripts/health kong
edgex-proxy               | critical
edgex-proxy               | + exec /consul/scripts/health kong
edgex-proxy               | passing
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | critical
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | critical
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | critical
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | critical
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | critical
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | critical
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | warning
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | warning
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | warning
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | warning
edgex-proxy               | + exec /consul/scripts/health security-secretstore-setup
edgex-proxy               | passing
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.424449286Z app=edgex-security-proxy-setup source=config.go:219 msg="Loaded configuration from ./res/configuration.toml"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.426939308Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'Clients.Scheduler.Host' by environment variable: Clients_Scheduler_Host=edgex-support-scheduler"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427029563Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'Clients.Command.Host' by environment variable: Clients_Command_Host=edgex-core-command"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427079141Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'Logging.File' by environment variable: Logging_File=/tmp/security-proxy-setup.log"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427126112Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'Clients.Metadata.Host' by environment variable: Clients_Metadata_Host=edgex-core-metadata"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427190746Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'SecretStore.RootCaCertPath' by environment variable: SecretStore_RootCaCertPath=/tmp/edgex/secrets/ca/ca.pem"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427237703Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'Clients.Notifications.Host' by environment variable: Clients_Notifications_Host=edgex-support-notifications"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427284542Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'SecretStore.ServerName' by environment variable: SecretStore_ServerName=edgex-vault"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427340755Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'Clients.CoreData.Host' by environment variable: Clients_CoreData_Host=edgex-core-data"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427408203Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'SecretStore.Host' by environment variable: SecretStore_Host=edgex-vault"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427455153Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'SecretService.CACertPath' by environment variable: SecretService_CACertPath=/tmp/edgex/secrets/ca/ca.pem"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427636601Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'Logging.EnableRemote' by environment variable: Logging_EnableRemote=false"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.427841007Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'KongURL.Server' by environment variable: KongURL_Server=kong"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.428025026Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'SecretService.Server' by environment variable: SecretService_Server=edgex-vault"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.428244726Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'SecretService.TokenPath' by environment variable: SecretService_TokenPath=/tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.428399742Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'Clients.Logging.Host' by environment variable: Clients_Logging_Host=edgex-support-logging"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.42846475Z app=edgex-security-proxy-setup source=environment.go:264 msg="Environment override of 'SecretService.SNIS' by environment variable: SecretService_SNIS=edgex-kong"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.42906035Z app=edgex-security-proxy-setup source=config.go:321 msg="Using local configuration from file (16 environment overrides applied)"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.499883217Z app=edgex-security-proxy-setup source=secret.go:59 msg="Creating SecretClient"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.600022969Z app=edgex-security-proxy-setup source=secret.go:67 msg="Reading secret store configuration and authentication token"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:43.791647289Z app=edgex-security-proxy-setup source=secret.go:73 msg="Attempting to create secretclient"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.205325168Z app=edgex-security-proxy-setup source=secret.go:77 msg="Created SecretClient"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.206252452Z app=edgex-security-proxy-setup source=requestor.go:47 msg="successfully loaded rootCA certificate."
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.216326781Z app=edgex-security-proxy-setup source=service.go:103 msg="the service on http://kong:8001 is up successfully"
edgex-proxy               | level=DEBUG ts=2020-04-08T17:20:44.223986911Z app=edgex-security-proxy-setup source=service.go:296 msg="trying to upload cert to proxy server"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.29765127Z app=edgex-security-proxy-setup source=service.go:318 msg="successfully added certificate to the reverse proxy"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.314889808Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for virtualdevice"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.340865801Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for virtualdevice"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.384760235Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for notifications"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.406856363Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for notifications"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.426913848Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for scheduler"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.456052063Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for scheduler"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.486621754Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for command"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.506902117Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for command"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.537297118Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for coredata"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.557016401Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for coredata"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.579407409Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for logging"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.599428908Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for logging"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.62203778Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for metadata"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.641993673Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for metadata"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.671113761Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for app-service-rules"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.701467309Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for app-service-rules"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.719595543Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for rulesengine"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.746496267Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for rulesengine"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.754682642Z app=edgex-security-proxy-setup source=service.go:454 msg="selected authetication method as jwt."
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.785240243Z app=edgex-security-proxy-setup source=service.go:488 msg="successful to set up jwt authentication"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.846918609Z app=edgex-security-proxy-setup source=service.go:443 msg="acl set up successfully"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.856674033Z app=edgex-security-proxy-setup source=service.go:189 msg="finishing initialization for reverse proxy"
edgex-proxy               | level=INFO ts=2020-04-08T17:20:44.864924459Z app=edgex-security-proxy-setup source=client.go:98 msg="context cancelled, dismiss the token renewal process"
edgex-proxy exited with code 0
```
5. Inspect the logging messaging of docker container for edgex-proxy and you should see the successful messages for Kong routes added for this `app-service-configurable-rules`
```sh
$ docker logs edgex-proxy | grep app-service-rules
+ exec /consul/scripts/health security-secretstore-setup
level=INFO ts=2020-04-08T17:20:44.671113761Z app=edgex-security-proxy-setup source=service.go:363 msg="successful to set up proxy service for app-service-rules"
level=INFO ts=2020-04-08T17:20:44.701467309Z app=edgex-security-proxy-setup source=service.go:403 msg="successful to set up route for app-service-rules"
```

6. Compose down if needed: 
```
docker-compose -f docker-compose-nexus-mongo.yml down -v
```
