### PR TITLE
fix: Added setting the Reading ID in the Events collection.

### DIFF
--- a/internal/pkg/db/redis/data.go
+++ b/internal/pkg/db/redis/data.go
@@ -1081,8 +1081,11 @@ func addEvent(conn redis.Conn, e correlation.Event) (id string, err error) {
 		if err != nil {
 			return id, err
 		}
+
+		e.Readings[i].Id = id
 		rids[i*2+1] = 0
 		rids[i*2+2] = id
+
 	}
 	if len(rids) > 1 {
 		_ = conn.Send("ZADD", rids...)


### PR DESCRIPTION
 PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Reading IDs not set when Event is pushed onto the Message Bus

Issue Number: #2569

## What is the new behavior?

Reading IDs available when Event is pushed onto the Message Bus

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
