### PR TITLE
Fix Reading Redis Binary Payload Persistence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.31
 	github.com/edgexfoundry/go-mod-configuration v0.0.3
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.57
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.58
 	github.com/edgexfoundry/go-mod-messaging v0.1.19
 	github.com/edgexfoundry/go-mod-registry v0.1.17
 	github.com/edgexfoundry/go-mod-secrets v0.0.17

--- a/internal/core/data/interfaces/db.go
+++ b/internal/core/data/interfaces/db.go
@@ -23,6 +23,8 @@ type DBClient interface {
 	CloseSession()
 
 	// ********************** EVENT FUNCTIONS *******************************
+	// NOTE: Readings that contain binary data will not be persisted.
+
 	// Return all the events
 	// UnexpectedError - failed to retrieve events from the database
 	Events() ([]contract.Event, error)
@@ -101,6 +103,8 @@ type DBClient interface {
 	ScrubAllEvents() error
 
 	// ********************* READING FUNCTIONS *************************
+	// NOTE: Readings that contain binary data will not be persisted.
+
 	// Return a list of readings sorted by reading id
 	Readings() ([]contract.Reading, error)
 

--- a/internal/pkg/db/interfaces/db.go
+++ b/internal/pkg/db/interfaces/db.go
@@ -16,12 +16,17 @@ package interfaces
 
 import (
 	correlation "github.com/edgexfoundry/edgex-go/internal/pkg/correlation/models"
+
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 type DBClient interface {
 	CloseSession()
 
+	/*
+		Events
+		NOTE: Readings that contain binary data will not be persisted.
+	*/
 	Events() ([]contract.Event, error)
 	EventsWithLimit(limit int) ([]contract.Event, error)
 	AddEvent(e correlation.Event) (string, error)
@@ -39,6 +44,10 @@ type DBClient interface {
 	EventsPushed() ([]contract.Event, error)
 	ScrubAllEvents() error
 
+	/*
+		Readings
+		NOTE: Readings that contain binary data will not be persisted.
+	*/
 	Readings() ([]contract.Reading, error)
 	AddReading(r contract.Reading) (string, error)
 	UpdateReading(r contract.Reading) error
@@ -52,6 +61,9 @@ type DBClient interface {
 	ReadingsByCreationTime(start, end int64, limit int) ([]contract.Reading, error)
 	ReadingsByDeviceAndValueDescriptor(deviceId, valueDescriptor string, limit int) ([]contract.Reading, error)
 
+	/*
+		ValueDescriptors
+	*/
 	ValueDescriptors() ([]contract.ValueDescriptor, error)
 	AddValueDescriptor(v contract.ValueDescriptor) (string, error)
 	UpdateValueDescriptor(cvd contract.ValueDescriptor) error
@@ -64,6 +76,9 @@ type DBClient interface {
 	ValueDescriptorsByType(t string) ([]contract.ValueDescriptor, error)
 	ScrubAllValueDescriptors() error
 
+	/*
+		Device Reports
+	*/
 	GetAllDeviceReports() ([]contract.DeviceReport, error)
 	GetDeviceReportByName(n string) (contract.DeviceReport, error)
 	GetDeviceReportByDeviceName(n string) ([]contract.DeviceReport, error)
@@ -73,6 +88,9 @@ type DBClient interface {
 	UpdateDeviceReport(dr contract.DeviceReport) error
 	DeleteDeviceReportById(id string) error
 
+	/*
+		Devices
+	*/
 	GetAllDevices() ([]contract.Device, error)
 	AddDevice(d contract.Device, commands []contract.Command) (string, error)
 	UpdateDevice(d contract.Device) error
@@ -83,6 +101,9 @@ type DBClient interface {
 	GetDevicesByServiceId(id string) ([]contract.Device, error)
 	GetDevicesWithLabel(l string) ([]contract.Device, error)
 
+	/*
+		Device Profiles
+	*/
 	GetAllDeviceProfiles() ([]contract.DeviceProfile, error)
 	GetDeviceProfileById(id string) (contract.DeviceProfile, error)
 	GetDeviceProfilesByModel(model string) ([]contract.DeviceProfile, error)
@@ -94,6 +115,9 @@ type DBClient interface {
 	UpdateDeviceProfile(dp contract.DeviceProfile) error
 	DeleteDeviceProfileById(id string) error
 
+	/*
+		Addressables
+	*/
 	GetAddressables() ([]contract.Addressable, error)
 	UpdateAddressable(a contract.Addressable) error
 	GetAddressableById(id string) (contract.Addressable, error)
@@ -105,6 +129,9 @@ type DBClient interface {
 	GetAddressablesByAddress(add string) ([]contract.Addressable, error)
 	DeleteAddressableById(id string) error
 
+	/*
+		Device Services
+	*/
 	GetDeviceServiceByName(n string) (contract.DeviceService, error)
 	GetDeviceServiceById(id string) (contract.DeviceService, error)
 	GetAllDeviceServices() ([]contract.DeviceService, error)
@@ -114,6 +141,9 @@ type DBClient interface {
 	UpdateDeviceService(ds contract.DeviceService) error
 	DeleteDeviceServiceById(id string) error
 
+	/*
+		Provision Watchers
+	*/
 	GetAllProvisionWatchers() (pw []contract.ProvisionWatcher, err error)
 	GetProvisionWatcherByName(n string) (pw contract.ProvisionWatcher, err error)
 	GetProvisionWatchersByIdentifier(k string, v string) (pw []contract.ProvisionWatcher, err error)
@@ -124,6 +154,9 @@ type DBClient interface {
 	UpdateProvisionWatcher(pw contract.ProvisionWatcher) error
 	DeleteProvisionWatcherById(id string) error
 
+	/*
+		Commands
+	*/
 	GetAllCommands() ([]contract.Command, error)
 	GetCommandById(id string) (contract.Command, error)
 	GetCommandsByName(n string) ([]contract.Command, error)
@@ -132,6 +165,9 @@ type DBClient interface {
 
 	ScrubMetadata() error
 
+	/*
+		Notifications
+	*/
 	GetNotifications() ([]contract.Notification, error)
 	GetNotificationById(id string) (contract.Notification, error)
 	GetNotificationBySlug(slug string) (contract.Notification, error)
@@ -149,6 +185,9 @@ type DBClient interface {
 	DeleteNotificationBySlug(slug string) error
 	DeleteNotificationsOld(age int) error
 
+	/*
+		Subscriptions
+	*/
 	GetSubscriptionBySlug(slug string) (contract.Subscription, error)
 	GetSubscriptionByCategories(categories []string) ([]contract.Subscription, error)
 	GetSubscriptionByLabels(labels []string) ([]contract.Subscription, error)
@@ -161,6 +200,9 @@ type DBClient interface {
 	DeleteSubscriptionBySlug(slug string) error
 	GetSubscriptions() ([]contract.Subscription, error)
 
+	/*
+		Transmissions
+	*/
 	AddTransmission(t contract.Transmission) (string, error)
 	UpdateTransmission(t contract.Transmission) error
 	DeleteTransmission(age int64, status contract.TransmissionStatus) error
@@ -175,6 +217,9 @@ type DBClient interface {
 	Cleanup() error
 	CleanupOld(age int) error
 
+	/*
+		Intervals
+	*/
 	Intervals() ([]contract.Interval, error)
 	IntervalsWithLimit(limit int) ([]contract.Interval, error)
 	IntervalByName(name string) (contract.Interval, error)
@@ -183,6 +228,9 @@ type DBClient interface {
 	UpdateInterval(interval contract.Interval) error
 	DeleteIntervalById(id string) error
 
+	/*
+		Interval Actions
+	*/
 	IntervalActions() ([]contract.IntervalAction, error)
 	IntervalActionsWithLimit(limit int) ([]contract.IntervalAction, error)
 	IntervalActionsByIntervalName(name string) ([]contract.IntervalAction, error)

--- a/internal/pkg/db/redis/client.go
+++ b/internal/pkg/db/redis/client.go
@@ -117,9 +117,7 @@ func (c *Client) Connect() error {
 
 // CloseSession closes the connections to Redis
 func (c *Client) CloseSession() {
-	c.Pool.Close()
-	close(deleteEventsChannel)
-	close(deleteReadingsChannel)
+	_ = c.Pool.Close()
 	currClient = nil
 	once = sync.Once{}
 }

--- a/internal/pkg/db/redis/data.go
+++ b/internal/pkg/db/redis/data.go
@@ -27,6 +27,8 @@ import (
 	"github.com/imdario/mergo"
 )
 
+var emptyBinaryValue = make([]byte, 0)
+
 // deleteReadingsChannel channel used to delete readings asynchronously
 var deleteReadingsChannel = make(chan string, 50)
 var deleteEventsChannel = make(chan string, 50)
@@ -1186,6 +1188,10 @@ func checksumByEventID(conn redis.Conn, id string) (string, error) {
 
 // Add a reading to the database
 func addReading(conn redis.Conn, tx bool, r contract.Reading) (id string, err error) {
+	// Clear the binary data since we do not want to persist binary data to save on memory.
+	// This is an explicit architectural decision.
+	r.BinaryValue = emptyBinaryValue
+
 	if r.Created == 0 {
 		r.Created = db.MakeTimestamp()
 	}

--- a/internal/pkg/db/test/db_metadata.go
+++ b/internal/pkg/db/test/db_metadata.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/errors"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
 	dataBase "github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetadataDB(t *testing.T, db interfaces.DBClient) {
@@ -537,13 +539,8 @@ func testDBCommand(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Name does not match %s - %s", command.Name, cn)
 	}
 
-	commands, err = db.GetCommandsByDeviceId(uuid.New().String())
-	if err != nil {
-		t.Fatalf("Error getting commands by device id %v", err)
-	}
-	if len(commands) != 0 {
-		t.Fatalf("There should be 0 commands instead of %d", len(commands))
-	}
+	_, err = db.GetCommandsByDeviceId(uuid.New().String())
+	require.IsType(t, err, errors.ErrItemNotFound{})
 
 	err = db.DeleteDeviceById(did)
 	if err != nil {

--- a/internal/pkg/db/test/db_notifications.go
+++ b/internal/pkg/db/test/db_notifications.go
@@ -294,8 +294,7 @@ func testDBTransmission(t *testing.T, db interfaces.DBClient) {
 		t.Fatalf("Error populating db: %v\n", err)
 	}
 	afterTime := dbp.MakeTimestamp()
-
-	transmissions, err = db.GetTransmissionsByStartEnd(beforeTime, afterTime, resendCount)
+	transmissions, err = db.GetTransmissionsByStartEnd(beforeTime, afterTime, amount)
 	if err != nil {
 		t.Fatalf("Fail to get transmission by start time and end time, %v", err)
 	}
@@ -304,7 +303,7 @@ func testDBTransmission(t *testing.T, db interfaces.DBClient) {
 	}
 
 	// Test GetTransmissionsByStart
-	transmissions, err = db.GetTransmissionsByStart(beforeTime, resendCount)
+	transmissions, err = db.GetTransmissionsByStart(beforeTime, amount)
 	if err != nil {
 		t.Fatalf("Fail to get transmission by start time, %v", err)
 	}
@@ -313,7 +312,7 @@ func testDBTransmission(t *testing.T, db interfaces.DBClient) {
 	}
 
 	// Test GetTransmissionsByEnd
-	transmissions, err = db.GetTransmissionsByEnd(afterTime, resendCount)
+	transmissions, err = db.GetTransmissionsByEnd(afterTime, amount)
 	if err != nil {
 		t.Fatalf("Fail to get transmission by start time, %v", err)
 	}
@@ -395,7 +394,10 @@ func populateSubscription(db interfaces.DBClient, count int) error {
 
 func getTransmission(slug string, resendCount int) contract.Transmission {
 	t := contract.Transmission{}
-	t.Notification = contract.Notification{Slug: slug}
+	t.Notification = getNotification(slug, contract.New)
+	t.Channel = contract.Channel{
+		Type: contract.Email,
+	}
 	t.Receiver = "test-receiver"
 	t.Status = contract.Sent
 	t.ResendCount = resendCount


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The Redis implementation of the DBClient persists the `BinaryValue` data within a reading.
Issue Number: #2527 


## What is the new behavior?

1. The Redis implementation of the DBClient does not persists the `BinaryValue` data within a reading.

1. A integration test for Redis has been added to verify the changes

1. Existing integration tests have been fixed to compile and run correctly.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?
These changes are non-breaking because this was the original intent of the system which was implemented correctly for Mongo and overlooked for Redis

To verify, create a `Reading` with a `BinaryValue` and ensure:

1. Issuing a GET for the `Reading` results in a response with an empty `BinaryValue`
1. Use the Redis CLI to ensure the JSON does not contain a `BinaryValue` (Execute a `GET {Reading ID}`)
1. Repeat steps 1 and 2 with an Event that contains a Reading with a `BinaryValue`


Next , verify the event on the MessageBus has the `BinaryValue` populated. I found it easiest to do this with a break-point and inspect the contents in memory.

Finally, run the integration test with Redis running locally. From you CLI run:
```shell
$  go test ./... -tags redisIntegration -count=1    
```
That will run all the tests and ignore cached test results.

## Other information

I verified these changes using the verification steps mentioned above