### PR TITLE
feat(data): Implement GET /reading/count V2 API

### DIFF
--- a/internal/core/data/v2/application/reading.go
+++ b/internal/core/data/v2/application/reading.go
@@ -1,0 +1,19 @@
+package application
+
+import (
+	v2DataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+)
+
+// ReadingTotalCount return the count of all of readings currently stored in the database and error if any
+func ReadingTotalCount(dic *di.Container) (uint32, errors.EdgeX) {
+	dbClient := v2DataContainer.DBClientFrom(dic.Get)
+
+	count, err := dbClient.ReadingTotalCount()
+	if err != nil {
+		return 0, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return count, nil
+}

--- a/internal/core/data/v2/controller/http/event.go
+++ b/internal/core/data/v2/controller/http/event.go
@@ -166,7 +166,7 @@ func (ec *EventController) EventTotalCount(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	correlationId := correlation.FromContext(ctx)
 
-	var eventResponse interface{}
+	var countResponse interface{}
 	var statusCode int
 
 	// Count the event
@@ -174,15 +174,15 @@ func (ec *EventController) EventTotalCount(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
-		eventResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		countResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
 		statusCode = err.Code()
 	} else {
-		eventResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
+		countResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
 		statusCode = http.StatusOK
 	}
 
 	utils.WriteHttpHeader(w, ctx, statusCode)
-	pkg.Encode(eventResponse, w, lc) // encode and send out the response
+	pkg.Encode(countResponse, w, lc) // encode and send out the response
 }
 
 func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Request) {
@@ -196,7 +196,7 @@ func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Req
 	vars := mux.Vars(r)
 	deviceName := vars[v2.DeviceName]
 
-	var eventResponse interface{}
+	var countResponse interface{}
 	var statusCode int
 
 	// Count the event by device
@@ -204,15 +204,15 @@ func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
-		eventResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		countResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
 		statusCode = err.Code()
 	} else {
-		eventResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
+		countResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
 		statusCode = http.StatusOK
 	}
 
 	utils.WriteHttpHeader(w, ctx, statusCode)
-	pkg.Encode(eventResponse, w, lc) // encode and send out the response
+	pkg.Encode(countResponse, w, lc) // encode and send out the response
 }
 
 func (ec *EventController) DeletePushedEvents(w http.ResponseWriter, r *http.Request) {

--- a/internal/core/data/v2/controller/http/reading.go
+++ b/internal/core/data/v2/controller/http/reading.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/data/v2/application"
+	"github.com/edgexfoundry/edgex-go/internal/pkg"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/v2/utils"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+)
+
+type ReadingController struct {
+	dic *di.Container
+}
+
+// NewReadingController creates and initializes a ReadingController
+func NewReadingController(dic *di.Container) *ReadingController {
+	return &ReadingController{
+		dic: dic,
+	}
+}
+
+func (rc *ReadingController) ReadingTotalCount(w http.ResponseWriter, r *http.Request) {
+	// retrieve all the service injections from bootstrap
+	lc := container.LoggingClientFrom(rc.dic.Get)
+
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	var countResponse interface{}
+	var statusCode int
+
+	// Count readings
+	count, err := application.ReadingTotalCount(rc.dic)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		countResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		countResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
+		statusCode = http.StatusOK
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(countResponse, w, lc) // encode and send out the countResponse
+}

--- a/internal/core/data/v2/controller/http/reading_test.go
+++ b/internal/core/data/v2/controller/http/reading_test.go
@@ -1,0 +1,47 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v2DataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/v2/bootstrap/container"
+	dbMock "github.com/edgexfoundry/edgex-go/internal/core/data/v2/infrastructure/interfaces/mocks"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/v2/mocks"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadingTotalCount(t *testing.T) {
+	expectedReadingCount := uint32(656672)
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingTotalCount").Return(expectedReadingCount, nil)
+
+	dic := mocks.NewMockDIC()
+	dic.Update(di.ServiceConstructorMap{
+		v2DataContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	rc := NewReadingController(dic)
+
+	req, err := http.NewRequest(http.MethodGet, v2.ApiReadingCountRoute, http.NoBody)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	handler := http.HandlerFunc(rc.ReadingTotalCount)
+	handler.ServeHTTP(recorder, req)
+
+	var actualResponse common.CountResponse
+	err = json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
+	require.NoError(t, err)
+	assert.Equal(t, v2.ApiVersion, actualResponse.ApiVersion, "API Version not as expected")
+	assert.Equal(t, http.StatusOK, recorder.Result().StatusCode, "HTTP status code not as expected")
+	assert.Equal(t, http.StatusOK, int(actualResponse.StatusCode), "Response status code not as expected")
+	assert.Empty(t, actualResponse.Message, "Message should be empty when it is successful")
+	assert.Equal(t, expectedReadingCount, actualResponse.Count, "Event count in the response body is not expected")
+}

--- a/internal/core/data/v2/infrastructure/interfaces/db.go
+++ b/internal/core/data/v2/infrastructure/interfaces/db.go
@@ -24,4 +24,5 @@ type DBClient interface {
 	DeletePushedEvents() errors.EdgeX
 	DeleteEventsByDeviceName(deviceName string) errors.EdgeX
 	EventsByTimeRange(start int, end int, offset int, limit int) ([]model.Event, errors.EdgeX)
+	ReadingTotalCount() (uint32, errors.EdgeX)
 }

--- a/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -235,6 +235,29 @@ func (_m *DBClient) EventsByTimeRange(start int, end int, offset int, limit int)
 	return r0, r1
 }
 
+// ReadingTotalCount provides a mock function with given fields:
+func (_m *DBClient) ReadingTotalCount() (uint32, errors.EdgeX) {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func() errors.EdgeX); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // UpdateEventPushedById provides a mock function with given fields: id
 func (_m *DBClient) UpdateEventPushedById(id string) errors.EdgeX {
 	ret := _m.Called(id)

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -3,7 +3,7 @@ package v2
 import (
 	"net/http"
 
-	eventController "github.com/edgexfoundry/edgex-go/internal/core/data/v2/controller/http"
+	dataController "github.com/edgexfoundry/edgex-go/internal/core/data/v2/controller/http"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	commonController "github.com/edgexfoundry/edgex-go/internal/pkg/v2/controller/http"
 
@@ -23,7 +23,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
 
 	// Events
-	ec := eventController.NewEventController(dic)
+	ec := dataController.NewEventController(dic)
 	r.HandleFunc(v2Constant.ApiEventRoute, ec.AddEvent).Methods(http.MethodPost)
 	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.EventById).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.DeleteEventById).Methods(http.MethodDelete)
@@ -35,6 +35,10 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiEventScrubRoute, ec.DeletePushedEvents).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.DeleteEventsByDeviceName).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiEventByTimeRangeRoute, ec.EventsByTimeRange).Methods(http.MethodGet)
+
+	// Readings
+	rc := dataController.NewReadingController(dic)
+	r.HandleFunc(v2Constant.ApiReadingCountRoute, rc.ReadingTotalCount).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -246,7 +246,7 @@ func (c *Client) EventTotalCount() (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	count, edgeXerr := c.eventTotalCount(conn)
+	count, edgeXerr := getMemberNumber(conn, ZCARD, EventsCollection)
 	if edgeXerr != nil {
 		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -259,7 +259,7 @@ func (c *Client) EventCountByDevice(deviceName string) (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	count, edgeXerr := c.eventCountByDevice(deviceName, conn)
+	count, edgeXerr := getMemberNumber(conn, ZCARD, fmt.Sprintf("%s:%s", EventsCollectionDeviceName, deviceName))
 	if edgeXerr != nil {
 		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -438,4 +438,17 @@ func (c *Client) EventsByTimeRange(start int, end int, offset int, limit int) (e
 			fmt.Sprintf("fail to query events by time range %v ~ %v, offset %d, and limit %d", start, end, offset, limit), edgeXerr)
 	}
 	return events, nil
+}
+
+// ReadingTotalCount returns the total count of Event from the database
+func (c *Client) ReadingTotalCount() (uint32, errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	count, edgeXerr := getMemberNumber(conn, ZCARD, ReadingsCollection)
+	if edgeXerr != nil {
+		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+
+	return count, nil
 }

--- a/internal/pkg/v2/infrastructure/redis/event.go
+++ b/internal/pkg/v2/infrastructure/redis/event.go
@@ -261,24 +261,6 @@ func eventById(conn redis.Conn, id string) (event models.Event, edgeXerr errors.
 	return
 }
 
-func (c *Client) eventTotalCount(conn redis.Conn) (uint32, errors.EdgeX) {
-	count, err := redis.Int(conn.Do(ZCARD, EventsCollection))
-	if err != nil {
-		return 0, errors.NewCommonEdgeX(errors.KindDatabaseError, "count event failed", err)
-	}
-
-	return uint32(count), nil
-}
-
-func (c *Client) eventCountByDevice(deviceName string, conn redis.Conn) (uint32, errors.EdgeX) {
-	count, err := redis.Int(conn.Do(ZCARD, fmt.Sprintf("%s:%s", EventsCollectionDeviceName, deviceName)))
-	if err != nil {
-		return 0, errors.NewCommonEdgeX(errors.KindDatabaseError, "count event failed", err)
-	}
-
-	return uint32(count), nil
-}
-
 func updateEventPushedById(conn redis.Conn, id string) (edgeXerr errors.EdgeX) {
 	// query Event by Id first to retrieve corresponding event
 	e, edgeXerr := eventById(conn, id)

--- a/internal/pkg/v2/infrastructure/redis/queries.go
+++ b/internal/pkg/v2/infrastructure/redis/queries.go
@@ -146,3 +146,12 @@ func objectIdExists(conn redis.Conn, id string) (bool, errors.EdgeX) {
 	}
 	return exists, nil
 }
+
+func getMemberNumber(conn redis.Conn, command string, key string) (uint32, errors.EdgeX) {
+	count, err := redis.Int(conn.Do(command, key))
+	if err != nil {
+		return 0, errors.NewCommonEdgeX(errors.KindDatabaseError, fmt.Sprintf("failed to get member number with command %s from %s", command, key), err)
+	}
+
+	return uint32(count), nil
+}

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -56,7 +56,8 @@ components:
           type: string
       required:
         - deviceName
-        - name
+        - resourceName
+        - profileName
         - origin
         - valueType
     BaseRequest:
@@ -112,16 +113,14 @@ components:
           required:
             - binaryValue
             - mediaType
-    EventCountResponse:
+    CountResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
-      description: "Returns an aggregate event count in uint32 integer type. If the deviceName property is blank then the count is applicable to all events in the database. Otherwise, the count is applicable to the specified device."
+      description: "Returns an aggregate count of specified objects, e.g. events or readings, in uint32 integer type."
       type: object
       properties:
         count:
           type: integer
-        deviceName:
-          type: string
     Event:
       description: "A discrete event containing one or more readings"
       properties:
@@ -242,16 +241,6 @@ components:
         timestamp:
           description: "Outputs the current server timestamp in RFC1123 format"
           example: "Mon, 02 Jan 2006 15:04:05 MST"
-          type: string
-    ReadingCountResponse:
-      allOf:
-        - $ref: '#/components/schemas/BaseResponse'
-      description: "Returns an aggregate reading count in uint32 integer type. If the deviceName property is blank then the count is applicable to all readings in the database. Otherwise, the count is applicable to the specified device."
-      type: object
-      properties:
-        count:
-          type: integer
-        deviceName:
           type: string
     ReadingResponse:
       allOf:
@@ -867,14 +856,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventCountResponse'
+                $ref: '#/components/schemas/CountResponse'
               example:
                 requestId: ""
                 apiVersion: "v2"
                 statusCode: 200
                 message: ""
                 count: 3
-                deviceName: ""
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -907,14 +895,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventCountResponse'
+                $ref: '#/components/schemas/CountResponse'
               example:
                 requestId: ""
                 apiVersion: "v2"
                 statusCode: 200
                 message: ""
                 count: 1
-                deviceName: "device-001"
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1246,7 +1233,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReadingCountResponse'
+                $ref: '#/components/schemas/CountResponse'
               example:
                 requestId: ""
                 apiVersion: "v2"
@@ -1285,14 +1272,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReadingCountResponse'
+                $ref: '#/components/schemas/CountResponse'
               example:
                 requestId: ""
                 apiVersion: "v2"
                 statusCode: 200
                 message: ""
                 count: 2
-                deviceName: "device-001"
         '404':
           description: "The requested resource does not exist"
           headers:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #2904 

## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/default/get_reading_count, implement GET /reading/count V2 API.

This commit also refactor GET /event/count and GET /event/count/device/{deviceName} to reduce duplicate codes.

This commit needs to use github.com/edgexfoundry/go-mod-core-contracts v0.1.117 to build and work properly.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No