### PR TITLE
build: update Jenkinsfile to test 'testScript'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,8 @@ edgeXBuildGoParallel(
     project: 'edgex-go',
     goVersion: '1.13',
     dockerFileGlobPath: 'cmd/**/Dockerfile',
-    testScript: 'make test raml_verify',
+    testScript: 'make test',
     buildScript: 'make build',
-    publishSwaggerDocs: true
+    publishSwaggerDocs: false, //leaving this false until PR-2644 is merged
+    swaggerApiFolders: ['openapi/v1', 'openapi/v2']
 )


### PR DESCRIPTION
This PR is being created to update the Jenkinsfile in preperation for https://github.com/edgexfoundry/edgex-go/pull/2644.

It contains the following changes:

- Remove raml_verify from `testScript`
- Disable `publishSwaggerDocs` (until PR-2644 is merged)
- Update `swaggerApiFolders` paths to match PR-2644

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:

## What is the new behavior?

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
