### PR TITLE
feat(data): Implement GET /reading/count V2 API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.60
 	github.com/edgexfoundry/go-mod-configuration v0.0.8
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.115
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.117
 	github.com/edgexfoundry/go-mod-messaging v0.1.28
 	github.com/edgexfoundry/go-mod-registry v0.1.26
 	github.com/edgexfoundry/go-mod-secrets v0.0.26

--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -256,3 +256,15 @@ func AllReadings(offset int, limit int, labels []string, dic *di.Container) (rea
 	}
 	return readings, nil
 }
+
+// ReadingTotalCount return the count of all of readings currently stored in the database and error if any
+func ReadingTotalCount(dic *di.Container) (uint32, errors.EdgeX) {
+	dbClient := v2DataContainer.DBClientFrom(dic.Get)
+
+	count, err := dbClient.ReadingTotalCount()
+	if err != nil {
+		return 0, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return count, nil
+}

--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -242,3 +242,17 @@ func EventsByTimeRange(start int, end int, offset int, limit int, dic *di.Contai
 	}
 	return events, nil
 }
+
+// AllReadings query events by offset, limit, and labels
+func AllReadings(offset int, limit int, labels []string, dic *di.Container) (readings []dtos.BaseReading, err errors.EdgeX) {
+	dbClient := v2DataContainer.DBClientFrom(dic.Get)
+	readingModels, err := dbClient.AllReadings(offset, limit, labels)
+	if err != nil {
+		return readings, errors.NewCommonEdgeXWrapper(err)
+	}
+	readings = make([]dtos.BaseReading, len(readingModels))
+	for i, r := range readingModels {
+		readings[i] = dtos.FromReadingModelToDTO(r)
+	}
+	return readings, nil
+}

--- a/internal/core/data/v2/controller/http/event.go
+++ b/internal/core/data/v2/controller/http/event.go
@@ -166,7 +166,7 @@ func (ec *EventController) EventTotalCount(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	correlationId := correlation.FromContext(ctx)
 
-	var eventResponse interface{}
+	var countResponse interface{}
 	var statusCode int
 
 	// Count the event
@@ -174,15 +174,15 @@ func (ec *EventController) EventTotalCount(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
-		eventResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		countResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
 		statusCode = err.Code()
 	} else {
-		eventResponse = responseDTO.NewEventCountResponse("", "", http.StatusOK, count, "")
+		countResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
 		statusCode = http.StatusOK
 	}
 
 	utils.WriteHttpHeader(w, ctx, statusCode)
-	pkg.Encode(eventResponse, w, lc) // encode and send out the response
+	pkg.Encode(countResponse, w, lc) // encode and send out the response
 }
 
 func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Request) {
@@ -196,7 +196,7 @@ func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	deviceName := vars[v2.DeviceName]
 
-	var eventResponse interface{}
+	var countResponse interface{}
 	var statusCode int
 
 	// Count the event by device
@@ -204,15 +204,15 @@ func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
-		eventResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		countResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
 		statusCode = err.Code()
 	} else {
-		eventResponse = responseDTO.NewEventCountResponse("", "", http.StatusOK, count, deviceName)
+		countResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
 		statusCode = http.StatusOK
 	}
 
 	utils.WriteHttpHeader(w, ctx, statusCode)
-	pkg.Encode(eventResponse, w, lc) // encode and send out the response
+	pkg.Encode(countResponse, w, lc) // encode and send out the response
 }
 
 func (ec *EventController) DeletePushedEvents(w http.ResponseWriter, r *http.Request) {
@@ -450,4 +450,30 @@ func (ec *EventController) AllReadings(w http.ResponseWriter, r *http.Request) {
 
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc)
+}
+
+func (ec *EventController) ReadingTotalCount(w http.ResponseWriter, r *http.Request) {
+	// retrieve all the service injections from bootstrap
+	lc := container.LoggingClientFrom(ec.dic.Get)
+
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	var countResponse interface{}
+	var statusCode int
+
+	// Count the event
+	count, err := application.ReadingTotalCount(ec.dic)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		countResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		countResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
+		statusCode = http.StatusOK
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(countResponse, w, lc) // encode and send out the countResponse
 }

--- a/internal/core/data/v2/controller/http/event.go
+++ b/internal/core/data/v2/controller/http/event.go
@@ -416,3 +416,38 @@ func (ec *EventController) EventsByTimeRange(w http.ResponseWriter, r *http.Requ
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc)
 }
+
+func (ec *EventController) AllReadings(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(ec.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+	config := dataContainer.ConfigurationFrom(ec.dic.Get)
+
+	var response interface{}
+	var statusCode int
+
+	// parse URL query string for offset, limit, and labels
+	offset, limit, labels, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		readings, err := application.AllReadings(offset, limit, labels, ec.dic)
+		if err != nil {
+			if errors.Kind(err) != errors.KindEntityDoesNotExist {
+				lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			}
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+			statusCode = err.Code()
+		} else {
+			response = responseDTO.NewMultiReadingsResponse("", "", http.StatusOK, readings)
+			statusCode = http.StatusOK
+		}
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}

--- a/internal/core/data/v2/controller/http/event_test.go
+++ b/internal/core/data/v2/controller/http/event_test.go
@@ -364,13 +364,12 @@ func TestEventTotalCount(t *testing.T) {
 	handler := http.HandlerFunc(ec.EventTotalCount)
 	handler.ServeHTTP(recorder, req)
 
-	var actualResponse responseDTO.EventCountResponse
+	var actualResponse common.CountResponse
 	err = json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
 	require.NoError(t, err)
 	assert.Equal(t, v2.ApiVersion, actualResponse.ApiVersion, "API Version not as expected")
 	assert.Equal(t, http.StatusOK, recorder.Result().StatusCode, "HTTP status code not as expected")
 	assert.Equal(t, http.StatusOK, int(actualResponse.StatusCode), "Response status code not as expected")
-	assert.Empty(t, actualResponse.DeviceName, "Device name should be empty when counting all the events")
 	assert.Empty(t, actualResponse.Message, "Message should be empty when it is successful")
 	assert.Equal(t, expectedEventCount, actualResponse.Count, "Event count in the response body is not expected")
 }
@@ -397,7 +396,7 @@ func TestEventCountByDevice(t *testing.T) {
 	handler := http.HandlerFunc(ec.EventCountByDevice)
 	handler.ServeHTTP(recorder, req)
 
-	var actualResponse responseDTO.EventCountResponse
+	var actualResponse common.CountResponse
 	err = json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
 	require.NoError(t, err)
 	assert.Equal(t, v2.ApiVersion, actualResponse.ApiVersion, "API Version not as expected")
@@ -405,7 +404,6 @@ func TestEventCountByDevice(t *testing.T) {
 	assert.Equal(t, http.StatusOK, int(actualResponse.StatusCode), "Response status code not as expected")
 	assert.Empty(t, actualResponse.Message, "Message should be empty when it is successful")
 	assert.Equal(t, expectedEventCount, actualResponse.Count, "Event count in the response body is not expected")
-	assert.Equal(t, deviceName, actualResponse.DeviceName, "Device name in the response body is not expected")
 }
 
 func TestDeletePushedEvents(t *testing.T) {
@@ -819,4 +817,34 @@ func TestAllReadings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadingTotalCount(t *testing.T) {
+	expectedReadingCount := uint32(656672)
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingTotalCount").Return(expectedReadingCount, nil)
+
+	dic := mocks.NewMockDIC()
+	dic.Update(di.ServiceConstructorMap{
+		v2DataContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	ec := NewEventController(dic)
+
+	req, err := http.NewRequest(http.MethodGet, v2.ApiReadingCountRoute, http.NoBody)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	handler := http.HandlerFunc(ec.ReadingTotalCount)
+	handler.ServeHTTP(recorder, req)
+
+	var actualResponse common.CountResponse
+	err = json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
+	require.NoError(t, err)
+	assert.Equal(t, v2.ApiVersion, actualResponse.ApiVersion, "API Version not as expected")
+	assert.Equal(t, http.StatusOK, recorder.Result().StatusCode, "HTTP status code not as expected")
+	assert.Equal(t, http.StatusOK, int(actualResponse.StatusCode), "Response status code not as expected")
+	assert.Empty(t, actualResponse.Message, "Message should be empty when it is successful")
+	assert.Equal(t, expectedReadingCount, actualResponse.Count, "Event count in the response body is not expected")
 }

--- a/internal/core/data/v2/infrastructure/interfaces/db.go
+++ b/internal/core/data/v2/infrastructure/interfaces/db.go
@@ -24,4 +24,5 @@ type DBClient interface {
 	DeletePushedEvents() errors.EdgeX
 	DeleteEventsByDeviceName(deviceName string) errors.EdgeX
 	EventsByTimeRange(start int, end int, offset int, limit int) ([]model.Event, errors.EdgeX)
+	AllReadings(offset int, limit int, labels []string) ([]model.Reading, errors.EdgeX)
 }

--- a/internal/core/data/v2/infrastructure/interfaces/db.go
+++ b/internal/core/data/v2/infrastructure/interfaces/db.go
@@ -25,4 +25,5 @@ type DBClient interface {
 	DeleteEventsByDeviceName(deviceName string) errors.EdgeX
 	EventsByTimeRange(start int, end int, offset int, limit int) ([]model.Event, errors.EdgeX)
 	AllReadings(offset int, limit int, labels []string) ([]model.Reading, errors.EdgeX)
+	ReadingTotalCount() (uint32, errors.EdgeX)
 }

--- a/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -260,6 +260,29 @@ func (_m *DBClient) EventsByTimeRange(start int, end int, offset int, limit int)
 	return r0, r1
 }
 
+// ReadingTotalCount provides a mock function with given fields:
+func (_m *DBClient) ReadingTotalCount() (uint32, errors.EdgeX) {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func() errors.EdgeX); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // UpdateEventPushedById provides a mock function with given fields: id
 func (_m *DBClient) UpdateEventPushedById(id string) errors.EdgeX {
 	ret := _m.Called(id)

--- a/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -63,6 +63,31 @@ func (_m *DBClient) AllEvents(offset int, limit int) ([]models.Event, errors.Edg
 	return r0, r1
 }
 
+// AllReadings provides a mock function with given fields: offset, limit, labels
+func (_m *DBClient) AllReadings(offset int, limit int, labels []string) ([]models.Reading, errors.EdgeX) {
+	ret := _m.Called(offset, limit, labels)
+
+	var r0 []models.Reading
+	if rf, ok := ret.Get(0).(func(int, int, []string) []models.Reading); ok {
+		r0 = rf(offset, limit, labels)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Reading)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, []string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, labels)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // CloseSession provides a mock function with given fields:
 func (_m *DBClient) CloseSession() {
 	_m.Called()

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -38,6 +38,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 
 	// Readings
 	r.HandleFunc(v2Constant.ApiAllReadingRoute, ec.AllReadings).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiReadingCountRoute, ec.ReadingTotalCount).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -36,6 +36,9 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.DeleteEventsByDeviceName).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiEventByTimeRangeRoute, ec.EventsByTimeRange).Methods(http.MethodGet)
 
+	// Readings
+	r.HandleFunc(v2Constant.ApiAllReadingRoute, ec.AllReadings).Methods(http.MethodGet)
+
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)
 	r.Use(correlation.OnRequestBegin)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -439,3 +439,16 @@ func (c *Client) EventsByTimeRange(start int, end int, offset int, limit int) (e
 	}
 	return events, nil
 }
+
+// AllReadings query events by offset, limit, and labels
+func (c *Client) AllReadings(offset int, limit int, labels []string) ([]model.Reading, errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	readings, edgeXerr := allReadings(conn, offset, limit, labels)
+	if edgeXerr != nil {
+		return readings, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
+			fmt.Sprintf("fail to query readings by offset %d, limit %d, and labels %v", offset, limit, labels), edgeXerr)
+	}
+	return readings, nil
+}

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -246,7 +246,7 @@ func (c *Client) EventTotalCount() (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	count, edgeXerr := c.eventTotalCount(conn)
+	count, edgeXerr := getMemberNumber(conn, ZCARD, EventsCollection)
 	if edgeXerr != nil {
 		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -259,7 +259,7 @@ func (c *Client) EventCountByDevice(deviceName string) (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	count, edgeXerr := c.eventCountByDevice(deviceName, conn)
+	count, edgeXerr := getMemberNumber(conn, ZCARD, fmt.Sprintf("%s:%s", EventsCollectionDeviceName, deviceName))
 	if edgeXerr != nil {
 		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -451,4 +451,17 @@ func (c *Client) AllReadings(offset int, limit int, labels []string) ([]model.Re
 			fmt.Sprintf("fail to query readings by offset %d, limit %d, and labels %v", offset, limit, labels), edgeXerr)
 	}
 	return readings, nil
+}
+
+// ReadingTotalCount returns the total count of Event from the database
+func (c *Client) ReadingTotalCount() (uint32, errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	count, edgeXerr := getMemberNumber(conn, ZCARD, ReadingsCollection)
+	if edgeXerr != nil {
+		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+
+	return count, nil
 }

--- a/internal/pkg/v2/infrastructure/redis/event.go
+++ b/internal/pkg/v2/infrastructure/redis/event.go
@@ -261,24 +261,6 @@ func eventById(conn redis.Conn, id string) (event models.Event, edgeXerr errors.
 	return
 }
 
-func (c *Client) eventTotalCount(conn redis.Conn) (uint32, errors.EdgeX) {
-	count, err := redis.Int(conn.Do(ZCARD, EventsCollection))
-	if err != nil {
-		return 0, errors.NewCommonEdgeX(errors.KindDatabaseError, "count event failed", err)
-	}
-
-	return uint32(count), nil
-}
-
-func (c *Client) eventCountByDevice(deviceName string, conn redis.Conn) (uint32, errors.EdgeX) {
-	count, err := redis.Int(conn.Do(ZCARD, fmt.Sprintf("%s:%s", EventsCollectionDeviceName, deviceName)))
-	if err != nil {
-		return 0, errors.NewCommonEdgeX(errors.KindDatabaseError, "count event failed", err)
-	}
-
-	return uint32(count), nil
-}
-
 func updateEventPushedById(conn redis.Conn, id string) (edgeXerr errors.EdgeX) {
 	// query Event by Id first to retrieve corresponding event
 	e, edgeXerr := eventById(conn, id)

--- a/internal/pkg/v2/infrastructure/redis/queries.go
+++ b/internal/pkg/v2/infrastructure/redis/queries.go
@@ -146,3 +146,12 @@ func objectIdExists(conn redis.Conn, id string) (bool, errors.EdgeX) {
 	}
 	return exists, nil
 }
+
+func getMemberNumber(conn redis.Conn, command string, key string) (uint32, errors.EdgeX) {
+	count, err := redis.Int(conn.Do(command, key))
+	if err != nil {
+		return 0, errors.NewCommonEdgeX(errors.KindDatabaseError, fmt.Sprintf("failed to get member number with command %s from %s", command, key), err)
+	}
+
+	return uint32(count), nil
+}

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -363,7 +363,13 @@ components:
         requestId: ""
         apiVersion: "v2"
         statusCode: 404
-        message: "Not Found"     
+        message: "Not Found"
+    416Example:
+      value:
+        requestId: ""
+        apiVersion: "v2"
+        statusCode: 416
+        message: "Range Not Satisfiable"
     500Example:
       value:
         requestId: ""
@@ -616,7 +622,30 @@ paths:
               examples:
                 MultiEventsExample:
                   $ref: '#/components/examples/AllEventsExample'
-
+        '400':
+          description: "Request is in an invalid state"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1185,6 +1214,30 @@ paths:
               examples:
                 MultiReadingsExample:
                   $ref: '#/components/examples/AllReadingsExample'
+        '400':
+          description: "Request is in an invalid state"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #2904 

## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/default/get_reading_count, implement GET /reading/count V2 API.

This commit also refactor GET /event/count and GET /event/count/device/{deviceName} to reduce duplicate codes.

This commit needs to use github.com/edgexfoundry/go-mod-core-contracts v0.1.117 to build and work properly.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No