### PR TITLE
docs(all): Add multiple responses schemas to V2 Swagger files

### DIFF
--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -265,14 +265,14 @@ components:
         - type: object
           properties:
             floatEncoding:
-              description: "Indicates how a float value is encoded, if the value property contains a float."
+              description: "Indicates how a float value is encoded, if the value property contains a float. It should be 'Base64' or 'eNotation'"
               type: string
             value:
               description: "A string representation of the reading's value"
               type: string
       required:
         - value
-    SimpleReadingResponse:
+    MultiSimpleReadingsResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
       description: "A response type for returning a Reading to the caller. The Reading may only be of type SimpleReading."
@@ -385,7 +385,8 @@ components:
             origin: 1602168089665565300
             pushed: 1594975851631
             readings:
-              - created: 1594876281221
+              - apiVersion: "v2"
+                created: 1594876281221
                 deviceName: "device-001"
                 id: "31569347-9369-43ec-aa6a-59ea9c624a6f"
                 labels:                            
@@ -393,10 +394,11 @@ components:
                 modified: 1594975851631
                 origin: 1602168089665565300
                 pushed: 1594975851631
-                floatEncoding: "IEEE-754"
+                floatEncoding: "eNotation"
                 valueType: "Float32"
                 value: "39.5"
-              - create: 1594876281221
+              - apiVersion: "v2"
+                create: 1594876281221
                 deviceName: "device-001"
                 id: "2fd73a5b-969f-483c-9c52-6bb460a06eb1"
                 labels:
@@ -410,8 +412,9 @@ components:
             deviceName: "device-002"
             id: "73fc4f9c-2d64-4920-addb-b1f33a8f8514"
             origin: 1602168089665565300
-            readings: 
-              - created: 1594879337014
+            readings:
+              - apiVersion: "v2"
+                created: 1594879337014
                 deviceName: "device-002"
                 id: "71c601d9-cb56-453a-8c75-54461e444713"
                 labels:
@@ -433,7 +436,7 @@ components:
                 labels:
                   - "co2"
                 origin: 1602168089665565300
-                floatEncoding: "IEEE-754"
+                floatEncoding: "eNotation"
                 valueType: "Float32"
                 value: "12.2"
     AllReadingsExample:
@@ -442,7 +445,7 @@ components:
         apiVersion: "v2"
         statusCode: 200
         message: ""
-        reading:
+        readings:
           - apiVersion: "v2"
             created: 1594876281221
             deviceName: "device-001"
@@ -452,7 +455,7 @@ components:
             modified: 1594975851631
             origin: 1602168089665565300
             pushed: 1594975851631
-            floatEncoding: "IEEE-754"
+            floatEncoding: "eNotation"
             valueType: "Float32"
             value: "39.5"
           - apiVersion: "v2"
@@ -482,7 +485,7 @@ components:
             labels:
               - "co2"
             origin: 1602168089665565300
-            floatEncoding: "IEEE-754"
+            floatEncoding: "eNotation"
             valueType: "Float32"
             value: "12.2"
 paths:
@@ -510,7 +513,7 @@ paths:
                       labels:
                         - co2
                       origin: 1602168089665565300
-                      floatEncoding: IEEE-754
+                      floatEncoding: eNotation
                       valueType: Float32
                       value: '12.2'
               - event:
@@ -523,7 +526,7 @@ paths:
                       labels:
                         - co2
                       origin: 1602168089665565300
-                      floatEncoding: IEEE-754
+                      floatEncoding: eNotation
                       valueType: Float32
                       value: '12.2'
               - event:
@@ -670,7 +673,7 @@ paths:
                       modified: 1594975851631
                       origin: 1602168089665565300
                       pushed: 1594975851631
-                      floatEncoding: "IEEE-754"
+                      floatEncoding: "eNotation"
                       valueType: "Float32"
                       value: "39.5"
                     - create: 1594876281221
@@ -842,6 +845,7 @@ paths:
                 statusCode: 200
                 message: ""
                 count: 3
+                deviceName: ""
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -881,7 +885,7 @@ paths:
                 statusCode: 200
                 message: ""
                 count: 1 
-                deviceId: "device-001"
+                deviceName: "device-001"
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1012,7 +1016,7 @@ paths:
                         labels:
                           - "co2"
                         origin: 1602168089665565300
-                        floatEncoding: "IEEE-754"
+                        floatEncoding: "eNotation"
                         valueType: "Float32"
                         value: "12.2"
         '404':
@@ -1331,7 +1335,7 @@ paths:
                   modified: 1594975851631
                   origin: 1602168089665565300
                   pushed: 1594975851631
-                  floatEncoding: "IEEE-754"
+                  floatEncoding: "eNotation"
                   valueType: "Float32"
                   value: "39.5"
         '404':
@@ -1396,7 +1400,7 @@ paths:
                     modified: 1594975851631
                     origin: 1602168089665565300
                     pushed: 1594975851631
-                    floatEncoding: "IEEE-754"
+                    floatEncoding: "eNotation"
                     valueType: "Float32"
                     value: "39.5"
                   - apiVersion: "v2"
@@ -1459,13 +1463,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SimpleReadingResponse'
+                $ref: '#/components/schemas/MultiSimpleReadingsResponse'
               example:
                 requestId: ""
                 apiVersion: "v2"
                 statusCode: 200
                 message: ""
-                reading: 
+                readings:
                   - apiVersion: "v2"
                     created: 1594876281221
                     deviceName: "device-001"
@@ -1475,7 +1479,7 @@ paths:
                     modified: 1594975851631
                     origin: 1602168089665565300
                     pushed: 1594975851631
-                    floatEncoding: "IEEE-754"
+                    floatEncoding: "eNotation"
                     valueType: "Float32"
                     value: "39.5"
                   - apiVersion: "v2"
@@ -1485,7 +1489,7 @@ paths:
                     labels:
                       - "co2"
                     origin: 1602168089665565300
-                    floatEncoding: "IEEE-754"
+                    floatEncoding: "eNotation"
                     valueType: "Float32"
                     value: "12.2"
         '400':

--- a/openapi/v2/core-metadata.yaml
+++ b/openapi/v2/core-metadata.yaml
@@ -62,8 +62,6 @@ components:
           type: string
           format: uuid
           example: "e6e8a2f4-eb14-4649-9e2b-175247911369"
-      required:
-        - requestId
     BaseResponse:
       description: "Defines basic properties which all use-case specific response DTO instances should support"
       type: object
@@ -395,6 +393,15 @@ components:
       properties:
         profile:
           $ref: '#/components/schemas/DeviceProfile'
+    MultiDeviceProfilesResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+      type: object
+      properties:
+        profiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeviceProfile'
     DeviceResource:
       description: "DeviceResource represents a value on a device that can be read or written."
       type: object
@@ -421,6 +428,15 @@ components:
       properties:
         device:
           $ref: '#/components/schemas/Device'
+    MultiDevicesResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+      type: object
+      properties:
+        devices:
+          type: array
+          items:
+            $ref: '#/components/schemas/Device'
     DeviceService:
       description: "A DeviceService is responsible for proxying connectivity between a set of devices and the EdgeX Foundry core services."
       type: object
@@ -527,6 +543,15 @@ components:
       properties:
         service:
           $ref: '#/components/schemas/DeviceService'
+    MultiDeviceServicesResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+      type: object
+      properties:
+        services:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeviceService'
     ErrorResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -937,7 +962,7 @@ components:
         requestId: "479439fa-0148-11eb-adc1-0242ac120002"
         statusCode: 200
         message: ""
-        device:
+        devices:
           - apiVersion: "v2"
             id: "55b68fcf-0fd2-445a-9fae-670b37fb9274"
             name: "Random-Boolean-Device"
@@ -993,7 +1018,7 @@ components:
         requestId: "bc979763-afde-492c-b0a2-79ff3025b6de"
         statusCode: 200
         message: ""
-        profile:
+        profiles:
         - apiVersion: "v2"
           id: "9d33b6fd-f38b-4f0e-aef4-0332578ff2c0"
           name: "Device-Virtual-Profile"
@@ -1237,7 +1262,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/MultiDevicesResponse'
               examples:
                 GetAllDevicesResponse:
                   $ref: '#/components/examples/GetAllDevicesResponse'
@@ -1683,7 +1708,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/MultiDevicesResponse'
               examples:
                 GetAllDevicesResponse:
                   $ref: '#/components/examples/GetAllDevicesResponse'
@@ -1733,7 +1758,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/MultiDevicesResponse'
               examples:
                 GetAllDevicesResponse:
                   $ref: '#/components/examples/GetAllDevicesResponse'
@@ -1783,7 +1808,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/MultiDevicesResponse'
               examples:
                 GetAllDevicesResponse:
                   $ref: '#/components/examples/GetAllDevicesResponse'
@@ -1833,7 +1858,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceResponse'
+                $ref: '#/components/schemas/MultiDevicesResponse'
               examples:
                 GetAllDevicesResponse:
                   $ref: '#/components/examples/GetAllDevicesResponse'
@@ -2119,7 +2144,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/MultiDeviceProfilesResponse'
               examples:
                 GetAllDeviceProfilesResponse:
                   $ref: '#/components/examples/GetAllDeviceProfilesResponse'
@@ -2494,7 +2519,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/MultiDeviceProfilesResponse'
               examples:
                 GetAllDeviceProfilesResponse:
                   $ref: '#/components/examples/GetAllDeviceProfilesResponse'
@@ -2550,7 +2575,7 @@ paths:
           content:
             application/json:
               schema:
-               $ref: '#/components/schemas/DeviceProfileResponse'
+               $ref: '#/components/schemas/MultiDeviceProfilesResponse'
               examples:
                 GetAllDeviceProfilesResponse:
                   $ref: '#/components/examples/GetAllDeviceProfilesResponse'
@@ -2600,7 +2625,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceProfileResponse'
+                $ref: '#/components/schemas/MultiDeviceProfilesResponse'
               examples:
                 GetAllDeviceProfilesResponse:
                   $ref: '#/components/examples/GetAllDeviceProfilesResponse'
@@ -2767,13 +2792,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeviceServiceResponse'
+                $ref: '#/components/schemas/MultiDeviceServicesResponse'
               example:
                 apiVersion: "v2"
                 requestId: "4c7c47a7-10e0-4489-99c5-f639b7d7eb5c"
                 statusCode: 200
                 message: ""
-                service:
+                services:
                   - apiVersion: "v2"
                     id: "1ff7762f-c432-4af0-9a5d-756bbc92744b"
                     name: "device-virtual"


### PR DESCRIPTION
Fix https://github.com/edgexfoundry/edgex-go/issues/2784
core-data: MultiEventsResponse, MultiReadingsResponse
core-metadata: MultiDevicesResponse, MultiDeviceProfilesResponse, MultiDeviceServicesResponse

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## Issue Number:
#2784 

## What is the new behavior?
1. Update `MultiReadingsResponse` examples in core-data V2 Swagger file 
2. Change `SimpleReadingResponse` schema name to `MultiSimpleReadingsResponse`
3. Add `MultiDevicesResponse`, `MultiDeviceProfilesResponse` and `MultiDeviceServicesResponsschemas` to core-metadata V2 Swagger file
4. Update `GET event/count` and `GET /event/count/device/{deviceName}` examples


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information