### PR TITLE
feat(data): Update V2 API path for consistency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.60
 	github.com/edgexfoundry/go-mod-configuration v0.0.8
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.128
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.130
 	github.com/edgexfoundry/go-mod-messaging v0.1.28
 	github.com/edgexfoundry/go-mod-registry v0.1.26
 	github.com/edgexfoundry/go-mod-secrets v0.0.26

--- a/internal/core/data/v2/controller/http/event.go
+++ b/internal/core/data/v2/controller/http/event.go
@@ -195,7 +195,7 @@ func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Req
 
 	// URL parameters
 	vars := mux.Vars(r)
-	deviceName := vars[v2.DeviceName]
+	deviceName := vars[v2.Name]
 
 	var countResponse interface{}
 	var statusCode int

--- a/internal/core/data/v2/controller/http/event_test.go
+++ b/internal/core/data/v2/controller/http/event_test.go
@@ -394,8 +394,8 @@ func TestEventCountByDevice(t *testing.T) {
 	})
 	ec := NewEventController(dic)
 
-	req, err := http.NewRequest(http.MethodGet, v2.ApiEventCountByDeviceRoute, http.NoBody)
-	req = mux.SetURLVars(req, map[string]string{v2.DeviceName: deviceName})
+	req, err := http.NewRequest(http.MethodGet, v2.ApiEventCountByDeviceNameRoute, http.NoBody)
+	req = mux.SetURLVars(req, map[string]string{v2.Name: deviceName})
 	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -28,7 +28,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.EventById).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.DeleteEventById).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiEventCountRoute, ec.EventTotalCount).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiEventCountByDeviceRoute, ec.EventCountByDevice).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiEventCountByDeviceNameRoute, ec.EventCountByDevice).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiAllEventRoute, ec.AllEvents).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.EventsByDeviceName).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.DeleteEventsByDeviceName).Methods(http.MethodDelete)

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -266,6 +266,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SimpleReading'
+    VersionResponse:
+      description: "A response returned from the /version endpoint whose purpose is to report out the latest version supported by the service."
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+      type: object
+      properties:
+        version:
+          description: "The latest version supported by the service."
+          type: string
   parameters:
     offsetParam:
       in: query
@@ -763,10 +772,10 @@ paths:
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'
-  /event/count/device/{deviceName}:
+  /event/count/device/name/{name}:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
-    - name: deviceName
+    - name: name
       in: path
       required: true
       schema:
@@ -1137,10 +1146,10 @@ paths:
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'
-  /reading/count/device/{deviceName}:
+  /reading/count/device/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
-      - name: deviceName
+      - name: name
         in: path
         required: true
         schema:
@@ -1164,69 +1173,6 @@ paths:
                 statusCode: 200
                 message: ""
                 count: 2
-        '404':
-          description: "The requested resource does not exist"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                404Example:
-                  $ref: '#/components/examples/404Example'
-        '500':
-          description: "An unexpected error occurred on the server"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                500Example:
-                  $ref: '#/components/examples/500Example'
-  /reading/id/{id}:
-    parameters:
-    - $ref: '#/components/parameters/correlatedRequestHeader'
-    - name: id
-      in: path
-      required: true
-      schema:
-        type: string
-        format: uuid
-      description: "An ID of datatype string, by default a GUID."
-    get:
-      summary: "Returns a reading by ID"
-      responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReadingResponse'
-              example:
-                requestId: ""
-                apiVersion: "v2"
-                statusCode: 200
-                message: ""
-                reading:
-                  apiVersion: "v2"
-                  created: 1594876281221
-                  deviceName: "device-001"
-                  resourceName: "resource-001"
-                  profileName: "profile-001"
-                  id: "31569347-9369-43ec-aa6a-59ea9c624a6f"
-                  modified: 1594975851631
-                  origin: 1602168089665565300
-                  pushed: 1594975851631
-                  valueType: "Float32"
-                  value: "39.5"
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1328,19 +1274,19 @@ paths:
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'
-  /reading/valueType/{valueType}:
+  /reading/resourceName/{resourceName}:
     parameters:
     - $ref: '#/components/parameters/correlatedRequestHeader'
-    - name: valueType
+    - name: resourceName
       in: path
       required: true
       schema:
         type: string
-      description: The datatype of a SimpleReading's value property.
+      description: The device resource name of readings.
     - $ref: '#/components/parameters/offsetParam'
     - $ref: '#/components/parameters/limitParam'
     get:
-      summary: Returns a paginated list of SimpleReadings whose value property is of the specified type.
+      summary: Returns a paginated list of SimpleReadings whose resource name is of the specified one.
       responses:
         '200':
           description: "OK"
@@ -1378,7 +1324,7 @@ paths:
                     valueType: "Float32"
                     value: "12.2"
         '400':
-          description: "Request is in an invalid state. \"{valueType}\" is defined in [Reading ValueTypes](https://github.com/edgexfoundry/go-mod-core-contracts/blob/8df1bc237b3746b67ec2754785c71dc83ce5d0c1/models/reading.go#L22-L49)."
+          description: "Request is in an invalid state. \"{resourceName}\" could only contain reserved characters as defined in https://tools.ietf.org/html/rfc3986#section-2.3"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #2875

## What is the new behavior?
Original V2 API defines `GET /event/count/device/{deviceName}` to retrieve the count of events that are associated with the specified device name, and `GET /event/device/name/{name}` to retrieve events that are associated with the specified device name. This two API path should be consistent to avoid user confusion.

This PR makes following changes:
1. Change `GET /event/count/device/{deviceName}` to `GET /event/count/device/name/{name}`
2. Update core-data v2 swagger yaml file with correct paths
3. Add missing VersionResponse back into core-data v2 swagger yaml file
4. Update go.mod to use go-mod-core-contracts v0.1.130 to pick up the updated API path constants

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No