### PR TITLE
fix: Query event API w/ limit always returns first $n records (redis)

### DIFF
--- a/internal/pkg/db/redis/data.go
+++ b/internal/pkg/db/redis/data.go
@@ -339,7 +339,7 @@ func (c *Client) EventsForDeviceLimit(id string, limit int) (events []contract.E
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	objects, err := getObjectsByRange(conn, db.EventsCollection+":device:"+id, 0, limit-1)
+	objects, err := getObjectsByRevRange(conn, db.EventsCollection+":device:"+id, 0, limit-1)
 	if err != nil {
 		if err != redis.ErrNil {
 			return events, err


### PR DESCRIPTION
In /internal/pkg/db/redis/data.go, the func EventsForDeviceLimit should call getObjectsByRevRange to retrieve the entries for keys in the reverse sorted set order.

fix #2604 

Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #2604 

## What is the new behavior?
This API [/v1/event/device/{deviceId}/{limit}](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/1.2.0#/default/get_v1_event_device__deviceId___limit_) now will return last(newest) $n records

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
