### PR TITLE
fix: Revert log level change for commit ff93af4

### DIFF
--- a/cmd/secrets-config/main.go
+++ b/cmd/secrets-config/main.go
@@ -14,6 +14,7 @@ import (
 )
 
 func main() {
+	os.Setenv("WRITABLE_LOGLEVEL", "ERROR") // Workaround for https://github.com/edgexfoundry/edgex-go/issues/2922
 	ctx, cancel := context.WithCancel(context.Background())
 	exitStatusCode := config.Main(ctx, cancel)
 	os.Exit(exitStatusCode)

--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -17,7 +17,7 @@
 # This is a TOML config file for edgexsecurity service.
 
 [Writable]
-LogLevel = "ERROR"
+LogLevel = "DEBUG"
 RequestTimeout = 10
 
 [KongURL]


### PR DESCRIPTION
TAF framework is using deprecated egdgex-proxy tool
to create proxy users and is senitive to logging level
in order to determine if user management is successful.
This fix reverts the log level change
as temporary fix for #2922

Permanent fix is that TAF needs to use new utility.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
#2922

## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information