### PR TITLE
Check EDGEX_SECURITY_SECRET_STORE before sending Redis password

### DIFF
--- a/internal/pkg/db/redis/client.go
+++ b/internal/pkg/db/redis/client.go
@@ -16,6 +16,7 @@ package redis
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -63,8 +64,10 @@ func NewClient(config db.Configuration, lc logger.LoggingClient) (*Client, error
 	once.Do(func() {
 		connectionString := fmt.Sprintf("%s:%d", config.Host, config.Port)
 		opts := []redis.DialOption{
-			redis.DialPassword(config.Password),
 			redis.DialConnectTimeout(time.Duration(config.Timeout) * time.Millisecond),
+		}
+		if os.Getenv("EDGEX_SECURITY_SECRET_STORE") != "false" {
+			opts = append(opts, redis.DialPassword(config.Password))
 		}
 
 		dialFunc := func() (redis.Conn, error) {


### PR DESCRIPTION
Signed-off-by: André Srinivasan <andre@redislabs.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The Redis client is not honoring `EDGEX_SECURITY_SECRET_STORE` and attempting to authenticate to the database even if security is disabled.

Issue Number: #2516 


## What is the new behavior?
Don't attempt to authenticate if `EDGEX_SECURITY_SECRET_STORE == false`


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information