### PR TITLE
fix: PR template broken link, and add yes/no checkboxes for new imports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,10 @@ Please check if your PR fulfills the following requirements:
 - [ ] No
 
 ## New Imports
-Are there any new imports or modules? If so, what are they used for and why?
+<!-- Are there any new imports or modules? If so, what are they used for and why? -->
+
+- [ ] Yes
+- [ ] No
 
 ## Specific Instructions
 Are there any specific instructions or things that should be known prior to reviewing?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Please check if your PR fulfills the following requirements:
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
-**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.
+**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.
 
 ## What is the current behavior?
 <!-- Please describe the current behavior and link to a relevant issue. -->


### PR DESCRIPTION
This PR fixes the link to Committing.md and adds yes/no checkboxes for the new imports section of the template.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?
**NA**

## Issue Number:
**NA**

## What is the new behavior?
**NA**

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
NA
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information