### PR TITLE
fix: accurately represent default port w/ EXPOSE in dockerfiles

### DIFF
--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -25,7 +25,6 @@ COPY go.mod .
 RUN go mod download
 
 COPY . .
-
 RUN make cmd/core-data/core-data
 
 #Next image - Copy built Go binary into new workspace
@@ -34,14 +33,16 @@ FROM alpine
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Dell, Cavium'
 
+ENV APP_PORT=48080
+#expose core data port
+EXPOSE $APP_PORT
+
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk --no-cache add zeromq
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-data/Attribution.txt /
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-data/core-data /
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/core-data/res/configuration.toml /res/configuration.toml
-
 ENTRYPOINT ["/core-data","-cp=consul.http://edgex-core-consul:8500","--registry","--confdir=/res"]

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -26,12 +26,13 @@ RUN go mod download
 COPY . .
 RUN make cmd/core-metadata/core-metadata
 
+#Next image - Copy built Go binary into new workspace
 FROM scratch
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Dell, Cavium'
 
-ENV APP_PORT=48082
+ENV APP_PORT=48081
 #expose meta data port
 EXPOSE $APP_PORT
 

--- a/cmd/support-logging/Dockerfile
+++ b/cmd/support-logging/Dockerfile
@@ -25,10 +25,15 @@ RUN go mod download
 COPY . .
 RUN make cmd/support-logging/support-logging
 
+#Next image - Copy built Go binary into new workspace
 FROM scratch
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Cavium'
+
+ENV APP_PORT=48061
+#expose support logging port
+EXPOSE $APP_PORT
 
 COPY --from=builder /bin/bash /bin/bash
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/support-logging/Attribution.txt /

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -30,6 +30,10 @@ FROM scratch
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Cavium'
 
+ENV APP_PORT=48060
+#expose support notifications port
+EXPOSE $APP_PORT
+
 COPY --from=builder /bin/sh /bin/sh
 COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
 COPY --from=builder /etc/ssl /etc/ssl

--- a/cmd/sys-mgmt-agent/Dockerfile
+++ b/cmd/sys-mgmt-agent/Dockerfile
@@ -37,6 +37,10 @@ RUN rm -rf /var/cache/apk/*
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2017-2019: Mainflux, Cavium, Dell'
 
+ENV APP_PORT=48090
+#expose system mgmt agent port
+EXPOSE $APP_PORT
+
 # Copy over the SMA executable bits.
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/sys-mgmt-agent/sys-mgmt-agent /
 COPY --from=builder /go/src/github.com/edgexfoundry/edgex-go/cmd/sys-mgmt-agent/res/configuration.toml /res/configuration.toml


### PR DESCRIPTION
closes #2572

Signed-off-by: Mike <michael.johanson@intel.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #2572 

## What is the new behavior?
Ports are accurately represented in Dockerfiles

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
