### PR TITLE
feat(data): Make Core Data publish events to <TopicPrefix>/<DeviceProfile>/<DeviceName>

### DIFF
--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -49,6 +49,7 @@ Host = '*'
 Port = 5563
 Type = 'zero'
 Topic = 'events'
+PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name> will be added to this Publish Topic prefix
 [MessageQueue.Optional]
     # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
     # Client Identifiers

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.70
 	github.com/edgexfoundry/go-mod-configuration v0.0.8
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.144
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.145
 	github.com/edgexfoundry/go-mod-messaging v0.1.30
 	github.com/edgexfoundry/go-mod-registry v0.1.27
 	github.com/edgexfoundry/go-mod-secrets v0.0.32

--- a/internal/core/data/config/config.go
+++ b/internal/core/data/config/config.go
@@ -51,7 +51,11 @@ type MessageQueueInfo struct {
 	// Indicates the message queue platform being used.
 	Type string
 	// Indicates the topic the data is published/subscribed
+	// TODO this configuration shall be removed once v1 API is deprecated.
 	Topic string
+	// Indicates the topic prefix the data is published to. Note that /<device-profile-name>/<device-name> will be
+	// added to this Publish Topic prefix as the complete publish topic
+	PublishTopicPrefix string
 	// Provides additional configuration properties which do not fit within the existing field.
 	// Typically the key is the name of the configuration property and the value is a string representation of the
 	// desired value for the configuration property.

--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -69,7 +69,7 @@ func AddEvent(e models.Event, profileName string, deviceName string, ctx context
 	return nil
 }
 
-// PublishEvent publish incoming array of AddEventRequest through MessageClient
+// PublishEvent publishes incoming AddEventRequest through MessageClient
 func PublishEvent(addEventReq dto.AddEventRequest, profileName string, deviceName string, ctx context.Context, dic *di.Container) {
 	lc := container.LoggingClientFrom(dic.Get)
 	msgClient := dataContainer.MessagingClientFrom(dic.Get)
@@ -99,7 +99,7 @@ func PublishEvent(addEventReq dto.AddEventRequest, profileName string, deviceNam
 			"Device Name: %s, Error: %v", correlationId, profileName, deviceName, err))
 	} else {
 		lc.Debug(fmt.Sprintf(
-			"Event Published on message queue. Topic: %s, Correlation-id: %s ", publishTopic, correlationId))
+			"V2 API Event Published on message queue. Topic: %s, Correlation-id: %s ", publishTopic, correlationId))
 	}
 }
 

--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -19,6 +19,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	dto "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/pkg/types"
@@ -26,24 +27,35 @@ import (
 	"github.com/google/uuid"
 )
 
+// ValidateEvent validates if e is a valid event with corresponding device profile name and device name
+// ValidateEvent throws error when profileName or deviceName doesn't match to e
+func ValidateEvent(e models.Event, profileName string, deviceName string, ctx context.Context, dic *di.Container) errors.EdgeX {
+	if e.ProfileName != profileName {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("event's profileName %s mismatches %s", e.ProfileName, profileName), nil)
+	}
+	if e.DeviceName != deviceName {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("event's deviceName %s mismatches %s", e.DeviceName, deviceName), nil)
+	}
+	return checkDevice(e.DeviceName, ctx, dic)
+}
+
 // The AddEvent function accepts the new event model from the controller functions
 // and invokes addEvent function in the infrastructure layer
-func AddEvent(e models.Event, ctx context.Context, dic *di.Container) (id string, err errors.EdgeX) {
+func AddEvent(e models.Event, profileName string, deviceName string, ctx context.Context, dic *di.Container) (err errors.EdgeX) {
 	configuration := dataContainer.ConfigurationFrom(dic.Get)
+	if !configuration.Writable.PersistData {
+		return nil
+	}
+
 	dbClient := v2DataContainer.DBClientFrom(dic.Get)
 	lc := container.LoggingClientFrom(dic.Get)
-
-	err = checkDevice(e.DeviceName, ctx, dic)
-	if err != nil {
-		return "", errors.NewCommonEdgeXWrapper(err)
-	}
 
 	// Add the event and readings to the database
 	if configuration.Writable.PersistData {
 		correlationId := correlation.FromContext(ctx)
 		addedEvent, err := dbClient.AddEvent(e)
 		if err != nil {
-			return "", errors.NewCommonEdgeXWrapper(err)
+			return errors.NewCommonEdgeXWrapper(err)
 		}
 		e = addedEvent
 
@@ -54,15 +66,11 @@ func AddEvent(e models.Event, ctx context.Context, dic *di.Container) (id string
 		))
 	}
 
-	//convert Event model to Event DTO
-	eventDTO := dtos.FromEventModelToDTO(e)
-	putEventOnQueue(eventDTO, ctx, dic) // Push event DTO to message bus for App Services to consume
-
-	return e.Id, nil
+	return nil
 }
 
-// Put event DTO on the message queue to be processed by the rules engine
-func putEventOnQueue(evt dtos.Event, ctx context.Context, dic *di.Container) {
+// PublishEvents publish incoming array of AddEventRequest through MessageClient
+func PublishEvents(addEvents []dto.AddEventRequest, profileName string, deviceName string, ctx context.Context, dic *di.Container) {
 	lc := container.LoggingClientFrom(dic.Get)
 	msgClient := dataContainer.MessagingClientFrom(dic.Get)
 	configuration := dataContainer.ConfigurationFrom(dic.Get)
@@ -77,21 +85,21 @@ func putEventOnQueue(evt dtos.Event, ctx context.Context, dic *di.Container) {
 		ctx = context.WithValue(ctx, clients.ContentType, clients.ContentTypeJSON)
 	}
 
-	data, err = json.Marshal(evt)
+	data, err = json.Marshal(addEvents)
 	if err != nil {
-		lc.Error(fmt.Sprintf("error marshaling V2 Event DTO: %+v", evt), clients.CorrelationHeader, correlationId)
+		lc.Error(fmt.Sprintf("error marshaling V2 AddEventRequest DTO: %+v", addEvents), clients.CorrelationHeader, correlationId)
 		return
 	}
 
+	publishTopic := fmt.Sprintf("%s/%s/%s", configuration.MessageQueue.PublishTopicPrefix, profileName, deviceName)
 	msgEnvelope := msgTypes.NewMessageEnvelope(data, ctx)
-	err = msgClient.Publish(msgEnvelope, configuration.MessageQueue.Topic)
+	err = msgClient.Publish(msgEnvelope, publishTopic)
 	if err != nil {
-		lc.Error(fmt.Sprintf("Unable to send message for V2 API event. Correlation-id: %s, Device Name: %s, Error: %v",
-			correlationId, evt.DeviceName, err))
+		lc.Error(fmt.Sprintf("Unable to send message for V2 API event. Correlation-id: %s, Profile Name: %s, "+
+			"Device Name: %s, Error: %v", correlationId, profileName, deviceName, err))
 	} else {
 		lc.Debug(fmt.Sprintf(
-			"Event Published on message queue. Topic: %s, Correlation-id: %s ",
-			configuration.MessageQueue.Topic, correlationId))
+			"Event Published on message queue. Topic: %s, Correlation-id: %s ", publishTopic, correlationId))
 	}
 }
 

--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -69,8 +69,8 @@ func AddEvent(e models.Event, profileName string, deviceName string, ctx context
 	return nil
 }
 
-// PublishEvents publish incoming array of AddEventRequest through MessageClient
-func PublishEvents(addEvents []dto.AddEventRequest, profileName string, deviceName string, ctx context.Context, dic *di.Container) {
+// PublishEvent publish incoming array of AddEventRequest through MessageClient
+func PublishEvent(addEventReq dto.AddEventRequest, profileName string, deviceName string, ctx context.Context, dic *di.Container) {
 	lc := container.LoggingClientFrom(dic.Get)
 	msgClient := dataContainer.MessagingClientFrom(dic.Get)
 	configuration := dataContainer.ConfigurationFrom(dic.Get)
@@ -85,9 +85,9 @@ func PublishEvents(addEvents []dto.AddEventRequest, profileName string, deviceNa
 		ctx = context.WithValue(ctx, clients.ContentType, clients.ContentTypeJSON)
 	}
 
-	data, err = json.Marshal(addEvents)
+	data, err = json.Marshal(addEventReq)
 	if err != nil {
-		lc.Error(fmt.Sprintf("error marshaling V2 AddEventRequest DTO: %+v", addEvents), clients.CorrelationHeader, correlationId)
+		lc.Error(fmt.Sprintf("error marshaling V2 AddEventRequest DTO: %+v", addEventReq), clients.CorrelationHeader, correlationId)
 		return
 	}
 

--- a/internal/core/data/v2/controller/http/event_test.go
+++ b/internal/core/data/v2/controller/http/event_test.go
@@ -82,7 +82,6 @@ var persistedEvent = models.Event{
 }
 
 func TestAddEvent(t *testing.T) {
-	expectedResponseCode := http.StatusMultiStatus
 	expectedRequestId := "82eb2e26-0f24-48aa-ae4c-de9dac3fb9bc"
 
 	dbClientMock := &dbMock.DBClient{}
@@ -172,31 +171,31 @@ func TestAddEvent(t *testing.T) {
 
 	tests := []struct {
 		Name               string
-		Request            []requests.AddEventRequest
+		Request            requests.AddEventRequest
 		ProfileName        string
 		DeviceName         string
 		ErrorExpected      bool
 		ExpectedStatusCode int
 	}{
-		{"Valid - AddEventRequest", []requests.AddEventRequest{validRequest}, validRequest.Event.ProfileName, validRequest.Event.DeviceName, false, http.StatusCreated},
-		{"Valid - No RequestId", []requests.AddEventRequest{noRequestId}, noRequestId.Event.ProfileName, noRequestId.Event.DeviceName, false, http.StatusCreated},
-		{"Invalid - Bad RequestId", []requests.AddEventRequest{badRequestId}, badRequestId.Event.ProfileName, badRequestId.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Event", []requests.AddEventRequest{noEvent}, "", "", true, http.StatusBadRequest},
-		{"Invalid - No Event Id", []requests.AddEventRequest{noEventID}, noEventID.Event.ProfileName, noEventID.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - Bad Event Id", []requests.AddEventRequest{badEventID}, badEventID.Event.ProfileName, badEventID.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Event DeviceName", []requests.AddEventRequest{noEventDevice}, noEventDevice.Event.ProfileName, noEventDevice.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Event ProfileName", []requests.AddEventRequest{noEventProfile}, noEventProfile.Event.ProfileName, noEventProfile.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Event Origin", []requests.AddEventRequest{noEventOrigin}, noEventOrigin.Event.ProfileName, noEventOrigin.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Reading", []requests.AddEventRequest{noReading}, noReading.Event.ProfileName, noReading.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Reading DeviceName", []requests.AddEventRequest{noReadingDevice}, noReadingDevice.Event.ProfileName, noReadingDevice.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Reading ResourceName", []requests.AddEventRequest{noReadingResourceName}, noReadingResourceName.Event.ProfileName, noReadingResourceName.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Reading ProfileName", []requests.AddEventRequest{noReadingProfileName}, noReadingProfileName.Event.ProfileName, noReadingProfileName.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Reading Origin", []requests.AddEventRequest{noReadingOrigin}, noReadingOrigin.Event.ProfileName, noReadingOrigin.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No Reading ValueType", []requests.AddEventRequest{noReadingValueType}, noReadingValueType.Event.ProfileName, noReadingValueType.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - Invalid Reading ValueType", []requests.AddEventRequest{invalidReadingInvalidValueType}, invalidReadingInvalidValueType.Event.ProfileName, invalidReadingInvalidValueType.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No SimpleReading Value", []requests.AddEventRequest{noSimpleValue}, noSimpleValue.Event.ProfileName, noSimpleValue.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No BinaryReading BinaryValue", []requests.AddEventRequest{noBinaryValue}, noBinaryValue.Event.ProfileName, noBinaryValue.Event.DeviceName, true, http.StatusBadRequest},
-		{"Invalid - No BinaryReading MediaType", []requests.AddEventRequest{noBinaryMediaType}, noBinaryMediaType.Event.ProfileName, noBinaryMediaType.Event.DeviceName, true, http.StatusBadRequest},
+		{"Valid - AddEventRequest", validRequest, validRequest.Event.ProfileName, validRequest.Event.DeviceName, false, http.StatusCreated},
+		{"Valid - No RequestId", noRequestId, noRequestId.Event.ProfileName, noRequestId.Event.DeviceName, false, http.StatusCreated},
+		{"Invalid - Bad RequestId", badRequestId, badRequestId.Event.ProfileName, badRequestId.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Event", noEvent, "", "", true, http.StatusBadRequest},
+		{"Invalid - No Event Id", noEventID, noEventID.Event.ProfileName, noEventID.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - Bad Event Id", badEventID, badEventID.Event.ProfileName, badEventID.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Event DeviceName", noEventDevice, noEventDevice.Event.ProfileName, noEventDevice.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Event ProfileName", noEventProfile, noEventProfile.Event.ProfileName, noEventProfile.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Event Origin", noEventOrigin, noEventOrigin.Event.ProfileName, noEventOrigin.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading", noReading, noReading.Event.ProfileName, noReading.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading DeviceName", noReadingDevice, noReadingDevice.Event.ProfileName, noReadingDevice.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading ResourceName", noReadingResourceName, noReadingResourceName.Event.ProfileName, noReadingResourceName.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading ProfileName", noReadingProfileName, noReadingProfileName.Event.ProfileName, noReadingProfileName.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading Origin", noReadingOrigin, noReadingOrigin.Event.ProfileName, noReadingOrigin.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading ValueType", noReadingValueType, noReadingValueType.Event.ProfileName, noReadingValueType.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - Invalid Reading ValueType", invalidReadingInvalidValueType, invalidReadingInvalidValueType.Event.ProfileName, invalidReadingInvalidValueType.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No SimpleReading Value", noSimpleValue, noSimpleValue.Event.ProfileName, noSimpleValue.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No BinaryReading BinaryValue", noBinaryValue, noBinaryValue.Event.ProfileName, noBinaryValue.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No BinaryReading MediaType", noBinaryMediaType, noBinaryMediaType.Event.ProfileName, noBinaryMediaType.Event.DeviceName, true, http.StatusBadRequest},
 	}
 
 	for _, testCase := range tests {
@@ -214,7 +213,7 @@ func TestAddEvent(t *testing.T) {
 			handler := http.HandlerFunc(ec.AddEvent)
 			handler.ServeHTTP(recorder, req)
 
-			var actualResponse []common.BaseWithIdResponse
+			var actualResponse common.BaseWithIdResponse
 			err = json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
 
 			if testCase.ErrorExpected {
@@ -223,13 +222,13 @@ func TestAddEvent(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, expectedResponseCode, recorder.Result().StatusCode, "HTTP status code not as expected")
-			assert.Equal(t, v2.ApiVersion, actualResponse[0].ApiVersion, "API Version not as expected")
-			assert.Equal(t, testCase.ExpectedStatusCode, int(actualResponse[0].StatusCode), "BaseResponse status code not as expected")
-			if actualResponse[0].RequestId != "" {
-				assert.Equal(t, expectedRequestId, actualResponse[0].RequestId, "RequestID not as expected")
+			assert.Equal(t, testCase.ExpectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+			assert.Equal(t, v2.ApiVersion, actualResponse.ApiVersion, "API Version not as expected")
+			assert.Equal(t, testCase.ExpectedStatusCode, int(actualResponse.StatusCode), "BaseResponse status code not as expected")
+			if actualResponse.RequestId != "" {
+				assert.Equal(t, expectedRequestId, actualResponse.RequestId, "RequestID not as expected")
 			}
-			assert.Empty(t, actualResponse[0].Message, "Message should be empty when it is successful")
+			assert.Empty(t, actualResponse.Message, "Message should be empty when it is successful")
 		})
 	}
 }

--- a/internal/core/data/v2/controller/http/event_test.go
+++ b/internal/core/data/v2/controller/http/event_test.go
@@ -173,28 +173,30 @@ func TestAddEvent(t *testing.T) {
 	tests := []struct {
 		Name               string
 		Request            []requests.AddEventRequest
+		ProfileName        string
+		DeviceName         string
 		ErrorExpected      bool
 		ExpectedStatusCode int
 	}{
-		{"Valid - AddEventRequest", []requests.AddEventRequest{validRequest}, false, http.StatusCreated},
-		{"Valid - No RequestId", []requests.AddEventRequest{noRequestId}, false, http.StatusCreated},
-		{"Invalid - Bad RequestId", []requests.AddEventRequest{badRequestId}, true, http.StatusBadRequest},
-		{"Invalid - No Event", []requests.AddEventRequest{noEvent}, true, http.StatusBadRequest},
-		{"Invalid - No Event Id", []requests.AddEventRequest{noEventID}, true, http.StatusBadRequest},
-		{"Invalid - Bad Event Id", []requests.AddEventRequest{badEventID}, true, http.StatusBadRequest},
-		{"Invalid - No Event DeviceName", []requests.AddEventRequest{noEventDevice}, true, http.StatusBadRequest},
-		{"Invalid - No Event ProfileName", []requests.AddEventRequest{noEventProfile}, true, http.StatusBadRequest},
-		{"Invalid - No Event Origin", []requests.AddEventRequest{noEventOrigin}, true, http.StatusBadRequest},
-		{"Invalid - No Reading", []requests.AddEventRequest{noReading}, true, http.StatusBadRequest},
-		{"Invalid - No Reading DeviceName", []requests.AddEventRequest{noReadingDevice}, true, http.StatusBadRequest},
-		{"Invalid - No Reading ResourceName", []requests.AddEventRequest{noReadingResourceName}, true, http.StatusBadRequest},
-		{"Invalid - No Reading ProfileName", []requests.AddEventRequest{noReadingProfileName}, true, http.StatusBadRequest},
-		{"Invalid - No Reading Origin", []requests.AddEventRequest{noReadingOrigin}, true, http.StatusBadRequest},
-		{"Invalid - No Reading ValueType", []requests.AddEventRequest{noReadingValueType}, true, http.StatusBadRequest},
-		{"Invalid - Invalid Reading ValueType", []requests.AddEventRequest{invalidReadingInvalidValueType}, true, http.StatusBadRequest},
-		{"Invalid - No SimpleReading Value", []requests.AddEventRequest{noSimpleValue}, true, http.StatusBadRequest},
-		{"Invalid - No BinaryReading BinaryValue", []requests.AddEventRequest{noBinaryValue}, true, http.StatusBadRequest},
-		{"Invalid - No BinaryReading MediaType", []requests.AddEventRequest{noBinaryMediaType}, true, http.StatusBadRequest},
+		{"Valid - AddEventRequest", []requests.AddEventRequest{validRequest}, validRequest.Event.ProfileName, validRequest.Event.DeviceName, false, http.StatusCreated},
+		{"Valid - No RequestId", []requests.AddEventRequest{noRequestId}, noRequestId.Event.ProfileName, noRequestId.Event.DeviceName, false, http.StatusCreated},
+		{"Invalid - Bad RequestId", []requests.AddEventRequest{badRequestId}, badRequestId.Event.ProfileName, badRequestId.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Event", []requests.AddEventRequest{noEvent}, "", "", true, http.StatusBadRequest},
+		{"Invalid - No Event Id", []requests.AddEventRequest{noEventID}, noEventID.Event.ProfileName, noEventID.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - Bad Event Id", []requests.AddEventRequest{badEventID}, badEventID.Event.ProfileName, badEventID.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Event DeviceName", []requests.AddEventRequest{noEventDevice}, noEventDevice.Event.ProfileName, noEventDevice.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Event ProfileName", []requests.AddEventRequest{noEventProfile}, noEventProfile.Event.ProfileName, noEventProfile.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Event Origin", []requests.AddEventRequest{noEventOrigin}, noEventOrigin.Event.ProfileName, noEventOrigin.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading", []requests.AddEventRequest{noReading}, noReading.Event.ProfileName, noReading.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading DeviceName", []requests.AddEventRequest{noReadingDevice}, noReadingDevice.Event.ProfileName, noReadingDevice.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading ResourceName", []requests.AddEventRequest{noReadingResourceName}, noReadingResourceName.Event.ProfileName, noReadingResourceName.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading ProfileName", []requests.AddEventRequest{noReadingProfileName}, noReadingProfileName.Event.ProfileName, noReadingProfileName.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading Origin", []requests.AddEventRequest{noReadingOrigin}, noReadingOrigin.Event.ProfileName, noReadingOrigin.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No Reading ValueType", []requests.AddEventRequest{noReadingValueType}, noReadingValueType.Event.ProfileName, noReadingValueType.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - Invalid Reading ValueType", []requests.AddEventRequest{invalidReadingInvalidValueType}, invalidReadingInvalidValueType.Event.ProfileName, invalidReadingInvalidValueType.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No SimpleReading Value", []requests.AddEventRequest{noSimpleValue}, noSimpleValue.Event.ProfileName, noSimpleValue.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No BinaryReading BinaryValue", []requests.AddEventRequest{noBinaryValue}, noBinaryValue.Event.ProfileName, noBinaryValue.Event.DeviceName, true, http.StatusBadRequest},
+		{"Invalid - No BinaryReading MediaType", []requests.AddEventRequest{noBinaryMediaType}, noBinaryMediaType.Event.ProfileName, noBinaryMediaType.Event.DeviceName, true, http.StatusBadRequest},
 	}
 
 	for _, testCase := range tests {
@@ -204,7 +206,8 @@ func TestAddEvent(t *testing.T) {
 
 			reader := strings.NewReader(string(jsonData))
 
-			req, err := http.NewRequest(http.MethodPost, v2.ApiEventRoute, reader)
+			req, err := http.NewRequest(http.MethodPost, v2.ApiEventProfileNameDeviceNameRoute, reader)
+			req = mux.SetURLVars(req, map[string]string{v2.ProfileName: testCase.ProfileName, v2.DeviceName: testCase.DeviceName})
 			require.NoError(t, err)
 
 			recorder := httptest.NewRecorder()

--- a/internal/core/data/v2/io/event.go
+++ b/internal/core/data/v2/io/event.go
@@ -15,7 +15,7 @@ import (
 
 // EventReader unmarshals a request body into an Event type
 type EventReader interface {
-	ReadAddEventRequest(reader io.Reader) ([]dto.AddEventRequest, errors.EdgeX)
+	ReadAddEventRequest(reader io.Reader) (dto.AddEventRequest, errors.EdgeX)
 }
 
 // NewRequestReader returns a BodyReader capable of processing the request body
@@ -32,11 +32,11 @@ func NewJsonReader() jsonEventReader {
 }
 
 // Read reads and converts the request's JSON event data into an Event struct
-func (jsonEventReader) ReadAddEventRequest(reader io.Reader) ([]dto.AddEventRequest, errors.EdgeX) {
-	var addEvents []dto.AddEventRequest
-	err := json.NewDecoder(reader).Decode(&addEvents)
+func (jsonEventReader) ReadAddEventRequest(reader io.Reader) (dto.AddEventRequest, errors.EdgeX) {
+	var addEvent dto.AddEventRequest
+	err := json.NewDecoder(reader).Decode(&addEvent)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "event json decoding failed", err)
+		return addEvent, errors.NewCommonEdgeX(errors.KindContractInvalid, "event json decoding failed", err)
 	}
-	return addEvents, nil
+	return addEvent, nil
 }

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -24,7 +24,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 
 	// Events
 	ec := dataController.NewEventController(dic)
-	r.HandleFunc(v2Constant.ApiEventRoute, ec.AddEvent).Methods(http.MethodPost)
+	r.HandleFunc(v2Constant.ApiEventProfileNameDeviceNameRoute, ec.AddEvent).Methods(http.MethodPost)
 	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.EventById).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.DeleteEventById).Methods(http.MethodDelete)
 	r.HandleFunc(v2Constant.ApiEventCountRoute, ec.EventTotalCount).Methods(http.MethodGet)

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -498,7 +498,7 @@ paths:
                     value: '12.2'
       responses:
         '201':
-          description: "Indicates the event has been successfully created."
+          description: "Indicates the event has been successfully added."
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -459,11 +459,23 @@ components:
             valueType: "Float32"
             value: "12.2"
 paths:
-  /event:
+  /event/{profileName}/{deviceName}:
     parameters:
-      - $ref: '#/components/parameters/correlatedRequestHeader'
+    - $ref: '#/components/parameters/correlatedRequestHeader'
+    - name: profileName
+      in: path
+      required: true
+      schema:
+        type: string
+      description: "Uniquely identifies a given device profile"
+    - name: deviceName
+      in: path
+      required: true
+      schema:
+        type: string
+      description: "Uniquely identifies a given device"
     post:
-      summary: "Allows for the ingestion of event/reading data"
+      summary: "Allows for the ingestion of event/reading data, and the deviceName and profileName of Events must match to the given deviceName and profileName specified in the path"
       requestBody:
         required: true
         content:

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -475,83 +475,43 @@ paths:
         type: string
       description: "Uniquely identifies a given device"
     post:
-      summary: "Allows for the ingestion of event/reading data, and the deviceName and profileName of Events must match to the given deviceName and profileName specified in the path"
+      summary: "Allows for the ingestion of event/reading data, and the deviceName and profileName of Event must match to the given deviceName and profileName as specified in the path"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/AddEventRequest'
+              $ref: '#/components/schemas/AddEventRequest'
             example:
-              - event:
-                  deviceName: device-002
-                  id: d5471d59-2810-419a-8744-18eb8fa03465
-                  origin: 1602168089665565300
-                  readings:
-                    - deviceName: device-002
-                      resourceName: resource-002
-                      profileName: profile-002
-                      id: 7003cacc-0e00-4676-977c-4e58b9612abd
-                      origin: 1602168089665565300
-                      valueType: Float32
-                      value: '12.2'
-              - event:
-                  deviceName: device-002
-                  id: d5471d59-2810-419a-8744-18eb8fa03465
-                  origin: 1602168089665565300
-                  readings:
-                    - deviceName: device-002
-                      resourceName: resource-002
-                      profileName: profile-002
-                      id: 7003cacc-0e00-4676-977c-4e58b9612abd
-                      origin: 1602168089665565300
-                      valueType: Float32
-                      value: '12.2'
-              - event:
-                  deviceName: device-002
-                  id: 73fc4f9c-2d64-4920-addb-b1f33a8f8514
-                  origin: 1602168089665565300
-                  readings:
-                    - apiVersion: v2
-                      created: 1594879337014
-                      deviceName: device-002
-                      resourceName: resource-002
-                      profileName: profile-002
-                      id: 71c601d9-cb56-453a-8c75-54461e444713
-                      origin: 1602168089665565300
-                      valueType: Binary
-                      binaryValue: '83010203'
-                      mediaType: image
+              event:
+                deviceName: device-002
+                profileName: profile-002
+                id: d5471d59-2810-419a-8744-18eb8fa03465
+                origin: 1602168089665565300
+                readings:
+                  - deviceName: device-002
+                    resourceName: resource-002
+                    profileName: profile-002
+                    id: 7003cacc-0e00-4676-977c-4e58b9612abd
+                    origin: 1602168089665565300
+                    valueType: Float32
+                    value: '12.2'
       responses:
-        '207':
-          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
+        '201':
+          description: "Indicates the event has been successfully created."
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  anyOf:
-                    - $ref: '#/components/schemas/ErrorResponse'
-                    - $ref: '#/components/schemas/BaseWithIdResponse'
+                $ref: '#/components/schemas/BaseWithIdResponse'
               example:
-                - requestId: ""
-                  apiVersion: "v2"
-                  statusCode: 201
-                  message: ""
-                  id: "040bd523-ec33-440d-9d72-e5813a465f37"
-                - requestId: ""
-                  apiVersion: "v2"
-                  statusCode: 409
-                  message: "Event Id exists"
-                - requestId: ""
-                  apiVersion: "v2"
-                  statusCode: 500
-                  message: "Interval Server Error"
+                requestId: ""
+                apiVersion: "v2"
+                statusCode: 201
+                message: ""
+                id: "040bd523-ec33-440d-9d72-e5813a465f37"
         '400':
           description: "Request is in an invalid state"
           headers:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #2934 
fix #2995 

## What is the new behavior?
Per https://github.com/edgexfoundry/edgex-docs/blob/master/docs_src/design/adr/013-Device-Service-Events-Message-Bus.md, Core data shall publish Events to <TopicPrefix>/<DeviceProfile>/<DeviceName>.

This PR made following changes:

1. Add new property PublishTopicPrefix into MessageQueue configuration.

2. Update Core Data configuration.toml to add PublishTopicPrefix set it to:
PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name> will be added to this Publish Topic prefix

3. Change V2 Add Event endpoint to be /event/{DeviceProfileName}/{DeviceName}

4. When publishing V2 Event DTO use topic PublishTopicPrefix+ /{DeviceProfileName}/{DeviceName}

5. Publish []AddEventRequestDTO instead of single EventDTO to message queue

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No