### PR TITLE
fix(core-data): Set ApiVersion on Event/Reading DTOs prior to publishing to MessageBus

### DIFF
--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -20,6 +20,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	dto "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
@@ -83,6 +84,13 @@ func PublishEvent(addEventReq dto.AddEventRequest, profileName string, deviceNam
 
 	if len(clients.FromContext(ctx, clients.ContentType)) == 0 {
 		ctx = context.WithValue(ctx, clients.ContentType, clients.ContentTypeJSON)
+	}
+
+	// Must make sure API Version for embedded DTOs is set since it isn't required by the request,
+	// but is needed when published to Message Bus.
+	addEventReq.Event.Versionable = common.NewVersionable()
+	for index := range addEventReq.Event.Readings {
+		addEventReq.Event.Readings[index].Versionable = common.NewVersionable()
 	}
 
 	data, err = json.Marshal(addEventReq)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

ApiVersion is not set in Event/Readings when published to MessageBus since it is not required to be set in the Add Event Request.
It needs to be set since the App Services use it to determine the version of object received and also needs to be included when the Event/Readings are exported.

## Issue Number: #3050


## What is the new behavior?

ApiVersion is now set in Event/Readings when published to MessageBus

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information