### PR TITLE
fix: Use DB credentials for Redis Streams MesssageBus connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.46
 	github.com/edgexfoundry/go-mod-configuration v0.0.6
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.94
-	github.com/edgexfoundry/go-mod-messaging v0.1.24
+	github.com/edgexfoundry/go-mod-messaging v0.1.26
 	github.com/edgexfoundry/go-mod-registry v0.1.24
 	github.com/edgexfoundry/go-mod-secrets v0.0.23
 	github.com/fxamacker/cbor/v2 v2.2.0


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?

Can not use Redis Streams MesssageBus in secure mode due to lack of password on connection.

## Issue Number: #2777


## What is the new behavior?

Now the DB credentials are used for the Redis Streams MessageBus connection enabling it to work in secure mode.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
no

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information