### PR TITLE
snap: update security-secrets-setup config

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -74,9 +74,8 @@ for svc in kong vault; do
     CONFIG_FILE_PATH="config/security-secrets-setup/res/pkisetup-$svc.json"
     if [ ! -f "$SNAP_DATA/$CONFIG_FILE_PATH" ]; then
         # replace the hostname with localhost using jq
-        jq --arg WORKDIR "$SNAP_DATA_CURRENT" \
-            '.x509_tls_server_parameters.tls_host = "localhost" | .pki_setup_dir = "pki" | .working_dir  = $WORKDIR' \
-            "$SNAP/$CONFIG_FILE_PATH" > "$SNAP_DATA/$CONFIG_FILE_PATH.tmp"
+        jq '.x509_tls_server_parameters.tls_host = "localhost"' \
+           "$SNAP/$CONFIG_FILE_PATH" > "$SNAP_DATA/$CONFIG_FILE_PATH.tmp"
         mv "$SNAP_DATA/$CONFIG_FILE_PATH.tmp" "$SNAP_DATA/$CONFIG_FILE_PATH"
         chmod 600 "$SNAP_DATA/$CONFIG_FILE_PATH"
     fi
@@ -92,8 +91,8 @@ mkdir -p "$SNAP_DATA/consul/config"
 # ensure mongodb data dirs exist
 mkdir -p "$SNAP_DATA/mongo/db"
 
-# ensure vault pki directory exists
-mkdir -p "$SNAP_DATA/vault/pki"
+# ensure secrets dir exists
+mkdir -p "$SNAP_DATA/secrets"
 
 # touch all the kong log files to ensure they exist
 mkdir -p "$SNAP_COMMON/logs"

--- a/snap/local/runtime-helpers/config/security-secret-store/vault-config.hcl.in
+++ b/snap/local/runtime-helpers/config/security-secret-store/vault-config.hcl.in
@@ -12,9 +12,9 @@ listener "tcp" {
   tls_disable = "0" 
   cluster_address = "localhost:8201"
   tls_min_version = "tls12"
-  tls_client_ca_file ="$SNAP_DATA/pki/EdgeXFoundryCA/EdgeXFoundryTrustCA.pem"
-  tls_cert_file ="$SNAP_DATA/pki/EdgeXFoundryCA/localhost.pem"
-  tls_key_file = "$SNAP_DATA/pki/EdgeXFoundryCA/localhost.priv.key"
+  tls_client_ca_file ="$SNAP_DATA/secrets/ca/ca.pem"
+  tls_cert_file ="$SNAP_DATA/secrets/edgex-vault/server.crt"
+  tls_key_file = "$SNAP_DATA/secrets/edgex-vault/server.key"
 }
 
 backend "consul" {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,7 @@ confinement: strict
 
 # This applies to all apps
 environment:
-  SecretStore_RootCaCertPath: $SNAP_DATA/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem
+  SecretStore_RootCaCertPath: $SNAP_DATA/secrets/ca/ca.pem
 apps:
   # edgex microservices
   consul:
@@ -137,7 +137,7 @@ apps:
     command: bin/security-secrets-setup -confdir $SNAP_DATA/config/security-secrets-setup/res generate
     daemon: oneshot
     environment:
-      SecretsSetup_DeployDir: $SNAP_DATA/pki/
+      SecretsSetup_DeployDir: $SNAP_DATA/secrets/
       SecretsSetup_CertConfigDir: $SNAP_DATA/config/security-secrets-setup/res
       XDG_RUNTIME_DIR: /tmp
     start-timeout: 15m
@@ -171,9 +171,9 @@ apps:
     environment:
       SecretService_Server: localhost
       SecretService_ServerName: localhost
-      SecretService_CaFilePath: $SNAP_DATA/pki/ca/ca.pem
-      SecretService_CertFilePath: $SNAP_DATA/pki/EdgeXFoundryCA/localhost.pem
-      SecretService_KeyFilePath: $SNAP_DATA/pki/EdgeXFoundryCA/localhost.priv.key
+      SecretService_CaFilePath: $SNAP_DATA/secrets/ca/ca.pem
+      SecretService_CertFilePath: $SNAP_DATA/secrets/edgex-kong/server.crt
+      SecretService_KeyFilePath: $SNAP_DATA/secrets/edgex-kong/server.key
       SecretService_TokenFolderPath: $SNAP_DATA/config/security-secrets-setup/res
       SecretService_TokenProvider: $SNAP/bin/security-file-token-provider
       SecretService_TokenProviderArgs: "-confdir, $SNAP_DATA/config/security-file-token-provider/res"
@@ -197,7 +197,7 @@ apps:
     environment:
       INIT_ARG: "--init=true"
       SecretService_TokenPath: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
-      SecretService_CACertPath: $SNAP_DATA/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem
+      SecretService_CACertPath: $SNAP_DATA/secrets/ca/ca.pem
     daemon: oneshot
     start-timeout: 15m
     plugs: [network]
@@ -347,7 +347,7 @@ apps:
     command: bin/security-proxy-setup
     environment:
       SecretService_TokenPath: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
-      SecretService_CACertPath: $SNAP_DATA/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem
+      SecretService_CACertPath: $SNAP_DATA/secrets/ca/ca.pem
     plugs: [home, removable-media, network]
   redis-cli:
     adapter: full
@@ -713,7 +713,7 @@ parts:
 
       cat "./cmd/res/configuration.toml" | \
         sed -e "s@TokenFile = \"/vault/config/assets/resp-init.json\"@TokenFile = \"\$SNAP_DATA/secrets/edgex-mongo/secrets-token.json\"@" \
-            -e "s@RootCaCertPath = \"/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem\"@RootCaCertPath = \"\$SNAP_DATA/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem\"@" \
+            -e "s@RootCaCertPath = \"/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem\"@RootCaCertPath = \"\$SNAP_DATA/secrets/ca/ca.pem\"@" \
             > \
        "$SNAPCRAFT_PART_INSTALL/config/edgex-mongo/res/configuration.toml"
 
@@ -740,7 +740,7 @@ parts:
               # configuration file at build time
               CONFIG_FILE="./cmd/$service/res/configuration.toml"
               if grep -q "/tmp/edgex" "$CONFIG_FILE"; then
-                  sed -e "s@\"/tmp/edgex/secrets/ca/ca.pem\"@\"\$SNAP_DATA/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem\"@" \
+                  sed -e "s@\"/tmp/edgex/secrets/ca/ca.pem\"@\"\$SNAP_DATA/secrets/ca/ca.pem\"@" \
                       -e "s@\"/tmp/edgex/secrets/edgex-redis/secrets-token.json\"@\"\$SNAP_DATA/secrets/edgex-redis/secrets-token.json\"@" \
                       -e "s@\"/tmp/edgex/secrets/edgex-redis/redis5-password\"@\"\$SNAP_DATA/secrets/edgex-redis/redis5-password\"@" \
                       -e "s@edgex-vault@localhost@" \


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #2547 

Also see related issue: #2495 

## What is the new behavior?
The new behavior is that PKI setup (aka security-secrets-setup) in the snap is now aligned with the docker deployment of Geneva, and the intermediate files in `$SNAP_DATA/pki/EdgeXFoundryCA` are no longer present.  See the issue for more details.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Testing Instructions

- [ ] Test that the snap builds and installs successfully
- [ ] Test that the expected certificates are generated inside $SNAP_DATA/secrets

```
$ export SNAP_DATA=/var/snap/edgexfoundry/current
espy@sumo$ sudo tree $SNAP_DATA/secrets/ -P "*.pem|*.crt|*.key" --prune
/var/snap/edgexfoundry/current/secrets/
├── ca
│   └── ca.pem
├── edgex-kong
│   ├── ca.pem
│   ├── server.crt
│   └── server.key
└── edgex-vault
    ├── ca.pem
    ├── server.crt
    └── server.key

3 directories, 7 files
```

Specifically, **ca.pem** (the root CA) and the TLS certificates (**server.crt**) and keys (**server.key**) for kong and vault.

- [x] Test that one can use the certificate from `$SNAP_DATA/secrets/ca/ca.pem` to connect with TLS host verification on with Vault and Kong

verify the curl generates a self-signed certificate error:
```
$ curl https://localhost:8443/
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

copy the CA to a user-readable area:
```
$ sudo cat /var/snap/edgexfoundry/current/secrets/ca/ca.pem > ca.pem
```

Kong uses a cert signed by the CA (on port 8443):
```
$ curl --cacert ca.pem https://localhost:8443; echo
{"message":"no Route matched with those values"}
``` 
Kong uses the specific cert from the edgex-kong folder (note you need `-servername` here to set the Host header and thus have Kong respond with the right cert, it can use different certs for different Host/SNIs settings):
```
$ sudo cat /var/snap/edgexfoundry/current/secrets/edgex-kong/server.crt > expected-kong.crt
$ openssl s_client -connect localhost:8443 -servername localhost 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > kong.crt
$ diff -u kong.crt expected-kong.crt
```

Vault uses a cert signed by the CA (on port 8200):
```
$ curl --cacert ca.pem https://localhost:8200; echo 
<a href="/ui/">Temporary Redirect</a>.


```

Vault uses the specific cert from edgex-vault folder:
```
$ openssl s_client -connect localhost:8200 -servername localhost 2>/dev/null </dev/null |  sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > vault.pem
$ sudo cat /var/snap/edgexfoundry/current/secrets/edgex-vault/server.crt > expected-vault.crt
$ diff -u vault.crt expected-vault.crt
```

- [ ] Test using an authentication token to access a core-* REST API thru Kong

```
$ curl --cacert ca.pem https://localhost:8443/command/api/v1/ping
{"message":"Unauthorized"}$
```
generate an auth token:

```
$ sudo edgexfoundry.security-proxy-setup-cmd --confdir $SNAP_DATA/config/security-proxy-setup/res/ --useradd=me --group=admin | grep "access token"
the access token for user me is: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ2Mmo3R3dzME1sd2ZnQ1F0bnhTMDR5N2NtSG5QZlgwVyIsImFjY291bnQiOiJtT1VaRVkifQ.4SjMGPYDMYF1KZEcuDyJtp-8G-O6bSd3030RyIxGNlU. Please keep the token for accessing edgex services
```
Note - your token will be different.

```
$ TOKEN=<cut & paste token from previous step>
$ curl --cacert ca.pem --header "Authorization: Bearer $TOKEN" \
https://localhost:8443/command/api/v1/ping
pong$
```


