### PR TITLE
Remove extra docker image tags that become malformed in the push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,6 @@ docker_core_metadata:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-core-metadata-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-core-metadata-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-core-metadata-go:$(DOCKER_TAG) \
 		.
 
 docker_core_data:
@@ -111,7 +110,6 @@ docker_core_data:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-core-data-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-core-data-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-core-data-go:$(DOCKER_TAG) \
 		.
 
 docker_core_command:
@@ -122,7 +120,6 @@ docker_core_command:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-core-command-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-core-command-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-core-command-go:$(DOCKER_TAG) \
 		.
 
 docker_support_logging:
@@ -133,7 +130,6 @@ docker_support_logging:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-support-logging-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-support-logging-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-support-logging-go:$(DOCKER_TAG) \
 		.
 
 docker_support_notifications:
@@ -144,7 +140,6 @@ docker_support_notifications:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-support-notifications-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-support-notifications-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-support-notifications-go:$(DOCKER_TAG) \
 		.
 
 docker_support_scheduler:
@@ -155,7 +150,6 @@ docker_support_scheduler:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-support-scheduler-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-support-scheduler-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-support-scheduler-go:$(DOCKER_TAG) \
 		.
 
 docker_sys_mgmt_agent:
@@ -166,7 +160,6 @@ docker_sys_mgmt_agent:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-sys-mgmt-agent-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-sys-mgmt-agent-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:$(DOCKER_TAG) \
 		.
 
 docker_security_secrets_setup:
@@ -177,7 +170,6 @@ docker_security_secrets_setup:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-edgex-secrets-setup-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-edgex-secrets-setup-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-edgex-secrets-setup-go:$(DOCKER_TAG) \
 		.
 
 docker_security_proxy_setup:
@@ -188,7 +180,6 @@ docker_security_proxy_setup:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-edgex-security-proxy-setup-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-edgex-security-proxy-setup-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:$(DOCKER_TAG) \
 		.
 
 docker_security_secretstore_setup:
@@ -199,7 +190,6 @@ docker_security_secretstore_setup:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-edgex-security-secretstore-setup-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-edgex-security-secretstore-setup-go:$(DOCKER_TAG) \
-		-t nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:$(DOCKER_TAG) \
 		.
 
 raml_verify:


### PR DESCRIPTION
Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [X] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Current build on Jenkins errors out because of these extra images. This happens after pushing the images that aren't malformed.

![image](https://user-images.githubusercontent.com/7851712/80047508-76361880-84c2-11ea-953a-c24f7540c36f.png)

https://jenkins.edgexfoundry.org/blue/organizations/jenkins/edgexfoundry%2Fedgex-go/detail/master/62/pipeline

Issue Number: N/A


## What is the new behavior?

This is reverting a change that caused this behavior. The nexus repository is filled in on push so there is no reason to build the extra images and cause errors. See:

https://github.com/edgexfoundry/ci-management/blob/master/shell/edgexfoundry-go-docker-push.sh#L32-L52## 

Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information