### PR TITLE
feat(data): Implement DELETE /event/age/{age} V2 API

### DIFF
--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -242,3 +242,16 @@ func EventsByTimeRange(start int, end int, offset int, limit int, dic *di.Contai
 	}
 	return events, nil
 }
+
+// The DeleteEventsByAge function will be invoked by controller functions
+// and then invokes DeleteEventsByAge function in the infrastructure layer to remove
+// events that are older than age.  Age is supposed in milliseconds since created timestamp.
+func DeleteEventsByAge(age int64, dic *di.Container) errors.EdgeX {
+	dbClient := v2DataContainer.DBClientFrom(dic.Get)
+
+	err := dbClient.DeleteEventsByAge(age)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}

--- a/internal/core/data/v2/application/event_test.go
+++ b/internal/core/data/v2/application/event_test.go
@@ -10,7 +10,7 @@ import (
 	v2DataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/v2/bootstrap/container"
 	dbMock "github.com/edgexfoundry/edgex-go/internal/core/data/v2/infrastructure/interfaces/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/v2/mocks"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/v2/utils"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
@@ -44,7 +44,7 @@ var persistedEvent = models.Event{
 }
 
 func buildReadings() []models.Reading {
-	ticks := db.MakeTimestamp()
+	ticks := utils.MakeTimestamp()
 
 	r1 := models.SimpleReading{
 		BaseReading: models.BaseReading{
@@ -90,6 +90,7 @@ func newMockDB(persist bool) *dbMock.DBClient {
 		myMock.On("EventCountByDevice", testDeviceName).Return(testEventCount, nil)
 		myMock.On("DeletePushedEvents").Return(nil)
 		myMock.On("DeleteEventsByDeviceName", testDeviceName).Return(nil)
+		myMock.On("DeleteEventsByAge", int64(0)).Return(nil)
 	}
 
 	return myMock
@@ -354,4 +355,18 @@ func TestEventsByTimeRange(t *testing.T) {
 			assert.Equal(t, testCase.expectedCount, len(events), "Event total count is not expected")
 		})
 	}
+}
+
+func TestDeleteEventsByAge(t *testing.T) {
+	dbClientMock := newMockDB(true)
+
+	dic := mocks.NewMockDIC()
+	dic.Update(di.ServiceConstructorMap{
+		v2DataContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+
+	err := DeleteEventsByAge(0, dic)
+	require.NoError(t, err)
 }

--- a/internal/core/data/v2/infrastructure/interfaces/db.go
+++ b/internal/core/data/v2/infrastructure/interfaces/db.go
@@ -24,6 +24,7 @@ type DBClient interface {
 	DeletePushedEvents() errors.EdgeX
 	DeleteEventsByDeviceName(deviceName string) errors.EdgeX
 	EventsByTimeRange(start int, end int, offset int, limit int) ([]model.Event, errors.EdgeX)
+	DeleteEventsByAge(age int64) errors.EdgeX
 	ReadingTotalCount() (uint32, errors.EdgeX)
 	AllReadings(offset int, limit int) ([]model.Reading, errors.EdgeX)
 }

--- a/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -109,6 +109,22 @@ func (_m *DBClient) DeleteEventById(id string) errors.EdgeX {
 	return r0
 }
 
+// DeleteEventsByAge provides a mock function with given fields: age
+func (_m *DBClient) DeleteEventsByAge(age int64) errors.EdgeX {
+	ret := _m.Called(age)
+
+	var r0 errors.EdgeX
+	if rf, ok := ret.Get(0).(func(int64) errors.EdgeX); ok {
+		r0 = rf(age)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(errors.EdgeX)
+		}
+	}
+
+	return r0
+}
+
 // DeleteEventsByDeviceName provides a mock function with given fields: deviceName
 func (_m *DBClient) DeleteEventsByDeviceName(deviceName string) errors.EdgeX {
 	ret := _m.Called(deviceName)

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -35,6 +35,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiEventScrubRoute, ec.DeletePushedEvents).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.DeleteEventsByDeviceName).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiEventByTimeRangeRoute, ec.EventsByTimeRange).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiEventByAgeRoute, ec.DeleteEventsByAge).Methods(http.MethodDelete)
 
 	// Readings
 	rc := dataController.NewReadingController(dic)

--- a/internal/pkg/v2/utils/db.go
+++ b/internal/pkg/v2/utils/db.go
@@ -1,0 +1,8 @@
+package utils
+
+import "time"
+
+// MakeTimestamp returns the Unix timestamp in milliseconds
+func MakeTimestamp() int64 {
+	return time.Now().UnixNano() / int64(time.Millisecond)
+}

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -336,6 +336,12 @@ components:
         apiVersion: "v2"
         statusCode: 200
         message: ""
+    202Example:
+      value:
+        requestId: ""
+        apiVersion: "v2"
+        statusCode: 202
+        message: ""
     400Example:
       value:
         requestId: ""
@@ -1020,7 +1026,7 @@ paths:
                 $ref: '#/components/schemas/BaseResponse'
               examples:
                 200Example:
-                  $ref: '#/components/examples/200Example'
+                  $ref: '#/components/examples/202Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1105,8 +1111,8 @@ paths:
     delete:
       summary: "Remove all old events (and associated readings) based on delimiting age"
       responses:
-        '200':
-          description: "Delete successful"
+        '202':
+          description: "Delete request accepted"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -1116,7 +1122,21 @@ paths:
                 $ref: '#/components/schemas/BaseResponse'
               examples:
                 200Example:
-                  $ref: '#/components/examples/200Example'
+                  $ref: '#/components/examples/202Example'
+        '400':
+          description: "\"{age}\" must be a parsable unix timestamp"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #2943

## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/default/delete_event_age__age_,
implement DELETE /event/age/{age} V2 API.

As this API may delete hugh volume of events/readings, this API is
intentionally implemented to use async way to delete events/readings.
As a result, the return HTTP status code is updated from 200 to 202.

Corresponding API doc is also updated for such change.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No