### PR TITLE
feat(meta): Implement ProvisionWatcher v2 GET API

### DIFF
--- a/internal/core/metadata/v2/application/provisionwatcher.go
+++ b/internal/core/metadata/v2/application/provisionwatcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
@@ -34,4 +35,76 @@ func AddProvisionWatcher(pw models.ProvisionWatcher, ctx context.Context, dic *d
 	)
 
 	return addProvisionWatcher.Id, nil
+}
+
+// ProvisionWatcherByName query the provision watcher by name
+func ProvisionWatcherByName(name string, dic *di.Container) (provisionWatcher dtos.ProvisionWatcher, err errors.EdgeX) {
+	if name == "" {
+		return provisionWatcher, errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
+	}
+
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	pw, err := dbClient.ProvisionWatcherByName(name)
+	if err != nil {
+		return provisionWatcher, errors.NewCommonEdgeXWrapper(err)
+	}
+	provisionWatcher = dtos.FromProvisionWatcherModelToDTO(pw)
+
+	return
+}
+
+// ProvisionWatchersByServiceName query provision watchers with offset, limit and service name
+func ProvisionWatchersByServiceName(offset int, limit int, name string, dic *di.Container) (provisionWatchers []dtos.ProvisionWatcher, err errors.EdgeX) {
+	if name == "" {
+		return provisionWatchers, errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
+	}
+
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	pwModels, err := dbClient.ProvisionWatchersByServiceName(offset, limit, name)
+	if err != nil {
+		return provisionWatchers, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	provisionWatchers = make([]dtos.ProvisionWatcher, len(pwModels))
+	for i, pw := range pwModels {
+		provisionWatchers[i] = dtos.FromProvisionWatcherModelToDTO(pw)
+	}
+
+	return
+}
+
+// ProvisionWatchersByProfileName query provision watchers with offset, limit and profile name
+func ProvisionWatchersByProfileName(offset int, limit int, name string, dic *di.Container) (provisionWatchers []dtos.ProvisionWatcher, err errors.EdgeX) {
+	if name == "" {
+		return provisionWatchers, errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
+	}
+
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	pwModels, err := dbClient.ProvisionWatchersByProfileName(offset, limit, name)
+	if err != nil {
+		return provisionWatchers, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	provisionWatchers = make([]dtos.ProvisionWatcher, len(pwModels))
+	for i, pw := range pwModels {
+		provisionWatchers[i] = dtos.FromProvisionWatcherModelToDTO(pw)
+	}
+
+	return
+}
+
+// AllProvisionWatchers query the provision watchers with offset, limit and labels
+func AllProvisionWatchers(offset int, limit int, labels []string, dic *di.Container) (provisionWatchers []dtos.ProvisionWatcher, err errors.EdgeX) {
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	pwModels, err := dbClient.AllProvisionWatchers(offset, limit, labels)
+	if err != nil {
+		return provisionWatchers, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	provisionWatchers = make([]dtos.ProvisionWatcher, len(pwModels))
+	for i, pw := range pwModels {
+		provisionWatchers[i] = dtos.FromProvisionWatcherModelToDTO(pw)
+	}
+
+	return
 }

--- a/internal/core/metadata/v2/controller/http/provisionwatcher.go
+++ b/internal/core/metadata/v2/controller/http/provisionwatcher.go
@@ -6,8 +6,10 @@
 package http
 
 import (
+	"math"
 	"net/http"
 
+	metadataContainer "github.com/edgexfoundry/edgex-go/internal/core/metadata/container"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/v2/application"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/v2/io"
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
@@ -16,8 +18,12 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	contractsV2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 	requestDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
+	responseDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+	"github.com/gorilla/mux"
 )
 
 type ProvisionWatcherController struct {
@@ -85,4 +91,144 @@ func (pwc *ProvisionWatcherController) AddProvisionWatcher(w http.ResponseWriter
 	utils.WriteHttpHeader(w, ctx, http.StatusMultiStatus)
 	// Encode and send the resp body as JSON format
 	pkg.Encode(addResponses, w, lc)
+}
+
+func (pwc *ProvisionWatcherController) ProvisionWatcherByName(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(pwc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	// URL parameters
+	vars := mux.Vars(r)
+	name := vars[contractsV2.Name]
+
+	var response interface{}
+	var statusCode int
+
+	provisionWatcher, err := application.ProvisionWatcherByName(name, pwc.dic)
+	if err != nil {
+		if errors.Kind(err) != errors.KindEntityDoesNotExist {
+			lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		}
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		response = responseDTO.NewProvisionWatcherResponse("", "", http.StatusOK, provisionWatcher)
+		statusCode = http.StatusOK
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}
+
+func (pwc *ProvisionWatcherController) ProvisionWatchersByServiceName(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(pwc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+	config := metadataContainer.ConfigurationFrom(pwc.dic.Get)
+
+	vars := mux.Vars(r)
+	name := vars[contractsV2.Name]
+
+	var response interface{}
+	var statusCode int
+
+	// parse URL query string for offset, limit
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		provisionWatchers, err := application.ProvisionWatchersByServiceName(offset, limit, name, pwc.dic)
+		if err != nil {
+			if errors.Kind(err) != errors.KindEntityDoesNotExist {
+				lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			}
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+			statusCode = err.Code()
+		} else {
+			response = responseDTO.NewMultiProvisionWatchersResponse("", "", http.StatusOK, provisionWatchers)
+			statusCode = http.StatusOK
+		}
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}
+
+func (pwc *ProvisionWatcherController) ProvisionWatchersByProfileName(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(pwc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+	config := metadataContainer.ConfigurationFrom(pwc.dic.Get)
+
+	vars := mux.Vars(r)
+	name := vars[contractsV2.Name]
+
+	var response interface{}
+	var statusCode int
+
+	// parse URL query string for offset, limit
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		provisionWatchers, err := application.ProvisionWatchersByProfileName(offset, limit, name, pwc.dic)
+		if err != nil {
+			if errors.Kind(err) != errors.KindEntityDoesNotExist {
+				lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			}
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+			statusCode = err.Code()
+		} else {
+			response = responseDTO.NewMultiProvisionWatchersResponse("", "", http.StatusOK, provisionWatchers)
+			statusCode = http.StatusOK
+		}
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}
+
+func (pwc *ProvisionWatcherController) AllProvisionWatchers(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(pwc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+	config := metadataContainer.ConfigurationFrom(pwc.dic.Get)
+
+	var response interface{}
+	var statusCode int
+
+	// parse URL query string for offset, limit
+	offset, limit, labels, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		provisionWatchers, err := application.AllProvisionWatchers(offset, limit, labels, pwc.dic)
+		if err != nil {
+			if errors.Kind(err) != errors.KindEntityDoesNotExist {
+				lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			}
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+			statusCode = err.Code()
+		} else {
+			response = responseDTO.NewMultiProvisionWatchersResponse("", "", http.StatusOK, provisionWatchers)
+			statusCode = http.StatusOK
+		}
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
 }

--- a/internal/core/metadata/v2/infrastructure/interfaces/db.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/db.go
@@ -44,4 +44,8 @@ type DBClient interface {
 	DevicesByProfileName(offset int, limit int, profileName string) ([]model.Device, errors.EdgeX)
 
 	AddProvisionWatcher(pw model.ProvisionWatcher) (model.ProvisionWatcher, errors.EdgeX)
+	ProvisionWatcherByName(name string) (model.ProvisionWatcher, errors.EdgeX)
+	ProvisionWatchersByServiceName(offset int, limit int, name string) ([]model.ProvisionWatcher, errors.EdgeX)
+	ProvisionWatchersByProfileName(offset int, limit int, name string) ([]model.ProvisionWatcher, errors.EdgeX)
+	AllProvisionWatchers(offset int, limit int, labels []string) ([]model.ProvisionWatcher, errors.EdgeX)
 }

--- a/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -182,6 +182,31 @@ func (_m *DBClient) AllDevices(offset int, limit int, labels []string) ([]models
 	return r0, r1
 }
 
+// AllProvisionWatchers provides a mock function with given fields: offset, limit, labels
+func (_m *DBClient) AllProvisionWatchers(offset int, limit int, labels []string) ([]models.ProvisionWatcher, errors.EdgeX) {
+	ret := _m.Called(offset, limit, labels)
+
+	var r0 []models.ProvisionWatcher
+	if rf, ok := ret.Get(0).(func(int, int, []string) []models.ProvisionWatcher); ok {
+		r0 = rf(offset, limit, labels)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.ProvisionWatcher)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, []string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, labels)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // CloseSession provides a mock function with given fields:
 func (_m *DBClient) CloseSession() {
 	_m.Called()
@@ -600,6 +625,79 @@ func (_m *DBClient) DevicesByServiceName(offset int, limit int, name string) ([]
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]models.Device)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, name)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
+// ProvisionWatcherByName provides a mock function with given fields: name
+func (_m *DBClient) ProvisionWatcherByName(name string) (models.ProvisionWatcher, errors.EdgeX) {
+	ret := _m.Called(name)
+
+	var r0 models.ProvisionWatcher
+	if rf, ok := ret.Get(0).(func(string) models.ProvisionWatcher); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Get(0).(models.ProvisionWatcher)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(string) errors.EdgeX); ok {
+		r1 = rf(name)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
+// ProvisionWatchersByProfileName provides a mock function with given fields: offset, limit, name
+func (_m *DBClient) ProvisionWatchersByProfileName(offset int, limit int, name string) ([]models.ProvisionWatcher, errors.EdgeX) {
+	ret := _m.Called(offset, limit, name)
+
+	var r0 []models.ProvisionWatcher
+	if rf, ok := ret.Get(0).(func(int, int, string) []models.ProvisionWatcher); ok {
+		r0 = rf(offset, limit, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.ProvisionWatcher)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, name)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
+// ProvisionWatchersByServiceName provides a mock function with given fields: offset, limit, name
+func (_m *DBClient) ProvisionWatchersByServiceName(offset int, limit int, name string) ([]models.ProvisionWatcher, errors.EdgeX) {
+	ret := _m.Called(offset, limit, name)
+
+	var r0 []models.ProvisionWatcher
+	if rf, ok := ret.Get(0).(func(int, int, string) []models.ProvisionWatcher); ok {
+		r0 = rf(offset, limit, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.ProvisionWatcher)
 		}
 	}
 

--- a/internal/core/metadata/v2/router.go
+++ b/internal/core/metadata/v2/router.go
@@ -1,3 +1,8 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package v2
 
 import (
@@ -61,6 +66,10 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	// ProvisionWatcher
 	pwc := metadataController.NewProvisionWatcherController(dic)
 	r.HandleFunc(v2Constant.ApiProvisionWatcherRoute, pwc.AddProvisionWatcher).Methods(http.MethodPost)
+	r.HandleFunc(v2Constant.ApiProvisionWatcherByNameRoute, pwc.ProvisionWatcherByName).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiProvisionWatcherByServiceNameRoute, pwc.ProvisionWatchersByServiceName).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiProvisionWatcherByProfileNameRoute, pwc.ProvisionWatchersByProfileName).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiAllProvisionWatcherRoute, pwc.AllProvisionWatchers).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -570,3 +570,57 @@ func (c *Client) AddProvisionWatcher(pw model.ProvisionWatcher) (model.Provision
 
 	return addProvisionWatcher(conn, pw)
 }
+
+// ProvisionWatcherByName gets a provision watcher by name
+func (c *Client) ProvisionWatcherByName(name string) (provisionWatcher model.ProvisionWatcher, edgexErr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	provisionWatcher, edgexErr = provisionWatcherByName(conn, name)
+	if edgexErr != nil {
+		return provisionWatcher, errors.NewCommonEdgeXWrapper(edgexErr)
+	}
+
+	return
+}
+
+//ProvisionWatchersByServiceName query provision watchers by offset, limit and service name
+func (c *Client) ProvisionWatchersByServiceName(offset int, limit int, name string) (provisionWatchers []model.ProvisionWatcher, edgexErr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	provisionWatchers, edgexErr = provisionWatchersByServiceName(conn, offset, limit, name)
+	if edgexErr != nil {
+		return provisionWatchers, errors.NewCommonEdgeX(errors.Kind(edgexErr),
+			fmt.Sprintf("failed to query provision watcher by offset %d, limit %d and service name %s", offset, limit, name), edgexErr)
+	}
+
+	return
+}
+
+//ProvisionWatchersByProfileName query provision watchers by offset, limit and profile name
+func (c *Client) ProvisionWatchersByProfileName(offset int, limit int, name string) (provisionWatchers []model.ProvisionWatcher, edgexErr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	provisionWatchers, edgexErr = provisionWatchersByProfileName(conn, offset, limit, name)
+	if edgexErr != nil {
+		return provisionWatchers, errors.NewCommonEdgeX(errors.Kind(edgexErr),
+			fmt.Sprintf("failed to query provision watcher by offset %d, limit %d and profile name %s", offset, limit, name), edgexErr)
+	}
+
+	return
+}
+
+// AllProvisionWatchers query provision watchers with offset, limit and labels
+func (c *Client) AllProvisionWatchers(offset int, limit int, labels []string) (provisionWatchers []model.ProvisionWatcher, edgexErr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	provisionWatchers, edgexErr = provisionWatchersByLabels(conn, offset, limit, labels)
+	if edgexErr != nil {
+		return provisionWatchers, errors.NewCommonEdgeXWrapper(edgexErr)
+	}
+
+	return
+}

--- a/openapi/v2/core-metadata.yaml
+++ b/openapi/v2/core-metadata.yaml
@@ -1305,23 +1305,23 @@ components:
                 frequency: "10s"
                 onChange: false
           - apiVersion: "v2"
-              id: "90c971f0-cb84-4bda-a9f0-d9494196b54d"
-              name: "simple-watcher"
-              created: 0
-              modified: 0
-              labels:
-                - simple
-              identifiers:
-                "address": "localhost"
-                "port": "4[0-9]{2}"
-              blockingIdentifiers:
-                "port":
-                  - "497"
-                  - "498"
-                  - "499"
-              profile: "device-simple"
-              service: "device-simple"
-              adminState: "UNLOCKED"
+            id: "90c971f0-cb84-4bda-a9f0-d9494196b54d"
+            name: "simple-watcher"
+            created: 0
+            modified: 0
+            labels:
+              - simple
+            identifiers:
+              "address": "localhost"
+              "port": "4[0-9]{2}"
+            blockingIdentifiers:
+              "port":
+                - "497"
+                - "498"
+                - "499"
+            profile: "device-simple"
+            service: "device-simple"
+            adminState: "UNLOCKED"
 paths:
   /batch:
     parameters:
@@ -3512,79 +3512,6 @@ paths:
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'
-  '/provisionwatcher/id/{id}':
-    parameters:
-      - $ref: '#/components/parameters/correlatedRequestHeader'
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-        description: "An ID of datatype string, by default a GUID."
-    delete:
-      summary: "Delete a provision watcher by ID"
-      responses:
-        '200':
-          description: "Delete successful"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                200Example:
-                  $ref: '#/components/examples/200Example'
-        '400':
-          description: "Request is in an invalid state"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                400Example:
-                  $ref: '#/components/examples/400Example'
-        '404':
-          description: "The requested resource does not exist"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                404Example:
-                  $ref: '#/components/examples/404Example'
-        '423':
-          description: "The requested resource is locked"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                423Example:
-                  $ref: '#/components/examples/423Example'
-        '500':
-          description: "Internal Server Error"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              examples:
-                500Example:
-                  $ref: '#/components/examples/500Example'
   '/provisionwatcher/name/{name}':
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -3746,6 +3673,56 @@ paths:
         description: "The name identifying a device service"
     get:
       summary: "Returns all provision watchers with specified device service name"
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultiProvisionWatchersResponse'
+              examples:
+                GetAllProvisionWatchersResponse:
+                  $ref: '#/components/examples/GetAllProvisionWatchersResponse'
+        '400':
+          description: "Request is in an invalid state"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '500':
+          description: "Internal Server Error"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
+  /provisionwatcher/profile/name/{name}:
+    parameters:
+      - $ref: '#/components/parameters/correlatedRequestHeader'
+      - $ref: '#/components/parameters/offsetParam'
+      - $ref: '#/components/parameters/limitParam'
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: "The name identifying a device profile"
+    get:
+      summary: "Returns all provision watchers with specified device profile name"
       responses:
         '200':
           description: "OK"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.


## Issue Number:
fix #3005 

## What is the new behavior?
Implement GET API of following routes:
- /provisionwatcher/name/{name}
- /provisionwatcher/all
- /provisionwatcher/service/name/{name}
- /provisionwatcher/profile/name/{name}

Also updates swagger file:
- fix indention error
- remove delete by id route
- add GET PWs by profile name route

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No
