### PR TITLE
fix(snap): update redis to 6.0.8

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -572,7 +572,7 @@ parts:
 
   redis:
     source: https://github.com/antirez/redis.git
-    source-tag: "5.0.8"
+    source-tag: "6.0.8"
     source-depth: 1
     plugin: make
     make-install-var: PREFIX


### PR DESCRIPTION
Updated the source-tag to 6.0.8 to align with docker-compose redis version.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Using an older version of redis.

## Issue Number:


## What is the new behavior?
Updated the source-tag to 6.0.8 - newer stable release of redis.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
Build snap from source.

## Other information
Ran blackbox tests and all tests passed. Note, you will need to install the latest/edge version of app-service-configurable before running the test suite.