### PR TITLE
fix(metadata): V2 GET /deviceservice/all returns inconsistent response when specifying labels or not

### DIFF
--- a/internal/core/metadata/v2/application/deviceservice.go
+++ b/internal/core/metadata/v2/application/deviceservice.go
@@ -131,9 +131,10 @@ func GetDeviceServices(offset int, limit int, labels []string, ctx context.Conte
 	if err != nil {
 		return deviceServices, errors.NewCommonEdgeXWrapper(err)
 	}
-	for _, ds := range services {
+	deviceServices = make([]dtos.DeviceService, len(services))
+	for i, ds := range services {
 		dsDTO := dtos.FromDeviceServiceModelToDTO(ds)
-		deviceServices = append(deviceServices, dsDTO)
+		deviceServices[i] = dsDTO
 	}
 	return deviceServices, nil
 }

--- a/internal/core/metadata/v2/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/config"
 	"gopkg.in/yaml.v2"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/config"
@@ -96,6 +97,9 @@ func mockDic() *di.Container {
 			return &config.ConfigurationStruct{
 				Writable: config.WritableInfo{
 					LogLevel: "DEBUG",
+				},
+				Service: bootstrapConfig.ServiceInfo{
+					MaxResultCount: 30,
 				},
 			}
 		},

--- a/internal/pkg/v2/infrastructure/redis/dbcommands.go
+++ b/internal/pkg/v2/infrastructure/redis/dbcommands.go
@@ -21,4 +21,10 @@ const (
 	ZREVRANGE = "ZREVRANGE"
 	MGET      = "MGET"
 	ZCARD     = "ZCARD"
+	ZCOUNT    = "ZCOUNT"
+)
+
+const (
+	InfiniteMin = "-inf"
+	InfiniteMax = "+inf"
 )

--- a/internal/pkg/v2/infrastructure/redis/device_service.go
+++ b/internal/pkg/v2/infrastructure/redis/device_service.go
@@ -145,7 +145,11 @@ func deleteDeviceServiceByName(conn redis.Conn, name string) errors.EdgeX {
 
 // deviceServicesByLabels query multiple device services from DB per labels
 func deviceServicesByLabels(conn redis.Conn, offset int, limit int, labels []string) (deviceServices []models.DeviceService, edgeXerr errors.EdgeX) {
-	objects, err := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, DeviceServiceCollection, labels, offset, offset+limit-1)
+	end := offset + limit - 1
+	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
+		end = limit
+	}
+	objects, err := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, DeviceServiceCollection, labels, offset, end)
 	if err != nil {
 		return deviceServices, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/pkg/v2/utils/http.go
+++ b/internal/pkg/v2/utils/http.go
@@ -24,18 +24,40 @@ func WriteHttpHeader(w http.ResponseWriter, ctx context.Context, statusCode int)
 	w.WriteHeader(statusCode)
 }
 
+func ParseGetAllObjectsRequestQueryString(r *http.Request, minOffset int, maxOffset int, minLimit int, maxLimit int) (offset int, limit int, labels []string, err errors.EdgeX) {
+	offset, err = ParseQueryStringToInt(r, contractsV2.Offset, contractsV2.DefaultOffset, minOffset, maxOffset)
+	if err != nil {
+		return offset, limit, labels, err
+	}
+
+	limit, err = ParseQueryStringToInt(r, contractsV2.Limit, contractsV2.DefaultLimit, minLimit, maxLimit)
+	if err != nil {
+		return offset, limit, labels, err
+	}
+
+	labels = ParseQueryStringToStrings(r, contractsV2.Labels, contractsV2.CommaSeparator)
+	return offset, limit, labels, err
+}
+
 // Parse the specified query string key to an integer.  If specified query string key is found more than once in the
 // http request, only the first specified query string will be parsed and converted to an integer.  If no specified
 // query string key could be found in the http request, specified default value will be returned.  EdgeX error will be
 // returned if any parsing error occurs.
-func ParseQueryStringToInt(r *http.Request, queryStringKey string, defaultValue int) (int, errors.EdgeX) {
+func ParseQueryStringToInt(r *http.Request, queryStringKey string, defaultValue int, min int, max int) (int, errors.EdgeX) {
+	// first check if specified min is bigger than max, throw error for such case
+	if min > max {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("specified min %v is bigger than specified max %v", min, max), nil)
+	}
 	var result = defaultValue
 	var parsingErr error
 	values, ok := r.URL.Query()[queryStringKey]
 	if ok && len(values) > 0 {
 		result, parsingErr = strconv.Atoi(strings.TrimSpace(values[0]))
 		if parsingErr != nil {
-			return 0, errors.NewCommonEdgeXWrapper(fmt.Errorf("failed to parse querystring %s's value %s into integer. Error:%s", queryStringKey, values[0], parsingErr.Error()))
+			return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("failed to parse querystring %s's value %s into integer. Error:%s", queryStringKey, values[0], parsingErr.Error()), nil)
+		}
+		if result < min || result > max {
+			return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("querystring %s's value %v is out of min %v ~ max %v range.", queryStringKey, result, min, max), nil)
 		}
 	}
 	return result, nil

--- a/openapi/v2/core-command.yaml
+++ b/openapi/v2/core-command.yaml
@@ -230,6 +230,7 @@ components:
       schema:
         type: integer
         minimum: 0
+        default: 0
       description: "The number of items to skip before starting to collect the result set."
     limitParam:
       in: query
@@ -237,10 +238,9 @@ components:
       required: false
       schema:
         type: integer
-        minimum: 1
-        maximum: 50
+        minimum: -1
         default: 20
-      description: "The numbers of items to return."
+      description: "The numbers of items to return.  Specify -1 will return all remaining items after offset.  The maximum will be the MaxResultCount as defined in the configuration of service."
     correlatedRequestHeader:
       in: header
       name: X-Correlation-ID

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -317,6 +317,7 @@ components:
       schema:
         type: integer
         minimum: 0
+        default: 0
       description: "The number of items to skip before starting to collect the result set."
     limitParam:
       in: query
@@ -324,10 +325,9 @@ components:
       required: false
       schema:
         type: integer
-        minimum: 1
-        maximum: 50
+        minimum: -1
         default: 20
-      description: "The numbers of items to return."
+      description: "The numbers of items to return.  Specify -1 will return all remaining items after offset.  The maximum will be the MaxResultCount as defined in the configuration of service."
     correlatedRequestHeader:
       in: header
       name: X-Correlation-ID

--- a/openapi/v2/core-metadata.yaml
+++ b/openapi/v2/core-metadata.yaml
@@ -785,6 +785,7 @@ components:
       schema:
         type: integer
         minimum: 0
+        default: 0
       description: "The number of items to skip before starting to collect the result set."
     limitParam:
       in: query
@@ -792,10 +793,9 @@ components:
       required: false
       schema:
         type: integer
-        minimum: 1
-        maximum: 50
+        minimum: -1
         default: 20
-      description: "The numbers of items to return."
+      description: "The numbers of items to return.  Specify -1 will return all remaining items after offset.  The maximum will be the MaxResultCount as defined in the configuration of service."
     correlatedRequestHeader:
       in: header
       name: X-Correlation-ID

--- a/openapi/v2/support-logging.yaml
+++ b/openapi/v2/support-logging.yaml
@@ -205,21 +205,21 @@ components:
     offsetParam:
       in: query
       name: offset
-      required: true
+      required: false
       schema:
         type: integer
         minimum: 0
+        default: 0
       description: "The number of items to skip before starting to collect the result set."
     limitParam:
       in: query
       name: limit
-      required: true
+      required: false
       schema:
         type: integer
-        minimum: 1
-        maximum: 50
+        minimum: -1
         default: 20
-      description: "The numbers of items to return."
+      description: "The numbers of items to return.  Specify -1 will return all remaining items after offset.  The maximum will be the MaxResultCount as defined in the configuration of service."
     logLevelsParam:
       in: query
       name: levels

--- a/openapi/v2/support-notifications.yaml
+++ b/openapi/v2/support-notifications.yaml
@@ -459,21 +459,21 @@ components:
     offsetParam:
       in: query
       name: offset
-      required: true
+      required: false
       schema:
         type: integer
         minimum: 0
+        default: 0
       description: "The number of items to skip before starting to collect the result set."
     limitParam:
       in: query
       name: limit
-      required: true
+      required: false
       schema:
         type: integer
-        minimum: 1
-        maximum: 50
+        minimum: -1
         default: 20
-      description: "The numbers of items to return."
+      description: "The numbers of items to return.  Specify -1 will return all remaining items after offset.  The maximum will be the MaxResultCount as defined in the configuration of service."
     correlatedRequestHeader:
       in: header
       name: X-Correlation-ID

--- a/openapi/v2/support-scheduler.yaml
+++ b/openapi/v2/support-scheduler.yaml
@@ -448,21 +448,21 @@ components:
     offsetParam:
       in: query
       name: offset
-      required: true
+      required: false
       schema:
         type: integer
         minimum: 0
+        default: 0
       description: "The number of items to skip before starting to collect the result set."
     limitParam:
       in: query
       name: limit
-      required: true
+      required: false
       schema:
         type: integer
-        minimum: 1
-        maximum: 50
+        minimum: -1
         default: 20
-      description: "The numbers of items to return."
+      description: "The numbers of items to return.  Specify -1 will return all remaining items after offset.  The maximum will be the MaxResultCount as defined in the configuration of service."
     correlatedRequestHeader:
       in: header
       name: X-Correlation-ID


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#2803 

## What is the new behavior?
Based on the original implementation of GET /deviceservice/all, when client
specify an out-of-range offset, query with labels will return out of range
errors(http status=416), but query without labels will return empty
array(http status=200).

This commit make query without labels to also return out of range errors
(http status=416) under such case.

Moreover, Swagger spec indicates that the maximum for limit query string
is 50 records, which is too arbitrary and not flexible enough for clients
to decide their own limit. Ideally, the maximum shall refer to MaxResultCount
as defined in the metadata configuration. For the minimum of limit, we shall
consider to have -1, meaning no limit and return all records. Our Swagger
spec is also revised to reflect such changes.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?
No
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information