### PR TITLE
fix(snap): cmdline args

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -64,7 +64,7 @@ restart_db_services () {
     # restart the services with updated configuration if they were
     # already running
     for svc in ${DB_SERVICES[*]}; do
-        status=`snapctl services "$SNAP_NAME.$svc" | grep -o "^active"`
+        status=$(snapctl services "$SNAP_NAME.$svc" | grep -o "^active")
 
         if [ "$status" = "active" ]; then
             snapctl restart "$SNAP_NAME.$svc"
@@ -100,9 +100,9 @@ for key in $ALL_SERVICES; do
             # app-service-configurable is on too
             if [ "$status" = "on" ]; then
                 handle_svc "app-service-configurable" "on"
-	    elif [ "$status" = "off" ]; then
+            elif [ "$status" = "off" ]; then
                 handle_svc "app-service-configurable" "off"
-	    fi
+            fi
             # handle the service too
             handle_svc "$key" "$status"
             ;;
@@ -152,16 +152,3 @@ for key in $ALL_SERVICES; do
             ;;
     esac
 done
-
-# handle usage of database provider
-#
-# FIXME (HANOI)
-#
-# The code to switch dbtype has been removed, however
-# I'm leaving the snapctl get to retrive the dbtype, as
-# this may be leveraged in the configure hook of Hanio
-# to block refresh from Geneva to Hanoi if the dbtype
-# is set to 'mongodb' and the project has not yet provided
-# a database migration script...
-dbProvider=$(snapctl get dbtype)
-PREV_DB_PROVIDER_FILE="$SNAP_DATA/prevdbtype"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -149,7 +149,7 @@ done
 # -n 1   -- generate a single password
 # -x 24  -- maximum password len
 # -m 16  -- minimum password len
-PGPASSWD=`$SNAP/usr/lib/apg/apg -a 0 -M ncl -n 1 -x 24 -m 16`
+PGPASSWD=$("$SNAP/usr/lib/apg/apg" -a 0 -M ncl -n 1 -x 24 -m 16)
 mkdir -p "$SNAP_DATA/config/postgres/"
 echo "$PGPASSWD" > "$SNAP_DATA/config/postgres/kongpw"
 
@@ -159,7 +159,7 @@ echo "$PGPASSWD" > "$SNAP_DATA/config/postgres/kongpw"
 export PGDATABASE="kong"
 iter_num=0
 until "$SNAP/bin/drop-snap-daemon.sh" "$SNAP/bin/perl5lib-launch.sh" "$SNAP/usr/bin/psql" \
-	   "-c CREATE ROLE kong WITH NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN PASSWORD '$PGPASSWD'"; do
+    "-c CREATE ROLE kong WITH NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN PASSWORD '$PGPASSWD'"; do
     sleep 1
     iter_num=$(( iter_num + 1 ))
     if [ $iter_num -gt $MAX_POSTGRES_INIT_ITERATIONS ]; then

--- a/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
+++ b/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
@@ -104,7 +104,7 @@ index 1e537489..faf42425 100644
    security-secretstore-setup:
      adapter: full
      after: [vault]
-@@ -271,32 +202,6 @@ apps:
+@@ -271,29 +202,6 @@ apps:
        ExecutorPath: $SNAP/bin/sys-mgmt-agent-snap-executor.sh
      daemon: simple
      plugs: [network, network-bind]
@@ -115,12 +115,9 @@ index 1e537489..faf42425 100644
 -      - security-proxy-setup
 -      - core-data
 -      - core-metadata
--    command: bin/device-virtual $CONF_ARG $PROFILE_ARG $REGISTRY_ARG
+-    command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual -cp -r
 -    daemon: simple
 -    environment:
--      CONF_ARG: "--confdir=$SNAP_DATA/config/device-virtual"
--      PROFILE_ARG: "--profile=res"
--      REGISTRY_ARG: "--registry=consul://localhost:8500"
 -      DEVICE_PROFILESDIR: $SNAP_DATA/config/device-virtual/res
 -    plugs: [network, network-bind]
 -  app-service-configurable:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -196,7 +196,7 @@ apps:
     after:
       - security-bootstrap-redis
       - security-proxy-setup
-    command: bin/core-data -confdir $SNAP_DATA/config/core-data/res --registry
+    command: bin/core-data -confdir $SNAP_DATA/config/core-data/res -cp -r
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
@@ -212,7 +212,7 @@ apps:
     after:
       - security-bootstrap-redis
       - security-proxy-setup
-    command: bin/core-metadata -confdir $SNAP_DATA/config/core-metadata/res --registry
+    command: bin/core-metadata -confdir $SNAP_DATA/config/core-metadata/res -cp -r
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
@@ -225,7 +225,7 @@ apps:
     after:
       - security-bootstrap-redis
       - security-proxy-setup
-    command: bin/core-command -confdir $SNAP_DATA/config/core-command/res --registry
+    command: bin/core-command -confdir $SNAP_DATA/config/core-command/res -cp -r
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
@@ -238,7 +238,7 @@ apps:
     after:
       - security-bootstrap-redis
       - security-proxy-setup
-    command: bin/support-notifications -confdir $SNAP_DATA/config/support-notifications/res --registry
+    command: bin/support-notifications -confdir $SNAP_DATA/config/support-notifications/res -cp -r
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
@@ -251,7 +251,7 @@ apps:
     after:
       - security-bootstrap-redis
       - security-proxy-setup
-    command: bin/support-scheduler -confdir $SNAP_DATA/config/support-scheduler/res --registry
+    command: bin/support-scheduler -confdir $SNAP_DATA/config/support-scheduler/res -cp -r
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
@@ -264,7 +264,7 @@ apps:
     after:
       - security-bootstrap-redis
       - security-proxy-setup
-    command: bin/sys-mgmt-agent -confdir $SNAP_DATA/config/sys-mgmt-agent/res --registry
+    command: bin/sys-mgmt-agent -confdir $SNAP_DATA/config/sys-mgmt-agent/res -cp -r
     command-chain:
       - bin/security-secret-store-env-var.sh
     environment:
@@ -278,12 +278,9 @@ apps:
       - security-proxy-setup
       - core-data
       - core-metadata
-    command: bin/device-virtual $CONF_ARG $PROFILE_ARG $REGISTRY_ARG
+    command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual -cp -r
     daemon: simple
     environment:
-      CONF_ARG: "--confdir=$SNAP_DATA/config/device-virtual"
-      PROFILE_ARG: "--profile=res"
-      REGISTRY_ARG: "--registry=consul://localhost:8500"
       DEVICE_PROFILESDIR: $SNAP_DATA/config/device-virtual/res
     plugs: [network, network-bind]
   app-service-configurable:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,8 +16,8 @@ icon: snap/local/assets/edgex-snap-icon.png
 # Different epochs prevent refreshes between major versions of EdgeX due
 # to continued configuration changes.
 #
-# delhi: 0, edinburgh: 1, fuji: 2, geneva: 3, hanoi: 4
-epoch: 4
+# delhi: 0, edinburgh: 1, fuji: 2, geneva: 3, hanoi: 4, ireland: 5
+epoch: 5
 
 architectures:
   - build-on: arm64


### PR DESCRIPTION
This PR updates the command lines of all the core-*, support-*, and sma services in the snap to use the preferred command-line options for the config provide and registry, as some of these services were still using the legacy command-line options. For most the change was just replacing `--registry` with `-cp -r`.

Also note, this PR also includes three unrelated snaps fixes:

 *  cleanup of inconsistent whitespace usage snap hooks
 *  address shellcheck warnings in the snap hooks
 *  bump the snap epoch to 5 for the Ireland release

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
If the snap is built from master and installed, the core-*, support-*, and sma services do not provision their configuration into the configuration provider (aka Consul) on first run because the legacy command-line options are used in the snap. This PR is similar to the recent PR #2981 which resolved some of the fallout from the recent change to go-mod-bootstrap which removed the legacy command-line option.

## Issue Number:
NA

## What is the new behavior?
Snap

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information