### PR TITLE
fix: Add Redis connection test during client creation so error will trigger retry

### DIFF
--- a/internal/pkg/db/redis/client.go
+++ b/internal/pkg/db/redis/client.go
@@ -101,6 +101,12 @@ func NewClient(config db.Configuration, lc logger.LoggingClient) (*Client, error
 			loggingClient: lc,
 		}
 	})
+
+	// Test connectivity now so don't have failures later when doing lazy connect.
+	if _, err := currClient.Pool.Dial(); err != nil {
+		return nil, err
+	}
+
 	return currClient, nil
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Redis lazy connection cause unrecoverable error since occur outside bootstrap retry loop

Issue Number:  #2545


## What is the new behavior?

Test Redis connection during bootstrap so failures trigger retry

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information