### PR TITLE
build: fix#2680 - update GoLang in all places to Go 1.15.2

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG BASE=golang:1.13-alpine
+ARG BASE=golang:1.15.2-alpine
 FROM ${BASE}
 
 RUN apk add --update make git curl bash zeromq-dev libsodium-dev pkgconfig build-base \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG BASE=golang:1.15.2-alpine
+ARG BASE=golang:1.15-alpine
 FROM ${BASE}
 
 RUN apk add --update make git curl bash zeromq-dev libsodium-dev pkgconfig build-base \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@
 
 edgeXBuildGoParallel(
     project: 'edgex-go',
-    goVersion: '1.13',
     dockerFileGlobPath: 'cmd/**/Dockerfile',
     testScript: 'make test',
     buildScript: 'make build',

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ on the snap, including how to install it, please refer to [EdgeX snap](https://g
 
 ##### Go
 
-- The current targeted version of the Go language runtime for release artifacts is v1.13.x
-- The minimum supported version of the Go language runtime is v1.13.x (currently v1.13)
+- The current targeted version of the Go language runtime for release artifacts is v1.15.x
+- The minimum supported version of the Go language runtime is v1.13.x
 
 ##### pkg-config
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ on the snap, including how to install it, please refer to [EdgeX snap](https://g
 ##### Go
 
 - The current targeted version of the Go language runtime for release artifacts is v1.15.x
-- The minimum supported version of the Go language runtime is v1.13.x
+- The minimum supported version of the Go language runtime is v1.15.x
 
 ##### pkg-config
 

--- a/bin/test-attribution-txt.sh
+++ b/bin/test-attribution-txt.sh
@@ -47,7 +47,7 @@ for cmd in cmd/* ; do
         else
             # loop over every library in the modules.txt file in vendor
             while IFS= read -r lib; do
-                if ! grep -q "$lib" Attribution.txt; then 
+                if ! grep -q "$lib" Attribution.txt && [ "$lib" != "explicit" ]; then 
                     echo "An attribution for $lib is missing from in $cmd Attribution.txt, please add"
                     # need to do this in a bash subshell, see SC2031
                     (( EXIT_CODE=1 ))

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # Docker image for Golang Core Data micro service
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go

--- a/cmd/security-proxy-setup/Dockerfile
+++ b/cmd/security-proxy-setup/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go

--- a/cmd/security-secrets-setup/Dockerfile
+++ b/cmd/security-secrets-setup/Dockerfile
@@ -25,7 +25,7 @@
 #  ----------------------------------------------------------------------------------
 
 # Docker image for building EdgeX Foundry security-secrets-setup
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS build-env
 
 # set the working directory

--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go

--- a/cmd/support-logging/Dockerfile
+++ b/cmd/support-logging/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go

--- a/cmd/sys-mgmt-agent/Dockerfile
+++ b/cmd/sys-mgmt-agent/Dockerfile
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ARG BUILDER_BASE=golang:1.13-alpine
+ARG BUILDER_BASE=golang:1.15-alpine
 FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go

--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.8
 )
 
-go 1.13
+go 1.15

--- a/snap/local/build-helpers/bin/go-build-helper.sh
+++ b/snap/local/build-helpers/bin/go-build-helper.sh
@@ -4,7 +4,7 @@
 # $2 - maj/min version of go; must correspond to a go part in the snap
 #
 # example usage:
-# $ gopartbootstrap github.com/edgexfoundry/edgex-go 1.13
+# $ gopartbootstrap github.com/edgexfoundry/edgex-go 1.15
 gopartbootstrap() 
 {
     # first set the GOPATH to be in the current directory and in ".gopath"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -537,7 +537,7 @@ parts:
     # are large - see the TODO on the kong part
     after: [go-build-helper, kong]
 
-  go113:
+  go115:
     plugin: nil
     source: snap/local/build-helpers
     override-build: |
@@ -545,26 +545,26 @@ parts:
       # note - we specifically don't use arch
       case "$(dpkg --print-architecture)" in
         amd64)
-          FILE_NAME=go1.13.8.linux-amd64.tar.gz
-          FILE_HASH=0567734d558aef19112f2b2873caa0c600f1b4a5827930eb5a7f35235219e9d8
+          FILE_NAME=go1.15.2.linux-amd64.tar.gz
+          FILE_HASH=b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552
           ;;
         arm64)
-          FILE_NAME=go1.13.8.linux-arm64.tar.gz
-          FILE_HASH=b46c0235054d0eb69a295a2634aec8a11c7ae19b3dc53556a626b89dc1f8cdb0
+          FILE_NAME=go1.15.2.linux-arm64.tar.gz
+          FILE_HASH=c8ec460cc82d61604b048f9439c06bd591722efce5cd48f49e19b5f6226bd36d
           ;;
       esac
       # download the archive, failing on ssl cert problems
       curl https://dl.google.com/go/$FILE_NAME -O
       echo "$FILE_HASH $FILE_NAME" > sha256
       sha256sum -c sha256 | grep OK
-      mkdir -p $SNAPCRAFT_STAGE/go1.13
-      tar -C $SNAPCRAFT_STAGE/go1.13 -xf "$FILE_NAME" --strip-components=1
+      mkdir -p $SNAPCRAFT_STAGE/go1.15
+      tar -C $SNAPCRAFT_STAGE/go1.15 -xf "$FILE_NAME" --strip-components=1
     prime:
       - "-*"
     after: [go112]
 
   consul:
-    after: [go113]
+    after: [go115]
     plugin: make
     source: https://github.com/hashicorp/consul.git
     source-tag: v1.7.3
@@ -585,7 +585,7 @@ parts:
       fi
 
       . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
-      gopartbootstrap github.com/hashicorp/consul 1.13
+      gopartbootstrap github.com/hashicorp/consul 1.15
       export GO111MODULES=off
       go get -u github.com/kardianos/govendor
       govendor install
@@ -628,9 +628,9 @@ parts:
   edgex-go:
     source: .
     plugin: make
-    after: [go113]
+    after: [go115]
     override-build: |
-      export PATH="$SNAPCRAFT_STAGE/go1.13/bin:$GOPATH/bin:$PATH"
+      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
       cd $SNAPCRAFT_PART_SRC
 
       make build
@@ -950,9 +950,9 @@ parts:
     source-depth: 1
     source-tag: v1.2.1
     plugin: make
-    after: [go113]
+    after: [go115]
     override-build: |
-      export PATH="$SNAPCRAFT_STAGE/go1.13/bin:$GOPATH/bin:$PATH"
+      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
       cd $SNAPCRAFT_PART_SRC
       # create VERSION file (supposed to be created by jenkins pipeline...)
       echo "1.2.1" > ./VERSION
@@ -978,9 +978,9 @@ parts:
     plugin: make
     build-packages: [gcc, git, libzmq3-dev, pkg-config]
     stage-packages: [libzmq5]
-    after: [go113]
+    after: [go115]
     override-build: |
-      export PATH="$SNAPCRAFT_STAGE/go1.13/bin:$GOPATH/bin:$PATH"
+      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
       cd $SNAPCRAFT_PART_SRC
       make build
 
@@ -998,9 +998,9 @@ parts:
     source: https://github.com/emqx/kuiper.git
     source-tag: 0.4.1
     plugin: make
-    after: [go113]
+    after: [go115]
     override-build: |
-      export PATH="$SNAPCRAFT_STAGE/go1.13/bin:$GOPATH/bin:$PATH"
+      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
 
       cd $SNAPCRAFT_PART_SRC
       export BUILD_PATH=$SNAPCRAFT_PART_BUILD


### PR DESCRIPTION
Updated Dockerfile.build, go.mod, README.md, snapcraft.yml to Go 1.15 or patch 1.15.2 where applicable.  Removed reference in Jenkinsfile to allow devops CI/CD default to apply

Signed-off-by: Jim White <jpwhite_mn@yahoo.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

also ran `make docker` and `snapcraft --debug`

## PR Type

What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] Other... Please describe:  update GoLang version used for all of edgex-go

## What is the current behavior?
n/a

Issue Number: #2680  

## What is the new behavior?
n/a

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
none

## Are there any specific instructions or things that should be known prior to reviewing?
Removed go lang reference in Jenkinsbuild.  This will now default to what devops has defaulted in CI/CD.

## Other information
