### PR TITLE
feat: Add config setting for value used for ListenAndServe

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -5,6 +5,7 @@ LogLevel = 'INFO'
 BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = '' # Leave blank so default to Host value unless different value is needed.
 Port = 48082
 Protocol = 'http'
 MaxResultCount = 50000

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -11,6 +11,7 @@ ChecksumAlgo = 'xxHash'
 BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = '' # Leave blank so default to Host value unless different value is needed.
 Port = 48080
 Protocol = 'http'
 MaxResultCount = 50000

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -6,6 +6,7 @@ EnableValueDescriptorManagement = false
 BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = '' # Leave blank so default to Host value unless different value is needed.
 Port = 48081
 Protocol = 'http'
 MaxResultCount = 50000

--- a/cmd/support-logging/res/configuration.toml
+++ b/cmd/support-logging/res/configuration.toml
@@ -6,6 +6,7 @@ LogLevel = 'INFO'
 BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = '' # Leave blank so default to Host value unless different value is needed.
 Port = 48061
 Protocol = 'http'
 MaxResultCount = 50000

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -6,6 +6,7 @@ LogLevel = 'INFO'
 BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = '' # Leave blank so default to Host value unless different value is needed.
 Port = 48060
 Protocol = 'http'
 MaxResultCount = 500000

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -6,6 +6,7 @@ LogLevel = 'INFO'
 BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = '' # Leave blank so default to Host value unless different value is needed.
 Port = 48085
 Protocol = 'http'
 MaxResultCount = 50000

--- a/cmd/sys-mgmt-agent/res/configuration.toml
+++ b/cmd/sys-mgmt-agent/res/configuration.toml
@@ -19,6 +19,7 @@ LogLevel = 'INFO'
 BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = '' # Leave blank so default to Host value unless different value is needed.
 Port = 48090
 Protocol = 'http'
 MaxResultCount = 50000

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/edgexfoundry/go-mod-bootstrap v0.0.33
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.36
 	github.com/edgexfoundry/go-mod-configuration v0.0.3
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.58
 	github.com/edgexfoundry/go-mod-messaging v0.1.19


### PR DESCRIPTION
- Updated to latest go-mod-bootstrap v0.0.36
- Added Service.ServerBindAddr setting to config files for all edgex-go microservices

fix: #2624 

Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Before go-mo-bootstrap v0.0.36, the ListenAndServe IP address defaults to binding to an all-interface listener value of 0.0.0.0

Issue Number: #2624 

## What is the new behavior?
Added a Service.`ServerBindAddr` configurable value to config file to reflect this change: https://github.com/edgexfoundry/go-mod-bootstrap/pull/84
The default value of `ServerBindAddr` of each service is blank, so the Service.`Host` value is now the ListenAndServe IP address. However, it allows env override to set a specific value as needed for different deployments.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

