### PR TITLE
fix: ADD_PROXY_ROUTE fails if URL contains dot

### DIFF
--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -218,7 +218,8 @@ func (s *Service) parseAdditionalProxyRoutes() (map[string]bootstrapConfig.Clien
 				"invalid syntax for defining additional kong route %s, it should contain dot . as separator", route)
 		}
 
-		routePair := strings.Split(route, ".")
+		// assume the routePair is in the format of serviceName.routeURL
+		routePair := strings.SplitN(route, ".", 2)
 		serviceName := strings.TrimSpace(routePair[0])
 		routeURL := strings.TrimSpace(routePair[1])
 

--- a/internal/security/proxy/service_test.go
+++ b/internal/security/proxy/service_test.go
@@ -156,8 +156,18 @@ func TestInit(t *testing.T) {
 			expectNumRoutes:    9,
 		},
 		{
+			name:               "add one unique route with URL containing IP address",
+			proxyRouteEnvValue: "testService.http://127.0.0.1:12345",
+			expectNumRoutes:    9,
+		},
+		{
 			name:               "add two unique routes",
 			proxyRouteEnvValue: "testService1.http://edgex-testService1:12345, testService2.http://edgex-testService2:12346",
+			expectNumRoutes:    10,
+		},
+		{
+			name:               "add two unique routes:one with URL containing IP address; the other one with hostname",
+			proxyRouteEnvValue: "testService1.http://127.0.0.1:12345, testService2.http://edgex-testService2:12346",
 			expectNumRoutes:    10,
 		},
 		{
@@ -174,6 +184,11 @@ func TestInit(t *testing.T) {
 			name:               "add one unique, multiple duplicate routes",
 			proxyRouteEnvValue: "testServcie.https://edgex-test-servcie1:12345, CoreData.http://edgex-core-data:48080, Command.https://edgex-core-command:48082",
 			expectNumRoutes:    9,
+		},
+		{
+			name:               "add two unique, multiple duplicate routes",
+			proxyRouteEnvValue: "testService1.http://127.0.0.1:12345, testService2.http://edgex-testService2:12346, CoreData.http://edgex-core-data:48080, Command.https://edgex-core-command:48082",
+			expectNumRoutes:    10,
 		},
 		// invalid syntax tests:
 		// the bad one is not added into kong route pool


### PR DESCRIPTION
The PR from #2474 introduces an enhancement that users could add
additional Kong routes via environment variable ADD_PROXY_ROUTE.
The value of ADD_PROXY_ROUTE takes a comma-separated list of one or
more (at least one) paired additional service name and URL for which
to create proxy Kong routes. The paired specification is in the format
 of {RoutePrefix}.{TargetRouteURL}. There is a bug here: if
{TargetRouteURL} contains dot characters, e.g. an IP address, the
route parsing logic will break, as the code simply use
`routePair := strings.Split(route, ".")`
to parse the route. To avoid this potential issue, the code should
consider to only spilt {RoutePrefix}.{TargetRouteURL} into 2 substrings
 with the very first dot: `routePair := strings.SplitN(route, ".", 2)`

Signed-off-by: Jude Hung <jude@iotechsys.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
When users specify ADD_PROXY_ROUTE env with routes containing dot characters, e.g. ADD_PROXY_ROUTE: "myService.http://10.0.2.15:12345", an parsing error will pop up:

`"failed to parse additional proxy Kong routes from env myService.http://10.0.2.15:12345: malformed host in route URL for additional kong route 10: address 10: missing port in address"`

Issue Number:  #2621

## What is the new behavior?

Users could also create Kong routes by specifying ADD_PROXY_ROUTE with URL containing IP address.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

No
## Are there any specific instructions or things that should be known prior to reviewing?
No
## Other information
