### PR TITLE
fix(meta): Delete DS API should check the associated Device existence

### DIFF
--- a/internal/core/metadata/v2/application/deviceservice.go
+++ b/internal/core/metadata/v2/application/deviceservice.go
@@ -103,7 +103,16 @@ func DeleteDeviceServiceByName(name string, ctx context.Context, dic *di.Contain
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
 	}
 	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
-	err := dbClient.DeleteDeviceServiceByName(name)
+
+	// Check the associated Device existence
+	devices, err := dbClient.DevicesByServiceName(0, 1, name)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if len(devices) > 0 {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "fail to delete the device service when associated device exists", nil)
+	}
+	err = dbClient.DeleteDeviceServiceByName(name)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}


### PR DESCRIPTION
fix 2989

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Delete Device Service API doesn't check the associated Device existence.

## Issue Number: #2989 


## What is the new behavior?
Delete Device Service API should check the associated Device existence.
If there is any associated Device exists, the Device Service deletion should return error.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information