### PR TITLE
feat(metadata): Implement GET device profiles by manufacturer V2 API

### DIFF
--- a/internal/core/metadata/v2/application/deviceprofile.go
+++ b/internal/core/metadata/v2/application/deviceprofile.go
@@ -135,3 +135,20 @@ func DeviceProfilesByModel(offset int, limit int, model string, dic *di.Containe
 	}
 	return deviceProfiles, nil
 }
+
+// DeviceProfilesByManufacturer query the device profiles with offset, limit and manufacturer
+func DeviceProfilesByManufacturer(offset int, limit int, manufacturer string, dic *di.Container) (deviceProfiles []dtos.DeviceProfile, err errors.EdgeX) {
+	if manufacturer == "" {
+		return deviceProfiles, errors.NewCommonEdgeX(errors.KindContractInvalid, "manufacturer is empty", nil)
+	}
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	dps, err := dbClient.DeviceProfilesByManufacturer(offset, limit, manufacturer)
+	if err != nil {
+		return deviceProfiles, errors.NewCommonEdgeXWrapper(err)
+	}
+	deviceProfiles = make([]dtos.DeviceProfile, len(dps))
+	for i, dp := range dps {
+		deviceProfiles[i] = dtos.FromDeviceProfileModelToDTO(dp)
+	}
+	return deviceProfiles, nil
+}

--- a/internal/core/metadata/v2/controller/http/deviceprofile.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile.go
@@ -392,3 +392,41 @@ func (dc *DeviceProfileController) DeviceProfilesByModel(w http.ResponseWriter, 
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc)
 }
+
+func (dc *DeviceProfileController) DeviceProfilesByManufacturer(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(dc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+	config := metadataContainer.ConfigurationFrom(dc.dic.Get)
+
+	vars := mux.Vars(r)
+	manufacturer := vars[v2.Manufacturer]
+
+	var response interface{}
+	var statusCode int
+
+	// parse URL query string for offset, limit
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		deviceProfiles, err := application.DeviceProfilesByManufacturer(offset, limit, manufacturer, dc.dic)
+		if err != nil {
+			if errors.Kind(err) != errors.KindEntityDoesNotExist {
+				lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			}
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+			statusCode = err.Code()
+		} else {
+			response = responseDTO.NewMultiDeviceProfilesResponse("", "", http.StatusOK, deviceProfiles)
+			statusCode = http.StatusOK
+		}
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}

--- a/internal/core/metadata/v2/infrastructure/interfaces/db.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/db.go
@@ -21,6 +21,7 @@ type DBClient interface {
 	DeviceProfileNameExists(name string) (bool, errors.EdgeX)
 	AllDeviceProfiles(offset int, limit int, labels []string) ([]model.DeviceProfile, errors.EdgeX)
 	DeviceProfilesByModel(offset int, limit int, model string) ([]model.DeviceProfile, errors.EdgeX)
+	DeviceProfilesByManufacturer(offset int, limit int, manufacturer string) ([]model.DeviceProfile, errors.EdgeX)
 
 	AddDeviceService(e model.DeviceService) (model.DeviceService, errors.EdgeX)
 	DeviceServiceById(id string) (model.DeviceService, errors.EdgeX)

--- a/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -423,6 +423,31 @@ func (_m *DBClient) DeviceProfilesByModel(offset int, limit int, model string) (
 	return r0, r1
 }
 
+// DeviceProfilesByManufacturer provides a mock function with given fields: offset, limit, manufacturer
+func (_m *DBClient) DeviceProfilesByManufacturer(offset int, limit int, manufacturer string) ([]models.DeviceProfile, errors.EdgeX) {
+	ret := _m.Called(offset, limit, manufacturer)
+
+	var r0 []models.DeviceProfile
+	if rf, ok := ret.Get(0).(func(int, int, string) []models.DeviceProfile); ok {
+		r0 = rf(offset, limit, manufacturer)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.DeviceProfile)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, manufacturer)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // DeviceServiceById provides a mock function with given fields: id
 func (_m *DBClient) DeviceServiceById(id string) (models.DeviceService, errors.EdgeX) {
 	ret := _m.Called(id)

--- a/internal/core/metadata/v2/router.go
+++ b/internal/core/metadata/v2/router.go
@@ -33,6 +33,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiDeviceProfileByNameRoute, dc.DeleteDeviceProfileByName).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiAllDeviceProfileRoute, dc.AllDeviceProfiles).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiDeviceProfileByModelRoute, dc.DeviceProfilesByModel).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiDeviceProfileByManufacturerRoute, dc.DeviceProfilesByManufacturer).Methods(http.MethodGet)
 
 	// Device Service
 	ds := metadataController.NewDeviceServiceController(dic)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -253,6 +253,18 @@ func (c *Client) DeviceProfilesByModel(offset int, limit int, model string) ([]m
 	return deviceProfiles, nil
 }
 
+// DeviceProfilesByManufacturer query device profiles with offset, limit and manufacturer
+func (c *Client) DeviceProfilesByManufacturer(offset int, limit int, manufacturer string) ([]model.DeviceProfile, errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	deviceProfiles, edgeXerr := deviceProfilesByManufacturer(conn, offset, limit, manufacturer)
+	if edgeXerr != nil {
+		return deviceProfiles, errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+	return deviceProfiles, nil
+}
+
 // EventTotalCount returns the total count of Event from the database
 func (c *Client) EventTotalCount() (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()

--- a/internal/pkg/v2/infrastructure/redis/device_profile.go
+++ b/internal/pkg/v2/infrastructure/redis/device_profile.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	DeviceProfileCollection      = "v2:deviceProfile"
-	DeviceProfileCollectionModel = DeviceProfileCollection + ":" + v2.Model
+	DeviceProfileCollection             = "v2:deviceProfile"
+	DeviceProfileCollectionModel        = DeviceProfileCollection + ":" + v2.Model
+	DeviceProfileCollectionManufacturer = DeviceProfileCollection + ":" + v2.Manufacturer
 )
 
 // deviceProfileStoredKey return the device profile's stored key which combines the collection name and object id
@@ -81,7 +82,7 @@ func addDeviceProfile(conn redis.Conn, dp models.DeviceProfile) (addedDeviceProf
 	_ = conn.Send(SET, storedKey, m)
 	_ = conn.Send(ZADD, DeviceProfileCollection, 0, storedKey)
 	_ = conn.Send(HSET, fmt.Sprintf("%s:%s", DeviceProfileCollection, v2.Name), dp.Name, storedKey)
-	_ = conn.Send(SADD, fmt.Sprintf("%s:%s:%s", DeviceProfileCollection, v2.Manufacturer, dp.Manufacturer), storedKey)
+	_ = conn.Send(ZADD, fmt.Sprintf("%s:%s", DeviceProfileCollectionManufacturer, dp.Manufacturer), dp.Modified, storedKey)
 	_ = conn.Send(ZADD, fmt.Sprintf("%s:%s", DeviceProfileCollectionModel, dp.Model), dp.Modified, storedKey)
 	for _, label := range dp.Labels {
 		_ = conn.Send(ZADD, fmt.Sprintf("%s:%s:%s", DeviceProfileCollection, v2.Label, label), dp.Modified, storedKey)
@@ -220,6 +221,29 @@ func deviceProfilesByModel(conn redis.Conn, offset int, limit int, model string)
 		end = limit
 	}
 	objects, err := getObjectsByRevRange(conn, fmt.Sprintf("%s:%s", DeviceProfileCollectionModel, model), offset, end)
+	if err != nil {
+		return deviceProfiles, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	deviceProfiles = make([]models.DeviceProfile, len(objects))
+	for i, in := range objects {
+		dp := models.DeviceProfile{}
+		err := json.Unmarshal(in, &dp)
+		if err != nil {
+			return deviceProfiles, errors.NewCommonEdgeX(errors.KindContractInvalid, "device profile parsing failed", err)
+		}
+		deviceProfiles[i] = dp
+	}
+	return deviceProfiles, nil
+}
+
+// deviceProfilesByManufacturer query device profiles by offset, limit and manufacturer
+func deviceProfilesByManufacturer(conn redis.Conn, offset int, limit int, manufacturer string) (deviceProfiles []models.DeviceProfile, edgeXerr errors.EdgeX) {
+	end := offset + limit - 1
+	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
+		end = limit
+	}
+	objects, err := getObjectsByRevRange(conn, fmt.Sprintf("%s:%s", DeviceProfileCollectionManufacturer, manufacturer), offset, end)
 	if err != nil {
 		return deviceProfiles, errors.NewCommonEdgeXWrapper(err)
 	}


### PR DESCRIPTION
Fix #2915

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #2915 


## What is the new behavior?
Implement GET /deviceprofile/manufacturer/{manufacturer} V2 API according to the doc https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/default/get_deviceprofile_manufacturer__manufacturer_

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information