### PR TITLE
fix: Invoke Validate function when adding yaml DeviceProfile

### DIFF
--- a/internal/core/metadata/errors/types.go
+++ b/internal/core/metadata/errors/types.go
@@ -183,3 +183,15 @@ func NewErrNameCollision(name, fromID, toID string) ErrNameCollision {
 		toID:   toID,
 	}
 }
+
+type ErrDeviceProfileMarshalJson struct {
+	msg string
+}
+
+func (e ErrDeviceProfileMarshalJson) Error() string {
+	return e.msg
+}
+
+func NewErrDeviceProfileMarshalJson(message string) error {
+	return ErrDeviceProfileMarshalJson{msg: message}
+}

--- a/internal/pkg/errorconcept/device_profile.go
+++ b/internal/pkg/errorconcept/device_profile.go
@@ -31,6 +31,7 @@ type deviceProfileErrorConcept struct {
 	InvalidState_StatusBadRequest          deviceProfileInvalidState_StatusBadRequest
 	InvalidState_StatusConflict            deviceProfileInvalidState_StatusConflict
 	MarshalYaml                            deviceProfileMarshalYaml
+	MarshalJson                            deviceProfileMarshalJson
 	MissingFile                            deviceProfileMissingFile
 	NotFound                               deviceProfileNotFound
 	ReadFile                               deviceProfileReadFile
@@ -111,6 +112,21 @@ func (r deviceProfileInvalidState_StatusConflict) isA(err error) bool {
 }
 
 func (r deviceProfileInvalidState_StatusConflict) message(err error) string {
+	return err.Error()
+}
+
+type deviceProfileMarshalJson struct{}
+
+func (r deviceProfileMarshalJson) httpErrorCode() int {
+	return http.StatusInternalServerError
+}
+
+func (r deviceProfileMarshalJson) isA(err error) bool {
+	_, ok := err.(metadataErrors.ErrDeviceProfileMarshalJson)
+	return ok
+}
+
+func (r deviceProfileMarshalJson) message(err error) string {
 	return err.Error()
 }
 

--- a/openapi/v1/core-metadata.yaml
+++ b/openapi/v1/core-metadata.yaml
@@ -931,8 +931,7 @@ paths:
         400:
           description: For malformed or unparsable requests
         409:
-          description: If an associated command's name is a duplicate for the profile
-            or if the name is determined to not be unique with regard to others.
+          description: If the profile's name matches an existing device profile.
         500:
           description: For unknown or unanticipated issues
   /v1/deviceprofile/id/{id}:
@@ -1114,8 +1113,7 @@ paths:
         400:
           description: If the YAML file is empty
         409:
-          description: If an associated command's name is a duplicate for the profile
-            or if the name is determined to not be unique with regard to others
+          description: If the profile's name matches an existing device profile.
         500:
           description: For unknown or unanticipated issues
   /v1/deviceprofile/uploadfile:
@@ -1128,8 +1126,7 @@ paths:
         400:
           description: If the YAML file is empty
         409:
-          description: If an associated command's name is a duplicate for the profile
-            or if the name is determined to not be unique with regard to others
+          description: If the profile's name matches an existing device profile.
         500:
           description: for unknown or unanticipated issues
   /v1/deviceprofile/yaml/name/{name}:


### PR DESCRIPTION
Fix #2596 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
YAML DeviceProfile uploading API doesn't validate the content.

Issue Number: #2596

## What is the new behavior?
Invoke Validate function when uploading yaml format DeviceProfile to prevent uploading invalid DeviceProfile.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?
Since deviceProfile.Validate() not validate the nested object, so create another function to validate that.


## Other information
