### PR TITLE
feat(support-notifications): use notification content type

### DIFF
--- a/internal/support/notifications/sending_service_test.go
+++ b/internal/support/notifications/sending_service_test.go
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright 2020 Technotects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+package notifications
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestBuildSmtpMessageNoContentType(t *testing.T) {
+	subject := uuid.New().String()
+	message := uuid.New().String()
+
+	result := buildSmtpMessage(subject, "", message)
+
+	require.NotNil(t, result)
+
+	stringResult := string(result)
+
+	expected := fmt.Sprintf("Subject: %s\r\n\r\n%s\r\n", subject, message)
+	assert.Equal(t, expected, stringResult)
+}
+
+func TestBuildSmtpMessageContentType(t *testing.T) {
+	subject := uuid.New().String()
+	contentType := uuid.New().String()
+	message := uuid.New().String()
+
+	result := buildSmtpMessage(subject, contentType, message)
+
+	require.NotNil(t, result)
+
+	stringResult := string(result)
+
+	expected := fmt.Sprintf("Subject: %s\r\nMIME-version: 1.0;\r\nContent-Type: %s; charset=\"UTF-8\";\r\n\r\n%s\r\n", subject, contentType, message)
+	assert.Equal(t, expected, stringResult)
+}
+
+func TestBuildSmtpMessageLongMessageIsChunkedIfNeeded(t *testing.T) {
+	subject := uuid.New().String()
+	message := uuid.New().String()
+
+	for i := 0; i < 5; i++ {
+		message += message
+	}
+
+	require.Greater(t, len(message), 998)
+	require.Less(t, len(message), 1896)
+
+	result := buildSmtpMessage(subject, "", message)
+
+	require.NotNil(t, result)
+
+	stringResult := string(result)
+
+	expected := fmt.Sprintf("Subject: %s\r\n\r\n%s\r\n%s\r\n", subject, message[0:998], message[998:])
+	assert.Equal(t, expected, stringResult)
+}
+
+func TestBuildSmtpMessageLongMessageIsPreChunked(t *testing.T) {
+	subject := uuid.New().String()
+	longLine := uuid.New().String()
+
+	for i := 0; i < 5; i++ {
+		longLine += longLine
+	}
+
+	require.Greater(t, len(longLine), 998)
+	require.Less(t, len(longLine), 1896)
+
+	formattedMessage := fmt.Sprintf("%s\r\n%s", longLine[0:998], longLine[998:])
+
+	result := buildSmtpMessage(subject, "", formattedMessage)
+
+	require.NotNil(t, result)
+
+	stringResult := string(result)
+
+	expected := fmt.Sprintf("Subject: %s\r\n\r\n%s\r\n", subject, formattedMessage)
+	assert.Equal(t, expected, stringResult)
+}
+
+func TestBuildSmtpMessageLongMessageIsPartlyChunked(t *testing.T) {
+	subject := uuid.New().String()
+	longLine := uuid.New().String()
+
+	for i := 0; i < 5; i++ {
+		longLine += longLine
+	}
+
+	require.Greater(t, len(longLine), 998)
+	require.Less(t, len(longLine), 1896)
+
+	goodLine := uuid.New().String() + uuid.New().String() + "\r\n"
+
+	formattedMessage := fmt.Sprintf("%s\r\n%s", longLine[0:998], longLine[998:])
+
+	result := buildSmtpMessage(subject, "", goodLine+formattedMessage)
+
+	require.NotNil(t, result)
+
+	stringResult := string(result)
+
+	expected := fmt.Sprintf("Subject: %s\r\n\r\n%s%s\r\n%s\r\n", subject, goodLine, longLine[0:998], longLine[998:])
+	assert.Equal(t, expected, stringResult)
+}


### PR DESCRIPTION
Use ContentType defined on notification on HTTP header for HTTP channel
and MIME header for SMTP channel.  Also add chunking with newlines for
long SMTP messages.

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

Not sure if a bug per se but current implementation disregards the content type set on the notification, and also runs into problems sending long SMTP messages

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #2682 

## What is the new behavior?
Includes content type specified on the notification in the HTTP header for REST transmission, and in the MIME header for SMTP transmission.  Also introduces chunking of SMTP payloads for messages longer than 1000 characters.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
I mentioned ability to specify character set and general sending service refactoring in the linked issue but not addressing at this time.  Not going to pursue 'smarter' chunking using bytes.Runes until I find a failure case with the current implementation - not sure if this will come with expanding charset support or not.

## Other information
