### PR TITLE
fix: Get deviceProfile by ID when updating the deviceProfile and valuedescriptor

### DIFF
--- a/internal/core/metadata/operators/device_profile/value_descriptor_test.go
+++ b/internal/core/metadata/operators/device_profile/value_descriptor_test.go
@@ -333,14 +333,14 @@ func createMockValueDescriptorClientError(addError, getError, updateError, delet
 
 func createMockDBClient() interfaces.DBClient {
 	mockDb := &mocks2.DBClient{}
-	mockDb.On("GetDeviceProfileByName", TestExistingDeviceProfile.Name).Return(TestExistingDeviceProfile, nil)
+	mockDb.On("GetDeviceProfileById", TestExistingDeviceProfile.Id).Return(TestExistingDeviceProfile, nil)
 	mockDb.On("GetDevicesByProfileId", TestExistingDeviceProfile.Id).Return([]contract.Device{}, nil)
 
 	return mockDb
 }
 func createMockDBClientDeviceProfileInUse() interfaces.DBClient {
 	mockDb := &mocks2.DBClient{}
-	mockDb.On("GetDeviceProfileByName", TestExistingDeviceProfile.Name).Return(TestExistingDeviceProfile, nil)
+	mockDb.On("GetDeviceProfileById", TestExistingDeviceProfile.Id).Return(TestExistingDeviceProfile, nil)
 	mockDb.On("GetDevicesByProfileId", TestExistingDeviceProfile.Id).Return(TestDevices, nil)
 
 	return mockDb
@@ -348,6 +348,7 @@ func createMockDBClientDeviceProfileInUse() interfaces.DBClient {
 
 func createMockErrorDBClient() interfaces.DBClient {
 	mockDb := &mocks2.DBClient{}
+	mockDb.On("GetDeviceProfileById", TestExistingDeviceProfile.Id).Return(contract.DeviceProfile{}, TestError)
 	mockDb.On("GetDeviceProfileByName", TestExistingDeviceProfile.Name).Return(contract.DeviceProfile{}, TestError)
 
 	return mockDb

--- a/internal/core/metadata/rest_deviceprofile_test.go
+++ b/internal/core/metadata/rest_deviceprofile_test.go
@@ -1363,6 +1363,7 @@ func createDBClientPersistDeviceInUseError() interfaces.DBClient {
 	d := &mocks.DBClient{}
 	inUse := TestDeviceProfile
 	inUse.DeviceResources = append(inUse.DeviceResources, TestInUseDeviceResource)
+	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(inUse, nil)
 	d.On("GetDeviceProfileByName", TestDeviceProfileName).Return(inUse, nil)
 	d.On("GetDevicesByProfileId", TestDeviceProfileID).Return([]contract.Device{}, nil)
 
@@ -1373,6 +1374,7 @@ func createDBClientUpdateValueDescriptorError() interfaces.DBClient {
 	d := &mocks.DBClient{}
 	inUse := TestDeviceProfile
 	inUse.DeviceResources = append(inUse.DeviceResources, TestInUseDeviceResource)
+	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(contract.DeviceProfile{}, TestError)
 	d.On("GetDeviceProfileByName", TestDeviceProfileName).Return(contract.DeviceProfile{}, TestError)
 
 	return d
@@ -1382,6 +1384,9 @@ func createDBServiceClientError(statusCode int) interfaces.DBClient {
 	d := &mocks.DBClient{}
 	inUse := TestDeviceProfile
 	inUse.DeviceResources = append(inUse.DeviceResources, TestInUseDeviceResource)
+	d.On("GetDeviceProfileById", TestDeviceProfileID).Return(contract.DeviceProfile{}, types.ErrServiceClient{
+		StatusCode: statusCode,
+	})
 	d.On("GetDeviceProfileByName", TestDeviceProfileName).Return(contract.DeviceProfile{}, types.ErrServiceClient{
 		StatusCode: statusCode,
 	})


### PR DESCRIPTION
Fix #2584 

PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Update device profile by ID will throw the item not found error

Issue Number: 2584

## What is the new behavior?
API query the device profile by id and name to prevent item not found error.
## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
