### PR TITLE
build: Added addingal tagging of docker images with nexus registry.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ docker_core_metadata:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-core-metadata-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-core-metadata-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-core-metadata-go:$(DOCKER_TAG) \
 		.
 
 docker_core_data:
@@ -110,6 +111,7 @@ docker_core_data:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-core-data-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-core-data-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-core-data-go:$(DOCKER_TAG) \
 		.
 
 docker_core_command:
@@ -120,6 +122,7 @@ docker_core_command:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-core-command-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-core-command-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-core-command-go:$(DOCKER_TAG) \
 		.
 
 docker_support_logging:
@@ -130,6 +133,7 @@ docker_support_logging:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-support-logging-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-support-logging-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-support-logging-go:$(DOCKER_TAG) \
 		.
 
 docker_support_notifications:
@@ -140,6 +144,7 @@ docker_support_notifications:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-support-notifications-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-support-notifications-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-support-notifications-go:$(DOCKER_TAG) \
 		.
 
 docker_support_scheduler:
@@ -150,6 +155,7 @@ docker_support_scheduler:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-support-scheduler-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-support-scheduler-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-support-scheduler-go:$(DOCKER_TAG) \
 		.
 
 docker_sys_mgmt_agent:
@@ -160,6 +166,7 @@ docker_sys_mgmt_agent:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-sys-mgmt-agent-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-sys-mgmt-agent-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-sys-mgmt-agent-go:$(DOCKER_TAG) \
 		.
 
 docker_security_secrets_setup:
@@ -170,6 +177,7 @@ docker_security_secrets_setup:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-edgex-secrets-setup-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-edgex-secrets-setup-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-edgex-secrets-setup-go:$(DOCKER_TAG) \
 		.
 
 docker_security_proxy_setup:
@@ -180,6 +188,7 @@ docker_security_proxy_setup:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-edgex-security-proxy-setup-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-edgex-security-proxy-setup-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-edgex-security-proxy-setup-go:$(DOCKER_TAG) \
 		.
 
 docker_security_secretstore_setup:
@@ -190,6 +199,7 @@ docker_security_secretstore_setup:
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/docker-edgex-security-secretstore-setup-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-edgex-security-secretstore-setup-go:$(DOCKER_TAG) \
+		-t nexus3.edgexfoundry.org:10004/docker-edgex-security-secretstore-setup-go:$(DOCKER_TAG) \
 		.
 
 raml_verify:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

No tagging of locally build images for the nexus registry.

Issue Number: #2592

## What is the new behavior?

Locally built images now have addition tag for nexus registry

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

No
## Are there any specific instructions or things that should be known prior to reviewing?
No
## Other information
