### PR TITLE
feat(data): Implement GET /reading/count/device/name/{name} V2 API

### DIFF
--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -138,6 +138,7 @@ func DeleteEventById(id string, dic *di.Container) errors.EdgeX {
 	return nil
 }
 
+// EventTotalCount return the count of all of events currently stored in the database and error if any
 func EventTotalCount(dic *di.Container) (uint32, errors.EdgeX) {
 	dbClient := v2DataContainer.DBClientFrom(dic.Get)
 
@@ -149,10 +150,11 @@ func EventTotalCount(dic *di.Container) (uint32, errors.EdgeX) {
 	return count, nil
 }
 
-func EventCountByDevice(deviceName string, dic *di.Container) (uint32, errors.EdgeX) {
+// EventCountByDeviceName return the count of all of events associated with given device and error if any
+func EventCountByDeviceName(deviceName string, dic *di.Container) (uint32, errors.EdgeX) {
 	dbClient := v2DataContainer.DBClientFrom(dic.Get)
 
-	count, err := dbClient.EventCountByDevice(deviceName)
+	count, err := dbClient.EventCountByDeviceName(deviceName)
 	if err != nil {
 		return 0, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/core/data/v2/application/event_test.go
+++ b/internal/core/data/v2/application/event_test.go
@@ -122,7 +122,7 @@ func newMockDB(persist bool) *dbMock.DBClient {
 		myMock.On("DeleteEventById", nonexistentEventID).Return(errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "event doesn't exist in the database", nil))
 		myMock.On("DeleteEventById", testUUIDString).Return(nil)
 		myMock.On("EventTotalCount").Return(testEventCount, nil)
-		myMock.On("EventCountByDevice", testDeviceName).Return(testEventCount, nil)
+		myMock.On("EventCountByDeviceName", testDeviceName).Return(testEventCount, nil)
 		myMock.On("DeleteEventsByDeviceName", testDeviceName).Return(nil)
 		myMock.On("DeleteEventsByAge", int64(0)).Return(nil)
 	}
@@ -279,7 +279,7 @@ func TestEventTotalCount(t *testing.T) {
 	assert.Equal(t, testEventCount, count, "Event total count is not expected")
 }
 
-func TestEventCountByDevice(t *testing.T) {
+func TestEventCountByDeviceName(t *testing.T) {
 	dbClientMock := newMockDB(true)
 
 	dic := mocks.NewMockDIC()
@@ -289,7 +289,7 @@ func TestEventCountByDevice(t *testing.T) {
 		},
 	})
 
-	count, err := EventCountByDevice(testDeviceName, dic)
+	count, err := EventCountByDeviceName(testDeviceName, dic)
 	require.NoError(t, err)
 	assert.Equal(t, testEventCount, count, "Event total count is not expected")
 }

--- a/internal/core/data/v2/application/reading.go
+++ b/internal/core/data/v2/application/reading.go
@@ -77,3 +77,17 @@ func convertReadingModelsToDTOs(readingModels []models.Reading) (readings []dtos
 	}
 	return readings, nil
 }
+
+// ReadingCountByDeviceName return the count of all of readings associated with given device and error if any
+func ReadingCountByDeviceName(deviceName string, dic *di.Container) (uint32, errors.EdgeX) {
+	if deviceName == "" {
+		return 0, errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
+	}
+	dbClient := v2DataContainer.DBClientFrom(dic.Get)
+	count, err := dbClient.ReadingCountByDeviceName(deviceName)
+	if err != nil {
+		return 0, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return count, nil
+}

--- a/internal/core/data/v2/controller/http/event.go
+++ b/internal/core/data/v2/controller/http/event.go
@@ -186,7 +186,7 @@ func (ec *EventController) EventTotalCount(w http.ResponseWriter, r *http.Reques
 	pkg.Encode(countResponse, w, lc) // encode and send out the response
 }
 
-func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Request) {
+func (ec *EventController) EventCountByDeviceName(w http.ResponseWriter, r *http.Request) {
 	// retrieve all the service injections from bootstrap
 	lc := container.LoggingClientFrom(ec.dic.Get)
 
@@ -201,7 +201,7 @@ func (ec *EventController) EventCountByDevice(w http.ResponseWriter, r *http.Req
 	var statusCode int
 
 	// Count the event by device
-	count, err := application.EventCountByDevice(deviceName, ec.dic)
+	count, err := application.EventCountByDeviceName(deviceName, ec.dic)
 	if err != nil {
 		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
 		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)

--- a/internal/core/data/v2/controller/http/event_test.go
+++ b/internal/core/data/v2/controller/http/event_test.go
@@ -380,11 +380,11 @@ func TestEventTotalCount(t *testing.T) {
 	assert.Equal(t, expectedEventCount, actualResponse.Count, "Event count in the response body is not expected")
 }
 
-func TestEventCountByDevice(t *testing.T) {
+func TestEventCountByDeviceName(t *testing.T) {
 	expectedEventCount := uint32(656672)
 	deviceName := "deviceA"
 	dbClientMock := &dbMock.DBClient{}
-	dbClientMock.On("EventCountByDevice", deviceName).Return(expectedEventCount, nil)
+	dbClientMock.On("EventCountByDeviceName", deviceName).Return(expectedEventCount, nil)
 
 	dic := mocks.NewMockDIC()
 	dic.Update(di.ServiceConstructorMap{
@@ -399,7 +399,7 @@ func TestEventCountByDevice(t *testing.T) {
 	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
-	handler := http.HandlerFunc(ec.EventCountByDevice)
+	handler := http.HandlerFunc(ec.EventCountByDeviceName)
 	handler.ServeHTTP(recorder, req)
 
 	var actualResponse common.CountResponse

--- a/internal/core/data/v2/controller/http/reading.go
+++ b/internal/core/data/v2/controller/http/reading.go
@@ -201,3 +201,33 @@ func (rc *ReadingController) ReadingsByDeviceName(w http.ResponseWriter, r *http
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc)
 }
+
+func (rc *ReadingController) ReadingCountByDeviceName(w http.ResponseWriter, r *http.Request) {
+	// retrieve all the service injections from bootstrap
+	lc := container.LoggingClientFrom(rc.dic.Get)
+
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	// URL parameters
+	vars := mux.Vars(r)
+	deviceName := vars[v2.Name]
+
+	var countResponse interface{}
+	var statusCode int
+
+	// Count the event by device
+	count, err := application.ReadingCountByDeviceName(deviceName, rc.dic)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		countResponse = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		countResponse = commonDTO.NewCountResponse("", "", http.StatusOK, count)
+		statusCode = http.StatusOK
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(countResponse, w, lc) // encode and send out the response
+}

--- a/internal/core/data/v2/infrastructure/interfaces/db.go
+++ b/internal/core/data/v2/infrastructure/interfaces/db.go
@@ -17,7 +17,7 @@ type DBClient interface {
 	EventById(id string) (model.Event, errors.EdgeX)
 	DeleteEventById(id string) errors.EdgeX
 	EventTotalCount() (uint32, errors.EdgeX)
-	EventCountByDevice(deviceName string) (uint32, errors.EdgeX)
+	EventCountByDeviceName(deviceName string) (uint32, errors.EdgeX)
 	AllEvents(offset int, limit int) ([]model.Event, errors.EdgeX)
 	EventsByDeviceName(offset int, limit int, name string) ([]model.Event, errors.EdgeX)
 	DeleteEventsByDeviceName(deviceName string) errors.EdgeX
@@ -28,4 +28,5 @@ type DBClient interface {
 	ReadingsByTimeRange(start int, end int, offset int, limit int) ([]model.Reading, errors.EdgeX)
 	ReadingsByResourceName(offset int, limit int, resourceName string) ([]model.Reading, errors.EdgeX)
 	ReadingsByDeviceName(offset int, limit int, name string) ([]model.Reading, errors.EdgeX)
+	ReadingCountByDeviceName(deviceName string) (uint32, errors.EdgeX)
 }

--- a/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -164,8 +164,8 @@ func (_m *DBClient) EventById(id string) (models.Event, errors.EdgeX) {
 	return r0, r1
 }
 
-// EventCountByDevice provides a mock function with given fields: deviceName
-func (_m *DBClient) EventCountByDevice(deviceName string) (uint32, errors.EdgeX) {
+// EventCountByDeviceName provides a mock function with given fields: deviceName
+func (_m *DBClient) EventCountByDeviceName(deviceName string) (uint32, errors.EdgeX) {
 	ret := _m.Called(deviceName)
 
 	var r0 uint32
@@ -251,6 +251,29 @@ func (_m *DBClient) EventsByTimeRange(start int, end int, offset int, limit int)
 	var r1 errors.EdgeX
 	if rf, ok := ret.Get(1).(func(int, int, int, int) errors.EdgeX); ok {
 		r1 = rf(start, end, offset, limit)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
+// ReadingCountByDeviceName provides a mock function with given fields: deviceName
+func (_m *DBClient) ReadingCountByDeviceName(deviceName string) (uint32, errors.EdgeX) {
+	ret := _m.Called(deviceName)
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func(string) uint32); ok {
+		r0 = rf(deviceName)
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(string) errors.EdgeX); ok {
+		r1 = rf(deviceName)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -28,7 +28,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.EventById).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.DeleteEventById).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiEventCountRoute, ec.EventTotalCount).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiEventCountByDeviceNameRoute, ec.EventCountByDevice).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiEventCountByDeviceNameRoute, ec.EventCountByDeviceName).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiAllEventRoute, ec.AllEvents).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.EventsByDeviceName).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.DeleteEventsByDeviceName).Methods(http.MethodDelete)
@@ -42,6 +42,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiReadingByDeviceNameRoute, rc.ReadingsByDeviceName).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiReadingByTimeRangeRoute, rc.ReadingsByTimeRange).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiReadingByResourceNameRoute, rc.ReadingsByResourceName).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiReadingCountByDeviceNameRoute, rc.ReadingCountByDeviceName).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -291,7 +291,7 @@ func (c *Client) EventTotalCount() (uint32, errors.EdgeX) {
 }
 
 // EventCountByDevice returns the count of Event associated a specific Device from the database
-func (c *Client) EventCountByDevice(deviceName string) (uint32, errors.EdgeX) {
+func (c *Client) EventCountByDeviceName(deviceName string) (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
@@ -544,4 +544,17 @@ func (c *Client) ReadingsByDeviceName(offset int, limit int, name string) (readi
 			fmt.Sprintf("fail to query readings by offset %d, limit %d and name %s", offset, limit, name), edgeXerr)
 	}
 	return readings, nil
+}
+
+// ReadingCountByDeviceName returns the count of Readings associated a specific Device from the database
+func (c *Client) ReadingCountByDeviceName(deviceName string) (uint32, errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	count, edgeXerr := getMemberNumber(conn, ZCARD, CreateKey(ReadingsCollectionDeviceName, deviceName))
+	if edgeXerr != nil {
+		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+
+	return count, nil
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #2961 

## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/default/get_reading_count_device_name__name_, implement GET /reading/count/device/name/{name} V2 API.

Also change method name from EventCountByDevice to
EventCountByDeviceName for consistency.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No