### PR TITLE
feat: Implement pluggable password generator

### DIFF
--- a/cmd/security-secretstore-setup/res/configuration.toml
+++ b/cmd/security-secretstore-setup/res/configuration.toml
@@ -39,6 +39,8 @@ TokenProvider = "/security-file-token-provider"
 TokenProviderArgs = [ "-confdir", "res-file-token-provider" ]
 TokenProviderType = "oneshot"
 TokenProviderAdminTokenPath = "/run/edgex/secrets/tokenprovider/secrets-token.json"
+PasswordProvider = ""
+PasswordProviderArgs = [ ]
 RevokeRootTokens = true
 
 [Databases]

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.5
-	github.com/cloudflare/gokey v0.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.37
 	github.com/edgexfoundry/go-mod-configuration v0.0.3

--- a/internal/security/secretstore/credentialgenerator.go
+++ b/internal/security/secretstore/credentialgenerator.go
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package secretstore
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+)
+
+const randomBytesLength = 33 // 264 bits of entropy
+
+// CredentialGenerator is the interface for pluggable password generators
+type CredentialGenerator interface {
+	Generate(ctx context.Context) (string, error)
+}
+
+type defaultCredentialGenerator struct{}
+
+// NewDefaultCredentialGenerator generates random passwords as base64-encoded strings
+func NewDefaultCredentialGenerator() CredentialGenerator {
+	return &defaultCredentialGenerator{}
+}
+
+// Generate implementation returns base64-encoded randomBytesLength random bytes
+func (cg *defaultCredentialGenerator) Generate(ctx context.Context) (string, error) {
+	randomBytes := make([]byte, randomBytesLength)
+	_, err := rand.Read(randomBytes) // all of salt guaranteed to be filled if err==nil
+	if err != nil {
+		return "", err
+	}
+	newCredential := base64.StdEncoding.EncodeToString(randomBytes)
+	return newCredential, nil
+}

--- a/internal/security/secretstore/credentialgenerator_test.go
+++ b/internal/security/secretstore/credentialgenerator_test.go
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package secretstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPasswordsAreRandom(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cg := NewDefaultCredentialGenerator()
+	cred1, err := cg.Generate(ctx)
+	assert.NoError(t, err)
+	cred2, err := cg.Generate(ctx)
+	assert.NoError(t, err)
+	assert.NotEqual(t, cred1, cred2)
+	defer cancel()
+}

--- a/internal/security/secretstore/execrunner-mock_test.go
+++ b/internal/security/secretstore/execrunner-mock_test.go
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package secretstore
+
+import (
+	"context"
+	"io"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type mockExecRunner struct {
+	mock.Mock
+}
+
+func (m *mockExecRunner) SetStdout(stdout io.Writer) {
+	m.Called(stdout)
+}
+
+func (m *mockExecRunner) LookPath(file string) (string, error) {
+	arguments := m.Called(file)
+	return arguments.String(0), arguments.Error(1)
+}
+
+func (m *mockExecRunner) CommandContext(ctx context.Context,
+	name string, arg ...string) CmdRunner {
+	arguments := m.Called(ctx, name, arg)
+	return arguments.Get(0).(CmdRunner)
+}
+
+type mockCmd struct {
+	mock.Mock
+}
+
+func (m *mockCmd) Start() error {
+	arguments := m.Called()
+	return arguments.Error(0)
+}
+
+func (m *mockCmd) Wait() error {
+	arguments := m.Called()
+	return arguments.Error(0)
+}

--- a/internal/security/secretstore/execrunner.go
+++ b/internal/security/secretstore/execrunner.go
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package secretstore
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// CmdRunner is mockable interface for golang's exec.Cmd
+type CmdRunner interface {
+	Start() error
+	Wait() error
+}
+
+// ExecRunner is mockable interface for wrapping os/exec functionality
+type ExecRunner interface {
+	SetStdout(stdout io.Writer)
+	LookPath(file string) (string, error)
+	CommandContext(ctx context.Context, name string, arg ...string) CmdRunner
+}
+
+type execWrapper struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewDefaultExecRunner creates an os/exec wrapper
+// that joins subprocesses' stdout and stderr with the caller's
+func NewDefaultExecRunner() ExecRunner {
+	return &execWrapper{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}
+
+// SetStdout allows overriding of stdout capture (for comsuming password generator output)
+func (w *execWrapper) SetStdout(stdout io.Writer) {
+	w.Stdout = stdout
+}
+
+// LookPath wraps os/exec.LookPath
+func (w *execWrapper) LookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+// CommandContext wraps os/exec.CommandContext
+func (w *execWrapper) CommandContext(ctx context.Context, name string, arg ...string) CmdRunner {
+	cmd := exec.CommandContext(ctx, name, arg...)
+	cmd.Stdout = w.Stdout
+	cmd.Stderr = w.Stderr
+	return cmd
+}

--- a/internal/security/secretstore/password_linux_test.go
+++ b/internal/security/secretstore/password_linux_test.go
@@ -1,0 +1,36 @@
+// +build linux
+
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package secretstore
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateWithAPG(t *testing.T) {
+	rootToken := "s.Ga5jyNq6kNfRMVQk2LY1j9iu"
+	mockLogger := logger.MockLogger{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Note: apg only available with gnome-desktop, expected to be missing on server Linux distros
+	gk := NewPasswordGenerator(mockLogger, "apg", []string{"-a", "1", "-n", "1", "-m", "12", "-x", "64"})
+	cr := NewCred(&http.Client{}, rootToken, gk, "", logger.MockLogger{})
+
+	p1, err := cr.GeneratePassword(ctx)
+	require.NoError(t, err, "failed to create credential")
+	p2, err := cr.GeneratePassword(ctx)
+	require.NoError(t, err, "failed to create credential")
+	assert.NotEqual(t, p1, p2, "each call to GeneratePassword should return a new password")
+}

--- a/internal/security/secretstore/passwordprovider.go
+++ b/internal/security/secretstore/passwordprovider.go
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package secretstore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+type PasswordProvider struct {
+	loggingClient        logger.LoggingClient
+	execRunner           ExecRunner
+	initialized          bool
+	passwordProvider     string
+	passwordProviderArgs []string
+	resolvedPath         string
+}
+
+// NewPasswordProvider creates a new PasswordProvider
+func NewPasswordProvider(lc logger.LoggingClient, execRunner ExecRunner) *PasswordProvider {
+	return &PasswordProvider{
+		loggingClient: lc,
+		execRunner:    execRunner,
+	}
+}
+
+// SetConfiguration parses token provider configuration and resolves paths specified therein
+func (p *PasswordProvider) SetConfiguration(passwordProvider string, passwordProviderArgs []string) error {
+	var err error
+	p.passwordProvider = passwordProvider
+	p.passwordProviderArgs = passwordProviderArgs
+	resolvedPath, err := p.execRunner.LookPath(p.passwordProvider)
+	if err != nil {
+		p.loggingClient.Error(fmt.Sprintf("Failed to locate %s on PATH: %s", p.passwordProvider, err.Error()))
+		return err
+	}
+	p.initialized = true
+	p.resolvedPath = resolvedPath
+	return nil
+}
+
+// Generate retrives the password from the tool
+func (p *PasswordProvider) Generate(ctx context.Context) (string, error) {
+	var outputBuffer bytes.Buffer
+
+	if !p.initialized {
+		err := fmt.Errorf("PasswordProvider object not initialized; call SetConfiguration() first")
+		return "", err
+	}
+
+	p.execRunner.SetStdout(&outputBuffer)
+
+	p.loggingClient.Info(fmt.Sprintf("Launching password provider %s with arguments %s", p.resolvedPath, strings.Join(p.passwordProviderArgs, " ")))
+	cmd := p.execRunner.CommandContext(ctx, p.resolvedPath, p.passwordProviderArgs...)
+	if err := cmd.Start(); err != nil {
+		// For example, this might occur if a shared library was missing
+		p.loggingClient.Error(fmt.Sprintf("%s failed to launch: %s", p.resolvedPath, err.Error()))
+		return "", err
+	}
+
+	err := cmd.Wait()
+	if exitError, ok := err.(*exec.ExitError); ok {
+		waitStatus := exitError.Sys().(syscall.WaitStatus)
+		p.loggingClient.Error(fmt.Sprintf("%s terminated with non-zero exit code %d", p.resolvedPath, waitStatus.ExitStatus()))
+		return "", err
+	}
+	if err != nil {
+		p.loggingClient.Error(fmt.Sprintf("%s failed with unexpected error: %s", p.resolvedPath, err.Error()))
+		return "", err
+	}
+
+	p.loggingClient.Info("password provider exited successfully")
+
+	pw := string(outputBuffer.Bytes())
+	pw = strings.TrimSuffix(pw, "\n")
+	return pw, nil
+}

--- a/internal/security/secretstore/passwordprovider_test.go
+++ b/internal/security/secretstore/passwordprovider_test.go
@@ -1,0 +1,97 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package secretstore
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstoreclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestInvalidPasswordProvider(t *testing.T) {
+	config := secretstoreclient.SecretServiceInfo{
+		PasswordProvider: "does-not-exist",
+	}
+	mockExecRunner := &mockExecRunner{}
+	mockExecRunner.On("LookPath", config.PasswordProvider).
+		Return("", errors.New("fake file does not exist"))
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p := NewPasswordProvider(logger.MockLogger{}, mockExecRunner)
+	err := p.SetConfiguration(config.PasswordProvider, config.PasswordProviderArgs)
+	assert.Error(t, err)
+	mockExecRunner.AssertExpectations(t)
+}
+
+func TestPasswordConfigNotInitialized(t *testing.T) {
+	mockExecRunner := &mockExecRunner{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p := NewPasswordProvider(logger.MockLogger{}, mockExecRunner)
+	// SetConfiguration deliberately missing
+	_, err := p.Generate(ctx)
+	assert.Error(t, err)
+	mockExecRunner.AssertExpectations(t)
+}
+
+func TestPasswordProviderFailsToStart(t *testing.T) {
+	config := secretstoreclient.SecretServiceInfo{
+		PasswordProvider:     "failing-executable",
+		PasswordProviderArgs: []string{"arg1", "arg2"},
+	}
+	mockExecRunner := &mockExecRunner{}
+	mockCmd := mockCmd{}
+	mockExecRunner.On("LookPath", config.PasswordProvider).
+		Return(config.PasswordProvider, nil)
+	mockExecRunner.On("SetStdout", mock.Anything).Once()
+	mockExecRunner.On("CommandContext", mock.Anything,
+		config.PasswordProvider, config.PasswordProviderArgs).
+		Return(&mockCmd)
+	mockCmd.On("Start").Return(errors.New("error starting"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p := NewPasswordProvider(logger.MockLogger{}, mockExecRunner)
+	err := p.SetConfiguration(config.PasswordProvider, config.PasswordProviderArgs)
+	assert.NoError(t, err)
+	_, err = p.Generate(ctx)
+	assert.Error(t, err)
+	mockExecRunner.AssertExpectations(t)
+}
+
+func TestPasswordProviderFailsAtRuntime(t *testing.T) {
+	config := secretstoreclient.SecretServiceInfo{
+		PasswordProvider:     "failing-executable",
+		PasswordProviderArgs: []string{"arg1", "arg2"},
+	}
+	mockExecRunner := &mockExecRunner{}
+	mockCmd := mockCmd{}
+	mockExecRunner.On("LookPath", config.PasswordProvider).
+		Return(config.PasswordProvider, nil)
+	mockExecRunner.On("SetStdout", mock.Anything).Once()
+	mockExecRunner.On("CommandContext", mock.Anything,
+		config.PasswordProvider, config.PasswordProviderArgs).
+		Return(&mockCmd)
+	mockCmd.On("Start").Return(nil)
+	mockCmd.On("Wait").Return(&exec.ExitError{ProcessState: &os.ProcessState{}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p := NewPasswordProvider(logger.MockLogger{}, mockExecRunner)
+	err := p.SetConfiguration(config.PasswordProvider, config.PasswordProviderArgs)
+	assert.NoError(t, err)
+	_, err = p.Generate(ctx)
+	assert.Error(t, err)
+	mockExecRunner.AssertExpectations(t)
+}

--- a/internal/security/secretstore/tokenprovider.go
+++ b/internal/security/secretstore/tokenprovider.go
@@ -19,7 +19,6 @@ package secretstore
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -29,29 +28,6 @@ import (
 )
 
 const OneShotProvider = "oneshot"
-
-type ExecRunner interface {
-	LookPath(file string) (string, error)
-	CommandContext(ctx context.Context, name string, arg ...string) CmdRunner
-}
-
-type CmdRunner interface {
-	Start() error
-	Wait() error
-}
-
-type ExecWrapper struct{}
-
-func (w ExecWrapper) LookPath(file string) (string, error) {
-	return exec.LookPath(file)
-}
-
-func (w ExecWrapper) CommandContext(ctx context.Context, name string, arg ...string) CmdRunner {
-	cmd := exec.CommandContext(ctx, name, arg...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd
-}
 
 type TokenProvider struct {
 	loggingClient logger.LoggingClient

--- a/internal/security/secretstore/tokenprovider_linux_test.go
+++ b/internal/security/secretstore/tokenprovider_linux_test.go
@@ -43,7 +43,7 @@ func TestCreatesFile(t *testing.T) {
 	err := os.RemoveAll(testfile)
 	defer os.RemoveAll(testfile) // cleanup
 
-	p := NewTokenProvider(ctx, logger.MockLogger{}, ExecWrapper{})
+	p := NewTokenProvider(ctx, logger.MockLogger{}, NewDefaultExecRunner())
 	p.SetConfiguration(config)
 	assert.NoError(t, err)
 

--- a/internal/security/secretstore/tokenprovider_test.go
+++ b/internal/security/secretstore/tokenprovider_test.go
@@ -58,7 +58,7 @@ func TestInvalidProviderType(t *testing.T) {
 
 func TestNoConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	p := NewTokenProvider(ctx, logger.MockLogger{}, ExecWrapper{})
+	p := NewTokenProvider(ctx, logger.MockLogger{}, NewDefaultExecRunner())
 	// don't call SetConfiguration()
 	err := p.Launch()
 	defer cancel()
@@ -116,33 +116,4 @@ func testCommon(config secretstoreclient.SecretServiceInfo, mockExecRunner ExecR
 		return cancel, err
 	}
 	return cancel, p.Launch()
-}
-
-type mockExecRunner struct {
-	mock.Mock
-}
-
-func (m *mockExecRunner) LookPath(file string) (string, error) {
-	arguments := m.Called(file)
-	return arguments.String(0), arguments.Error(1)
-}
-
-func (m *mockExecRunner) CommandContext(ctx context.Context,
-	name string, arg ...string) CmdRunner {
-	arguments := m.Called(ctx, name, arg)
-	return arguments.Get(0).(CmdRunner)
-}
-
-type mockCmd struct {
-	mock.Mock
-}
-
-func (m *mockCmd) Start() error {
-	arguments := m.Called()
-	return arguments.Error(0)
-}
-
-func (m *mockCmd) Wait() error {
-	arguments := m.Called()
-	return arguments.Error(0)
 }

--- a/internal/security/secretstoreclient/types.go
+++ b/internal/security/secretstoreclient/types.go
@@ -37,6 +37,8 @@ type SecretServiceInfo struct {
 	TokenProviderArgs           []string
 	TokenProviderType           string
 	TokenProviderAdminTokenPath string
+	PasswordProvider            string
+	PasswordProviderArgs        []string
 	RevokeRootTokens            bool
 }
 


### PR DESCRIPTION
Remove dependency on GoKey for password generator;
if not specified, the built-in password generator
does the equivalent of "openssl rand -base64 33"
which generates a base64 encoded random string
of 264 random bits.

Otherwise, the code looks for a PasswordProvider
in configuration that points to an executable,
and PasswordProviderArgs that specify the
arguments to that executable.  The code then
launches that exectuable, trims the trailing
newline, and uses the result as a password.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Current functionality uses Vault root token and database name to feed into GoKey password generator.  The GoKey password generator was never fully vetted for this purpose before being introduced.  Community would like a pluggable password generator rather than forcing use of Gokey

Issue Number:

Fixes #1946

## What is the new behavior?
Remove dependency on GoKey for password generator;
if not specified, the built-in password generator
does the equivalent of "openssl rand -base64 33"
which generates a base64 encoded random string
of 264 random bits.

Otherwise, the code looks for a PasswordProvider
in configuration that points to an executable,
and PasswordProviderArgs that specify the
arguments to that executable.  The code then
launches that exectuable, trims the trailing
newline, and uses the result as a password.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information

While doing research, although openssl is a commonly installed dependency (though by no means guaranteed to there in a minimal container), the apg (automatic password generator) tool is only installed (in Ubuntu) by the Gnome packages.  It is reasonable to assume that in a gui-less installation, that apg tool will not be available.  Thus, no default external password generator is configured by default.  Instead, the code simulates the output of openssl rand -base64 33