### PR TITLE
fix(snap): remove kong TLS config overrides

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -164,8 +164,6 @@ apps:
     environment:
       VAULT_INTERVAL: "--vaultInterval=10"
       SecretService_Server: localhost
-      SecretService_CertFilePath: $SNAP_DATA/secrets/edgex-kong/server.crt
-      SecretService_KeyFilePath: $SNAP_DATA/secrets/edgex-kong/server.key
       SecretService_TokenFolderPath: $SNAP_DATA/config/security-secrets-setup/res
       SecretService_TokenProvider: $SNAP/bin/security-file-token-provider
       SecretService_TokenProviderArgs: "-confdir, $SNAP_DATA/config/security-file-token-provider/res"


### PR DESCRIPTION
Due to the recent decision to remove use of TLS on a
single device/node, it was also decided to let Kong
generate its own self-signed certificate and get rid
of the EdgeX CA altogether. A PR landed this weekend
which updated some of the default configuration values
in security-secretstore-setup's configuration.toml file
related to TLS configuration. As the snap still contained
overrides for some of these files, installation of the
snap fail when security-secretstore-setup fails to start.
This change removes the configuration overrides related
to Kong TLS configuration from snapcraft.yaml, which then
allows the snap to be installed.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
The snap built from master fails to install due to configuration overrides in snapcraft.yaml specifying alternate paths for Kong TLS files.  This regression was introduced by the followingf PR:

https://github.com/edgexfoundry/edgex-go/pull/2940

## Issue Number:
None

## What is the new behavior?
NA

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information