### PR TITLE
fix(snap): fix redis persistence/snapshots

### DIFF
--- a/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
+++ b/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
@@ -28,7 +28,7 @@ diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
 index 1e537489..faf42425 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -73,75 +73,6 @@ confinement: strict
+@@ -73,77 +73,6 @@ confinement: strict
  
  apps:
    # edgex microservices
@@ -40,9 +40,11 @@ index 1e537489..faf42425 100644
 -  redis:
 -    adapter: full
 -    after: [security-secretstore-setup]
--    command: bin/redis-server --dir $SNAP_DATA/redis $REDIS_SAVE_OPTS
+-    command: bin/redis-server $DIR_OPT $SAVE_OPT1 $SAVE_OPT2
 -    environment:
--      REDIS_SAVE_OPTS: "--save 900 1 --save 300 10"
+-      DIR_OPT: "--dir $SNAP_DATA/redis"
+-      SAVE_OPT1: "--save 900 1"
+-      SAVE_OPT2: "--save 300 10"
 -    daemon: simple
 -    plugs: [network, network-bind]
 -  postgres:
@@ -115,7 +117,7 @@ index 1e537489..faf42425 100644
 -      - security-proxy-setup
 -      - core-data
 -      - core-metadata
--    command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual -cp -r
+-    command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual/res -cp -r
 -    daemon: simple
 -    environment:
 -      DEVICE_PROFILESDIR: $SNAP_DATA/config/device-virtual/res
@@ -357,8 +359,8 @@ index 1e537489..faf42425 100644
 -      - zip
 -
 -  redis:
--    source: https://github.com/antirez/redis.git
--    source-tag: "6.0.8"
+-    source: https://github.com/redis/redis.git
+-    source-tag: "6.0.9"
 -    source-depth: 1
 -    plugin: make
 -    make-install-var: PREFIX

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -280,7 +280,7 @@ apps:
       - security-proxy-setup
       - core-data
       - core-metadata
-    command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual -cp -r
+    command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual/res -cp -r
     daemon: simple
     environment:
       DEVICE_PROFILESDIR: $SNAP_DATA/config/device-virtual/res

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,9 +81,11 @@ apps:
   redis:
     adapter: full
     after: [security-secretstore-setup]
-    command: bin/redis-server --dir $SNAP_DATA/redis $REDIS_SAVE_OPTS
+    command: bin/redis-server $DIR_OPT $SAVE_OPT1 $SAVE_OPT2
     environment:
-      REDIS_SAVE_OPTS: "--save 900 1 --save 300 10"
+      DIR_OPT: "--dir $SNAP_DATA/redis"
+      SAVE_OPT1: "--save 900 1"
+      SAVE_OPT2: "--save 300 10"
     daemon: simple
     plugs: [network, network-bind]
   postgres:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -573,8 +573,8 @@ parts:
       - zip
 
   redis:
-    source: https://github.com/antirez/redis.git
-    source-tag: "6.0.8"
+    source: https://github.com/redis/redis.git
+    source-tag: "6.0.9"
     source-depth: 1
     plugin: make
     make-install-var: PREFIX


### PR DESCRIPTION
This PR fixes an issue with Redis snapshots in the snap. It also updates the snap to the latest 6.0.9 release of Redis.

This PR also contains one unrelated minor change to the device-virtual command-line, which fixes a regression introduced recently when the service command line options in the snap were all updated to use `--cp` and `-r` for the config provider and registry options.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Redis [snapshots](https://redis.io/topics/persistence) do not function properly in the edgexfoundry snap. When snapshots are working correctly, Redis will occasionally (based on the save options specified on its command line) write a file called dump.rdb to the directory `$SNAP_DATA/current/redis` (`/var/snap/edgexfoundry/current/redis`).

## Issue Number:
[2876](https://github.com/edgexfoundry/edgex-go/issues/2876)

## What is the new behavior?
Redis snapshots work as expected.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
To test, build the snap from this branch, install (using --dangerous) and then enable device-virtual so that something gets written to Redis, triggering a snapshot:

`$ sudo snap set edgexfoundry device-virtual=on
`

After ~5m, you should see a snapshot file written to `/var/snap/edgexfoundry/current/redis`.

## Other information
It appears we didn't have a blackbox test to ensure that snapshot files are periodically written. It might be a good idea to add such a test to the TAF tests for Ireland.