### PR TITLE
fix: Fix nil pointer error when update the unreachable DS adminState

### DIFF
--- a/internal/core/metadata/operators/device_service/update.go
+++ b/internal/core/metadata/operators/device_service/update.go
@@ -179,6 +179,7 @@ func adminStateCallback(
 	resp, err := client.Do(req)
 	if err != nil {
 		lc.Error(fmt.Sprintf("fail to invoke callback for %s, %v", service.Name, err))
+		return
 	} else if resp.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
Fix #2991

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Since the http.Client fail to send the request and the response body is nil, if we try to close the response body, it will cause invalid address or nil pointer error.


## Issue Number: #2911


## What is the new behavior?

To fix it, just finish the function call when error occurs.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information