### PR TITLE
feat(data): implement GET /reading/resourcename/{resourcename} V2 API

### DIFF
--- a/internal/core/data/v2/application/event_test.go
+++ b/internal/core/data/v2/application/event_test.go
@@ -12,25 +12,23 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/data/v2/mocks"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/v2/utils"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
-	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
-
 	"github.com/google/uuid"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	testDeviceName     string = "TestDevice"
-	testUUIDString     string = "ca93c8fa-9919-4ec5-85d3-f81b2b6a7bc1"
-	testCreatedTime           = 1600666214495
-	testOriginTime            = 1600666185705354000
-	nonexistentEventID        = "8ad33474-fbc5-11ea-adc1-0242ac120002"
-	testEventCount            = uint32(7778)
+	testDeviceResourceName = "TestDeviceResource"
+	testDeviceName         = "TestDevice"
+	testUUIDString         = "ca93c8fa-9919-4ec5-85d3-f81b2b6a7bc1"
+	testCreatedTime        = 1600666214495
+	testOriginTime         = 1600666185705354000
+	nonexistentEventID     = "8ad33474-fbc5-11ea-adc1-0242ac120002"
+	testEventCount         = uint32(7778)
 )
 
 var persistedEvent = models.Event{
@@ -50,7 +48,7 @@ func buildReadings() []models.Reading {
 			Created:      ticks,
 			Origin:       testOriginTime,
 			DeviceName:   testDeviceName,
-			ResourceName: "Temperature",
+			ResourceName: testDeviceResourceName,
 			ProfileName:  "TempProfile",
 			ValueType:    v2.ValueTypeUint16,
 		},
@@ -63,7 +61,7 @@ func buildReadings() []models.Reading {
 			Created:      ticks + 20,
 			Origin:       testOriginTime,
 			DeviceName:   testDeviceName,
-			ResourceName: "FileData",
+			ResourceName: testDeviceResourceName,
 			ProfileName:  "FileDataProfile",
 		},
 		BinaryValue: []byte("1010"),
@@ -76,7 +74,7 @@ func buildReadings() []models.Reading {
 			Created:      ticks + 30,
 			Origin:       testOriginTime,
 			DeviceName:   testDeviceName,
-			ResourceName: "Temperature",
+			ResourceName: testDeviceResourceName,
 			ProfileName:  "TempProfile",
 			ValueType:    v2.ValueTypeUint16,
 		},
@@ -89,7 +87,7 @@ func buildReadings() []models.Reading {
 			Created:      ticks + 40,
 			Origin:       testOriginTime,
 			DeviceName:   testDeviceName,
-			ResourceName: "Temperature",
+			ResourceName: testDeviceResourceName,
 			ProfileName:  "TempProfile",
 			ValueType:    v2.ValueTypeUint16,
 		},
@@ -102,7 +100,7 @@ func buildReadings() []models.Reading {
 			Created:      ticks + 50,
 			Origin:       testOriginTime,
 			DeviceName:   testDeviceName,
-			ResourceName: "Temperature",
+			ResourceName: testDeviceResourceName,
 			ProfileName:  "TempProfile",
 			ValueType:    v2.ValueTypeUint16,
 		},

--- a/internal/core/data/v2/application/reading.go
+++ b/internal/core/data/v2/application/reading.go
@@ -30,6 +30,23 @@ func AllReadings(offset int, limit int, dic *di.Container) (readings []dtos.Base
 	return convertReadingModelsToDTOs(readingModels)
 }
 
+// ReadingsByResourceName query readings with offset, limit, and resource name
+func ReadingsByResourceName(offset int, limit int, resourceName string, dic *di.Container) (readings []dtos.BaseReading, err errors.EdgeX) {
+	if resourceName == "" {
+		return readings, errors.NewCommonEdgeX(errors.KindContractInvalid, "resourceName is empty", nil)
+	}
+	dbClient := v2DataContainer.DBClientFrom(dic.Get)
+	readingModels, err := dbClient.ReadingsByResourceName(offset, limit, resourceName)
+	if err != nil {
+		return readings, errors.NewCommonEdgeXWrapper(err)
+	}
+	readings = make([]dtos.BaseReading, len(readingModels))
+	for i, r := range readingModels {
+		readings[i] = dtos.FromReadingModelToDTO(r)
+	}
+	return readings, nil
+}
+
 // ReadingsByDeviceName query readings with offset, limit, and device name
 func ReadingsByDeviceName(offset int, limit int, name string, dic *di.Container) (readings []dtos.BaseReading, err errors.EdgeX) {
 	if name == "" {

--- a/internal/core/data/v2/application/reading_test.go
+++ b/internal/core/data/v2/application/reading_test.go
@@ -102,6 +102,49 @@ func TestReadingsByTimeRange(t *testing.T) {
 	}
 }
 
+func TestReadingsByResourceName(t *testing.T) {
+	readings := buildReadings()
+
+	dic := mocks.NewMockDIC()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByResourceName", 0, 20, testDeviceResourceName).Return(readings, nil)
+	dbClientMock.On("ReadingsByResourceName", len(readings)+1, 10, testDeviceResourceName).Return([]models.Reading{}, errors.NewCommonEdgeX(errors.KindRangeNotSatisfiable, "query objects bounds out of range.", nil))
+	dic.Update(di.ServiceConstructorMap{
+		v2DataContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+
+	tests := []struct {
+		name               string
+		offset             int
+		limit              int
+		resourceName       string
+		errorExpected      bool
+		ExpectedErrKind    errors.ErrKind
+		expectedCount      int
+		expectedStatusCode int
+	}{
+		{"Valid - all readings", 0, 20, testDeviceResourceName, false, "", len(readings), http.StatusOK},
+		{"Invalid - bounds out of range", len(readings) + 1, 10, testDeviceResourceName, true, errors.KindRangeNotSatisfiable, 0, http.StatusRequestedRangeNotSatisfiable},
+		{"Invalid - empty resource name", len(readings) + 1, 10, "", true, errors.KindContractInvalid, 0, http.StatusBadRequest},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			readings, err := ReadingsByResourceName(testCase.offset, testCase.limit, testCase.resourceName, dic)
+			if testCase.errorExpected {
+				require.Error(t, err)
+				assert.NotEmpty(t, err.Error(), "Error message is empty")
+				assert.Equal(t, testCase.ExpectedErrKind, errors.Kind(err), "Error kind not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, err.Code(), "Status code not as expected")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, testCase.expectedCount, len(readings), "Reading total count is not expected")
+			}
+		})
+	}
+}
+
 func TestReadingsByDeviceName(t *testing.T) {
 	readings := buildReadings()
 

--- a/internal/core/data/v2/controller/http/reading.go
+++ b/internal/core/data/v2/controller/http/reading.go
@@ -126,6 +126,44 @@ func (rc *ReadingController) ReadingsByTimeRange(w http.ResponseWriter, r *http.
 	pkg.Encode(response, w, lc)
 }
 
+func (rc *ReadingController) ReadingsByResourceName(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(rc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+	config := dataContainer.ConfigurationFrom(rc.dic.Get)
+
+	vars := mux.Vars(r)
+	resourceName := vars[v2.ResourceName]
+
+	var response interface{}
+	var statusCode int
+
+	// parse URL query string for offset, limit
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		readings, err := application.ReadingsByResourceName(offset, limit, resourceName, rc.dic)
+		if err != nil {
+			if errors.Kind(err) != errors.KindEntityDoesNotExist {
+				lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			}
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+			statusCode = err.Code()
+		} else {
+			response = responseDTO.NewMultiReadingsResponse("", "", http.StatusOK, readings)
+			statusCode = http.StatusOK
+		}
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}
+
 func (rc *ReadingController) ReadingsByDeviceName(w http.ResponseWriter, r *http.Request) {
 	lc := container.LoggingClientFrom(rc.dic.Get)
 	ctx := r.Context()

--- a/internal/core/data/v2/controller/http/reading_test.go
+++ b/internal/core/data/v2/controller/http/reading_test.go
@@ -183,6 +183,73 @@ func TestReadingsByTimeRange(t *testing.T) {
 	}
 }
 
+func TestReadingsByResourceName(t *testing.T) {
+	dic := mocks.NewMockDIC()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("ReadingsByResourceName", 0, 20, TestDeviceResourceName).Return([]models.Reading{}, nil)
+	dbClientMock.On("ReadingsByResourceName", 0, 1, TestDeviceResourceName).Return([]models.Reading{}, nil)
+	dic.Update(di.ServiceConstructorMap{
+		v2DataContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	controller := NewReadingController(dic)
+	require.NotNil(t, controller)
+
+	tests := []struct {
+		name               string
+		offset             string
+		limit              string
+		resourceName       string
+		errorExpected      bool
+		expectedStatusCode int
+	}{
+		{"Valid - get readings without offset, and limit", "", "", TestDeviceResourceName, false, http.StatusOK},
+		{"Valid - get readings with offset, and limit", "0", "1", TestDeviceResourceName, false, http.StatusOK},
+		{"Invalid - invalid offset format", "aaa", "1", TestDeviceResourceName, true, http.StatusBadRequest},
+		{"Invalid - invalid limit format", "1", "aaa", TestDeviceResourceName, true, http.StatusBadRequest},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, v2.ApiReadingByResourceNameRoute, http.NoBody)
+			query := req.URL.Query()
+			if testCase.offset != "" {
+				query.Add(v2.Offset, testCase.offset)
+			}
+			if testCase.limit != "" {
+				query.Add(v2.Limit, testCase.limit)
+			}
+			req.URL.RawQuery = query.Encode()
+			req = mux.SetURLVars(req, map[string]string{v2.ResourceName: testCase.resourceName})
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(controller.ReadingsByResourceName)
+			handler.ServeHTTP(recorder, req)
+
+			// Assert
+			if testCase.errorExpected {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res responseDTO.MultiReadingsResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}
+
 func TestReadingsByDeviceName(t *testing.T) {
 	dic := mocks.NewMockDIC()
 	dbClientMock := &dbMock.DBClient{}

--- a/internal/core/data/v2/infrastructure/interfaces/db.go
+++ b/internal/core/data/v2/infrastructure/interfaces/db.go
@@ -26,5 +26,6 @@ type DBClient interface {
 	ReadingTotalCount() (uint32, errors.EdgeX)
 	AllReadings(offset int, limit int) ([]model.Reading, errors.EdgeX)
 	ReadingsByTimeRange(start int, end int, offset int, limit int) ([]model.Reading, errors.EdgeX)
+	ReadingsByResourceName(offset int, limit int, resourceName string) ([]model.Reading, errors.EdgeX)
 	ReadingsByDeviceName(offset int, limit int, name string) ([]model.Reading, errors.EdgeX)
 }

--- a/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/data/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -308,6 +308,31 @@ func (_m *DBClient) ReadingsByDeviceName(offset int, limit int, name string) ([]
 	return r0, r1
 }
 
+// ReadingsByResourceName provides a mock function with given fields: offset, limit, resourceName
+func (_m *DBClient) ReadingsByResourceName(offset int, limit int, resourceName string) ([]models.Reading, errors.EdgeX) {
+	ret := _m.Called(offset, limit, resourceName)
+
+	var r0 []models.Reading
+	if rf, ok := ret.Get(0).(func(int, int, string) []models.Reading); ok {
+		r0 = rf(offset, limit, resourceName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Reading)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, resourceName)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // ReadingsByTimeRange provides a mock function with given fields: start, end, offset, limit
 func (_m *DBClient) ReadingsByTimeRange(start int, end int, offset int, limit int) ([]models.Reading, errors.EdgeX) {
 	ret := _m.Called(start, end, offset, limit)

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -41,6 +41,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiAllReadingRoute, rc.AllReadings).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiReadingByDeviceNameRoute, rc.ReadingsByDeviceName).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiReadingByTimeRangeRoute, rc.ReadingsByTimeRange).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiReadingByResourceNameRoute, rc.ReadingsByResourceName).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -520,6 +520,19 @@ func (c *Client) ReadingsByTimeRange(start int, end int, offset int, limit int) 
 	return readings, nil
 }
 
+// ReadingsByResourceName query readings by offset, limit and resource name
+func (c *Client) ReadingsByResourceName(offset int, limit int, resourceName string) (readings []model.Reading, edgeXerr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	readings, edgeXerr = readingsByResourceName(conn, offset, limit, resourceName)
+	if edgeXerr != nil {
+		return readings, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
+			fmt.Sprintf("fail to query readings by offset %d, limit %d and resourceName %s", offset, limit, resourceName), edgeXerr)
+	}
+	return readings, nil
+}
+
 // ReadingsByDeviceName query readings by offset, limit and device name
 func (c *Client) ReadingsByDeviceName(offset int, limit int, name string) (readings []model.Reading, edgeXerr errors.EdgeX) {
 	conn := c.Pool.Get()

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -606,7 +606,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                400Example:
+                416Example:
                   $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
@@ -904,7 +904,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                400Example:
+                416Example:
                   $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
@@ -1011,7 +1011,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                400Example:
+                416Example:
                   $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
@@ -1119,7 +1119,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                400Example:
+                416Example:
                   $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
@@ -1267,7 +1267,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                400Example:
+                416Example:
                   $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
@@ -1346,6 +1346,18 @@ paths:
               examples:
                 400Example:
                   $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1416,7 +1428,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                400Example:
+                416Example:
                   $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #2967 

## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/core-data/2.x#/default/get_reading_resourceName__resourceName_, implement GET /reading/resourcename/{resourcename} V2 API.

Also update swagger yaml file to add 416 response when query range out of bound.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No