### PR TITLE
feat(security): make the built fully statically linked for dockerize

### DIFF
--- a/cmd/security-bootstrapper/Dockerfile
+++ b/cmd/security-bootstrapper/Dockerfile
@@ -49,14 +49,19 @@ RUN make cmd/security-bootstrapper/security-bootstrapper && \
     case "$arch" in \
         x86_64   ) \
             echo "building [dockerize] for amd64 ... "; \
-            GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -a -tags netgo -installsuffix netgo \
+            CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -a -tags netgo -installsuffix netgo \
                     -o "$BUILD_BASE_DIR"/dockerize ;; \
         aarch64  ) \
             echo "building [dockerize] for arm64 ... "; \
-            GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o "$BUILD_BASE_DIR"/dockerize ;; \
+            CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o "$BUILD_BASE_DIR"/dockerize ;; \
         *) echo >&2 "Error: dockerize is not supported in arch $arch"; exit 1 ;;\
     esac && \
     echo "$(date) dockerize executable build done and output at directory: $BUILD_BASE_DIR"
+
+# test the built one is statically linked
+RUN mkdir -p /test && \
+    cp "$BUILD_BASE_DIR"/dockerize /test/ && \
+    ldd /test/dockerize 2>&1 > /test/ldd_out.log || echo "statically linked"
 
 FROM alpine:3.12
 


### PR DESCRIPTION
Add CGO_ENABLED=0 flag to make dockerize build statically linked

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:  #3081 


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ X] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information