### PR TITLE
Fix (core-data): add back dbclient variable init

### DIFF
--- a/internal/core/data/v2/application/device.go
+++ b/internal/core/data/v2/application/device.go
@@ -8,11 +8,10 @@ package application
 import (
 	"context"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/di"
-
 	dataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/container"
 	v2DataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/v2/bootstrap/container"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
 )
 

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -25,14 +25,15 @@ type Client struct {
 	*redisClient.Client
 }
 
-func NewClient(config db.Configuration, logger logger.LoggingClient) (dc *Client, edgeXerr errors.EdgeX) {
+func NewClient(config db.Configuration, logger logger.LoggingClient) (*Client, errors.EdgeX) {
 	var err error
+	dc := &Client{}
 	dc.Client, err = redisClient.NewClient(config, logger)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindDatabaseError, "redis client creation failed", err)
 	}
 
-	return
+	return dc, nil
 }
 
 // CloseSession closes the connections to Redis


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The dbclient variable initialization was removed accidentally.

Issue Number: Fix https://github.com/edgexfoundry/edgex-go/issues/2693

## What is the new behavior?
Add the dbclient variable initialization back to fix the nil pointer panic.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No