### PR TITLE
fix(metadata): Notify both device services when a Device is moved…

### DIFF
--- a/internal/core/metadata/operators/device/events.go
+++ b/internal/core/metadata/operators/device/events.go
@@ -1,9 +1,10 @@
 package device
 
 type DeviceEvent struct {
-	DeviceId   string
-	DeviceName string
-	Error      error
-	HttpMethod string
-	ServiceId  string
+	DeviceId           string
+	DeviceName         string
+	Error              error
+	HttpMethod         string
+	ServiceId          string
+	SecondaryServiceId string
 }

--- a/internal/core/metadata/operators/device/notify.go
+++ b/internal/core/metadata/operators/device/notify.go
@@ -85,6 +85,19 @@ func (op deviceNotifier) Execute() {
 		if err := op.callback(service, deviceId, httpMethod, models.DEVICE); err != nil {
 			op.logger.Error(err.Error())
 		}
+
+		if msg.SecondaryServiceId != "" {
+			// Callback for secondary device service
+			service, err := op.database.GetDeviceServiceById(msg.SecondaryServiceId)
+			if err != nil {
+				op.logger.Error(err.Error())
+				return
+			}
+
+			if err := op.callback(service, deviceId, httpMethod, models.DEVICE); err != nil {
+				op.logger.Error(err.Error())
+			}
+		}
 	}
 }
 

--- a/internal/core/metadata/operators/device/update.go
+++ b/internal/core/metadata/operators/device/update.go
@@ -143,6 +143,10 @@ func (op updateDevice) Execute() (err error) {
 	evt.HttpMethod = http.MethodPut
 	evt.ServiceId = op.device.Service.Id
 
+	if op.device.Service.Id != oldDevice.Service.Id {
+		evt.SecondaryServiceId = oldDevice.Service.Id
+	}
+
 	op.events <- evt
 
 	return nil


### PR DESCRIPTION
…from one to the other (#2716)

Signed-off-by: Iain Anderson <iain@iotechsys.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: as per #2716 

## What is the new behavior?
Callbacks issued to both device service when a device moves.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
