### PR TITLE
Set Empty LogFile Path for All Services

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -17,9 +17,10 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
 EnableRemote = false
-File = './logs/edgex-core-command.log'
+File = ''
 
 [Clients]
   [Clients.Metadata]

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -23,9 +23,10 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
 EnableRemote = false
-File = './logs/edgex-core-data.log'
+File = ''
 
 [Clients]
   [Clients.Metadata]

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -18,9 +18,10 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
 EnableRemote = false
-File = './logs/edgex-core-metadata.log'
+File = ''
 
 [Clients]
   [Clients.Logging]

--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -20,9 +20,10 @@
 LogLevel = "DEBUG"
 RequestTimeout = 10
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
 EnableRemote = false
-File = "./logs/security-proxy-setup.log"
+File = ""
 
 [KongURL]
 Server = "127.0.0.1"

--- a/cmd/security-secrets-setup/res/configuration.toml
+++ b/cmd/security-secrets-setup/res/configuration.toml
@@ -1,9 +1,10 @@
 [Writable]
 LogLevel = 'INFO'
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
 EnableRemote = false
-File = './logs/security-secrets-setup.log'
+File = ''
 
 [SecretsSetup]
 WorkDir = "/tmp/edgex/secrets-setup"

--- a/cmd/security-secretstore-setup/res/configuration.toml
+++ b/cmd/security-secretstore-setup/res/configuration.toml
@@ -18,9 +18,10 @@
 [Writable]
 LogLevel = 'DEBUG'
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
 EnableRemote = false
-File = './logs/security-secretstore-setup.log'
+File = ""
 
 [SecretService]
 Scheme = "https"

--- a/cmd/support-logging/res/configuration.toml
+++ b/cmd/support-logging/res/configuration.toml
@@ -18,8 +18,9 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
-File = './logs/edgex-support-logging.log'
+File = ''
 
 [Databases]
   [Databases.Primary]

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -18,9 +18,10 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
 EnableRemote = false
-File = './logs/edgex-support-notifications.log'
+File = ''
 
 [Clients]
   [Clients.Logging]

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -18,9 +18,10 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
 EnableRemote = false
-File = './logs/edgex-support-scheduler.log'
+File = ''
 
 [Clients]
   [Clients.Logging]

--- a/cmd/sys-mgmt-agent/res/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/configuration.toml
@@ -32,9 +32,10 @@ Host = 'localhost'
 Port = 8500
 Type = 'consul'
 
+# Remote and file logging disabled so only stdout logging is used
 [Logging]
 EnableRemote = false
-File = './logs/edgex-sys-mgmt-agent.log'
+File = ''
 
 [Clients]
   [Clients.Notifications]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/edgexfoundry/go-mod-bootstrap v0.0.26
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.27
 	github.com/edgexfoundry/go-mod-configuration v0.0.3
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.52
 	github.com/edgexfoundry/go-mod-messaging v0.1.16


### PR DESCRIPTION
Fix #2479

Signed-off-by: Trevor Conn <trevor_conn@dell.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X ] Other... Please describe:
Configuration changes to enable logging to only write to `StdOut` by default.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: 2479


## What is the new behavior?
Services will no longer write to a file by default. The absence of an explicitly specified log file path will cause the logger to just write to `StdOut`.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ X] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information