### PR TITLE
fix(meta): Delete API return 409 when associated object exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.4
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.1
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.12
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.13
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.1
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.1
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.2

--- a/internal/core/metadata/v2/application/deviceprofile.go
+++ b/internal/core/metadata/v2/application/deviceprofile.go
@@ -86,14 +86,14 @@ func DeleteDeviceProfileByName(name string, ctx context.Context, dic *di.Contain
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 	if len(devices) > 0 {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, "fail to delete the device profile when associated device exists", nil)
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device profile when associated device exists", nil)
 	}
 	provisionWatchers, err := dbClient.ProvisionWatchersByProfileName(0, 1, name)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 	if len(provisionWatchers) > 0 {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, "fail to delete the device profile when associated provisionWatcher exists", nil)
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device profile when associated provisionWatcher exists", nil)
 	}
 
 	err = dbClient.DeleteDeviceProfileByName(name)

--- a/internal/core/metadata/v2/application/deviceservice.go
+++ b/internal/core/metadata/v2/application/deviceservice.go
@@ -105,14 +105,14 @@ func DeleteDeviceServiceByName(name string, ctx context.Context, dic *di.Contain
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 	if len(devices) > 0 {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, "fail to delete the device service when associated device exists", nil)
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device service when associated device exists", nil)
 	}
 	provisionWatchers, err := dbClient.ProvisionWatchersByServiceName(0, 1, name)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 	if len(provisionWatchers) > 0 {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, "fail to delete the device service when associated provisionWatcher exists", nil)
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device service when associated provisionWatcher exists", nil)
 	}
 
 	err = dbClient.DeleteDeviceServiceByName(name)

--- a/internal/core/metadata/v2/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile_test.go
@@ -841,8 +841,8 @@ func TestDeleteDeviceProfileByName(t *testing.T) {
 		{"Valid - delete device profile by name", deviceProfile.Name, false, http.StatusOK},
 		{"Invalid - name parameter is empty", noName, true, http.StatusBadRequest},
 		{"Invalid - device profile not found by name", notFoundName, true, http.StatusNotFound},
-		{"Invalid - associated device exists", deviceExists, true, http.StatusBadRequest},
-		{"Invalid - associated provisionWatcher Exists", provisionWatcherExists, true, http.StatusBadRequest},
+		{"Invalid - associated device exists", deviceExists, true, http.StatusConflict},
+		{"Invalid - associated provisionWatcher Exists", provisionWatcherExists, true, http.StatusConflict},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/core/metadata/v2/controller/http/deviceservice_test.go
+++ b/internal/core/metadata/v2/controller/http/deviceservice_test.go
@@ -497,8 +497,8 @@ func TestDeleteDeviceServiceByName(t *testing.T) {
 		{"Valid - delete device service by name", deviceService.Name, false, http.StatusOK},
 		{"Invalid - name parameter is empty", noName, true, http.StatusBadRequest},
 		{"Invalid - device service not found by name", notFoundName, true, http.StatusNotFound},
-		{"Invalid - associated device exists", deviceExists, true, http.StatusBadRequest},
-		{"Invalid - associated provisionWatcher Exists", provisionWatcherExists, true, http.StatusBadRequest},
+		{"Invalid - associated device exists", deviceExists, true, http.StatusConflict},
+		{"Invalid - associated provisionWatcher Exists", provisionWatcherExists, true, http.StatusConflict},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
Fix #3087

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Delete API return 400 when associated object exist


## Issue Number: #3087 


## What is the new behavior?
DeviceProfile and DeviceService Delete API should return 409 instead of the 400 when associated object exists

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information