### PR TITLE
feat(data): Implement GET /reading/start/{start}/end/{end} V2 API

### DIFF
--- a/internal/core/data/v2/application/reading.go
+++ b/internal/core/data/v2/application/reading.go
@@ -5,6 +5,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
 // ReadingTotalCount return the count of all of readings currently stored in the database and error if any
@@ -26,11 +27,7 @@ func AllReadings(offset int, limit int, dic *di.Container) (readings []dtos.Base
 	if err != nil {
 		return readings, errors.NewCommonEdgeXWrapper(err)
 	}
-	readings = make([]dtos.BaseReading, len(readingModels))
-	for i, r := range readingModels {
-		readings[i] = dtos.FromReadingModelToDTO(r)
-	}
-	return readings, nil
+	return convertReadingModelsToDTOs(readingModels)
 }
 
 // ReadingsByDeviceName query readings with offset, limit, and device name
@@ -43,6 +40,20 @@ func ReadingsByDeviceName(offset int, limit int, name string, dic *di.Container)
 	if err != nil {
 		return readings, errors.NewCommonEdgeXWrapper(err)
 	}
+	return convertReadingModelsToDTOs(readingModels)
+}
+
+// ReadingsByTimeRange query readings with offset, limit and time range
+func ReadingsByTimeRange(start int, end int, offset int, limit int, dic *di.Container) (readings []dtos.BaseReading, err errors.EdgeX) {
+	dbClient := v2DataContainer.DBClientFrom(dic.Get)
+	readingModels, err := dbClient.ReadingsByTimeRange(start, end, offset, limit)
+	if err != nil {
+		return readings, errors.NewCommonEdgeXWrapper(err)
+	}
+	return convertReadingModelsToDTOs(readingModels)
+}
+
+func convertReadingModelsToDTOs(readingModels []models.Reading) (readings []dtos.BaseReading, err errors.EdgeX) {
 	readings = make([]dtos.BaseReading, len(readingModels))
 	for i, r := range readingModels {
 		readings[i] = dtos.FromReadingModelToDTO(r)

--- a/internal/core/data/v2/application/reading_test.go
+++ b/internal/core/data/v2/application/reading_test.go
@@ -55,6 +55,53 @@ func TestAllReadings(t *testing.T) {
 	}
 }
 
+func TestReadingsByTimeRange(t *testing.T) {
+	readings := buildReadings()
+
+	dic := mocks.NewMockDIC()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByTimeRange", int(readings[0].GetBaseReading().Created), int(readings[4].GetBaseReading().Created), 0, 10).Return(readings, nil)
+	dbClientMock.On("ReadingsByTimeRange", int(readings[1].GetBaseReading().Created), int(readings[3].GetBaseReading().Created), 0, 10).Return([]models.Reading{readings[3], readings[2], readings[1]}, nil)
+	dbClientMock.On("ReadingsByTimeRange", int(readings[1].GetBaseReading().Created), int(readings[3].GetBaseReading().Created), 1, 2).Return([]models.Reading{readings[2], readings[1]}, nil)
+	dbClientMock.On("ReadingsByTimeRange", int(readings[1].GetBaseReading().Created), int(readings[3].GetBaseReading().Created), 4, 2).Return(nil, errors.NewCommonEdgeX(errors.KindRangeNotSatisfiable, "query objects bounds out of range", nil))
+	dic.Update(di.ServiceConstructorMap{
+		v2DataContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+
+	tests := []struct {
+		name               string
+		start              int
+		end                int
+		offset             int
+		limit              int
+		errorExpected      bool
+		ExpectedErrKind    errors.ErrKind
+		expectedCount      int
+		expectedStatusCode int
+	}{
+		{"Valid - all readings", int(readings[0].GetBaseReading().Created), int(readings[4].GetBaseReading().Created), 0, 10, false, "", 5, http.StatusOK},
+		{"Valid - readings trimmed by latest and oldest", int(readings[1].GetBaseReading().Created), int(readings[3].GetBaseReading().Created), 0, 10, false, "", 3, http.StatusOK},
+		{"Valid - readings trimmed by latest and oldest and skipped first", int(readings[1].GetBaseReading().Created), int(readings[3].GetBaseReading().Created), 1, 2, false, "", 2, http.StatusOK},
+		{"Invalid - bounds out of range", int(readings[1].GetBaseReading().Created), int(readings[3].GetBaseReading().Created), 4, 2, true, errors.KindRangeNotSatisfiable, 0, http.StatusRequestedRangeNotSatisfiable},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			readings, err := ReadingsByTimeRange(testCase.start, testCase.end, testCase.offset, testCase.limit, dic)
+			if testCase.errorExpected {
+				require.Error(t, err)
+				assert.NotEmpty(t, err.Error(), "Error message is empty")
+				assert.Equal(t, testCase.ExpectedErrKind, errors.Kind(err), "Error kind not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, err.Code(), "Status code not as expected")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, testCase.expectedCount, len(readings), "Reading total count is not expected")
+			}
+		})
+	}
+}
+
 func TestReadingsByDeviceName(t *testing.T) {
 	readings := buildReadings()
 

--- a/internal/core/data/v2/controller/http/reading_test.go
+++ b/internal/core/data/v2/controller/http/reading_test.go
@@ -114,6 +114,75 @@ func TestAllReadings(t *testing.T) {
 	}
 }
 
+func TestReadingsByTimeRange(t *testing.T) {
+	dic := mocks.NewMockDIC()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByTimeRange", 0, 100, 0, 10).Return([]models.Reading{}, nil)
+	dic.Update(di.ServiceConstructorMap{
+		v2DataContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	rc := NewReadingController(dic)
+	assert.NotNil(t, rc)
+
+	tests := []struct {
+		name               string
+		start              string
+		end                string
+		offset             string
+		limit              string
+		errorExpected      bool
+		expectedCount      int
+		expectedStatusCode int
+	}{
+		{"Valid - with proper start/end/offset/limit", "0", "100", "0", "10", false, 0, http.StatusOK},
+		{"Invalid - invalid start format", "aaa", "100", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - invalid end format", "0", "bbb", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - empty start", "", "100", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - empty end", "0", "", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - end before start", "10", "0", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - invalid offset format", "0", "100", "aaa", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - invalid limit format", "0", "100", "0", "aaa", true, 0, http.StatusBadRequest},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, v2.ApiReadingByTimeRangeRoute, http.NoBody)
+			query := req.URL.Query()
+			query.Add(v2.Offset, testCase.offset)
+			query.Add(v2.Limit, testCase.limit)
+			req.URL.RawQuery = query.Encode()
+			req = mux.SetURLVars(req, map[string]string{v2.Start: testCase.start, v2.End: testCase.end})
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(rc.ReadingsByTimeRange)
+			handler.ServeHTTP(recorder, req)
+
+			// Assert
+			if testCase.errorExpected {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res responseDTO.MultiReadingsResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
+				assert.Equal(t, testCase.expectedCount, len(res.Readings), "Device count not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}
+
 func TestReadingsByDeviceName(t *testing.T) {
 	dic := mocks.NewMockDIC()
 	dbClientMock := &dbMock.DBClient{}

--- a/internal/core/data/v2/infrastructure/interfaces/db.go
+++ b/internal/core/data/v2/infrastructure/interfaces/db.go
@@ -25,5 +25,6 @@ type DBClient interface {
 	DeleteEventsByAge(age int64) errors.EdgeX
 	ReadingTotalCount() (uint32, errors.EdgeX)
 	AllReadings(offset int, limit int) ([]model.Reading, errors.EdgeX)
+	ReadingsByTimeRange(start int, end int, offset int, limit int) ([]model.Reading, errors.EdgeX)
 	ReadingsByDeviceName(offset int, limit int, name string) ([]model.Reading, errors.EdgeX)
 }

--- a/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -307,3 +307,28 @@ func (_m *DBClient) ReadingsByDeviceName(offset int, limit int, name string) ([]
 
 	return r0, r1
 }
+
+// ReadingsByTimeRange provides a mock function with given fields: start, end, offset, limit
+func (_m *DBClient) ReadingsByTimeRange(start int, end int, offset int, limit int) ([]models.Reading, errors.EdgeX) {
+	ret := _m.Called(start, end, offset, limit)
+
+	var r0 []models.Reading
+	if rf, ok := ret.Get(0).(func(int, int, int, int) []models.Reading); ok {
+		r0 = rf(start, end, offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Reading)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, int, int) errors.EdgeX); ok {
+		r1 = rf(start, end, offset, limit)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -40,6 +40,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiReadingCountRoute, rc.ReadingTotalCount).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiAllReadingRoute, rc.AllReadings).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiReadingByDeviceNameRoute, rc.ReadingsByDeviceName).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiReadingByTimeRangeRoute, rc.ReadingsByTimeRange).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -507,6 +507,19 @@ func (c *Client) AllReadings(offset int, limit int) ([]model.Reading, errors.Edg
 	return readings, nil
 }
 
+// ReadingsByTimeRange query readings by time range, offset, and limit
+func (c *Client) ReadingsByTimeRange(start int, end int, offset int, limit int) (readings []model.Reading, edgeXerr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	readings, edgeXerr = readingsByTimeRange(conn, start, end, offset, limit)
+	if edgeXerr != nil {
+		return readings, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
+			fmt.Sprintf("fail to query readings by time range %v ~ %v, offset %d, and limit %d", start, end, offset, limit), edgeXerr)
+	}
+	return readings, nil
+}
+
 // ReadingsByDeviceName query readings by offset, limit and device name
 func (c *Client) ReadingsByDeviceName(offset int, limit int, name string) (readings []model.Reading, edgeXerr errors.EdgeX) {
 	conn := c.Pool.Get()

--- a/internal/pkg/v2/infrastructure/redis/event.go
+++ b/internal/pkg/v2/infrastructure/redis/event.go
@@ -270,21 +270,7 @@ func (c *Client) allEvents(conn redis.Conn, offset int, limit int) (events []mod
 	if err != nil {
 		return events, errors.NewCommonEdgeXWrapper(err)
 	}
-
-	events = make([]models.Event, len(objects))
-	for i, in := range objects {
-		e := models.Event{}
-		err := json.Unmarshal(in, &e)
-		if err != nil {
-			return []models.Event{}, errors.NewCommonEdgeX(errors.KindDatabaseError, "event format parsing failed from the database", err)
-		}
-		e.Readings, edgeXerr = readingsByEventId(conn, e.Id)
-		if edgeXerr != nil {
-			return events, errors.NewCommonEdgeXWrapper(edgeXerr)
-		}
-		events[i] = e
-	}
-	return events, nil
+	return convertObjectsToEvents(conn, objects)
 }
 
 // eventsByDeviceName query events by offset, limit and device name
@@ -297,36 +283,19 @@ func eventsByDeviceName(conn redis.Conn, offset int, limit int, name string) (ev
 	if err != nil {
 		return events, errors.NewCommonEdgeXWrapper(err)
 	}
-
-	events = make([]models.Event, len(objects))
-	for i, in := range objects {
-		e := models.Event{}
-		err := json.Unmarshal(in, &e)
-		if err != nil {
-			return events, errors.NewCommonEdgeX(errors.KindContractInvalid, "event parsing failed", err)
-		}
-		e.Readings, edgeXerr = readingsByEventId(conn, e.Id)
-		if edgeXerr != nil {
-			return events, errors.NewCommonEdgeXWrapper(edgeXerr)
-		}
-		events[i] = e
-	}
-	return events, nil
+	return convertObjectsToEvents(conn, objects)
 }
 
 // eventsByTimeRange query events by time range, offset, and limit
 func eventsByTimeRange(conn redis.Conn, start int, end int, offset int, limit int) (events []models.Event, edgeXerr errors.EdgeX) {
-	// Use following redis command to retrieve the id of events satisfied with time range/offset/limit
-	// ZREVRANGEBYSCORE v2:event:created max min LIMIT offset count
-	eventIds, err := redis.Strings(conn.Do(ZREVRANGEBYSCORE, EventsCollectionCreated, end, start, LIMIT, offset, limit))
-	if err != nil {
-		return nil, errors.NewCommonEdgeXWrapper(err)
-	}
-	objects, edgeXerr := getObjectsByIds(conn, common.ConvertStringsToInterfaces(eventIds))
+	objects, edgeXerr := getObjectsByScoreRange(conn, EventsCollectionCreated, start, end, offset, limit)
 	if edgeXerr != nil {
 		return events, edgeXerr
 	}
+	return convertObjectsToEvents(conn, objects)
+}
 
+func convertObjectsToEvents(conn redis.Conn, objects [][]byte) (events []models.Event, edgeXerr errors.EdgeX) {
 	events = make([]models.Event, len(objects))
 	for i, in := range objects {
 		e := models.Event{}

--- a/internal/pkg/v2/infrastructure/redis/reading.go
+++ b/internal/pkg/v2/infrastructure/redis/reading.go
@@ -202,6 +202,15 @@ func readingsByDeviceName(conn redis.Conn, offset int, limit int, name string) (
 	return convertObjectsToReadings(objects)
 }
 
+// readingsByTimeRange query readings by time range, offset, and limit
+func readingsByTimeRange(conn redis.Conn, start int, end int, offset int, limit int) (readings []models.Reading, edgeXerr errors.EdgeX) {
+	objects, edgeXerr := getObjectsByScoreRange(conn, ReadingsCollectionCreated, start, end, offset, limit)
+	if edgeXerr != nil {
+		return readings, edgeXerr
+	}
+	return convertObjectsToReadings(objects)
+}
+
 func convertObjectsToReadings(objects [][]byte) (readings []models.Reading, edgeXerr errors.EdgeX) {
 	readings = make([]models.Reading, len(objects))
 	for i, in := range objects {

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -894,6 +894,18 @@ paths:
               examples:
                 404Example:
                   $ref: '#/components/examples/404Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -989,6 +1001,18 @@ paths:
               examples:
                 400Example:
                   $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1382,6 +1406,18 @@ paths:
               examples:
                 400Example:
                   $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #2963 

## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/default/get_reading_start__start__end__end_, implement GET /reading/start/{start}/end/{end} V2 API

Also update the swagger yaml file to have ReadingsByTimeRange and EventsByTimeRange to reply http 416 RangeNotSatisfiable when offset is greater than the total count of entries satisfied with time range in the DB.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No