### PR TITLE
fix: Created timestamp is 0 on message queue

### DIFF
--- a/internal/core/data/event.go
+++ b/internal/core/data/event.go
@@ -134,6 +134,9 @@ func addNewEvent(
 
 	// Add the event and readings to the database
 	if configuration.Writable.PersistData {
+		if e.Created == 0 {
+			e.Created = db.MakeTimestamp()
+		}
 		id, err := dbClient.AddEvent(e)
 		if err != nil {
 			return "", err

--- a/internal/pkg/db/redis/data.go
+++ b/internal/pkg/db/redis/data.go
@@ -1036,10 +1036,6 @@ func (c *Client) ScrubAllValueDescriptors() error {
 
 // ************************** HELPER FUNCTIONS ***************************
 func addEvent(conn redis.Conn, e correlation.Event) (id string, err error) {
-	if e.Created == 0 {
-		e.Created = db.MakeTimestamp()
-	}
-
 	if e.ID == "" {
 		e.ID = uuid.New().String()
 	}


### PR DESCRIPTION
Fix by using the db creation time on message queue for Event.
closes #2602

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The created timestamp of Event/Reading is zero on the message queue (can be seen on the app services pushed via 0MQ or message bus).
Issue Number: #2602 

## What is the new behavior?
The created timestamp of Event/Reading value should be the same as the created field saved in the database on the message queue, which is the entry creation timestamp in the database.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No.

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
