### PR TITLE
Swap ugorji/go with fxamacker/cbor library

### DIFF
--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/core-data/Attribution.txt
+++ b/cmd/core-data/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/security-file-token-provider/Attribution.txt
+++ b/cmd/security-file-token-provider/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/security-proxy-setup/Attribution.txt
+++ b/cmd/security-proxy-setup/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/security-secrets-setup/Attribution.txt
+++ b/cmd/security-secrets-setup/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/security-secretstore-setup/Attribution.txt
+++ b/cmd/security-secretstore-setup/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/cmd/sys-mgmt-executor/Attribution.txt
+++ b/cmd/sys-mgmt-executor/Attribution.txt
@@ -141,8 +141,11 @@ https://github.com/stretchr/objx/blob/master/LICENSE
 stretchr/testify (MIT) https://github.com/stretchr/testify
 https://github.com/stretchr/testify/blob/master/LICENSE
 
-ugorji/go (MIT) https://github.com/ugorji/go
-https://github.com/ugorji/go/blob/master/LICENSE
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,11 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.27
 	github.com/edgexfoundry/go-mod-configuration v0.0.3
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.52
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.57
 	github.com/edgexfoundry/go-mod-messaging v0.1.16
 	github.com/edgexfoundry/go-mod-registry v0.1.17
 	github.com/edgexfoundry/go-mod-secrets v0.0.17
+	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/uuid v1.1.0
@@ -20,7 +21,6 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
 	github.com/stretchr/testify v1.5.1
-	github.com/ugorji/go v1.1.4
 	gopkg.in/eapache/queue.v1 v1.1.0
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/internal/core/data/io.go
+++ b/internal/core/data/io.go
@@ -16,11 +16,12 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 
 	"github.com/OneOfOne/xxhash"
-	"github.com/ugorji/go/codec"
+	"github.com/fxamacker/cbor/v2"
 )
 
 const (
 	checksumContextKey = "payload-checksum"
+	maxEventSize       = int64(25 * 1e6) // 25 MB
 )
 
 // ErrUnsupportedContentType an error used when a request is received with an unsupported content type
@@ -73,13 +74,12 @@ func NewCborReader(configuration *config.ConfigurationStruct) cborReader {
 func (cr cborReader) Read(reader io.Reader, ctx *context.Context) (models.Event, error) {
 	c := context.WithValue(*ctx, clients.ContentType, clients.ContentTypeCBOR)
 	event := models.Event{}
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := ioutil.ReadAll(io.LimitReader(reader, maxEventSize))
 	if err != nil {
 		return event, err
 	}
 
-	x := codec.CborHandle{}
-	err = codec.NewDecoderBytes(bytes, &x).Decode(&event)
+	err = cbor.Unmarshal(bytes, &event)
 	if err != nil {
 		return event, err
 	}


### PR DESCRIPTION
Fixes #2439.

Replaces ugorji/go with fxamacker/cbor and updates
dependencies and Attribution.txt files.

Ensures calls to read cbor buffers are wrapped in
a LimitReader of reasonable size before exhausting.

This PR contains the parts of #2481 that still need to be carried over, and is scoped to only CBOR related changes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:
#2439

## What is the new behavior?
Purely refactoring, no change in behavior.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information