### PR TITLE
feat(security): add build code in Dockerfile for ARM64 of dockerize executable

### DIFF
--- a/cmd/security-bootstrapper/Dockerfile
+++ b/cmd/security-bootstrapper/Dockerfile
@@ -32,31 +32,49 @@ RUN go mod download
 
 COPY . .
 
-RUN make cmd/security-bootstrapper/security-bootstrapper \
-    && make cmd/security-bootstrap-redis/security-bootstrap-redis
+ARG BUILD_BASE_DIR="/tmp/build/dist/linux"
+
+RUN make cmd/security-bootstrapper/security-bootstrapper && \
+    make cmd/security-bootstrap-redis/security-bootstrap-redis && \
+    # build "dockerize" executable based on the architecture that is currently running on
+    set -eux; \
+    mkdir -p "$BUILD_BASE_DIR" && \
+    cd "$BUILD_BASE_DIR" && \
+    git clone https://github.com/jwilder/dockerize.git . && \
+    go get github.com/robfig/glock && \
+    glock sync -n < GLOCKFILE && \
+    TAG=$(git describe --abbrev=0 --tags) && \
+    LDFLAGS="-X main.buildVersion=$TAG" && \
+    arch="$(apk --print-arch)"; \
+    case "$arch" in \
+        x86_64   ) \
+            echo "building [dockerize] for amd64 ... "; \
+            GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -a -tags netgo -installsuffix netgo \
+                    -o "$BUILD_BASE_DIR"/dockerize ;; \
+        aarch64  ) \
+            echo "building [dockerize] for arm64 ... "; \
+            GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o "$BUILD_BASE_DIR"/dockerize ;; \
+        *) echo >&2 "Error: dockerize is not supported in arch $arch"; exit 1 ;;\
+    esac && \
+    echo "$(date) dockerize executable build done and output at directory: $BUILD_BASE_DIR"
 
 FROM alpine:3.12
-
-RUN apk add --update --no-cache dumb-init openssl su-exec
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2021 Intel Corporation'
 
-# Use dockerize utility for services to wait for certain ports to be available
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+RUN apk add --update --no-cache dumb-init openssl su-exec
 
 ENV SECURITY_INIT_DIR /edgex-init
 ARG BOOTSTRAP_REDIS_DIR=${SECURITY_INIT_DIR}/bootstrap-redis
 
 RUN mkdir -p ${SECURITY_INIT_DIR} \
-    && mkdir -p ${BOOTSTRAP_REDIS_DIR} \
-    && echo "Move dockerize executable" \
-    && mv /usr/local/bin/dockerize ${SECURITY_INIT_DIR}
+    && mkdir -p ${BOOTSTRAP_REDIS_DIR}
 
 WORKDIR ${SECURITY_INIT_DIR}
+
+# Use dockerize utility for services to wait for certain ports to be available
+COPY --from=builder /tmp/build/dist/linux/dockerize .
 
 # copy all entrypoint scripts into shared folder
 COPY --from=builder /edgex-go/cmd/security-bootstrapper/entrypoint-scripts/ ${SECURITY_INIT_DIR}/


### PR DESCRIPTION
This PR add the ability to build ARM64 version of dockerize binary installation.

Fixes: #3081

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
currently dockerize only works for amd64 arch. box

## Issue Number: #3081 


## What is the new behavior?
Will add support for ARM64 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information