### PR TITLE
feat(data): Update corresponding V2 API per the recent changes from Reading DTO/Model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.60
 	github.com/edgexfoundry/go-mod-configuration v0.0.8
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.115
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.118
 	github.com/edgexfoundry/go-mod-messaging v0.1.28
 	github.com/edgexfoundry/go-mod-registry v0.1.26
 	github.com/edgexfoundry/go-mod-secrets v0.0.26

--- a/internal/core/data/v2/application/event_test.go
+++ b/internal/core/data/v2/application/event_test.go
@@ -48,25 +48,27 @@ func buildReadings() []models.Reading {
 
 	r1 := models.SimpleReading{
 		BaseReading: models.BaseReading{
-			Id:         uuid.New().String(),
-			Created:    ticks,
-			Origin:     testOriginTime,
-			DeviceName: testDeviceName,
-			Name:       "Temperature",
-			Labels:     []string{"Fahrenheit"},
-			ValueType:  dtos.ValueTypeUint16,
+			Id:           uuid.New().String(),
+			Created:      ticks,
+			Origin:       testOriginTime,
+			DeviceName:   testDeviceName,
+			ResourceName: "Temperature",
+			ProfileName:  "TempProfile",
+			Labels:       []string{"Fahrenheit"},
+			ValueType:    dtos.ValueTypeUint16,
 		},
 		Value: "45",
 	}
 
 	r2 := models.BinaryReading{
 		BaseReading: models.BaseReading{
-			Id:         uuid.New().String(),
-			Created:    ticks,
-			Origin:     testOriginTime,
-			DeviceName: testDeviceName,
-			Name:       "FileData",
-			Labels:     []string{"text"},
+			Id:           uuid.New().String(),
+			Created:      ticks,
+			Origin:       testOriginTime,
+			DeviceName:   testDeviceName,
+			ResourceName: "FileData",
+			ProfileName:  "FileDataProfile",
+			Labels:       []string{"text"},
 		},
 		BinaryValue: []byte("1010"),
 		MediaType:   "file",

--- a/internal/core/data/v2/controller/http/const_test.go
+++ b/internal/core/data/v2/controller/http/const_test.go
@@ -12,6 +12,7 @@ const (
 	TestCreatedTime        = 1600666214495
 	TestOriginTime         = 1600666185705354000
 	TestDeviceResourceName = "TestDeviceResourceName"
+	TestDeviceProfileName  = "TestDeviceProfileName"
 
 	TestReadingValue           = "45"
 	TestBinaryReadingMediaType = "File"

--- a/internal/core/data/v2/controller/http/event.go
+++ b/internal/core/data/v2/controller/http/event.go
@@ -177,7 +177,7 @@ func (ec *EventController) EventTotalCount(w http.ResponseWriter, r *http.Reques
 		eventResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
 		statusCode = err.Code()
 	} else {
-		eventResponse = responseDTO.NewEventCountResponse("", "", http.StatusOK, count, "")
+		eventResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
 		statusCode = http.StatusOK
 	}
 
@@ -207,7 +207,7 @@ func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Req
 		eventResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
 		statusCode = err.Code()
 	} else {
-		eventResponse = responseDTO.NewEventCountResponse("", "", http.StatusOK, count, deviceName)
+		eventResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
 		statusCode = http.StatusOK
 	}
 

--- a/internal/pkg/v2/infrastructure/redis/reading.go
+++ b/internal/pkg/v2/infrastructure/redis/reading.go
@@ -22,7 +22,6 @@ const (
 	ReadingsCollection           = "v2:reading"
 	ReadingsCollectionCreated    = ReadingsCollection + ":" + v2.Created
 	ReadingsCollectionDeviceName = ReadingsCollection + ":" + v2.Device + ":" + v2.Name
-	ReadingsCollectionName       = ReadingsCollection + ":" + v2.Name
 )
 
 var emptyBinaryValue = make([]byte, 0)
@@ -57,7 +56,6 @@ func (c *Client) asyncDeleteReadingsByIds(readingIds []string) {
 		_ = conn.Send(ZREM, ReadingsCollection, storedKey)
 		_ = conn.Send(ZREM, ReadingsCollectionCreated, storedKey)
 		_ = conn.Send(ZREM, fmt.Sprintf("%s:%s", ReadingsCollectionDeviceName, r.DeviceName), storedKey)
-		_ = conn.Send(ZREM, fmt.Sprintf("%s:%s", ReadingsCollectionName, r.Name), storedKey)
 		queriesInQueue++
 
 		if queriesInQueue >= c.BatchSize {
@@ -124,7 +122,6 @@ func addReading(conn redis.Conn, r models.Reading) (reading models.Reading, edge
 	_ = conn.Send(ZADD, ReadingsCollection, 0, storedKey)
 	_ = conn.Send(ZADD, ReadingsCollectionCreated, baseReading.Created, storedKey)
 	_ = conn.Send(ZADD, fmt.Sprintf("%s:%s", ReadingsCollectionDeviceName, baseReading.DeviceName), baseReading.Created, storedKey)
-	_ = conn.Send(ZADD, fmt.Sprintf("%s:%s", ReadingsCollectionName, baseReading.Name), baseReading.Created, storedKey)
 
 	return reading, nil
 }
@@ -143,7 +140,6 @@ func deleteReadingById(conn redis.Conn, id string) (edgeXerr errors.EdgeX) {
 	_ = conn.Send(ZREM, ReadingsCollection, storedKey)
 	_ = conn.Send(ZREM, ReadingsCollectionCreated, storedKey)
 	_ = conn.Send(ZREM, fmt.Sprintf("%s:%s", ReadingsCollectionDeviceName, r.DeviceName), storedKey)
-	_ = conn.Send(ZREM, fmt.Sprintf("%s:%s", ReadingsCollectionName, r.Name), storedKey)
 	_, err := conn.Do(EXEC)
 	if err != nil {
 		return errors.NewCommonEdgeX(errors.KindDatabaseError, fmt.Sprintf("reading[id:%s] delete failed", id), err)

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -37,8 +37,11 @@ components:
           description: "The unique identifier for the reading"
           type: string
           format: uuid
-        name:
-          description: "The name for the reading"
+        resourceName:
+          description: "The device resource name for the reading"
+          type: string
+        profileName:
+          description: "The device profile name for the reading"
           type: string
         labels:
           description: "One or more custom labels that can be assigned to a reading"
@@ -388,6 +391,8 @@ components:
               - apiVersion: "v2"
                 created: 1594876281221
                 deviceName: "device-001"
+                resourceName: "resource-001"
+                profileName: "profile-001"
                 id: "31569347-9369-43ec-aa6a-59ea9c624a6f"
                 labels:                            
                   - "power"
@@ -400,6 +405,8 @@ components:
               - apiVersion: "v2"
                 create: 1594876281221
                 deviceName: "device-001"
+                resourceName: "resource-001"
+                profileName: "profile-001"
                 id: "2fd73a5b-969f-483c-9c52-6bb460a06eb1"
                 labels:
                   - "Fahrenheit"
@@ -416,6 +423,8 @@ components:
               - apiVersion: "v2"
                 created: 1594879337014
                 deviceName: "device-002"
+                resourceName: "resource-002"
+                profileName: "profile-002"
                 id: "71c601d9-cb56-453a-8c75-54461e444713"
                 labels:
                   - "image"
@@ -432,6 +441,8 @@ components:
               - apiVersion: "v2"
                 created: 594983105886
                 deviceName: "device-002"
+                resourceName: "resource-002"
+                profileName: "profile-002"
                 id: "7003cacc-0e00-4676-977c-4e58b9612abd"
                 labels:
                   - "co2"
@@ -449,6 +460,8 @@ components:
           - apiVersion: "v2"
             created: 1594876281221
             deviceName: "device-001"
+            resourceName: "resource-001"
+            profileName: "profile-001"
             id: "31569347-9369-43ec-aa6a-59ea9c624a6f"
             labels:
               - "power"
@@ -461,6 +474,8 @@ components:
           - apiVersion: "v2"
             create: 1594876281221
             deviceName: "device-001"
+            resourceName: "resource-001"
+            profileName: "profile-001"
             id: "2fd73a5b-969f-483c-9c52-6bb460a06eb1"
             labels:
               - "Fahrenheit"
@@ -471,6 +486,8 @@ components:
           - apiVersion: "v2"
             created: 1594879337014
             deviceName: "device-002"
+            resourceName: "resource-002"
+            profileName: "profile-002"
             id: "71c601d9-cb56-453a-8c75-54461e444713"
             labels:
               - "image"
@@ -481,6 +498,8 @@ components:
           - apiVersion: "v2"
             created: 594983105886
             deviceName: "device-002"
+            resourceName: "resource-002"
+            profileName: "profile-002"
             id: "7003cacc-0e00-4676-977c-4e58b9612abd"
             labels:
               - "co2"
@@ -509,6 +528,8 @@ paths:
                   origin: 1602168089665565300
                   readings:
                     - deviceName: device-002
+                      resourceName: resource-002
+                      profileName: profile-002
                       id: 7003cacc-0e00-4676-977c-4e58b9612abd
                       labels:
                         - co2
@@ -522,6 +543,8 @@ paths:
                   origin: 1602168089665565300
                   readings:
                     - deviceName: device-002
+                      resourceName: resource-002
+                      profileName: profile-002
                       id: 7003cacc-0e00-4676-977c-4e58b9612abd
                       labels:
                         - co2
@@ -537,6 +560,8 @@ paths:
                     - apiVersion: v2
                       created: 1594879337014
                       deviceName: device-002
+                      resourceName: resource-002
+                      profileName: profile-002
                       id: 71c601d9-cb56-453a-8c75-54461e444713
                       labels:
                         - image
@@ -667,6 +692,8 @@ paths:
                   readings:
                     - created: 1594876281221
                       deviceName: "device-001"
+                      resourceName: "resource-001"
+                      profileName: "profile-001"
                       id: "31569347-9369-43ec-aa6a-59ea9c624a6f"
                       labels:                            
                         - "power"
@@ -678,6 +705,8 @@ paths:
                       value: "39.5"
                     - create: 1594876281221
                       deviceName: "device-001"
+                      resourceName: "resource-001"
+                      profileName: "profile-001"
                       id: "2fd73a5b-969f-483c-9c52-6bb460a06eb1"
                       labels:
                         - "Fahrenheit"
@@ -884,7 +913,7 @@ paths:
                 apiVersion: "v2"
                 statusCode: 200
                 message: ""
-                count: 1 
+                count: 1
                 deviceName: "device-001"
         '404':
           description: "The requested resource does not exist"
@@ -947,6 +976,8 @@ paths:
                     readings:
                       - created: 1594879337014
                         deviceName: "device-002"
+                        resourceName: "resource-002"
+                        profileName: "profile-002"
                         id: "71c601d9-cb56-453a-8c75-54461e444713"
                         labels:
                           - "image"
@@ -963,6 +994,8 @@ paths:
                       - apiVersion: "v2"
                         created: 594983105886
                         deviceName: "device-002"
+                        resourceName: "resource-002"
+                        profileName: "profile-002"
                         id: "7003cacc-0e00-4676-977c-4e58b9612abd"
                         labels:
                           - "co2"
@@ -1315,6 +1348,8 @@ paths:
                   apiVersion: "v2"
                   created: 1594876281221
                   deviceName: "device-001"
+                  resourceName: "resource-001"
+                  profileName: "profile-001"
                   id: "31569347-9369-43ec-aa6a-59ea9c624a6f"
                   labels:
                     - "power"
@@ -1380,6 +1415,8 @@ paths:
                   - apiVersion: "v2"
                     created: 1594876281221
                     deviceName: "device-001"
+                    resourceName: "resource-001"
+                    profileName: "profile-001"
                     id: "31569347-9369-43ec-aa6a-59ea9c624a6f"
                     labels:
                       - "power"
@@ -1392,6 +1429,8 @@ paths:
                   - apiVersion: "v2"
                     create: 1594876281221
                     deviceName: "device-001"
+                    resourceName: "resource-001"
+                    profileName: "profile-001"
                     id: "2fd73a5b-969f-483c-9c52-6bb460a06eb1"
                     origin: 1602168089665565300
                     labels:
@@ -1459,6 +1498,8 @@ paths:
                   - apiVersion: "v2"
                     created: 1594876281221
                     deviceName: "device-001"
+                    resourceName: "resource-001"
+                    profileName: "profile-001"
                     id: "31569347-9369-43ec-aa6a-59ea9c624a6f"
                     labels:
                       - "power"
@@ -1471,6 +1512,8 @@ paths:
                   - apiVersion: "v2"
                     created: 594983105886
                     deviceName: "device-002"
+                    resourceName: "resource-002"
+                    profileName: "profile-002"
                     id: "7003cacc-0e00-4676-977c-4e58b9612abd"
                     labels:
                       - "co2"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

## Issue Number:
fix #2903 

## What is the new behavior?
Per decision made in Ireland planning meeting, Reading DTO/Model of V2 API shall be updated with following changes:

1. change field Name to ResourceName
2. add new field ProfileName

A corresponding PR was merged at edgexfoundry/go-mod-core-contracts#374

This commit revises current V2 API of coredata correspondingly to reflect above changes, and also updates openapi doc.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No