### PR TITLE
Revert "chore: Remove security services initialization for mongodb"

### DIFF
--- a/cmd/security-file-token-provider/res/token-config.json
+++ b/cmd/security-file-token-provider/res/token-config.json
@@ -3,6 +3,12 @@
     "edgex_use_defaults": true,
     "custom_policy": {
       "path": {
+        "secret/edgex/metadata/mongodb": {
+          "capabilities": [
+            "list",
+            "read"
+          ]
+        },
         "secret/edgex/metadata/redisdb": {
           "capabilities": [
             "list",
@@ -16,6 +22,12 @@
     "edgex_use_defaults": true,
     "custom_policy": {
       "path": {
+        "secret/edgex/coredata/mongodb": {
+          "capabilities": [
+            "list",
+            "read"
+          ]
+        },
         "secret/edgex/coredata/redisdb": {
           "capabilities": [
             "list",
@@ -29,7 +41,26 @@
     "edgex_use_defaults": true,
     "custom_policy": {
       "path": {
+        "secret/edgex/metadata/mongodb": {
+          "capabilities": [
+            "list",
+            "read"
+          ]
+        },
         "secret/edgex/metadata/redisdb": {
+          "capabilities": [
+            "list",
+            "read"
+          ]
+        }
+      }
+    }
+  },
+  "edgex-mongo": {
+    "edgex_use_defaults": true,
+    "custom_policy": {
+      "path": {
+        "secret/edgex/mongo/*": {
           "capabilities": [
             "list",
             "read"
@@ -51,10 +82,29 @@
       }
     }
   },
+  "edgex-support-logging": {
+    "edgex_use_defaults": true,
+    "custom_policy": {
+      "path": {
+        "secret/edgex/logging/mongodb": {
+          "capabilities": [
+            "list",
+            "read"
+          ]
+        }
+      }
+    }
+  },
   "edgex-support-notifications": {
     "edgex_use_defaults": true,
     "custom_policy": {
       "path": {
+        "secret/edgex/notifications/mongodb": {
+          "capabilities": [
+            "list",
+            "read"
+          ]
+        },
         "secret/edgex/notifications/redisdb": {
           "capabilities": [
             "list",
@@ -68,6 +118,12 @@
     "edgex_use_defaults": true,
     "custom_policy": {
       "path": {
+        "secret/edgex/rulesengine/mongodb": {
+          "capabilities": [
+            "list",
+            "read"
+          ]
+        },
         "secret/edgex/rulesengine/redisdb": {
           "capabilities": [
             "list",
@@ -81,6 +137,12 @@
     "edgex_use_defaults": true,
     "custom_policy": {
       "path": {
+        "secret/edgex/appservice/mongodb": {
+          "capabilities": [
+            "list",
+            "read"
+          ]
+        },
         "secret/edgex/appservice/redisdb": {
           "capabilities": [
             "list",
@@ -97,6 +159,12 @@
     "edgex_use_defaults": true,
     "custom_policy": {
       "path": {
+        "secret/edgex/scheduler/mongodb": {
+          "capabilities": [
+            "list",
+            "read"
+          ]
+        },
         "secret/edgex/scheduler/redisdb": {
           "capabilities": [
             "list",
@@ -111,6 +179,15 @@
     "custom_policy": {
       "path": {
         "secret/edgex/edgex-security-proxy-setup/kong-tls": {
+          "capabilities": [
+            "list",
+            "read",
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        "secret/edgex/mongo/*": {
           "capabilities": [
             "list",
             "read",

--- a/internal/security/secretread/types.go
+++ b/internal/security/secretread/types.go
@@ -32,7 +32,7 @@ type SecretStoreInfo struct {
 }
 
 type ServiceInfo struct {
-	// BootTimeout indicates, in milliseconds, how long the service will retry connecting to the database
+	// BootTimeout indicates, in milliseconds, how long the service will retry connecting to mongo database
 	// before giving up. Default is 30,000.
 	BootTimeout int
 }


### PR DESCRIPTION
This reverts commit 87b21bebefd6aee52e42130607210e5adb257784.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

Revert previous breaking change as discussed EdgeX archtiecture meeting 2020-07-20.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:
#2538 

## What is the new behavior?

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
