### PR TITLE
Update version of go-mod-messaging

### DIFF
--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/core-data/Attribution.txt
+++ b/cmd/core-data/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/security-file-token-provider/Attribution.txt
+++ b/cmd/security-file-token-provider/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/security-proxy-setup/Attribution.txt
+++ b/cmd/security-proxy-setup/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/security-secrets-setup/Attribution.txt
+++ b/cmd/security-secrets-setup/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/security-secretstore-setup/Attribution.txt
+++ b/cmd/security-secretstore-setup/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/cmd/sys-mgmt-executor/Attribution.txt
+++ b/cmd/sys-mgmt-executor/Attribution.txt
@@ -87,6 +87,10 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
 gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
 https://github.com/gomodule/redigo/blob/master/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.30
 	github.com/edgexfoundry/go-mod-configuration v0.0.3
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.57
-	github.com/edgexfoundry/go-mod-messaging v0.1.16
+	github.com/edgexfoundry/go-mod-messaging v0.1.19
 	github.com/edgexfoundry/go-mod-registry v0.1.17
 	github.com/edgexfoundry/go-mod-secrets v0.0.17
 	github.com/fxamacker/cbor/v2 v2.2.0


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

Update go-mod-messaging version to allow the usage of the RedisStreams functionality. This is an opt in feature and not a default. 

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

EdgeX Go is using an older version of go-mod-messaging which does not have RedisStreams functionality

Issue Number: #2508


## What is the new behavior?
Using a newer version which provides RedisStreams functionality 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information
A new issue was created to consolidate the Redis libraries used to just one across EdgeX. See #2509 for more details.