### PR TITLE
fix (snap): use version 0.6.3 of lua-resty-openssl

### DIFF
--- a/snap/local/patches/0002-lua-resty-openssl-fix.patch
+++ b/snap/local/patches/0002-lua-resty-openssl-fix.patch
@@ -1,0 +1,11 @@
+--- kong-2.0.4-0.rockspec	2020-09-08 14:52:00.257090462 +0100
++++ kong-2.0.4-0.rockspec	2020-09-10 10:14:17.960907669 +0100
+@@ -35,7 +35,7 @@
+   "lua-resty-cookie == 0.1.0",
+   "lua-resty-mlcache == 2.4.1",
+   "lua-messagepack == 0.5.2",
+-  "lua-resty-openssl == 0.4.4",
++  "lua-resty-openssl == 0.6.3",
+   "lua-resty-counter == 0.2.0",
+   -- external Kong plugins
+   "kong-plugin-azure-functions ~> 0.4",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -843,6 +843,10 @@ parts:
       - luarocks
       - lua5.1
       - libyaml-0-2
+    override-pull : |
+      snapcraftctl pull
+      cd $SNAPCRAFT_PART_SRC
+      patch  < "$SNAPCRAFT_PROJECT_DIR/snap/local/patches/0002-lua-resty-openssl-fix.patch"
     override-build: |
       # first copy the default config file provided and install it into $SNAPCRAFT_PART_INSTALL
       # it will be generated/configured during the install hook


### PR DESCRIPTION
Without this patch, Kong's spec for lua-resty-openssl is overriden by lua-resty-acme, causing the latest version (0.6.4-1) to get installed, which causes the service to fail to start.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:

## What is the new behavior?
NA
## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
no

## Are there any specific instructions or things that should be known prior to reviewing?
no
## Other information
