### PR TITLE
Deprecate Mongo Functionality

### DIFF
--- a/api/openapi/v2/system-agent.yaml
+++ b/api/openapi/v2/system-agent.yaml
@@ -148,7 +148,7 @@ components:
         service:
           description: "The name of the targeted service"
           type: string
-          example: edgex-mongo
+          example: edgex-redis
         executor:
           description: "The type of executor which processed the operation"
           type: string

--- a/bin/edgex-docker-launch.sh
+++ b/bin/edgex-docker-launch.sh
@@ -15,7 +15,7 @@
 # Usage: bin/edgex-docker-launch.sh [mongo]
 #
 # By default download the Redis based Docker Compose file and attempt to start EdgeX. If the mongo
-# option is used, download the Mongo based Docker Compose file and attemp to start EdgeX.
+# option is used, download the Mongo based Docker Compose file and attempt to start EdgeX.
 #
 # To override the compose file entirely set the COMPOSE_FILE_PATH environment variable to the full
 # pathname of the compose file you want to use.

--- a/internal/pkg/bootstrap/handlers/database/database.go
+++ b/internal/pkg/bootstrap/handlers/database/database.go
@@ -72,6 +72,7 @@ func (d Database) newDBClient(
 
 	databaseInfo := d.database.GetDatabaseInfo()["Primary"]
 	switch databaseInfo.Type {
+	// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 	case db.MongoDB:
 		return mongo.NewClient(
 			db.Configuration{

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -21,6 +21,10 @@ import (
 
 const (
 	// Databases
+
+	// MongoDB the unique identifier used in configuring the system to signal the underlying database used is MongoDB.
+	//
+	// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 	MongoDB = "mongodb"
 	RedisDB = "redisdb"
 

--- a/internal/pkg/db/mongo/client.go
+++ b/internal/pkg/db/mongo/client.go
@@ -11,6 +11,11 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
+// Package mongo provides an implementation of DBClient which uses MongoDB as the underlying data-store.
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release and no new functionality should be added;
+// Only bugs which address legacy issues
 package mongo
 
 import (
@@ -23,12 +28,18 @@ import (
 
 var currentMongoClient MongoClient // Singleton used so that mongoEvent can use it to de-reference readings
 
+// MongoClient implements DBClient and provides functionality for interacting with MongoDB.
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release and no new functionality should be added;
+// Only bugs which address legacy issues
 type MongoClient struct {
 	session  *mgo.Session  // Mongo database session
 	database *mgo.Database // Mongo database
 }
 
 // Return a pointer to the MongoClient
+//
+// Deprecated: MongoClient is deprecated as of the Geneva release.
 func NewClient(config db.Configuration) (MongoClient, error) {
 	m := MongoClient{}
 

--- a/internal/pkg/db/mongo/client_test.go
+++ b/internal/pkg/db/mongo/client_test.go
@@ -10,6 +10,10 @@
 // the tests with a command like:
 // go test -tags mongoRunning
 
+// Package mongo provides integration tests for interaction with MongoDO.
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release and no new functionality should be added;
+// Only bugs which address legacy issues
 package mongo
 
 import (
@@ -19,6 +23,9 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/test"
 )
 
+// TestMongoDB
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 func TestMongoDB(t *testing.T) {
 
 	t.Log("This test needs to have a running mongo on localhost")
@@ -57,6 +64,9 @@ func TestMongoDB(t *testing.T) {
 	test.TestSchedulerDB(t, mongo)
 }
 
+// BenchmarkMongoDB
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 func BenchmarkMongoDB(b *testing.B) {
 
 	b.Log("This benchmark needs to have a running mongo on localhost")

--- a/internal/pkg/db/mongo/models/addressable.go
+++ b/internal/pkg/db/mongo/models/addressable.go
@@ -11,6 +11,11 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
+// Package models provides an internal representation of data structures that can be used when interacting with MongoDB.
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release and no new functionality should be added;
+// Only bugs which address legacy issues
 package models
 
 import (
@@ -26,6 +31,9 @@ type addressableTransform interface {
 	GetAddressableByName(n string) (contract.Addressable, error)
 }
 
+// Addressable
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Addressable struct {
 	Created    int64         `bson:"created"`
 	Modified   int64         `bson:"modified"`

--- a/internal/pkg/db/mongo/models/channel.go
+++ b/internal/pkg/db/mongo/models/channel.go
@@ -16,6 +16,9 @@ package models
 
 import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 
+// Channel
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Channel struct {
 	Type          contract.ChannelType `bson:"type,omitempty"`
 	MailAddresses []string             `bson:"mailAddresses,omitempty"`

--- a/internal/pkg/db/mongo/models/command.go
+++ b/internal/pkg/db/mongo/models/command.go
@@ -20,18 +20,27 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
+// Response
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Response struct {
 	Code           string   `bson:"code"`
 	Description    string   `bson:"description"`
 	ExpectedValues []string `bson:"expectedValues"`
 }
 
+// Get
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Get struct {
 	Path      string     `bson:"path"`      // path used by service for action on a device or sensor
 	Responses []Response `bson:"responses"` // responses from get or put requests to service
 	URL       string     // url for requests from command service
 }
 
+// Put
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Put struct {
 	Path           string     `bson:"path"`      // path used by service for action on a device or sensor
 	Responses      []Response `bson:"responses"` // responses from get or put requests to service
@@ -39,6 +48,9 @@ type Put struct {
 	ParameterNames []string   `bson:"parameterNames"`
 }
 
+// CommandProfile
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type CommandProfile struct {
 	Name string `bson:"name"`
 	Get  Get    `bson:"get"`
@@ -115,6 +127,9 @@ func (c *Command) TimestampForAdd() {
 	c.Created = c.Modified
 }
 
+// Command
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Command struct {
 	CommandProfile `bson:",inline"`
 	Id             bson.ObjectId `bson:"_id,omitempty"`

--- a/internal/pkg/db/mongo/models/device.go
+++ b/internal/pkg/db/mongo/models/device.go
@@ -22,12 +22,9 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
-/*
- * This file is the model for the Device object in EdgeX
- *
- *
- * Device struct
- */
+// Device
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Device struct {
 	Created        int64                   `bson:"created"`
 	Modified       int64                   `bson:"modified"`

--- a/internal/pkg/db/mongo/models/deviceprofile.go
+++ b/internal/pkg/db/mongo/models/deviceprofile.go
@@ -26,6 +26,9 @@ type deviceProfileTransform interface {
 	DeviceProfileToDBRef(model DeviceProfile) (dbRef mgo.DBRef, err error)
 }
 
+// PropertyValue
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type PropertyValue struct {
 	Type          string `bson:"type"`         // ValueDescriptor Type of property after transformations
 	ReadWrite     string `bson:"readWrite"`    // Read/Write Permissions set for this property
@@ -44,17 +47,26 @@ type PropertyValue struct {
 	MediaType     string `bson:"mediaType"`
 }
 
+// Units
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Units struct {
 	Type         string `bson:"type"`
 	ReadWrite    string `bson:"readWrite"`
 	DefaultValue string `bson:"defaultValue"`
 }
 
+// ProfileProperty
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type ProfileProperty struct {
 	Value PropertyValue `bson:"value"`
 	Units Units         `bson:"units"`
 }
 
+// DeviceResource
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type DeviceResource struct {
 	Description string            `bson:"description"`
 	Name        string            `bson:"name"`
@@ -63,6 +75,9 @@ type DeviceResource struct {
 	Attributes  map[string]string `bson:"attributes"`
 }
 
+// ResourceOperation
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type ResourceOperation struct {
 	Index          string            `bson:"index"`
 	Operation      string            `bson:"operation"`
@@ -75,12 +90,18 @@ type ResourceOperation struct {
 	Mappings       map[string]string `bson:"mappings"`
 }
 
+// ProfileResource
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type ProfileResource struct {
 	Name string              `bson:"name"`
 	Get  []ResourceOperation `bson:"get"`
 	Set  []ResourceOperation `bson:"set"`
 }
 
+// Addressable
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type DeviceProfile struct {
 	Created         int64             `bson:"created"`
 	Modified        int64             `bson:"modified"`

--- a/internal/pkg/db/mongo/models/devicereport.go
+++ b/internal/pkg/db/mongo/models/devicereport.go
@@ -20,6 +20,9 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
+// DeviceReport
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type DeviceReport struct {
 	Created  int64         `bson:"created"`
 	Modified int64         `bson:"modified"`

--- a/internal/pkg/db/mongo/models/deviceservice.go
+++ b/internal/pkg/db/mongo/models/deviceservice.go
@@ -26,6 +26,9 @@ type deviceServiceTransform interface {
 	DeviceServiceToDBRef(model DeviceService) (dbRef mgo.DBRef, err error)
 }
 
+// DeviceService
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type DeviceService struct {
 	Created        int64                   `bson:"created"`
 	Modified       int64                   `bson:"modified"`

--- a/internal/pkg/db/mongo/models/event.go
+++ b/internal/pkg/db/mongo/models/event.go
@@ -23,6 +23,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Event
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Event struct {
 	Created  int64         `bson:"created"`
 	Modified int64         `bson:"modified"`

--- a/internal/pkg/db/mongo/models/interval.go
+++ b/internal/pkg/db/mongo/models/interval.go
@@ -20,6 +20,9 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
+// Interval
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Interval struct {
 	Created   int64         `bson:"created"`
 	Modified  int64         `bson:"modified"`

--- a/internal/pkg/db/mongo/models/interval_action.go
+++ b/internal/pkg/db/mongo/models/interval_action.go
@@ -6,6 +6,9 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
+// IntervalAction
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type IntervalAction struct {
 	Created    int64         `bson:"created"`
 	Modified   int64         `bson:"modified"`

--- a/internal/pkg/db/mongo/models/notification.go
+++ b/internal/pkg/db/mongo/models/notification.go
@@ -21,6 +21,9 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
+// Notification
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Notification struct {
 	Created     int64                          `bson:"created"`
 	Modified    int64                          `bson:"modified"`

--- a/internal/pkg/db/mongo/models/provisionwatcher.go
+++ b/internal/pkg/db/mongo/models/provisionwatcher.go
@@ -21,6 +21,9 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
+// ProvisionWatcher
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type ProvisionWatcher struct {
 	Created             int64                   `bson:"created"`
 	Modified            int64                   `bson:"modified"`

--- a/internal/pkg/db/mongo/models/reading.go
+++ b/internal/pkg/db/mongo/models/reading.go
@@ -25,6 +25,9 @@ type readingTransform interface {
 	ReadingToDBRef(a Reading) (dbRef mgo.DBRef, err error)
 }
 
+// Reading
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Reading struct {
 	Created       int64         `bson:"created"`
 	Modified      int64         `bson:"modified"`

--- a/internal/pkg/db/mongo/models/subscription.go
+++ b/internal/pkg/db/mongo/models/subscription.go
@@ -22,12 +22,9 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
-/*
- * A subscription for notification alerts
- *
- *
- * Subscription struct
- */
+// Subscription
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Subscription struct {
 	Created              int64                            `bson:"created"`
 	Modified             int64                            `bson:"modified"`

--- a/internal/pkg/db/mongo/models/transmission.go
+++ b/internal/pkg/db/mongo/models/transmission.go
@@ -27,6 +27,9 @@ type TransmissionRecord struct {
 	Sent     int64                       `bson:"sent"`
 }
 
+// Transmission
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type Transmission struct {
 	Created      int64                       `bson:"created"`
 	Modified     int64                       `bson:"modified"`

--- a/internal/pkg/db/mongo/models/value_descriptor.go
+++ b/internal/pkg/db/mongo/models/value_descriptor.go
@@ -19,6 +19,9 @@ import (
 	"github.com/globalsign/mgo/bson"
 )
 
+// ValueDescriptor
+//
+// Deprecated: Mongo functionality is deprecated as of the Geneva release.
 type ValueDescriptor struct {
 	Id            bson.ObjectId `bson:"_id,omitempty"`
 	Uuid          string        `bson:"uuid"`


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Mongo functionality is not marked as deprecated.

Issue Number: #2478


## What is the new behavior?
Mongo functionaltiy is marked as deprecated in GoDocs according to the Go standard for deprecating code. This will aid in persuading future developers from using or updating the code which is expected to be removed. Also we can leverage a linter to identify any deprecated code to aid in removing the code in the future.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information

Along with updated or added GoDoc comments, I updated a few example references to Mongo. Those are examples in the OpenAPI spec and have no impact on functionality.