### PR TITLE
Fix(data):query event doesn't print error message

### DIFF
--- a/internal/core/data/v2/controller/http/event.go
+++ b/internal/core/data/v2/controller/http/event.go
@@ -11,6 +11,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2"
 	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 	requestDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
@@ -97,7 +98,10 @@ func (ec *EventController) EventById(w http.ResponseWriter, r *http.Request) {
 	// Get the event
 	e, err := application.EventById(id, ec.dic)
 	if err != nil {
-		lc.Error(err.Error())
+		// Event not found is not a real error, so the error message should not be printed out
+		if errors.Kind(err) != errors.KindEntityDoesNotExist {
+			lc.Error(err.Error())
+		}
 		lc.Debug(err.DebugMessages())
 		eventResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
 		statusCode = err.Code()

--- a/internal/pkg/v2/infrastructure/redis/event.go
+++ b/internal/pkg/v2/infrastructure/redis/event.go
@@ -26,6 +26,7 @@ func addEvent(conn redis.Conn, e models.Event) (addedEvent models.Event, edgeXer
 	if errors.Kind(edgeXerr) != errors.KindEntityDoesNotExist {
 		return addedEvent, errors.NewCommonEdgeX(errors.KindDuplicateName, "Event Id exists", nil)
 	}
+	edgeXerr = nil
 
 	if e.Created == 0 {
 		e.Created = common.MakeTimestamp()


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: Fix https://github.com/edgexfoundry/edgex-go/issues/2738

## What is the new behavior?
If the query error is errors.KindEntityDoesNotExist, the error log
should not be printed out because it is not a real error.
In the infrastructure layer, if the event doesn't exist when adding, the
error should not be returned.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

