### PR TITLE
fix(metadata): fix V2 API int overflow error on 32bit ARM build

### DIFF
--- a/internal/core/data/v2/controller/http/event.go
+++ b/internal/core/data/v2/controller/http/event.go
@@ -265,7 +265,7 @@ func (ec *EventController) AllEvents(w http.ResponseWriter, r *http.Request) {
 	var statusCode int
 
 	// parse URL query string for offset, limit
-	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxUint32, -1, config.Service.MaxResultCount)
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
@@ -303,7 +303,7 @@ func (ec *EventController) EventsByDeviceName(w http.ResponseWriter, r *http.Req
 	var statusCode int
 
 	// parse URL query string for offset, limit
-	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxUint32, -1, config.Service.MaxResultCount)
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)

--- a/internal/core/metadata/v2/controller/http/device.go
+++ b/internal/core/metadata/v2/controller/http/device.go
@@ -167,7 +167,7 @@ func (dc *DeviceController) DevicesByServiceName(w http.ResponseWriter, r *http.
 	var statusCode int
 
 	// parse URL query string for offset, limit
-	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxUint32, -1, config.Service.MaxResultCount)
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
@@ -310,7 +310,7 @@ func (dc *DeviceController) AllDevices(w http.ResponseWriter, r *http.Request) {
 	var statusCode int
 
 	// parse URL query string for offset, limit, and labels
-	offset, limit, labels, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxUint32, -1, config.Service.MaxResultCount)
+	offset, limit, labels, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)

--- a/internal/core/metadata/v2/controller/http/deviceprofile.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile.go
@@ -330,7 +330,7 @@ func (dc *DeviceProfileController) AllDeviceProfiles(w http.ResponseWriter, r *h
 	var statusCode int
 
 	// parse URL query string for offset, limit, and labels
-	offset, limit, labels, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxUint32, -1, config.Service.MaxResultCount)
+	offset, limit, labels, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)

--- a/internal/core/metadata/v2/controller/http/deviceservice.go
+++ b/internal/core/metadata/v2/controller/http/deviceservice.go
@@ -243,7 +243,7 @@ func (dc *DeviceServiceController) AllDeviceServices(w http.ResponseWriter, r *h
 	var statusCode int
 
 	// parse URL query string for offset, limit, and labels
-	offset, limit, labels, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxUint32, -1, config.Service.MaxResultCount)
+	offset, limit, labels, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)


### PR DESCRIPTION
Fix #2870

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Golang build failed with 32bits ARCH

## Issue Number: #2870 

## What is the new behavior?
Since 32bits ARCH only support 2,147,483,647 as the maximum positive signed integer, so use math.MaxInt32 instead of the math.MaxUint32.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information