### PR TITLE
feat(metadata): Implement GET /device/service/name/{name} V2 API

### DIFF
--- a/internal/core/metadata/v2/application/device.go
+++ b/internal/core/metadata/v2/application/device.go
@@ -11,9 +11,11 @@ import (
 
 	v2MetadataContainer "github.com/edgexfoundry/edgex-go/internal/core/metadata/v2/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 
 	"github.com/google/uuid"
@@ -80,4 +82,21 @@ func DeleteDeviceByName(name string, dic *di.Container) errors.EdgeX {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 	return nil
+}
+
+// AllDeviceByServiceName query devices with offset, limit and name
+func AllDeviceByServiceName(offset int, limit int, name string, ctx context.Context, dic *di.Container) (devices []dtos.Device, err errors.EdgeX) {
+	if name == "" {
+		return devices, errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
+	}
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	deviceModels, err := dbClient.AllDeviceByServiceName(offset, limit, name)
+	if err != nil {
+		return devices, errors.NewCommonEdgeXWrapper(err)
+	}
+	devices = make([]dtos.Device, len(deviceModels))
+	for i, d := range deviceModels {
+		devices[i] = dtos.FromDeviceModelToDTO(d)
+	}
+	return devices, nil
 }

--- a/internal/core/metadata/v2/controller/http/deviceprofile.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile.go
@@ -77,7 +77,7 @@ func (dc *DeviceProfileController) AddDeviceProfile(w http.ResponseWriter, r *ht
 		} else {
 			addDeviceProfileResponse = commonDTO.NewBaseWithIdResponse(
 				reqId,
-				"Add device profiles successfully",
+				"",
 				http.StatusCreated,
 				newId)
 		}
@@ -127,7 +127,7 @@ func (dc *DeviceProfileController) UpdateDeviceProfile(w http.ResponseWriter, r 
 		} else {
 			response = commonDTO.NewBaseResponse(
 				reqId,
-				"Update device profile successfully",
+				"",
 				http.StatusOK)
 		}
 		responses = append(responses, response)
@@ -174,7 +174,7 @@ func (dc *DeviceProfileController) AddDeviceProfileByYaml(w http.ResponseWriter,
 	} else {
 		addDeviceProfileResponse = commonDTO.NewBaseWithIdResponse(
 			"",
-			"Add device profiles successfully",
+			"",
 			http.StatusCreated,
 			newId)
 		statusCode = http.StatusCreated
@@ -222,7 +222,7 @@ func (dc *DeviceProfileController) UpdateDeviceProfileByYaml(w http.ResponseWrit
 	} else {
 		response = commonDTO.NewBaseResponse(
 			"",
-			"Update device profile successfully",
+			"",
 			http.StatusOK)
 		statusCode = http.StatusOK
 	}
@@ -281,7 +281,7 @@ func (dc *DeviceProfileController) DeleteDeviceProfileById(w http.ResponseWriter
 	} else {
 		response = commonDTO.NewBaseResponse(
 			"",
-			"Delete device profile successfully",
+			"",
 			http.StatusOK)
 		statusCode = http.StatusOK
 	}
@@ -311,7 +311,7 @@ func (dc *DeviceProfileController) DeleteDeviceProfileByName(w http.ResponseWrit
 	} else {
 		response = commonDTO.NewBaseResponse(
 			"",
-			"Delete device profile successfully",
+			"",
 			http.StatusOK)
 		statusCode = http.StatusOK
 	}

--- a/internal/core/metadata/v2/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile_test.go
@@ -136,7 +136,6 @@ func TestAddDeviceProfile_Created(t *testing.T) {
 	deviceProfileRequest := buildTestDeviceProfileRequest()
 	deviceProfileModel := requests.DeviceProfileReqToDeviceProfileModel(deviceProfileRequest)
 	expectedRequestId := ExampleUUID
-	expectedMessage := "Add device profiles successfully"
 
 	dic := mockDic()
 	dbClientMock := &dbMock.DBClient{}
@@ -185,7 +184,7 @@ func TestAddDeviceProfile_Created(t *testing.T) {
 				assert.Equal(t, expectedRequestId, res[0].RequestId, "RequestID not as expected")
 			}
 			assert.Equal(t, http.StatusCreated, res[0].StatusCode, "BaseResponse status code not as expected")
-			assert.Equal(t, expectedMessage, res[0].Message, "Message not as expected")
+			assert.Empty(t, res[0].Message, "Message should be empty when it is successful")
 		})
 	}
 }
@@ -459,7 +458,6 @@ func TestUpdateDeviceProfile(t *testing.T) {
 func TestAddDeviceProfileByYaml_Created(t *testing.T) {
 	deviceProfileDTO := buildTestDeviceProfileRequest().Profile
 	deviceProfileModel := dtos.ToDeviceProfileModel(deviceProfileDTO)
-	expectedMessage := "Add device profiles successfully"
 
 	dic := mockDic()
 	dbClientMock := &dbMock.DBClient{}
@@ -490,7 +488,7 @@ func TestAddDeviceProfileByYaml_Created(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, recorder.Result().StatusCode, "HTTP status code not as expected")
 	assert.Equal(t, contractsV2.ApiVersion, res.ApiVersion, "API Version not as expected")
 	assert.Equal(t, http.StatusCreated, res.StatusCode, "BaseResponse status code not as expected")
-	assert.Equal(t, expectedMessage, res.Message, "Message not as expected")
+	assert.Empty(t, res.Message, "Message should be empty when it is successful")
 }
 
 func TestAddDeviceProfileByYaml_BadRequest(t *testing.T) {
@@ -853,7 +851,11 @@ func TestDeleteDeviceProfileById(t *testing.T) {
 			assert.Equal(t, contractsV2.ApiVersion, res.ApiVersion, "API Version not as expected")
 			assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
 			assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
-			assert.NotEmpty(t, res.Message, "Message is empty")
+			if testCase.errorExpected {
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
 		})
 	}
 }
@@ -905,7 +907,11 @@ func TestDeleteDeviceProfileByName(t *testing.T) {
 			assert.Equal(t, contractsV2.ApiVersion, res.ApiVersion, "API Version not as expected")
 			assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
 			assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
-			assert.NotEmpty(t, res.Message, "Message is empty")
+			if testCase.errorExpected {
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
 		})
 	}
 }

--- a/internal/core/metadata/v2/controller/http/deviceservice.go
+++ b/internal/core/metadata/v2/controller/http/deviceservice.go
@@ -6,7 +6,6 @@
 package http
 
 import (
-	"fmt"
 	"math"
 	"net/http"
 
@@ -77,7 +76,7 @@ func (dc *DeviceServiceController) AddDeviceService(w http.ResponseWriter, r *ht
 		if err == nil {
 			addDeviceServiceResponse = commonDTO.NewBaseWithIdResponse(
 				reqId,
-				fmt.Sprintf("Add device service %s successfully", d.Name),
+				"",
 				http.StatusCreated,
 				newId)
 		} else {
@@ -194,7 +193,7 @@ func (dc *DeviceServiceController) DeleteDeviceServiceById(w http.ResponseWriter
 	} else {
 		response = commonDTO.NewBaseResponse(
 			"",
-			"Delete device service successfully",
+			"",
 			http.StatusOK)
 		statusCode = http.StatusOK
 	}
@@ -224,7 +223,7 @@ func (dc *DeviceServiceController) DeleteDeviceServiceByName(w http.ResponseWrit
 	} else {
 		response = commonDTO.NewBaseResponse(
 			"",
-			"Delete device service successfully",
+			"",
 			http.StatusOK)
 		statusCode = http.StatusOK
 	}

--- a/internal/core/metadata/v2/infrastructure/interfaces/db.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/db.go
@@ -32,4 +32,5 @@ type DBClient interface {
 	AddDevice(d model.Device) (model.Device, errors.EdgeX)
 	DeleteDeviceById(id string) errors.EdgeX
 	DeleteDeviceByName(name string) errors.EdgeX
+	AllDeviceByServiceName(offset int, limit int, name string) ([]model.Device, errors.EdgeX)
 }

--- a/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -84,6 +84,31 @@ func (_m *DBClient) AddDeviceService(e models.DeviceService) (models.DeviceServi
 	return r0, r1
 }
 
+// AllDeviceByServiceName provides a mock function with given fields: offset, limit, name
+func (_m *DBClient) AllDeviceByServiceName(offset int, limit int, name string) ([]models.Device, errors.EdgeX) {
+	ret := _m.Called(offset, limit, name)
+
+	var r0 []models.Device
+	if rf, ok := ret.Get(0).(func(int, int, string) []models.Device); ok {
+		r0 = rf(offset, limit, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Device)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, name)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // CloseSession provides a mock function with given fields:
 func (_m *DBClient) CloseSession() {
 	_m.Called()

--- a/internal/core/metadata/v2/router.go
+++ b/internal/core/metadata/v2/router.go
@@ -47,6 +47,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiDeviceRoute, d.AddDevice).Methods(http.MethodPost)
 	r.HandleFunc(v2Constant.ApiDeviceByIdRoute, d.DeleteDeviceById).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiDeviceByNameRoute, d.DeleteDeviceByName).Methods(http.MethodDelete)
+	r.HandleFunc(v2Constant.ApiAllDeviceByServiceNameRoute, d.AllDeviceByServiceName).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -314,3 +314,16 @@ func (c *Client) DeleteDeviceByName(name string) errors.EdgeX {
 
 	return nil
 }
+
+// AllDeviceByServiceName query devices by offset, limit and name
+func (c *Client) AllDeviceByServiceName(offset int, limit int, name string) (devices []model.Device, edgeXerr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	devices, edgeXerr = allDeviceByServiceName(conn, offset, limit, name)
+	if edgeXerr != nil {
+		return devices, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
+			fmt.Sprintf("fail to query devices by offset %d, limit %d and name %s", offset, limit, name), edgeXerr)
+	}
+	return devices, nil
+}


### PR DESCRIPTION
Fix #2826

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #2826 


## What is the new behavior?
Implement the V2 API for querying all devices by deviceService name, Redis DB should add v2:device:service:name:{serviceName} as new key for searching.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

This PR should add deletion code for new Redis key after the [DELETE device API](https://github.com/edgexfoundry/edgex-go/pull/2813) PR merged

## Other information