### PR TITLE
Adding vault config default env var and allowing setting VAULT_LOCAL_…

### DIFF
--- a/cmd/security-secrets-setup/start_vault.sh
+++ b/cmd/security-secrets-setup/start_vault.sh
@@ -21,7 +21,7 @@ set -e
 
 VAULT_TLS_PATH=${VAULT_TLS_PATH:-/tmp/edgex/secrets/edgex-vault}
 
-VAULT_LOCAL_CONFIG='
+DEFAULT_VAULT_LOCAL_CONFIG='
 listener "tcp" { 
               address = "edgex-vault:8200" 
               tls_disable = "0" 
@@ -42,6 +42,8 @@ listener "tcp" {
           default_lease_ttl = "168h" 
           max_lease_ttl = "720h"
 '
+
+VAULT_LOCAL_CONFIG=${VAULT_LOCAL_CONFIG:-$DEFAULT_VAULT_LOCAL_CONFIG}
 
 echo "VAULT_LOCAL_CONFIG:" ${VAULT_LOCAL_CONFIG}
 


### PR DESCRIPTION
Adding vault config default env var and allowing setting VAULT_LOCAL_CONFIG variable from the compose file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:
https://github.com/edgexfoundry/edgex-docs/issues/135

## What is the new behavior?
Enables environment variable override of vault configuration.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
