### PR TITLE
feat(security): Remove Vault dependency on Consul by using file backend

### DIFF
--- a/cmd/security-secrets-setup/start_vault.sh
+++ b/cmd/security-secrets-setup/start_vault.sh
@@ -27,13 +27,9 @@ listener "tcp" {
               tls_disable = "1" 
               cluster_address = "edgex-vault:8201" 
           } 
-          backend "consul" { 
-              path = "vault/" 
-              address = "edgex-core-consul:8500" 
-              scheme = "http" 
-              redirect_addr = "http://edgex-vault:8200"
-              cluster_addr = "http://edgex-vault:8201"
-          }
+          backend "file" {
+              path = "vault/file"
+          } 
           default_lease_ttl = "168h" 
           max_lease_ttl = "720h"
 '

--- a/cmd/security-secrets-setup/start_vault.sh
+++ b/cmd/security-secrets-setup/start_vault.sh
@@ -28,7 +28,7 @@ listener "tcp" {
               cluster_address = "edgex-vault:8201" 
           } 
           backend "file" {
-              path = "vault/file"
+              path = "/vault/file"
           } 
           default_lease_ttl = "168h" 
           max_lease_ttl = "720h"


### PR DESCRIPTION
Change the Vault backend storage configuration from Consul to filesystem so that we can remove Vault dependency on Consul.

The docker-compose file will also need to change to remove the -consul dependency from repo developer-script.

The current edgex-consul healthy check on Vault also need to be remove as that check becomes superfluous.

Closes: #2882

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently the Vault's backend storage is `Consul` and thus has the dependency on `Consul`. 

## Issue Number:  #2882  


## What is the new behavior?
To break and remove the direct dependency on `Consul`.  After this PR is merged, Vault won't directly depend on Consul.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
_Pending on the related ADR to be approved_

## Other information
To test it, one can use docker-compose file generated from developer-script and remove the dependency on consul for `vault` service like:
```yaml
  vault:
    image: vault:${VAULT_VERSION}
    container_name: edgex-vault
    hostname: edgex-vault
    networks:
      - edgex-network
    ports:
      - "127.0.0.1:8200:8200"
    cap_add:
      - "IPC_LOCK"
    tmpfs:
      - /vault/config
    entrypoint: ["/vault/init/start_vault.sh"]
    environment:
      VAULT_ADDR: https://edgex-vault:8200
      VAULT_CONFIG_DIR: /vault/config
      VAULT_UI: "true"
    volumes:
      - vault-file:/vault/file:z
      - vault-logs:/vault/logs:z
      - vault-init:/vault/init:ro,z
      - /tmp/edgex/secrets/edgex-vault:/tmp/edgex/secrets/edgex-vault:ro,z
    depends_on:
      - security-secrets-setup
```
Note that the services list under the `depends_on` now does not have `consul` any more. In other words, it is changed from 
```yaml
   depends_on:
    -consul
    -security-secrets-setup
```
to 
```yaml
   depends_on:
    -security-secrets-setup
```

Run `docker-compose up vault` to test it and see there is no error in the docker logs regarding the Vault itself.
```
jim@jim-NUC7i5DNHE:~/go/src/github.com/edgexfoundry/developer-scripts/compose-builder$ docker logs edgex-vault
VAULT_LOCAL_CONFIG: listener "tcp" { address = "edgex-vault:8200" tls_disable = "0" cluster_address = "edgex-vault:8201" tls_min_version = "tls12" tls_client_ca_file ="/tmp/edgex/secrets/edgex-vault/ca.pem" tls_cert_file ="/tmp/edgex/secrets/edgex-vault/server.crt" tls_key_file = "/tmp/edgex/secrets/edgex-vault/server.key" tls_perfer_server_cipher_suites = "true" } backend "file" { path = "vault/file" } default_lease_ttl = "168h" max_lease_ttl = "720h"
Starting edgex-vault...
==> Vault server configuration:

                     Cgo: disabled
              Go Version: go1.14.7
              Listener 1: tcp (addr: "edgex-vault:8200", cluster address: "edgex-vault:8201", max_request_duration: "1m30s", max_request_size: "33554432", tls: "enabled")
               Log Level: debug
                   Mlock: supported: true, enabled: true
           Recovery Mode: false
                 Storage: file
                 Version: Vault v1.5.3
             Version Sha: 9fcd81405feb320390b9d71e15a691c3bc1daeef

==> Vault server started! Log data will stream in below:

2020-11-18T21:45:43.297Z [INFO]  proxy environment: http_proxy= https_proxy= no_proxy=
2020-11-18T21:45:43.299Z [WARN]  no `api_addr` value specified in config or in VAULT_API_ADDR; falling back to detection if possible, but this value should be manually set
2020-11-18T21:45:43.299Z [DEBUG] storage.cache: creating LRU cache: size=0
2020-11-18T21:45:43.341Z [DEBUG] cluster listener addresses synthesized: cluster_addresses=[192.168.16.3:8201]
2020-11-18T21:45:46.083Z [INFO]  core: security barrier not initialized
2020-11-18T21:45:46.131Z [INFO]  core: security barrier not initialized
2020-11-18T21:45:46.131Z [INFO]  core: security barrier initialized: stored=1 shares=5 threshold=3
2020-11-18T21:45:46.132Z [DEBUG] core: cluster name not found/set, generating new
2020-11-18T21:45:46.132Z [DEBUG] core: cluster name set: name=vault-cluster-f78a221b
2020-11-18T21:45:46.132Z [DEBUG] core: cluster ID not found, generating new
2020-11-18T21:45:46.132Z [DEBUG] core: cluster ID set: id=76cb4446-f698-4eea-2f5c-3acb26411626
2020-11-18T21:45:46.132Z [INFO]  core: post-unseal setup starting
2020-11-18T21:45:46.132Z [DEBUG] core: clearing forwarding clients
2020-11-18T21:45:46.132Z [DEBUG] core: done clearing forwarding clients
2020-11-18T21:45:46.132Z [DEBUG] core: persisting feature flags
2020-11-18T21:45:46.143Z [INFO]  core: loaded wrapping token key
2020-11-18T21:45:46.143Z [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-11-18T21:45:46.143Z [INFO]  core: no mounts; adding default mount table
2020-11-18T21:45:46.143Z [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-11-18T21:45:46.144Z [INFO]  core: successfully mounted backend: type=system path=sys/
2020-11-18T21:45:46.144Z [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-11-18T21:45:46.145Z [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-11-18T21:45:46.145Z [INFO]  core: restoring leases
2020-11-18T21:45:46.145Z [DEBUG] expiration: collecting leases
2020-11-18T21:45:46.145Z [DEBUG] expiration: leases collected: num_existing=0
2020-11-18T21:45:46.145Z [INFO]  rollback: starting rollback manager
2020-11-18T21:45:46.146Z [INFO]  expiration: lease restore complete
2020-11-18T21:45:46.147Z [DEBUG] identity: loading entities
2020-11-18T21:45:46.147Z [DEBUG] identity: entities collected: num_existing=0
2020-11-18T21:45:46.147Z [INFO]  identity: entities restored
2020-11-18T21:45:46.147Z [DEBUG] identity: identity loading groups
2020-11-18T21:45:46.147Z [DEBUG] identity: groups collected: num_existing=0
2020-11-18T21:45:46.147Z [INFO]  identity: groups restored
2020-11-18T21:45:46.147Z [INFO]  core: post-unseal setup complete
2020-11-18T21:45:46.147Z [INFO]  core: usage gauge collection is disabled
2020-11-18T21:45:46.148Z [INFO]  core: root token generated
2020-11-18T21:45:46.148Z [INFO]  core: pre-seal teardown starting
2020-11-18T21:45:46.148Z [DEBUG] expiration: stop triggered
2020-11-18T21:45:46.148Z [DEBUG] expiration: finished stopping
2020-11-18T21:45:46.148Z [INFO]  rollback: stopping rollback manager
2020-11-18T21:45:46.148Z [INFO]  core: pre-seal teardown complete
2020-11-18T21:45:46.149Z [DEBUG] core: unseal key supplied
2020-11-18T21:45:46.149Z [DEBUG] core: cannot unseal, not enough keys: keys=1 threshold=3 nonce=c04bbf35-f6e3-b124-b65e-760d26df066c
2020-11-18T21:45:46.150Z [DEBUG] core: unseal key supplied
2020-11-18T21:45:46.150Z [DEBUG] core: cannot unseal, not enough keys: keys=2 threshold=3 nonce=c04bbf35-f6e3-b124-b65e-760d26df066c
2020-11-18T21:45:46.150Z [DEBUG] core: unseal key supplied
2020-11-18T21:45:46.150Z [DEBUG] core: starting cluster listeners
2020-11-18T21:45:46.150Z [INFO]  core.cluster-listener.tcp: starting listener: listener_address=192.168.16.3:8201
2020-11-18T21:45:46.150Z [INFO]  core.cluster-listener: serving cluster requests: cluster_listen_address=192.168.16.3:8201
2020-11-18T21:45:46.151Z [INFO]  core: post-unseal setup starting
2020-11-18T21:45:46.151Z [DEBUG] core: clearing forwarding clients
2020-11-18T21:45:46.151Z [DEBUG] core: done clearing forwarding clients
2020-11-18T21:45:46.151Z [DEBUG] core: persisting feature flags
2020-11-18T21:45:46.151Z [INFO]  core: loaded wrapping token key
2020-11-18T21:45:46.151Z [INFO]  core: successfully setup plugin catalog: plugin-directory=
2020-11-18T21:45:46.151Z [INFO]  core: successfully mounted backend: type=system path=sys/
2020-11-18T21:45:46.151Z [INFO]  core: successfully mounted backend: type=identity path=identity/
2020-11-18T21:45:46.151Z [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2020-11-18T21:45:46.152Z [INFO]  core: successfully enabled credential backend: type=token path=token/
2020-11-18T21:45:46.152Z [INFO]  core: restoring leases
2020-11-18T21:45:46.153Z [DEBUG] identity: loading entities
2020-11-18T21:45:46.153Z [DEBUG] identity: entities collected: num_existing=0
2020-11-18T21:45:46.153Z [INFO]  rollback: starting rollback manager
2020-11-18T21:45:46.153Z [DEBUG] expiration: collecting leases
2020-11-18T21:45:46.153Z [DEBUG] expiration: leases collected: num_existing=0
2020-11-18T21:45:46.153Z [INFO]  identity: entities restored
2020-11-18T21:45:46.153Z [DEBUG] identity: identity loading groups
2020-11-18T21:45:46.153Z [DEBUG] identity: groups collected: num_existing=0
2020-11-18T21:45:46.153Z [INFO]  identity: groups restored
2020-11-18T21:45:46.153Z [DEBUG] core: request forwarding setup function
2020-11-18T21:45:46.153Z [DEBUG] core: clearing forwarding clients
2020-11-18T21:45:46.153Z [DEBUG] core: done clearing forwarding clients
2020-11-18T21:45:46.153Z [DEBUG] core: request forwarding not setup
2020-11-18T21:45:46.153Z [DEBUG] core: leaving request forwarding setup function
2020-11-18T21:45:46.153Z [INFO]  core: post-unseal setup complete
2020-11-18T21:45:46.153Z [INFO]  core: vault is unsealed
2020-11-18T21:45:46.153Z [INFO]  expiration: lease restore complete
2020-11-18T21:45:46.153Z [INFO]  core: usage gauge collection is disabled
2020-11-18T21:45:47.213Z [INFO]  core: root generation initialized: nonce=00a198cb-c281-954c-6204-7d45081cb709
2020-11-18T21:45:47.214Z [DEBUG] core: cannot generate root, not enough keys: keys=1 threshold=3
2020-11-18T21:45:47.215Z [DEBUG] core: cannot generate root, not enough keys: keys=2 threshold=3
2020-11-18T21:45:47.215Z [INFO]  core: root generation finished: nonce=00a198cb-c281-954c-6204-7d45081cb709
2020-11-18T21:45:47.226Z [INFO]  expiration: revoked lease: lease_id=auth/token/root/h602fa89a044d262007277be0107fe5540bc751f4478cfbda9a4ed5a9be99c72e
2020-11-18T21:45:47.445Z [INFO]  core: successful mount: namespace= path=secret/ type=kv
2020-11-18T21:45:48.398Z [INFO]  expiration: revoked lease: lease_id=auth/token/create/h289724c68798321bf3c27394fd3754ae889239367e340e3b4afdc2ad872428f0
2020-11-18T21:45:48.400Z [INFO]  expiration: revoked lease: lease_id=auth/token/root/h1180769418dec0c6f882aefeed795bc86b6b691579cf7c3b41ae9694404d270c
2020-11-18T22:45:47.379Z [INFO]  expiration: revoked lease: lease_id=auth/token/create/h99a06bbbd285fd59966d71abbe21376d6d8bf0bbd6db4b5432095fb8b9be95cc
2020-11-18T22:45:47.385Z [INFO]  expiration: revoked lease: lease_id=auth/token/create/h07f50ee80459db238eef5c782d83fae66c2a68fdcef25aae2a166f8e3fd590bb
2020-11-18T22:45:47.397Z [INFO]  expiration: revoked lease: lease_id=auth/token/create/h726fb5b24348474758d85ffdcd9aa60ddc23a793bc435016cc3ab7a805886604
2020-11-18T22:45:47.400Z [INFO]  expiration: revoked lease: lease_id=auth/token/create/h8d722daa4f3b72d934e60e7f3676384fdc3e72bec889e2bb972da70fed998e2c
2020-11-18T22:45:47.406Z [INFO]  expiration: revoked lease: lease_id=auth/token/create/h2acae2f64b48f9458dbff8b2710f4f9cd71da77bedd1bee671bc809ff3609e37
2020-11-18T22:45:47.412Z [INFO]  expiration: revoked lease: lease_id=auth/token/create/h99352a69d0bb3cdfa1a55d1ea9e8107f772e98e8849a1a4d163e197ad56b2cca
```
