### PR TITLE
fix(data):add content-type before writing header

### DIFF
--- a/internal/pkg/v2/utils/http.go
+++ b/internal/pkg/v2/utils/http.go
@@ -1,0 +1,21 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+func WriteHttpHeader(w http.ResponseWriter, ctx context.Context, statusCode int) {
+	w.Header().Set(clients.CorrelationHeader, correlation.FromContext(ctx))
+	w.Header().Set(clients.ContentType, clients.ContentTypeJSON)
+	w.WriteHeader(statusCode)
+}


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Write the http header before setting the correct content type.

Issue Number: Fix https://github.com/edgexfoundry/edgex-go/issues/2718

## What is the new behavior?
Create an utils package for the future V2 API implementation.
Create WriteHttpHeader helper function to set up header for http controllers.
Set content-type before calling `w.WtiteHeader()`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

