### PR TITLE
fix(metadata): Device profile post returns 409 if id exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,14 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.41
 	github.com/edgexfoundry/go-mod-configuration v0.0.5
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.85
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.90
 	github.com/edgexfoundry/go-mod-messaging v0.1.19
 	github.com/edgexfoundry/go-mod-registry v0.1.22
 	github.com/edgexfoundry/go-mod-secrets v0.0.22
 	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gomodule/redigo v2.0.0+incompatible
-	github.com/google/uuid v1.1.0
+	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.7.1
 	github.com/imdario/mergo v0.3.11
 	github.com/pkg/errors v0.8.1

--- a/internal/core/metadata/v2/controller/http/deviceprofile.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile.go
@@ -107,7 +107,7 @@ func (dc *DeviceProfileController) AddDeviceProfileByYaml(w http.ResponseWriter,
 		pkg.Encode(addDeviceProfileResponse, w, lc)
 		return
 	}
-	deviceProfile := dtos.ToDeviceProfileModels(deviceProfileDTO)
+	deviceProfile := dtos.ToDeviceProfileModel(deviceProfileDTO)
 
 	newId, err := application.AddDeviceProfile(deviceProfile, ctx, dc.dic)
 	if err != nil {

--- a/internal/pkg/v2/infrastructure/redis/dbcommands.go
+++ b/internal/pkg/v2/infrastructure/redis/dbcommands.go
@@ -5,7 +5,9 @@ package redis
 const (
 	MULTI     = "MULTI"
 	SET       = "SET"
+	EXISTS    = "EXISTS"
 	HSET      = "HSET"
+	HEXISTS   = "HEXISTS"
 	SADD      = "SADD"
 	ZADD      = "ZADD"
 	GET       = "GET"

--- a/internal/pkg/v2/infrastructure/redis/device_profile.go
+++ b/internal/pkg/v2/infrastructure/redis/device_profile.go
@@ -18,13 +18,48 @@ import (
 
 const DeviceProfileCollection = "v2:deviceProfile"
 
+// deviceProfileStoredKey return the device profile's stored key which combines the collection name and object id
+func deviceProfileStoredKey(id string) string {
+	return fmt.Sprintf("%s:%s", DeviceProfileCollection, id)
+}
+
+// deviceProfileExistByName whether the device profile exists by name
+func deviceProfileExistByName(conn redis.Conn, name string) (bool, errors.EdgeX) {
+	exists, err := redis.Bool(conn.Do(HEXISTS, DeviceProfileCollection+":name", name))
+	if err != nil {
+		return false, errors.NewCommonEdgeX(errors.KindDatabaseError, "device profile existence check by name failed", err)
+	} else if exists {
+		return true, nil
+	}
+	return false, nil
+}
+
+// deviceProfileExistById checks whether the device profile exists by id
+func deviceProfileExistById(conn redis.Conn, id string) (bool, errors.EdgeX) {
+	exists, err := redis.Bool(conn.Do(EXISTS, deviceProfileStoredKey(id)))
+	if err != nil {
+		return false, errors.NewCommonEdgeX(errors.KindDatabaseError, "device profile existence check by id failed", err)
+	} else if exists {
+		return true, nil
+	}
+	return false, nil
+}
+
 // addDeviceProfile adds a device profile to DB
 func addDeviceProfile(conn redis.Conn, dp model.DeviceProfile) (addedDeviceProfile model.DeviceProfile, edgeXerr errors.EdgeX) {
-	exists, err := redis.Bool(conn.Do("HEXISTS", DeviceProfileCollection+":name", dp.Name))
-	if err != nil {
-		return addedDeviceProfile, errors.NewCommonEdgeX(errors.KindDatabaseError, "device profile existence check failed", err)
+	// query device profile name and id to avoid the conflict
+	exists, edgeXerr := deviceProfileExistById(conn, dp.Id)
+	if edgeXerr != nil {
+		return addedDeviceProfile, errors.NewCommonEdgeXWrapper(edgeXerr)
 	} else if exists {
-		return addedDeviceProfile, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("device profile %s already existence", dp.Name), err)
+		return addedDeviceProfile, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("device profile id %s exists", dp.Id), edgeXerr)
+	}
+
+	exists, edgeXerr = deviceProfileExistByName(conn, dp.Name)
+	if edgeXerr != nil {
+		return addedDeviceProfile, errors.NewCommonEdgeXWrapper(edgeXerr)
+	} else if exists {
+		return addedDeviceProfile, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("device profile name %s exists", dp.Name), edgeXerr)
 	}
 
 	if dp.Created == 0 {
@@ -36,13 +71,13 @@ func addDeviceProfile(conn redis.Conn, dp model.DeviceProfile) (addedDeviceProfi
 		return addedDeviceProfile, errors.NewCommonEdgeX(errors.KindContractInvalid, "unable to JSON marshal device profile for Redis persistence", err)
 	}
 
-	storeKey := fmt.Sprintf("%s:%s", DeviceProfileCollection, dp.Id)
+	storedKey := deviceProfileStoredKey(dp.Id)
 	_ = conn.Send(MULTI)
-	_ = conn.Send(SET, storeKey, m)
-	_ = conn.Send(ZADD, DeviceProfileCollection, 0, storeKey)
-	_ = conn.Send(HSET, DeviceProfileCollection+":name", dp.Name, storeKey)
-	_ = conn.Send(SADD, DeviceProfileCollection+":manufacturer:"+dp.Manufacturer, storeKey)
-	_ = conn.Send(SADD, DeviceProfileCollection+":model:"+dp.Model, storeKey)
+	_ = conn.Send(SET, storedKey, m)
+	_ = conn.Send(ZADD, DeviceProfileCollection, 0, storedKey)
+	_ = conn.Send(HSET, DeviceProfileCollection+":name", dp.Name, storedKey)
+	_ = conn.Send(SADD, DeviceProfileCollection+":manufacturer:"+dp.Manufacturer, storedKey)
+	_ = conn.Send(SADD, DeviceProfileCollection+":model:"+dp.Model, storedKey)
 
 	_, err = conn.Do(EXEC)
 	if err != nil {


### PR DESCRIPTION
Fix #2736

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #2736 

## What is the new behavior?
Add a check in the infrastructure layer to check whether the device profile Id
exists.  If it exists, the API should return 409 conflict.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
