### PR TITLE
feat: Add default MQTT optional MessageQueue values to enable env overrides

### DIFF
--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -55,6 +55,20 @@ Host = '*'
 Port = 5563
 Type = 'zero'
 Topic = 'events'
+[MessageQueue.Optional]
+    # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
+    # Client Identifiers
+    Username =""
+    Password =""
+    ClientId ="core-data"
+    # Connection information
+    Qos          =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+    KeepAlive    =  "10" # Seconds (must be 2 or greater)
+    Retained     = "false"
+    AutoReconnect  = "true"
+    ConnectTimeout = "5" # Seconds
+    # TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified
+    SkipCertVerify = "false"
 
 [SecretStore]
 Host = 'localhost'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Unable to use env overrides for the optional MQTT values

Issue Number: 2563

## What is the new behavior?
Now able to use env overrides for the optional MQTT values

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
