### PR TITLE
fix: Use Itoa() instead of string() for int conversion

### DIFF
--- a/internal/support/scheduler/schedule.go
+++ b/internal/support/scheduler/schedule.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -553,7 +554,7 @@ func getHttpRequest(
 	req.Header.Set(ContentTypeKey, ContentTypeJsonValue)
 
 	if len(params) > 0 {
-		req.Header.Set(ContentLengthKey, string(len(params)))
+		req.Header.Set(ContentLengthKey, strconv.Itoa(len(params)))
 	}
 
 	return req, err


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Code was incorrectly using `string()` to convert int to readable string. 

Issue Number: #2662

## What is the new behavior?

Code now correctly uses Itoa() to convert the int to a readable string.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
