### PR TITLE
Fix issue (Content-Type-related) reported by Blackbox Testing .

### DIFF
--- a/internal/core/command/rest_device.go
+++ b/internal/core/command/rest_device.go
@@ -255,6 +255,7 @@ func restGetCommandsByDeviceName(
 		return
 	}
 
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(&devices)
 }


### PR DESCRIPTION
This fixes the following issue: https://github.com/edgexfoundry/blackbox-testing/issues/434

- Essentially, added back in a missing line in `func restGetCommandsByDeviceName()` for setting the ContentType. This was missed during one of the several refactorings which were done in the recent past. 
- It applies to the function restGetCommandsByDeviceName(), and the missing line (`w.Header().Set(clients.ContentType, clients.ContentTypeJSON)`) has been reinstated. Note that since the execution of a core-command is effectively a pass-through, a JSON result can be passed back to the caller as a string.
- Ran the blackbox tests, which passed. Here's the individual command, which resulted in the expected response body and `application/json` for `Content-Type`, which addresses the issue reported per `black-box testing`:
curl --location --request GET 'localhost:48082/api/v1/device/name/Random-Binary-Device' 