### PR TITLE
feat(core-data): Event ID has to be pre-populated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.37
 	github.com/edgexfoundry/go-mod-configuration v0.0.3
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.78
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.80
 	github.com/edgexfoundry/go-mod-messaging v0.1.19
 	github.com/edgexfoundry/go-mod-registry v0.1.17
 	github.com/edgexfoundry/go-mod-secrets v0.0.17

--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -40,7 +40,6 @@ func AddEvent(e models.Event, ctx context.Context, dic *di.Container) (id string
 	// Add the event and readings to the database
 	if configuration.Writable.PersistData {
 		correlationId := correlation.FromContext(ctx)
-		e.CorrelationId = correlationId
 		addedEvent, err := dbClient.AddEvent(e)
 		if err != nil {
 			return "", errors.NewCommonEdgeXWrapper(err)

--- a/internal/core/data/v2/controller/http/event_test.go
+++ b/internal/core/data/v2/controller/http/event_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 var expectedCorrelationId = uuid.New().String()
+var expectedEventId = uuid.New().String()
 
 var testReading = dtos.BaseReading{
 	DeviceName: TestDeviceName,
@@ -46,6 +47,7 @@ var testAddEvent = requests.AddEventRequest{
 		RequestID: ExampleUUID,
 	},
 	Event: dtos.Event{
+		ID:         expectedEventId,
 		DeviceName: TestDeviceName,
 		Origin:     TestOriginTime,
 		Readings:   []dtos.BaseReading{testReading},
@@ -83,6 +85,10 @@ func TestAddEvent(t *testing.T) {
 	badRequestId.RequestID = "niv3sl"
 	noEvent := validRequest
 	noEvent.Event = dtos.Event{}
+	noEventID := validRequest
+	noEventID.Event.ID = ""
+	badEventID := validRequest
+	badEventID.Event.ID = "DIWNI09320"
 	noEventDevice := validRequest
 	noEventDevice.Event.DeviceName = ""
 	noEventOrigin := validRequest
@@ -146,6 +152,8 @@ func TestAddEvent(t *testing.T) {
 		{"Valid - No RequestId", []requests.AddEventRequest{noRequestId}, false, http.StatusCreated},
 		{"Invalid - Bad RequestId", []requests.AddEventRequest{badRequestId}, true, http.StatusBadRequest},
 		{"Invalid - No Event", []requests.AddEventRequest{noEvent}, true, http.StatusBadRequest},
+		{"Invalid - No Event Id", []requests.AddEventRequest{noEventID}, true, http.StatusBadRequest},
+		{"Invalid - Bad Event Id", []requests.AddEventRequest{badEventID}, true, http.StatusBadRequest},
 		{"Invalid - No Event DeviceName", []requests.AddEventRequest{noEventDevice}, true, http.StatusBadRequest},
 		{"Invalid - No Event Origin", []requests.AddEventRequest{noEventOrigin}, true, http.StatusBadRequest},
 		{"Invalid - No Reading", []requests.AddEventRequest{noReading}, true, http.StatusBadRequest},


### PR DESCRIPTION



Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Event ID will be generated before storing into the database

Issue Number: Fix https://github.com/edgexfoundry/edgex-go/issues/2684

## What is the new behavior?
In V2 API, Event ID has to be UUID and pre-populated.
Adopt the latest go-mod-contracts to include this validation.
Modify the related unit test to verify this feature.
Remove the UUID assignment before storing into the database.
Remove checksum and correlation id from Event model.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
