### PR TITLE
fix(data): correct the id when storing V2 event

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/event.go
+++ b/internal/pkg/v2/infrastructure/redis/event.go
@@ -69,7 +69,7 @@ func addEvent(conn redis.Conn, e models.Event) (addedEvent models.Event, edgeXer
 
 		// set the sorted set score to the index of the reading
 		rids[i*2+1] = i
-		rids[i*2+2] = newReading.GetBaseReading().Id
+		rids[i*2+2] = fmt.Sprintf("%s:%s", ReadingsCollection, newReading.GetBaseReading().Id)
 	}
 	e.Readings = newReadings
 	if len(rids) > 1 {
@@ -85,7 +85,7 @@ func addEvent(conn redis.Conn, e models.Event) (addedEvent models.Event, edgeXer
 }
 
 func eventById(conn redis.Conn, id string) (event models.Event, edgeXerr errors.EdgeX) {
-	edgeXerr = getObjectById(conn, EventsCollection+":"+id, &event)
+	edgeXerr = getObjectById(conn, fmt.Sprintf("%s:%s", EventsCollection, id), &event)
 	if edgeXerr != nil {
 		return event, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}

--- a/internal/pkg/v2/infrastructure/redis/reading.go
+++ b/internal/pkg/v2/infrastructure/redis/reading.go
@@ -55,10 +55,10 @@ func addReading(conn redis.Conn, r models.Reading) (reading models.Reading, edge
 	storedKey := fmt.Sprintf("%s:%s", ReadingsCollection, baseReading.Id)
 	// use the SET command to save reading as blob
 	_ = conn.Send(SET, storedKey, m)
-	_ = conn.Send(ZADD, ReadingsCollection, 0, baseReading.Id)
-	_ = conn.Send(ZADD, ReadingsCollection+":created", baseReading.Created, ReadingsCollection)
-	_ = conn.Send(ZADD, ReadingsCollection+":deviceName:"+baseReading.DeviceName, baseReading.Created, ReadingsCollection)
-	_ = conn.Send(ZADD, ReadingsCollection+":name:"+baseReading.Name, baseReading.Created, ReadingsCollection)
+	_ = conn.Send(ZADD, ReadingsCollection, 0, storedKey)
+	_ = conn.Send(ZADD, ReadingsCollection+":created", baseReading.Created, storedKey)
+	_ = conn.Send(ZADD, ReadingsCollection+":deviceName:"+baseReading.DeviceName, baseReading.Created, storedKey)
+	_ = conn.Send(ZADD, ReadingsCollection+":name:"+baseReading.Name, baseReading.Created, storedKey)
 
 	return reading, nil
 }


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: Fix https://github.com/edgexfoundry/edgex-go/issues/2770


## What is the new behavior?
The V2 reading id didn't store correctly. Make them store the reading id
with collection prefix in Redis.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No