### PR TITLE
fix(notifications): include From/To in SMTP header

### DIFF
--- a/internal/support/notifications/sending_service.go
+++ b/internal/support/notifications/sending_service.go
@@ -119,7 +119,7 @@ func sendMail(
 
 	tr := getTransmissionRecord("SMTP server received", models.Sent)
 
-	smtpMessage := buildSmtpMessage(smtp.Subject, contentType, message)
+	smtpMessage := buildSmtpMessage(smtp.Sender, smtp.Subject, addressees, contentType, message)
 
 	err := smtpSend(addressees, smtpMessage, smtp)
 	if err != nil {
@@ -131,11 +131,15 @@ func sendMail(
 	return tr
 }
 
-func buildSmtpMessage(subject string, contentType string, message string) []byte {
+func buildSmtpMessage(sender string, subject string, toAddresses []string, contentType string, message string) []byte {
 	smtpNewline := "\r\n"
 
 	// required CRLF at ends of lines and CRLF between header and body for SMTP RFC 822 style email
 	buf := bytes.NewBufferString("Subject: " + subject + smtpNewline)
+
+	buf.WriteString("From: " + sender + smtpNewline)
+
+	buf.WriteString("To: " + strings.Join(toAddresses, ",") + smtpNewline)
 
 	// only add MIME header if notification content type was set
 	// maybe provide charset overrides as well?

--- a/internal/support/notifications/sending_service_test.go
+++ b/internal/support/notifications/sending_service_test.go
@@ -24,35 +24,44 @@ import (
 
 func TestBuildSmtpMessageNoContentType(t *testing.T) {
 	subject := uuid.New().String()
+	from := uuid.New().String()
+	to1 := uuid.New().String()
+	to2 := uuid.New().String()
+
 	message := uuid.New().String()
 
-	result := buildSmtpMessage(subject, "", message)
+	result := buildSmtpMessage(from, subject, []string{to1, to2}, "", message)
 
 	require.NotNil(t, result)
 
 	stringResult := string(result)
 
-	expected := fmt.Sprintf("Subject: %s\r\n\r\n%s\r\n", subject, message)
+	expected := fmt.Sprintf("Subject: %s\r\nFrom: %s\r\nTo: %s,%s\r\n\r\n%s\r\n", subject, from, to1, to2, message)
 	assert.Equal(t, expected, stringResult)
 }
 
 func TestBuildSmtpMessageContentType(t *testing.T) {
 	subject := uuid.New().String()
+	from := uuid.New().String()
+	to := uuid.New().String()
 	contentType := uuid.New().String()
 	message := uuid.New().String()
 
-	result := buildSmtpMessage(subject, contentType, message)
+	result := buildSmtpMessage(from, subject, []string{to}, contentType, message)
 
 	require.NotNil(t, result)
 
 	stringResult := string(result)
 
-	expected := fmt.Sprintf("Subject: %s\r\nMIME-version: 1.0;\r\nContent-Type: %s; charset=\"UTF-8\";\r\n\r\n%s\r\n", subject, contentType, message)
+	expected := fmt.Sprintf("Subject: %s\r\nFrom: %s\r\nTo: %s\r\nMIME-version: 1.0;\r\nContent-Type: %s; charset=\"UTF-8\";\r\n\r\n%s\r\n", subject, from, to, contentType, message)
 	assert.Equal(t, expected, stringResult)
 }
 
 func TestBuildSmtpMessageLongMessageIsChunkedIfNeeded(t *testing.T) {
 	subject := uuid.New().String()
+	from := uuid.New().String()
+	to := uuid.New().String()
+
 	message := uuid.New().String()
 
 	for i := 0; i < 5; i++ {
@@ -62,18 +71,21 @@ func TestBuildSmtpMessageLongMessageIsChunkedIfNeeded(t *testing.T) {
 	require.Greater(t, len(message), 998)
 	require.Less(t, len(message), 1896)
 
-	result := buildSmtpMessage(subject, "", message)
+	result := buildSmtpMessage(from, subject, []string{to}, "", message)
 
 	require.NotNil(t, result)
 
 	stringResult := string(result)
 
-	expected := fmt.Sprintf("Subject: %s\r\n\r\n%s\r\n%s\r\n", subject, message[0:998], message[998:])
+	expected := fmt.Sprintf("Subject: %s\r\nFrom: %s\r\nTo: %s\r\n\r\n%s\r\n%s\r\n", subject, from, to, message[0:998], message[998:])
 	assert.Equal(t, expected, stringResult)
 }
 
 func TestBuildSmtpMessageLongMessageIsPreChunked(t *testing.T) {
 	subject := uuid.New().String()
+	from := uuid.New().String()
+	to := uuid.New().String()
+
 	longLine := uuid.New().String()
 
 	for i := 0; i < 5; i++ {
@@ -85,18 +97,21 @@ func TestBuildSmtpMessageLongMessageIsPreChunked(t *testing.T) {
 
 	formattedMessage := fmt.Sprintf("%s\r\n%s", longLine[0:998], longLine[998:])
 
-	result := buildSmtpMessage(subject, "", formattedMessage)
+	result := buildSmtpMessage(from, subject, []string{to}, "", formattedMessage)
 
 	require.NotNil(t, result)
 
 	stringResult := string(result)
 
-	expected := fmt.Sprintf("Subject: %s\r\n\r\n%s\r\n", subject, formattedMessage)
+	expected := fmt.Sprintf("Subject: %s\r\nFrom: %s\r\nTo: %s\r\n\r\n%s\r\n", subject, from, to, formattedMessage)
 	assert.Equal(t, expected, stringResult)
 }
 
 func TestBuildSmtpMessageLongMessageIsPartlyChunked(t *testing.T) {
 	subject := uuid.New().String()
+	from := uuid.New().String()
+	to := uuid.New().String()
+
 	longLine := uuid.New().String()
 
 	for i := 0; i < 5; i++ {
@@ -110,12 +125,12 @@ func TestBuildSmtpMessageLongMessageIsPartlyChunked(t *testing.T) {
 
 	formattedMessage := fmt.Sprintf("%s\r\n%s", longLine[0:998], longLine[998:])
 
-	result := buildSmtpMessage(subject, "", goodLine+formattedMessage)
+	result := buildSmtpMessage(from, subject, []string{to}, "", goodLine+formattedMessage)
 
 	require.NotNil(t, result)
 
 	stringResult := string(result)
 
-	expected := fmt.Sprintf("Subject: %s\r\n\r\n%s%s\r\n%s\r\n", subject, goodLine, longLine[0:998], longLine[998:])
+	expected := fmt.Sprintf("Subject: %s\r\nFrom: %s\r\nTo: %s\r\n\r\n%s%s\r\n%s\r\n", subject, from, to, goodLine, longLine[0:998], longLine[998:])
 	assert.Equal(t, expected, stringResult)
 }


### PR DESCRIPTION
Using only RCPT calls to resolve recipient leads to empty to: fields in some email clients, and seems like it may cause some destination hosts to reject messages.

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:
#2757 

## What is the new behavior?
Write sender and to addresses into SMTP message header

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
