### PR TITLE
Fix update intervalAction when changing paramater interval or path

### DIFF
--- a/internal/support/scheduler/interval.go
+++ b/internal/support/scheduler/interval.go
@@ -75,13 +75,6 @@ func addNewInterval(interval contract.Interval) (string, error) {
 		return "", err
 	}
 
-	// Push the new interval into scheduler queue
-	interval.ID = ID
-	err = scClient.AddIntervalToQueue(interval)
-	if err != nil {
-		//failed to add to scheduler queue
-		LoggingClient.Error(err.Error())
-	}
 	return ID, nil
 }
 

--- a/internal/support/scheduler/interval_action.go
+++ b/internal/support/scheduler/interval_action.go
@@ -161,6 +161,12 @@ func updateIntervalAction(from contract.IntervalAction) error {
 		to.Parameters = params
 	}
 
+	// Path
+	path := from.Path
+	if path != to.Path {
+		to.Path = path
+	}
+
 	// Validate the IntervalAction does not exist in the scheduler queue
 	_, err = scClient.QueryIntervalActionByName(to.Name)
 	if err == nil {

--- a/internal/support/scheduler/loader.go
+++ b/internal/support/scheduler/loader.go
@@ -176,21 +176,10 @@ func loadConfigIntervals() error {
 
 		if errExistingSchedule != nil {
 			// add the interval support-scheduler
-			newIntervalID, errAddedInterval := addIntervalToSchedulerDB(interval)
+			_, errAddedInterval := addIntervalToSchedulerDB(interval)
 			if errAddedInterval != nil {
 				LoggingClient.Error("problem adding interval to the scheduler database:" + errAddedInterval.Error())
 				return errAddedInterval
-			}
-
-			// add the support-scheduler scheduler.id
-			interval.ID = newIntervalID
-
-			// add the interval to the scheduler
-			err := scClient.AddIntervalToQueue(interval)
-
-			if err != nil {
-				LoggingClient.Error("problem loading interval from the scheduler config: " + err.Error())
-				return err
 			}
 		} else {
 			LoggingClient.Debug("did not add interval as it already exists in the scheduler database", "name", interval.Name)
@@ -249,19 +238,6 @@ func loadConfigIntervalActions() error {
 
 // Query support-scheduler database information
 func loadSupportSchedulerDBInformation() error {
-
-	receivedIntervals, err := getSchedulerDBIntervals()
-	if err != nil {
-		LoggingClient.Error("failed to receive intervals from support-scheduler database:" + err.Error())
-		return err
-	}
-
-	err = addReceivedIntervals(receivedIntervals)
-	if err != nil {
-		LoggingClient.Error("failed to add received intervals from support-scheduler database:" + err.Error())
-		return err
-	}
-
 	intervalActions, err := getSchedulerDBIntervalActions()
 	if err != nil {
 		LoggingClient.Error("failed to receive interval actions from support-scheduler database:" + err.Error())

--- a/internal/support/scheduler/loader.go
+++ b/internal/support/scheduler/loader.go
@@ -171,10 +171,10 @@ func loadConfigIntervals() error {
 			RunOnce:    intervals[i].RunOnce,
 		}
 
-		// query scheduler service for interval in memory queue
-		_, errExistingSchedule := scClient.QueryIntervalByName(interval.Name)
+		// query interval in db
+		_, errExistInterval := dbClient.IntervalByName(interval.Name)
 
-		if errExistingSchedule != nil {
+		if errExistInterval != nil {
 			// add the interval support-scheduler
 			_, errAddedInterval := addIntervalToSchedulerDB(interval)
 			if errAddedInterval != nil {
@@ -207,10 +207,10 @@ func loadConfigIntervalActions() error {
 			Address:    intervalActions[ia].Host,
 		}
 
-		// query scheduler in memory queue and determine of intervalAction exists
-		_, err := scClient.QueryIntervalActionByName(intervalAction.Name)
+		// query IntervalAction in db
+		_, errExistIntervalAction := dbClient.IntervalActionByName(intervalAction.Name)
 
-		if err != nil {
+		if errExistIntervalAction != nil {
 
 			// add the interval action to support-scheduler database
 			newIntervalActionID, err := addIntervalActionToSchedulerDB(intervalAction)

--- a/internal/support/scheduler/rest_interval.go
+++ b/internal/support/scheduler/rest_interval.go
@@ -169,6 +169,8 @@ func restDeleteIntervalByID(w http.ResponseWriter, r *http.Request) {
 		switch err.(type) {
 		case errors.ErrIntervalNotFound:
 			http.Error(w, err.Error(), http.StatusNotFound)
+		case errors.ErrIntervalStillUsedByIntervalActions:
+			http.Error(w, err.Error(), http.StatusConflict)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

    1. when updating intervalAction with the paramater interval changed, support-scheduler failed to delete the intervalAction from the old interval queue but added a new one to the new interval queue.
    2. interval should not be added to scheduler queue when itself is added, but when the first intervalAction using it is added.
    3. parameter path should also be updated when updating intervalAction.

Issue Number:


## What is the new behavior?
    1. update intervalAction with parameter interval changed now works fine.
    2. intervals not used by any intervalActions will not be added to scheduler queue.
    3. update intervalAction with parameter path changed now works fine.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information