### PR TITLE
fix(security): fix proxy vault configuration

### DIFF
--- a/internal/security/proxy/config/config.go
+++ b/internal/security/proxy/config/config.go
@@ -76,6 +76,7 @@ type KongAclInfo struct {
 }
 
 type SecretServiceInfo struct {
+	Scheme          string
 	Server          string
 	Port            int
 	HealthcheckPath string
@@ -130,11 +131,18 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	//To keep config file for proxy unchanged in Geneva we need to create a temporary SecretStore struct so that bootstrapHandler can use it to create a secret client
 	//The config file may be changed in the future version and SecretStore can be used directly like other core services
+
+	// Note - see issue #2873 for details on why this default value is set here
+	scheme := c.SecretService.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	
 	ss := bootstrapConfig.SecretStoreInfo{
 		Host:                    c.SecretService.Server,
 		Port:                    c.SecretService.Port,
 		Path:                    c.SecretService.CertPath,
-		Protocol:                "https",
+		Protocol:                scheme,
 		RootCaCertPath:          c.SecretService.CACertPath,
 		ServerName:              c.SecretService.Server,
 		Authentication:          vault.AuthenticationInfo{AuthType: "X-Vault-Token"},


### PR DESCRIPTION
This change fixes an issue with security-proxy-setup
which prevents the SecretService.Scheme from being
overridden via environment configuration override.
The existing code hard-coded Scheme to "https", which
this change overrides.

Fixes: 2873

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
If a configuration environment override is created for security-proxy-setup's SecretService.Scheme configuration value, it's currently ignored because security-proxy-setup hard-codes this value to "https".

## Issue Number: 2873


## What is the new behavior?
security-proxy-setup honors a configuration override for `SecretService.Scheme`


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
A configuration override of Scheme (set to "http") has been tested in the snap. No changes were made to the configuration.toml, and the override now actually works.