### PR TITLE
feat: Add persisting of new Tags property on V1 & V2 Event models for Redis

### DIFF
--- a/internal/pkg/db/redis/event.go
+++ b/internal/pkg/db/redis/event.go
@@ -32,6 +32,7 @@ type redisEvent struct {
 	Created  int64
 	Modified int64
 	Origin   int64
+	Tags     map[string]string
 }
 
 func marshalEvent(event correlation.Event) (out []byte, err error) {
@@ -43,6 +44,7 @@ func marshalEvent(event correlation.Event) (out []byte, err error) {
 		Created:  event.Created,
 		Modified: event.Modified,
 		Origin:   event.Origin,
+		Tags:     event.Tags,
 	}
 
 	return marshalObject(s)
@@ -74,6 +76,7 @@ func unmarshalEvent(o []byte) (contract.Event, error) {
 		Created:  s.Created,
 		Modified: s.Modified,
 		Origin:   s.Origin,
+		Tags:     s.Tags,
 	}
 
 	conn, err := getConnection()

--- a/internal/pkg/v2/infrastructure/redis/event.go
+++ b/internal/pkg/v2/infrastructure/redis/event.go
@@ -36,6 +36,7 @@ func addEvent(conn redis.Conn, e model.Event) (addedEvent model.Event, err error
 		DeviceName:    e.DeviceName,
 		Created:       e.Created,
 		Origin:        e.Origin,
+		Tags:          e.Tags,
 	}
 
 	m, err := json.Marshal(event)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

New Tags property on V1 & V2 models not persisted to Redis DB

Issue Number: #2668

## What is the new behavior?

New Tags property on V1 & V2 models is now persisted to Redis DB

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

no
## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
