### PR TITLE
fix(snap): remove support-logging

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -62,7 +62,6 @@ The following services are disabled by default:
 * app-service-configurable (required for Kuiper)
 * device-virtual
 * kuiper
-* support-logging
 * support-notifications
 * support-scheduler
 * sys-mgmt-agent

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -15,7 +15,6 @@ ALL_SERVICES="$ALL_SERVICES core-command"
 
 # support services
 ALL_SERVICES="$ALL_SERVICES support-notifications"
-ALL_SERVICES="$ALL_SERVICES support-logging"
 ALL_SERVICES="$ALL_SERVICES support-scheduler"
 
 # app-services

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,7 +10,7 @@ SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
 # into $SNAP_DATA/config
 # note that app-service-configurable is handled separately
 mkdir -p "$SNAP_DATA/config"
-for service in security-file-token-provider security-proxy-setup security-secrets-setup security-secretstore-setup core-command core-data core-metadata support-logging support-notifications support-scheduler sys-mgmt-agent device-virtual security-secretstore-read; do
+for service in security-file-token-provider security-proxy-setup security-secrets-setup security-secretstore-setup core-command core-data core-metadata support-notifications support-scheduler sys-mgmt-agent device-virtual security-secretstore-read; do
     if [ ! -f "$SNAP_DATA/config/$service/res/configuration.toml" ]; then
         mkdir -p "$SNAP_DATA/config/$service/res"
         cp "$SNAP/config/$service/res/configuration.toml" "$SNAP_DATA/config/$service/res/configuration.toml"
@@ -197,7 +197,7 @@ snapctl stop "$SNAP_NAME.postgres"
 # - support-*
 # - sys-mgmt-agent (see https://github.com/edgexfoundry/edgex-go/issues/2486)
 #
-for svc in support-notifications support-scheduler support-logging app-service-configurable device-virtual sys-mgmt-agent kuiper; do
+for svc in support-notifications support-scheduler app-service-configurable device-virtual sys-mgmt-agent kuiper; do
     # set the service as off, so that the setting is persistent after a refresh
     # due to snapd bug: https://bugs.launchpad.net/snapd/+bug/1818306
     snapctl set $svc=off

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -3,4 +3,4 @@
 # save this revision for when we run again in the post-refresh
 snapctl set lastrev="$SNAP_REVISION"
 
-snapctl set release="geneva"
+snapctl set release="hanoi"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -233,23 +233,6 @@ apps:
     daemon: simple
     plugs: [network, network-bind]
     stop-timeout: 10s
-  support-logging:
-    adapter: none
-    after:
-      - redis
-      - security-proxy-setup
-    command: bin/support-logging -confdir $SNAP_DATA/config/support-logging/res --registry
-    command-chain:
-      - bin/security-secret-store-env-var.sh
-    environment:
-      # for support-logging we also want the default persistence to be on a
-      # file so that we can use redis (which isn't supported with support-logging)
-      # in the snap by default
-      Writable_Persistence: 'file'
-      SecretStore_TokenFile: $SNAP_DATA/secrets/edgex-support-logging/secrets-token.json
-    daemon: simple
-    plugs: [network, network-bind]
-    stop-timeout: 10s
   support-notifications:
     adapter: none
     after:
@@ -295,7 +278,6 @@ apps:
       - security-proxy-setup
       - core-data
       - core-metadata
-      - support-logging
     command: bin/device-virtual $CONF_ARG $PROFILE_ARG $REGISTRY_ARG
     daemon: simple
     environment:
@@ -636,7 +618,7 @@ parts:
       make build
 
       # copy service binaries, configuration, and license files into the snap install
-      for service in core-command core-data core-metadata support-logging support-notifications support-scheduler sys-mgmt-agent \
+      for service in core-command core-data core-metadata support-notifications support-scheduler sys-mgmt-agent \
           security-proxy-setup security-secrets-setup security-secretstore-setup security-file-token-provider security-secretstore-read; do
 
           install -DT "./cmd/$service/$service" "$SNAPCRAFT_PART_INSTALL/bin/$service"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,10 +16,9 @@ icon: snap/local/assets/edgex-snap-icon.png
 # Different epochs prevent refreshes between major versions of EdgeX due
 # to continued configuration changes.
 #
-# delhi: 0, edinburgh: 1, fuji: 2, geneva: 3
-epoch: 3
+# delhi: 0, edinburgh: 1, fuji: 2, geneva: 3, hanoi: 4
+epoch: 4
 
-# TODO: add armhf here when that's supported
 architectures:
   - build-on: arm64
   - build-on: amd64


### PR DESCRIPTION
Remove deprecated support-logging service from snap.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [NA] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [NA] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: removes the deprecated support-logging service from the snap

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

Up til this point, it's not been possible to update from one major/minor version of EdgeX due to the use of sequential epochs in snapcraft.yaml. This policy may be changed with the Hanoi. If so, when someone attempts to refresh from the geneva snap and they have support-logging enabled, the refresh/update should fail to install with an appropriate error message (**note**, this has not been implemented in this PR). This is similar to what would happen if someone were to update from geneva and they had mongo or the old support rules-engine enabled.

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
