### PR TITLE
feat(data): Implement DELETE /event/device/name/{name} V2 API

### DIFF
--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	dataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/container"
 	v2DataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/v2/bootstrap/container"
@@ -164,6 +165,22 @@ func DeletePushedEvents(dic *di.Container) errors.EdgeX {
 	dbClient := v2DataContainer.DBClientFrom(dic.Get)
 
 	err := dbClient.DeletePushedEvents()
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}
+
+// The DeleteEventsByDeviceName function will be invoked by controller functions
+// and then invokes DeleteEventsByDeviceName function in the infrastructure layer to remove
+// all events/readings that are associated with the given deviceName
+func DeleteEventsByDeviceName(deviceName string, dic *di.Container) errors.EdgeX {
+	if len(strings.TrimSpace(deviceName)) <= 0 {
+		return errors.NewCommonEdgeX(errors.KindInvalidId, "blank device name is not allowed", nil)
+	}
+	dbClient := v2DataContainer.DBClientFrom(dic.Get)
+
+	err := dbClient.DeleteEventsByDeviceName(deviceName)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/core/data/v2/controller/http/event.go
+++ b/internal/core/data/v2/controller/http/event.go
@@ -352,3 +352,32 @@ func (ec *EventController) EventsByDeviceName(w http.ResponseWriter, r *http.Req
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc)
 }
+
+func (ec *EventController) DeleteEventsByDeviceName(w http.ResponseWriter, r *http.Request) {
+	// retrieve all the service injections from bootstrap
+	lc := container.LoggingClientFrom(ec.dic.Get)
+
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	vars := mux.Vars(r)
+	deviceName := vars[v2.Name]
+
+	var response interface{}
+	var statusCode int
+
+	// Delete events with associated Device deviceName
+	err := application.DeleteEventsByDeviceName(deviceName, ec.dic)
+	if err != nil {
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		response = commonDTO.NewBaseResponse("", "", http.StatusAccepted)
+		statusCode = http.StatusAccepted
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	// encode and send out the response
+	pkg.Encode(response, w, lc)
+}

--- a/internal/core/data/v2/controller/http/event_test.go
+++ b/internal/core/data/v2/controller/http/event_test.go
@@ -437,6 +437,35 @@ func TestDeletePushedEvents(t *testing.T) {
 	assert.Empty(t, actualResponse.Message, "Message should be empty when it is successful")
 }
 
+func TestDeleteEventsByDeviceName(t *testing.T) {
+	deviceName := "deviceA"
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("DeleteEventsByDeviceName", deviceName).Return(nil)
+
+	dic := mocks.NewMockDIC()
+	dic.Update(di.ServiceConstructorMap{
+		v2DataContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	ec := NewEventController(dic)
+
+	req, err := http.NewRequest(http.MethodDelete, v2.ApiEventByDeviceNameRoute, http.NoBody)
+	req = mux.SetURLVars(req, map[string]string{v2.Name: deviceName})
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	handler := http.HandlerFunc(ec.DeleteEventsByDeviceName)
+	handler.ServeHTTP(recorder, req)
+
+	var actualResponse common.BaseResponse
+	err = json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
+
+	assert.Equal(t, v2.ApiVersion, actualResponse.ApiVersion, "API Version not as expected")
+	assert.Equal(t, http.StatusAccepted, recorder.Result().StatusCode, "HTTP status code not as expected")
+	assert.Empty(t, actualResponse.Message, "Message should be empty when it is successful")
+}
+
 func TestUpdateEventPushedById(t *testing.T) {
 	expectedResponseCode := http.StatusMultiStatus
 

--- a/internal/core/data/v2/infrastructure/interfaces/db.go
+++ b/internal/core/data/v2/infrastructure/interfaces/db.go
@@ -22,4 +22,5 @@ type DBClient interface {
 	AllEvents(offset int, limit int) ([]model.Event, errors.EdgeX)
 	EventsByDeviceName(offset int, limit int, name string) ([]model.Event, errors.EdgeX)
 	DeletePushedEvents() errors.EdgeX
+	DeleteEventsByDeviceName(deviceName string) errors.EdgeX
 }

--- a/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -84,6 +84,22 @@ func (_m *DBClient) DeleteEventById(id string) errors.EdgeX {
 	return r0
 }
 
+// DeleteEventsByDeviceName provides a mock function with given fields: deviceName
+func (_m *DBClient) DeleteEventsByDeviceName(deviceName string) errors.EdgeX {
+	ret := _m.Called(deviceName)
+
+	var r0 errors.EdgeX
+	if rf, ok := ret.Get(0).(func(string) errors.EdgeX); ok {
+		r0 = rf(deviceName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(errors.EdgeX)
+		}
+	}
+
+	return r0
+}
+
 // DeletePushedEvents provides a mock function with given fields:
 func (_m *DBClient) DeletePushedEvents() errors.EdgeX {
 	ret := _m.Called()

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -33,6 +33,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiAllEventRoute, ec.AllEvents).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.EventsByDeviceName).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventScrubRoute, ec.DeletePushedEvents).Methods(http.MethodDelete)
+	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.DeleteEventsByDeviceName).Methods(http.MethodDelete)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -1021,18 +1021,6 @@ paths:
               examples:
                 200Example:
                   $ref: '#/components/examples/200Example'
-        '404':
-          description: "The requested resource does not exist"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                404Example:
-                  $ref: '#/components/examples/404Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -910,68 +910,19 @@ paths:
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'
-  /event/device/{deviceId}:
-    parameters:
-    - $ref: '#/components/parameters/correlatedRequestHeader'
-    - name: deviceId
-      in: path
-      required: true
-      schema:
-        type: string
-        format: uuid
-      description: "Uniquely identifies a given device"
-    delete:
-      summary: "Deletes all events for the specified device"
-      responses:
-        '200':
-          description: "Delete successful"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseResponse'
-              examples:
-                200Example:
-                  $ref: '#/components/examples/200Example'
-        '404':
-          description: "The requested resource does not exist"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-               $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                404Example:
-                  $ref: '#/components/examples/404Example'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-               $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                500Example:
-                  $ref: '#/components/examples/500Example'
   /event/device/name/{name}:
-    parameters:
-    - $ref: '#/components/parameters/correlatedRequestHeader'
-    - name: name
-      in: path
-      required: true
-      schema:
-        type: string
-      description: "Uniquely identifies a given device"
-    - $ref: '#/components/parameters/offsetParam'
-    - $ref: '#/components/parameters/limitParam'
     get:
       summary: "Given the entire range of events sorted by created descending, returns a portion of that range according to the device name, offset and limit parameters."
+      parameters:
+        - $ref: '#/components/parameters/correlatedRequestHeader'
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "Uniquely identifies a given device"
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/limitParam'
       responses:
         '200':
           description: "OK"
@@ -987,13 +938,13 @@ paths:
                 apiVersion: "v2"
                 statusCode: 200
                 message: ""
-                events: 
+                events:
                   - apiVersion: "v2"
                     created: 1594877691305
                     deviceName: "device-002"
                     id: "73fc4f9c-2d64-4920-addb-b1f33a8f8514"
                     origin: 1602168089665565300
-                    readings: 
+                    readings:
                       - created: 1594879337014
                         deviceName: "device-002"
                         id: "71c601d9-cb56-453a-8c75-54461e444713"
@@ -1028,7 +979,7 @@ paths:
             application/json:
               schema:
                 type: array
-                items: 
+                items:
                   $ref: '#/components/schemas/ErrorResponse'
               examples:
                 404Example:
@@ -1042,8 +993,55 @@ paths:
             application/json:
               schema:
                 type: array
-                items: 
+                items:
                   $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
+    delete:
+      summary: "Deletes all events for the specified device"
+      parameters:
+        - $ref: '#/components/parameters/correlatedRequestHeader'
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "Uniquely identifies a given device"
+      responses:
+        '202':
+          description: "Delete request accepted"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
+              examples:
+                200Example:
+                  $ref: '#/components/examples/200Example'
+        '404':
+          description: "The requested resource does not exist"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                404Example:
+                  $ref: '#/components/examples/404Example'
+        '500':
+          description: "An unexpected error occurred on the server"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#2837

## What is the new behavior?
Implement DELETE /event/device/name/{name} for V2 API. The current V2 API doc still lists DELETE /event/device/{deviceId}; however, as https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/v2/models/event.go#L14 will be updated to DeviceName instead of DeviceId, the V2 API spec shall be updated to reflect this change.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No
