### PR TITLE
fix: Add defaults for User and Group to Secret Store Setup

### DIFF
--- a/cmd/security-secretstore-setup/entrypoint.sh
+++ b/cmd/security-secretstore-setup/entrypoint.sh
@@ -32,8 +32,13 @@ echo "Initializing secret store..."
 # write a sentinel file when we're done because consul is not
 # secure and we don't trust it it access to the EdgeX secret store
 if [ -n "${SECRETSTORE_SETUP_DONE_FLAG}" ]; then
+    # default User and Group in case never set
+    if [ -z "${EDGEX_USER}" ]; then
+      EDGEX_USER="2002"
+      EDGEX_GROUP="2001"
+    fi
 
-    echo "Changing ownership of secrets to edgex_user:edgex_group"
+    echo "Changing ownership of secrets to ${EDGEX_USER}:${EDGEX_GROUP}"
     chown -R ${EDGEX_USER}:${EDGEX_GROUP} /tmp/edgex/secrets
 
     echo "Signaling secretstore-setup completion"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Since the developer scripts update for non-root user has not yet merged yet the EDGEX_USER and EDGEX_GROUP are never set causing Secret Store Setup to fail before signaling done. This causes Proxy Setup to never run which results in no Kong proxies configured. 

## Issue Number: #3006


## What is the new behavior?
This fix sets the EDGEX_USER and EDGEX_GROUP to a default value when they are not set.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information