### PR TITLE
Remove old password file

### DIFF
--- a/cmd/security-secrets-setup/entrypoint.sh
+++ b/cmd/security-secrets-setup/entrypoint.sh
@@ -33,6 +33,12 @@ export XDG_RUNTIME_DIR PATH VAULT_TLS_PATH
 echo XDG_RUNTIME_DIR $XDG_RUNTIME_DIR
 echo BASE_DIR $BASE_DIR
 
+# Cleanup old password file. Remove this for Hanoi.
+if [ -n "${REDIS5_PASSWORD_PATHNAME}" ] && [ -f "${REDIS5_PASSWORD_PATHNAME}" ]; then
+    echo Removing old Redis5 password file
+    rm -f "${REDIS5_PASSWORD_PATHNAME}"
+fi
+
 # if running security-secrets-setup subcommand
 # build full command line into positional args
 if [ "$1" = 'generate' -o "$1" = 'cache' -o "$1" = 'import' -o "$1" = 'legacy' ]; then


### PR DESCRIPTION
Signed-off-by: André Srinivasan <andre@redislabs.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #2542 


## What is the new behavior?

Old Redis password file is removed when secrets are initialized

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

This is dependent on [developer-scripts #274](https://github.com/edgexfoundry/developer-scripts/pull/274)

## Other information