### PR TITLE
feat(security): secure containers run as non-root

### DIFF
--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -49,5 +49,6 @@ WORKDIR /
 COPY --from=builder /edgex-go/cmd/core-command/Attribution.txt /
 COPY --from=builder /edgex-go/cmd/core-command/core-command /
 COPY --from=builder /edgex-go/cmd/core-command/res/configuration.toml /res/configuration.toml
+
 ENTRYPOINT ["/core-command"]
 CMD ["-cp=consul.http://edgex-core-consul:8500", "--registry", "--confdir=/res"]

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -49,5 +49,6 @@ WORKDIR /
 COPY --from=builder /edgex-go/cmd/core-metadata/Attribution.txt /
 COPY --from=builder /edgex-go/cmd/core-metadata/core-metadata /
 COPY --from=builder /edgex-go/cmd/core-metadata/res/configuration.toml /res/configuration.toml
+
 ENTRYPOINT ["/core-metadata"]
 CMD ["-cp=consul.http://edgex-core-consul:8500", "--registry", "--confdir=/res"]

--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -50,9 +50,11 @@ COPY --from=builder /edgex-go/cmd/security-secretstore-setup/res/configuration.t
 COPY --from=builder /edgex-go/cmd/security-file-token-provider/security-file-token-provider .
 COPY --from=builder /edgex-go/cmd/security-secretstore-setup/security-secretstore-setup .
 
-# setup the entry point script
+# Setup the entry point script, create token dir, and assign perms
 COPY --from=builder /edgex-go/cmd/security-secretstore-setup/entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh \
-    && ln -s /usr/local/bin/entrypoint.sh /
+    && ln -s /usr/local/bin/entrypoint.sh / \
+    && mkdir -p /vault/config/assets \
+    && chown -Rh 100:1000 /vault/    
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/cmd/security-secretstore-setup/entrypoint.sh
+++ b/cmd/security-secretstore-setup/entrypoint.sh
@@ -24,27 +24,21 @@ if [ -n "${SECRETSTORE_SETUP_DONE_FLAG}" ] && [ -f "${SECRETSTORE_SETUP_DONE_FLA
   rm -f "${SECRETSTORE_SETUP_DONE_FLAG}"
 fi
 
-echo "creating /vault/config/assets"
+echo "Starting vault-worker..."
 
-# create token directory and
-# grant permissions of folders for vault:vault
-mkdir -p /vault/config/assets
-chown -Rh 100:1000 /vault/
-
-echo "starting vault-worker..."
-
-echo "Initializing secret store"
+echo "Initializing secret store..."
 /security-secretstore-setup --vaultInterval=10
-
-echo "Executing custom command: $@"
-"$@"
 
 # write a sentinel file when we're done because consul is not
 # secure and we don't trust it it access to the EdgeX secret store
 if [ -n "${SECRETSTORE_SETUP_DONE_FLAG}" ]; then
+
+    echo "Changing ownership of secrets to edgex_user:edgex_group"
+    chown -R ${EDGEX_USER}:${EDGEX_GROUP} /tmp/edgex/secrets
+
     echo "Signaling secretstore-setup completion"
-    mkdir -p $(dirname "${SECRETSTORE_SETUP_DONE_FLAG}")
-    touch "${SECRETSTORE_SETUP_DONE_FLAG}"
+    mkdir -p $(dirname "${SECRETSTORE_SETUP_DONE_FLAG}") && \
+      touch "${SECRETSTORE_SETUP_DONE_FLAG}"
 fi
 
 echo "Waiting for termination signal"

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -49,5 +49,6 @@ COPY --from=builder /etc/ssl /etc/ssl
 COPY --from=builder /edgex-go/cmd/support-notifications/Attribution.txt /
 COPY --from=builder /edgex-go/cmd/support-notifications/support-notifications /
 COPY --from=builder /edgex-go/cmd/support-notifications/res/configuration.toml /res/configuration.toml
+
 ENTRYPOINT ["/support-notifications"]
 CMD ["-cp=consul.http://edgex-core-consul:8500", "--registry", "--confdir=/res"]

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -47,5 +47,6 @@ EXPOSE $APP_PORT
 COPY --from=builder /edgex-go/cmd/support-scheduler/Attribution.txt /
 COPY --from=builder /edgex-go/cmd/support-scheduler/support-scheduler /
 COPY --from=builder /edgex-go/cmd/support-scheduler/res/configuration.toml /res/configuration.toml
+
 ENTRYPOINT ["/support-scheduler"]
 CMD ["-cp=consul.http://edgex-core-consul:8500", "--registry", "--confdir=/res"]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Docker containers run as root user.


## Issue Number:
#2983 

## What is the new behavior?
Modified the dockerfiles of various services to create/run as
"edgex_user:edgex_group".

Modified the entrypoint script of security-secretstore-setup to set
the appropriate ownership of the /tmp/edgex/secrets directory that's
mounted to retrieve secrets in various services used throughout.

Removed a security concern from the entrypoint script of
security-secretstore-setup that allowed root level CLI execution access
to anyone that could add parameters via CMD in the dockerfile.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information