### PR TITLE
build: Use yaml.v3 library instead of yaml.v2

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -152,9 +152,6 @@ https://github.com/x448/float16/blob/master/LICENSE
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE
 
-gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
-https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
-
 gopkg.in/yaml.v3 (MIT) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v3/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	gopkg.in/eapache/queue.v1 v1.1.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 go 1.15

--- a/internal/core/metadata/rest_deviceprofile.go
+++ b/internal/core/metadata/rest_deviceprofile.go
@@ -34,7 +34,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 
 	"github.com/gorilla/mux"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func restGetAllDeviceProfiles(

--- a/internal/core/metadata/rest_deviceprofile_test.go
+++ b/internal/core/metadata/rest_deviceprofile_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/mock"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var TestLabelError1 = "TestErrorLabel1"

--- a/internal/core/metadata/v2/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile_test.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"

--- a/internal/core/metadata/v2/io/deviceprofile.go
+++ b/internal/core/metadata/v2/io/deviceprofile.go
@@ -7,7 +7,7 @@ package io
 
 import (
 	"encoding/json"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 	"mime/multipart"


### PR DESCRIPTION
Close #3060

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Yaml lib use v2

## Issue Number: #3060


## What is the new behavior?
Upgrade Yaml lib to v3

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information