### PR TITLE
feat(metadata): Implement Metadata V2 API for deleting device profile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.46
 	github.com/edgexfoundry/go-mod-configuration v0.0.6
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.90
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.91
 	github.com/edgexfoundry/go-mod-messaging v0.1.24
 	github.com/edgexfoundry/go-mod-registry v0.1.24
 	github.com/edgexfoundry/go-mod-secrets v0.0.23

--- a/internal/core/metadata/v2/application/deviceprofile.go
+++ b/internal/core/metadata/v2/application/deviceprofile.go
@@ -72,3 +72,29 @@ func GetDeviceProfileByName(name string, ctx context.Context, dic *di.Container)
 	deviceProfile = dtos.FromDeviceProfileModelToDTO(dp)
 	return deviceProfile, nil
 }
+
+// DeleteDeviceProfileById delete the device profile by Id
+func DeleteDeviceProfileById(id string, ctx context.Context, dic *di.Container) errors.EdgeX {
+	if id == "" {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "id is empty", nil)
+	}
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	err := dbClient.DeleteDeviceProfileById(id)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}
+
+// DeleteDeviceProfileByName delete the device profile by name
+func DeleteDeviceProfileByName(name string, ctx context.Context, dic *di.Container) errors.EdgeX {
+	if name == "" {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
+	}
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	err := dbClient.DeleteDeviceProfileByName(name)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}

--- a/internal/core/metadata/v2/controller/http/deviceprofile.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile.go
@@ -204,3 +204,67 @@ func (dc *DeviceProfileController) GetDeviceProfileByName(w http.ResponseWriter,
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc) // encode and send out the response
 }
+
+func (dc *DeviceProfileController) DeleteDeviceProfileById(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(dc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	// URL parameters
+	vars := mux.Vars(r)
+	id := vars[v2.Id]
+
+	var response interface{}
+	var statusCode int
+
+	err := application.DeleteDeviceProfileById(id, ctx, dc.dic)
+	if err != nil {
+		if errors.Kind(err) != errors.KindEntityDoesNotExist {
+			lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		}
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		response = commonDTO.NewBaseResponse(
+			"",
+			"Delete device profile successfully",
+			http.StatusOK)
+		statusCode = http.StatusOK
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}
+
+func (dc *DeviceProfileController) DeleteDeviceProfileByName(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(dc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	// URL parameters
+	vars := mux.Vars(r)
+	name := vars[v2.Name]
+
+	var response interface{}
+	var statusCode int
+
+	err := application.DeleteDeviceProfileByName(name, ctx, dc.dic)
+	if err != nil {
+		if errors.Kind(err) != errors.KindEntityDoesNotExist {
+			lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		}
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		response = commonDTO.NewBaseResponse(
+			"",
+			"Delete device profile successfully",
+			http.StatusOK)
+		statusCode = http.StatusOK
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}

--- a/internal/core/metadata/v2/infrastructure/interfaces/db.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/db.go
@@ -16,6 +16,8 @@ type DBClient interface {
 	AddDeviceProfile(e model.DeviceProfile) (model.DeviceProfile, errors.EdgeX)
 	UpdateDeviceProfile(e model.DeviceProfile) errors.EdgeX
 	GetDeviceProfileByName(name string) (model.DeviceProfile, errors.EdgeX)
+	DeleteDeviceProfileById(id string) errors.EdgeX
+	DeleteDeviceProfileByName(name string) errors.EdgeX
 
 	AddDeviceService(e model.DeviceService) (model.DeviceService, errors.EdgeX)
 }

--- a/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -66,13 +66,29 @@ func (_m *DBClient) CloseSession() {
 	_m.Called()
 }
 
-// UpdateDeviceProfile provides a mock function with given fields: e
-func (_m *DBClient) UpdateDeviceProfile(e models.DeviceProfile) errors.EdgeX {
-	ret := _m.Called(e)
+// DeleteDeviceProfileById provides a mock function with given fields: id
+func (_m *DBClient) DeleteDeviceProfileById(id string) errors.EdgeX {
+	ret := _m.Called(id)
 
 	var r0 errors.EdgeX
-	if rf, ok := ret.Get(0).(func(models.DeviceProfile) errors.EdgeX); ok {
-		r0 = rf(e)
+	if rf, ok := ret.Get(0).(func(string) errors.EdgeX); ok {
+		r0 = rf(id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(errors.EdgeX)
+		}
+	}
+
+	return r0
+}
+
+// DeleteDeviceProfileByName provides a mock function with given fields: name
+func (_m *DBClient) DeleteDeviceProfileByName(name string) errors.EdgeX {
+	ret := _m.Called(name)
+
+	var r0 errors.EdgeX
+	if rf, ok := ret.Get(0).(func(string) errors.EdgeX); ok {
+		r0 = rf(name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(errors.EdgeX)
@@ -103,4 +119,20 @@ func (_m *DBClient) GetDeviceProfileByName(name string) (models.DeviceProfile, e
 	}
 
 	return r0, r1
+}
+
+// UpdateDeviceProfile provides a mock function with given fields: e
+func (_m *DBClient) UpdateDeviceProfile(e models.DeviceProfile) errors.EdgeX {
+	ret := _m.Called(e)
+
+	var r0 errors.EdgeX
+	if rf, ok := ret.Get(0).(func(models.DeviceProfile) errors.EdgeX); ok {
+		r0 = rf(e)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(errors.EdgeX)
+		}
+	}
+
+	return r0
 }

--- a/internal/core/metadata/v2/router.go
+++ b/internal/core/metadata/v2/router.go
@@ -29,6 +29,8 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiDeviceProfileUploadFileRoute, dc.AddDeviceProfileByYaml).Methods(http.MethodPost)
 	r.HandleFunc(v2Constant.ApiDeviceProfileUploadFileRoute, dc.UpdateDeviceProfileByYaml).Methods(http.MethodPut)
 	r.HandleFunc(v2Constant.ApiDeviceProfileByNameRoute, dc.GetDeviceProfileByName).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiDeviceProfileByIdRoute, dc.DeleteDeviceProfileById).Methods(http.MethodDelete)
+	r.HandleFunc(v2Constant.ApiDeviceProfileByNameRoute, dc.DeleteDeviceProfileByName).Methods(http.MethodDelete)
 
 	// Device Service
 	ds := metadataController.NewDeviceServiceController(dic)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -129,3 +129,35 @@ func (c *Client) GetDeviceProfileByName(name string) (deviceProfile model.Device
 
 	return
 }
+
+// Delete a device profile by id
+func (c *Client) DeleteDeviceProfileById(id string) errors.EdgeX {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	edgeXerr := deleteDeviceProfileById(conn, id)
+	if edgeXerr != nil {
+		if edgeXerr == redis.ErrNil {
+			return errors.NewCommonEdgeXWrapper(edgeXerr)
+		}
+		return errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+
+	return nil
+}
+
+// Delete a device profile by name
+func (c *Client) DeleteDeviceProfileByName(name string) errors.EdgeX {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	edgeXerr := deleteDeviceProfileByName(conn, name)
+	if edgeXerr != nil {
+		if edgeXerr == redis.ErrNil {
+			return errors.NewCommonEdgeXWrapper(edgeXerr)
+		}
+		return errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fix #2752

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit subject follows the [Conventional Commits spec](https://github.com/zeke/semantic-pull-requests)
- [x] The commit message follows the [EdgeX Contributor Guide](https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] `make test` has completed successfully

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #2752

## What is the new behavior?
Implement Core Metadata V2 API for deleting device profile by name and id according to the API doc

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?
This PR works with https://github.com/edgexfoundry/go-mod-core-contracts/pull/323


## Other information
