### PR TITLE
fix(snap): remove external symlink to openresty

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -675,6 +675,15 @@ parts:
 
       mkdir -p $SNAPCRAFT_PART_INSTALL/config/security-proxy-setup
       cp $SNAPCRAFT_PART_INSTALL/etc/kong/kong.conf.default $SNAPCRAFT_PART_INSTALL/config/security-proxy-setup/kong.conf
+
+      # by default the Kong deb contains an absolute symlink @ /usr/local/openresty/bin/openresty which points to /usr/local/openresty/nginx/sbin/nginx
+      # because the review-tools for the snap store do not currently allow using absolute symlinks that point outside of the snap
+      # (and are not smart enough to realize there is a layout involved in our usage here), we delete the absolute symlink
+      # and re-create it as a relative symlink pointing to ../nginx/sbin/nginx instead
+      cd $SNAPCRAFT_PART_INSTALL/usr/local/openresty/bin
+      rm openresty
+      ln -s ../nginx/sbin/nginx openresty
+
     prime:
        - -lib/systemd/*
        - -usr/share/man/*


### PR DESCRIPTION
The Kong Debian package has a symbolic link to an external path, which the review tools in the snap store do not allow. The openresty symlink to /usr/local/openresty/nginx/sbin/nginx needs therefore to be changed to ../nginx/sbin/nginx

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
NA


## Issue Number:
NA

## What is the new behavior?
NA

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information