### PR TITLE
feat(meta): Implement GET /device/profile/name/{name} V2 API

### DIFF
--- a/internal/core/metadata/v2/application/device.go
+++ b/internal/core/metadata/v2/application/device.go
@@ -224,3 +224,20 @@ func DeviceByName(name string, dic *di.Container) (device dtos.Device, err error
 	device = dtos.FromDeviceModelToDTO(d)
 	return device, nil
 }
+
+// DevicesByProfileName query the devices with offset, limit, and profile name
+func DevicesByProfileName(offset int, limit int, profileName string, dic *di.Container) (devices []dtos.Device, err errors.EdgeX) {
+	if profileName == "" {
+		return devices, errors.NewCommonEdgeX(errors.KindContractInvalid, "profileName is empty", nil)
+	}
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	deviceModels, err := dbClient.DevicesByProfileName(offset, limit, profileName)
+	if err != nil {
+		return devices, errors.NewCommonEdgeXWrapper(err)
+	}
+	devices = make([]dtos.Device, len(deviceModels))
+	for i, d := range deviceModels {
+		devices[i] = dtos.FromDeviceModelToDTO(d)
+	}
+	return devices, nil
+}

--- a/internal/core/metadata/v2/infrastructure/interfaces/db.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/db.go
@@ -41,4 +41,5 @@ type DBClient interface {
 	DeviceById(id string) (model.Device, errors.EdgeX)
 	DeviceByName(name string) (model.Device, errors.EdgeX)
 	AllDevices(offset int, limit int, labels []string) ([]model.Device, errors.EdgeX)
+	DevicesByProfileName(offset int, limit int, profileName string) ([]model.Device, errors.EdgeX)
 }

--- a/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -542,6 +542,31 @@ func (_m *DBClient) DeviceServiceNameExists(name string) (bool, errors.EdgeX) {
 	return r0, r1
 }
 
+// DevicesByProfileName provides a mock function with given fields: offset, limit, profileName
+func (_m *DBClient) DevicesByProfileName(offset int, limit int, profileName string) ([]models.Device, errors.EdgeX) {
+	ret := _m.Called(offset, limit, profileName)
+
+	var r0 []models.Device
+	if rf, ok := ret.Get(0).(func(int, int, string) []models.Device); ok {
+		r0 = rf(offset, limit, profileName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Device)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, profileName)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // DevicesByServiceName provides a mock function with given fields: offset, limit, name
 func (_m *DBClient) DevicesByServiceName(offset int, limit int, name string) ([]models.Device, errors.EdgeX) {
 	ret := _m.Called(offset, limit, name)

--- a/internal/core/metadata/v2/router.go
+++ b/internal/core/metadata/v2/router.go
@@ -56,6 +56,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiDeviceRoute, d.PatchDevice).Methods(http.MethodPatch)
 	r.HandleFunc(v2Constant.ApiAllDeviceRoute, d.AllDevices).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiDeviceByNameRoute, d.DeviceByName).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiDeviceByProfileNameRoute, d.DevicesByProfileName).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -425,6 +425,19 @@ func (c *Client) DeviceByName(name string) (device model.Device, edgeXerr errors
 	return
 }
 
+// DevicesByProfileName query devices by offset, limit and profile name
+func (c *Client) DevicesByProfileName(offset int, limit int, profileName string) (devices []model.Device, edgeXerr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	devices, edgeXerr = devicesByProfileName(conn, offset, limit, profileName)
+	if edgeXerr != nil {
+		return devices, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
+			fmt.Sprintf("fail to query devices by offset %d, limit %d and name %s", offset, limit, profileName), edgeXerr)
+	}
+	return devices, nil
+}
+
 // AllEvents query events by offset and limit
 func (c *Client) AllEvents(offset int, limit int) ([]model.Event, errors.EdgeX) {
 	conn := c.Pool.Get()


### PR DESCRIPTION
Fix #2931

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #2931 


## What is the new behavior?
Implement GET  /device/profile/name/{name} V2 API according to the https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-metadata/2.x#/default/get_device_profile_name__name_

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information