### PR TITLE
snap: revert to go-mod-bootstrap v0.0.32

### DIFF
--- a/snap/local/patches/0001-Go-mod-bootstrap-fix.patch
+++ b/snap/local/patches/0001-Go-mod-bootstrap-fix.patch
@@ -1,0 +1,26 @@
+From fb533601025c921927928cff02039e4c6cce1f32 Mon Sep 17 00:00:00 2001
+From: Haresh Kainth <haresh.kainth@canonical.com>
+Date: Mon, 13 Jul 2020 09:31:02 +0100
+Subject: [PATCH] Use previous version of bootstrap (v0.0.32) due to the
+ 0.0.0.0 'bug' see https://github.com/edgexfoundry/device-sdk-go/issues/456
+
+---
+ go.mod | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/go.mod b/go.mod
+index 4eec4b11..21d6c1ec 100644
+--- a/go.mod
++++ b/go.mod
+@@ -6,7 +6,7 @@ require (
+ 	github.com/OneOfOne/xxhash v1.2.5
+ 	github.com/cloudflare/gokey v0.1.0
+ 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+-	github.com/edgexfoundry/go-mod-bootstrap v0.0.33
++	github.com/edgexfoundry/go-mod-bootstrap v0.0.32
+ 	github.com/edgexfoundry/go-mod-configuration v0.0.3
+ 	github.com/edgexfoundry/go-mod-core-contracts v0.1.58
+ 	github.com/edgexfoundry/go-mod-messaging v0.1.19
+-- 
+2.24.3
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -724,6 +724,11 @@ parts:
     source: .
     plugin: make
     after: [go113]
+    override-pull: |
+      snapcraftctl pull
+      cd $SNAPCRAFT_PART_SRC
+      patch -p1 < "$SNAPCRAFT_PROJECT_DIR/snap/local/patches/0001-Go-mod-bootstrap-fix.patch"
+
     override-build: |
       export PATH="$SNAPCRAFT_STAGE/go1.13/bin:$GOPATH/bin:$PATH"
       cd $SNAPCRAFT_PART_SRC


### PR DESCRIPTION
Use previous version of bootstrap due to the 0.0.0.0 'bug',
which causes edgex services to listen on all interfaces instead
of localhost when run in the snap (or natively).

Fixes: https://github.com/edgexfoundry/device-sdk-go/issues/456

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: 456 (https://github.com/edgexfoundry/device-sdk-go/issues/456)

## What is the new behavior?

Services are listening to the correct address instead of 0.0.0.0.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

The existing dependency (referenced in go.mod) go-mod-bootstrap contains a bug. To resolve this issue is by referencing the previous version of the go-mod-bootstrap dependency.

## Are there any specific instructions or things that should be known prior to reviewing?

Please review the patch file and snapcraft.yaml.
