### PR TITLE
 fix(metadata): device PATCH V2 API should check service and profile

### DIFF
--- a/internal/core/metadata/v2/application/device.go
+++ b/internal/core/metadata/v2/application/device.go
@@ -166,6 +166,19 @@ func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container) 
 
 	requests.ReplaceDeviceModelFieldsWithDTO(&device, dto)
 
+	exists, edgeXerr := dbClient.DeviceServiceNameExists(device.ServiceName)
+	if edgeXerr != nil {
+		return errors.NewCommonEdgeX(errors.Kind(edgeXerr), fmt.Sprintf("device service '%s' existence check failed", device.ServiceName), edgeXerr)
+	} else if !exists {
+		return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device service '%s' does not exists", device.ServiceName), nil)
+	}
+	exists, edgeXerr = dbClient.DeviceProfileNameExists(device.ProfileName)
+	if edgeXerr != nil {
+		return errors.NewCommonEdgeX(errors.Kind(edgeXerr), fmt.Sprintf("device profile '%s' existence check failed", device.ProfileName), edgeXerr)
+	} else if !exists {
+		return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exists", device.ProfileName), nil)
+	}
+
 	edgeXerr = dbClient.DeleteDeviceById(device.Id)
 	if edgeXerr != nil {
 		return errors.NewCommonEdgeXWrapper(edgeXerr)


### PR DESCRIPTION
Fix #2860

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
The device PATCH V2 API doesn't check the service and profile whether is exists.


## Issue Number: #2860


## What is the new behavior?
If the serviceName or profileName doesn't exist in the DB, device PATCH V2 API should return 404 in the baseResponse


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information