### PR TITLE
snap: remove mongod

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -3,9 +3,8 @@
 
 This folder contains snap packaging for the EdgeX Foundry reference implementation.
 
-The snap contains Consul, MongoDB, Redis, and all of the EdgeX Go-based micro services from
-this repository, device-virtual, as well as Vault, Kong, PostgreSQL. The snap also contains a
-single OpenJDK JRE used to run the legacy support-rulesengine (deprecated).
+The snap contains Consul, Redis, and all of the EdgeX Go-based micro services from
+this repository, device-virtual, as well as Vault, Kong, PostgreSQL.
 
 The project maintains a rolling release of the snap on the `edge` channel that is rebuilt and published at least once daily through the jenkins jobs setup for the EdgeX project.
 
@@ -60,12 +59,11 @@ Upon installation, the following EdgeX services are automatically and immediatel
 
 The following services are disabled by default:
 
-* app-service-configurable (required for Kuiper and support-rulesengine)
+* app-service-configurable (required for Kuiper)
 * device-virtual
 * kuiper
 * support-logging
 * support-notifications
-* support-rulesengine (deprecated)
 * support-scheduler
 * sys-mgmt-agent
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -6,7 +6,6 @@ ALL_SERVICES=""
 
 # base services
 ALL_SERVICES="$ALL_SERVICES consul"
-ALL_SERVICES="$ALL_SERVICES mongod"
 ALL_SERVICES="$ALL_SERVICES redis"
 
 # core services
@@ -158,112 +157,14 @@ for key in $ALL_SERVICES; do
 done
 
 # handle usage of database provider
+#
+# FIXME (HANOI)
+#
+# The code to switch dbtype has been removed, however
+# I'm leaving the snapctl get to retrive the dbtype, as
+# this may be leveraged in the configure hook of Hanio
+# to block refresh from Geneva to Hanoi if the dbtype
+# is set to 'mongodb' and the project has not yet provided
+# a database migration script...
 dbProvider=$(snapctl get dbtype)
 PREV_DB_PROVIDER_FILE="$SNAP_DATA/prevdbtype"
-
-case "$dbProvider" in 
-    "")
-        # not set, don't do anything 
-        ;;
-    "redis")
-        prevDBtype=$(cat "$PREV_DB_PROVIDER_FILE")
-        if [ "$prevDBtype" != "redis" ]; then
-            # change provider to redis:
-            #
-            # first check for service config in consul, if found
-            # update directly, otherwise update configuration.toml
-            # (this should practically only ever happen for the
-            # two support-* services, as they're disabled by
-            # default in the snap).
-            #
-            # * core-command
-            # * core-data
-            # * core-metadata
-            # * support-notifications
-            # * support-scheduler
-            for svc in ${DB_SERVICES[*]}; do
-                updated="false"
-
-                exists=`curl -s http://localhost:8500/v1/kv/edgex/core/1.0/edgex-$svc/Databases/Primary/Type?raw`
-                if [ "$exists" = "mongodb" ]; then
-                    update_consul_db_type "$svc" "redisdb" "6379"
-                    updated="true"
-		fi
-
-                # if consul wasn't updated, then the service has never been started
-                # so just modify the service's local configuration.toml file
-                if [ "$updated" = "false" ]; then
-                    configFile=$SNAP_DATA/config/$svc/res/configuration.toml
-                    toml2json --preserve-key-order "$configFile" | \
-                        jq -r '.Databases.Primary.Type = "redisdb" | .Databases.Primary.Port = 6379' | \
-                        json2toml --preserve-key-order > "$configFile.tmp"
-                    mv "$configFile.tmp" "$configFile"
-                fi
-            done
-
-            # turn mongod and edgex-mongo off
-            handle_svc "edgex-mongo" "off"
-            handle_svc "mongod" "off"
-
-            # turn redis on
-            handle_svc "redis" "on"
-
-            restart_db_services
-        fi
-        # save the database provider as redis for next invocation
-        echo "redis" > "$PREV_DB_PROVIDER_FILE"
-        ;;
-    "mongodb")
-        prevDBtype=$(cat "$PREV_DB_PROVIDER_FILE")
-        if [ "$prevDBtype" != "mongodb" ]; then
-            # change provider to mongo:
-            #
-            # first check for service config in consul, if found
-            # update directly, otherwise update configuration.toml
-            # (this should practically only ever happen for the
-            # two support-* services, as they're disabled by
-            # default in the snap).
-            #
-            # * core-command
-            # * core-data
-            # * core-metadata
-            # * support-notifications
-            # * support-scheduler
-            for svc in ${DB_SERVICES[*]}; do
-                updated="false"
-
-                exists=`curl -s http://localhost:8500/v1/kv/edgex/core/1.0/edgex-$svc/Databases/Primary/Type?raw`
-                if [ "$exists" = "redisdb" ]; then
-                    update_consul_db_type "$svc" "mongodb" "27017"
-                    updated="true"
-                fi
-
-                # if consul wasn't updated, then the support-* service has never been started
-                # so just modify the service's local configuration.toml file
-                if [ "$updated" = "false" ]; then
-                    configFile=$SNAP_DATA/config/$svc/res/configuration.toml
-                    toml2json --preserve-key-order "$configFile" | \
-                        jq -r '.Databases.Primary.Type = "mongodb" | .Databases.Primary.Port = 27017' | \
-                        json2toml --preserve-key-order > "$configFile.tmp"
-                    mv "$configFile.tmp" "$configFile"
-                fi
-            done
-
-            # turn redis off
-            handle_svc "redis" "off"
-
-            # turn edgex-mongo and mongod on
-            handle_svc "mongod" "on"
-            handle_svc "edgex-mongo" "on"
-
-            restart_db_services
-        fi
-
-        # save the database provider as mongodb for next invocation
-        echo "mongodb" > "$PREV_DB_PROVIDER_FILE"
-        ;;
-    *)
-        echo "invalid setting for dbtype: $dbProvider"
-        exit 1
-        ;;
-esac

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,15 +10,14 @@ SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
 # into $SNAP_DATA/config
 # note that app-service-configurable is handled separately
 mkdir -p "$SNAP_DATA/config"
-for service in edgex-mongo security-file-token-provider security-proxy-setup security-secrets-setup security-secretstore-setup core-command core-data core-metadata support-logging support-notifications support-scheduler sys-mgmt-agent device-virtual security-secretstore-read; do
+for service in security-file-token-provider security-proxy-setup security-secrets-setup security-secretstore-setup core-command core-data core-metadata support-logging support-notifications support-scheduler sys-mgmt-agent device-virtual security-secretstore-read; do
     if [ ! -f "$SNAP_DATA/config/$service/res/configuration.toml" ]; then
         mkdir -p "$SNAP_DATA/config/$service/res"
         cp "$SNAP/config/$service/res/configuration.toml" "$SNAP_DATA/config/$service/res/configuration.toml"
 
-        # replace $SNAP, $SNAP_DATA, $SNAP_COMMON env vars for edgex-mono, file-token-provider,
+        # replace $SNAP, $SNAP_DATA, $SNAP_COMMON env vars for file-token-provider,
         # and security-secretstore-setup, as they don't support env var overrides
-        if [ "$service" = "edgex-mongo" ] ||
-	    [ "$service" == "security-file-token-provider" ] ||
+        if [ "$service" == "security-file-token-provider" ] ||
             [ "$service" == "security-secretstore-read" ]; then
             sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
                 -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
@@ -77,9 +76,6 @@ cp "$SNAP/config/security-file-token-provider/res/token-config.json" "$SNAP_DATA
 # ensure consul dirs exist
 mkdir -p "$SNAP_DATA/consul/data"
 mkdir -p "$SNAP_DATA/consul/config"
-
-# ensure mongodb data dirs exist
-mkdir -p "$SNAP_DATA/mongo/db"
 
 # ensure secrets dir exists
 mkdir -p "$SNAP_DATA/secrets"
@@ -198,12 +194,10 @@ drop sed -i -e "s@trust@md5@g" "$SNAP_DATA/postgresql/10/main/pg_hba.conf"
 # - app-service-configurable (used for rules integration)
 # - device-virtual
 # - kuiper (replacement for support-rulesengine)
-# - mongo
 # - support-*
 # - sys-mgmt-agent (see https://github.com/edgexfoundry/edgex-go/issues/2486)
 #
-for svc in support-notifications support-scheduler support-logging app-service-configurable \
-    device-virtual edgex-mongo mongod sys-mgmt-agent kuiper; do
+for svc in support-notifications support-scheduler support-logging app-service-configurable device-virtual sys-mgmt-agent kuiper; do
     # set the service as off, so that the setting is persistent after a refresh
     # due to snapd bug: https://bugs.launchpad.net/snapd/+bug/1818306
     snapctl set $svc=off

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
   EdgeX Foundry is a vendor-neutral open source project hosted by The Linux 
   Foundation building a common open framework for IoT edge computing. This 
   snap contains all of the EdgeX core, security, and support reference 
-  services, as well as Consul, Kong, MongoDB, Vault, and device-virtual.
+  services, as well as Consul, Kong, Redis, Vault, and device-virtual.
   The packaging for this snap can be found at:
     https://github.com/edgexfoundry/edgex-go
 
@@ -83,16 +83,6 @@ apps:
     command: bin/redis-launch.sh
     daemon: simple
     plugs: [network, network-bind]
-  mongod:
-    adapter: full
-    after: [consul]
-    command: >-
-      bin/mongod
-      --dbpath $SNAP_DATA/mongo/db
-      --logpath $SNAP_COMMON/mongodb.log
-    daemon: simple
-    plugs: [hardware-observe, network, network-bind, system-observe]
-    stop-command: bin/mongod --shutdown --dbpath $SNAP_DATA/mongo/db
   postgres:
     adapter: full
     command: usr/lib/postgresql/10/bin/postgres -D $SNAP_DATA/postgresql/10/main -c $CONFIG_ARG
@@ -200,19 +190,10 @@ apps:
     daemon: oneshot
     start-timeout: 15m
     plugs: [network]
-  edgex-mongo:
-    adapter: full
-    after: [mongod, security-secretstore-setup]
-    command: bin/edgex-mongo -confdir $SNAP_DATA/config/edgex-mongo/res
-    command-chain:
-      - bin/security-secret-store-env-var.sh
-    daemon: oneshot
-    start-timeout: 15m
-    plugs: [network]
   core-data:
     adapter: full
     after:
-      - edgex-mongo
+      - redis
       - security-proxy-setup
     command: bin/core-data -confdir $SNAP_DATA/config/core-data/res --registry
     command-chain:
@@ -228,7 +209,7 @@ apps:
   core-metadata:
     adapter: none
     after:
-      - edgex-mongo
+      - redis
       - security-proxy-setup
     command: bin/core-metadata -confdir $SNAP_DATA/config/core-metadata/res --registry
     command-chain:
@@ -241,7 +222,7 @@ apps:
   core-command:
     adapter: none
     after:
-      - edgex-mongo
+      - redis
       - security-proxy-setup
     command: bin/core-command -confdir $SNAP_DATA/config/core-command/res --registry
     command-chain:
@@ -254,7 +235,7 @@ apps:
   support-logging:
     adapter: none
     after:
-      - edgex-mongo
+      - redis
       - security-proxy-setup
     command: bin/support-logging -confdir $SNAP_DATA/config/support-logging/res --registry
     command-chain:
@@ -271,7 +252,7 @@ apps:
   support-notifications:
     adapter: none
     after:
-      - edgex-mongo
+      - redis
       - security-proxy-setup
     command: bin/support-notifications -confdir $SNAP_DATA/config/support-notifications/res --registry
     command-chain:
@@ -284,7 +265,7 @@ apps:
   support-scheduler:
     adapter: none
     after:
-      - edgex-mongo
+      - redis
       - security-proxy-setup
     command: bin/support-scheduler -confdir $SNAP_DATA/config/support-scheduler/res --registry
     command-chain:
@@ -297,7 +278,7 @@ apps:
   sys-mgmt-agent:
     adapter: none
     after:
-      - edgex-mongo
+      - redis
       - security-proxy-setup
     command: bin/sys-mgmt-agent -confdir $SNAP_DATA/config/sys-mgmt-agent/res --registry
     command-chain:
@@ -309,7 +290,7 @@ apps:
   device-virtual:
     adapter: none
     after:
-      - edgex-mongo
+      - redis
       - security-proxy-setup
       - core-data
       - core-metadata
@@ -345,18 +326,6 @@ apps:
     adapter: full
     command: bin/redis-cli
     plugs: [home, removable-media, network]
-  mongo:
-    adapter: full
-    command: bin/mongo
-    plugs: [home, removable-media, network]
-  mongostat:
-    adapter: full
-    command: bin/mongostat
-    plugs: [network]
-  mongodump:
-    adapter: full
-    command: bin/mongodump
-    plugs: [network]
   consul-cli:
     adapter: none
     command: bin/consul
@@ -649,65 +618,12 @@ parts:
       - make
       - zip
 
-  mongodb:
-    plugin: dump
-    source:
-      - on amd64: http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.6.tgz
-      - else:
-          - on arm64: http://downloads.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-4.2.6.tgz
-      - else fail
-    organize:
-      MPL-2: usr/share/doc/mongodb/MPL-2
-      README: usr/share/doc/mongodb/README
-      THIRD-PARTY-NOTICES: usr/share/doc/mongodb/THIRD-PARTY-NOTICES
-      LICENSE-Community.txt: usr/share/doc/mongodb/LICENSE-Community.txt
-    stage-packages:
-      - libssl1.1
-    stage:
-      - -bin/bsondump
-      - -bin/mongoexport
-      - -bin/mongofiles
-      - -bin/mongoimport
-      - -bin/mongooplog
-      - -bin/mongoperf
-      - -bin/mongoreplay
-      - -bin/mongorestore
-      - -bin/mongos
-      - -bin/mongotop
-  remarshal:
-    plugin: python
-    source: https://github.com/dbohdan/remarshal.git
-    source-tag: v0.10.0
-    source-depth: 1
-    organize:
-      LICENSE: usr/share/doc/remarshal/LICENSE
   redis:
     source: https://github.com/antirez/redis.git
     source-tag: "5.0.8"
     source-depth: 1
     plugin: make
     make-install-var: PREFIX
-  edgex-mongo:
-    source: https://github.com/edgexfoundry/docker-edgex-mongo.git
-    # TODO (geneva): pin this to a commit or tag for release
-    source-branch: master
-    source-depth: 1
-    plugin: make
-    after: [go113]
-    override-build: |
-      export PATH="$SNAPCRAFT_STAGE/go1.13/bin:$GOPATH/bin:$PATH"
-      cd $SNAPCRAFT_PART_SRC
-      make build
-
-      install -DT "./cmd/edgex-mongo" "$SNAPCRAFT_PART_INSTALL/bin/edgex-mongo"
-
-      install -d "$SNAPCRAFT_PART_INSTALL/config/edgex-mongo/res/"
-
-      cat "./cmd/res/configuration.toml" | \
-        sed -e "s@TokenFile = \"/vault/config/assets/resp-init.json\"@TokenFile = \"\$SNAP_DATA/secrets/edgex-mongo/secrets-token.json\"@" \
-            -e "s@RootCaCertPath = \"/vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem\"@RootCaCertPath = \"\$SNAP_DATA/secrets/ca/ca.pem\"@" \
-            > \
-       "$SNAPCRAFT_PART_INSTALL/config/edgex-mongo/res/configuration.toml"
 
   edgex-go:
     source: .


### PR DESCRIPTION
Mongo was announced as deprecated in the Geneva (1.2.0)
release, and removed as part of the Hanoi release (1.3.0).

Fixes: https://github.com/edgexfoundry/edgex-go/issues/2612

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [**NA**] Tests for the changes have been added (for bug fixes / features)
- [**NA**] Docs have been added / updated (for bug fixes / features)
- [**NA**] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: deprecation

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
EdgeX has supported Mongodb as one of it's data persistence options since the first release. Redis support was added in the Fuji release and became the default database provider in the Geneva release. Mongo was declared deprecated in the Geneva release and slated for removal as part of Hanoi.

Issue Number: #2612

## What is the new behavior?

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
**NA**

## Are there any specific instructions or things that should be known prior to reviewing?
**NA**
