### PR TITLE
feat(security): Add waitFor subcommand for security-bootstrapper

### DIFF
--- a/cmd/security-bootstrapper/Dockerfile
+++ b/cmd/security-bootstrapper/Dockerfile
@@ -32,43 +32,15 @@ RUN go mod download
 
 COPY . .
 
-ARG BUILD_BASE_DIR="/tmp/build/dist/linux"
-
 RUN make cmd/security-bootstrapper/security-bootstrapper && \
-    make cmd/security-bootstrap-redis/security-bootstrap-redis && \
-    # build "dockerize" executable based on the architecture that is currently running on
-    set -eux; \
-    mkdir -p "$BUILD_BASE_DIR" && \
-    cd "$BUILD_BASE_DIR" && \
-    git clone https://github.com/jwilder/dockerize.git . && \
-    go get github.com/robfig/glock && \
-    glock sync -n < GLOCKFILE && \
-    TAG=$(git describe --abbrev=0 --tags) && \
-    LDFLAGS="-X main.buildVersion=$TAG" && \
-    arch="$(apk --print-arch)"; \
-    case "$arch" in \
-        x86_64   ) \
-            echo "building [dockerize] for amd64 ... "; \
-            CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$LDFLAGS" -a -tags netgo -installsuffix netgo \
-                    -o "$BUILD_BASE_DIR"/dockerize ;; \
-        aarch64  ) \
-            echo "building [dockerize] for arm64 ... "; \
-            CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o "$BUILD_BASE_DIR"/dockerize ;; \
-        *) echo >&2 "Error: dockerize is not supported in arch $arch"; exit 1 ;;\
-    esac && \
-    echo "$(date) dockerize executable build done and output at directory: $BUILD_BASE_DIR"
-
-# test the built one is statically linked
-RUN mkdir -p /test && \
-    cp "$BUILD_BASE_DIR"/dockerize /test/ && \
-    ldd /test/dockerize 2>&1 > /test/ldd_out.log || echo "statically linked"
+    make cmd/security-bootstrap-redis/security-bootstrap-redis
 
 FROM alpine:3.12
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2021 Intel Corporation'
 
-RUN apk add --update --no-cache dumb-init openssl su-exec
+RUN apk add --update --no-cache dumb-init su-exec
 
 ENV SECURITY_INIT_DIR /edgex-init
 ARG BOOTSTRAP_REDIS_DIR=${SECURITY_INIT_DIR}/bootstrap-redis
@@ -77,9 +49,6 @@ RUN mkdir -p ${SECURITY_INIT_DIR} \
     && mkdir -p ${BOOTSTRAP_REDIS_DIR}
 
 WORKDIR ${SECURITY_INIT_DIR}
-
-# Use dockerize utility for services to wait for certain ports to be available
-COPY --from=builder /tmp/build/dist/linux/dockerize .
 
 # copy all entrypoint scripts into shared folder
 COPY --from=builder /edgex-go/cmd/security-bootstrapper/entrypoint-scripts/ ${SECURITY_INIT_DIR}/

--- a/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
@@ -67,10 +67,11 @@ echo "$(date) Starting edgex-consul..."
 exec docker-entrypoint.sh agent -ui -bootstrap -server -client 0.0.0.0 &
 
 # wait for the consul port
-echo "$(date) Executing dockerize on Consul with waiting on its own port \
+echo "$(date) Executing waitFor on Consul with waiting on its own port \
   tcp://${STAGEGATE_REGISTRY_HOST}:${STAGEGATE_REGISTRY_PORT}"
-/edgex-init/dockerize -wait tcp://"${STAGEGATE_REGISTRY_HOST}":"${STAGEGATE_REGISTRY_PORT}" \
-  -timeout "${SECTY_BOOTSTRAP_GATING_TIMEOUT_DURATION}"
+/edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+  -uri tcp://"${STAGEGATE_REGISTRY_HOST}":"${STAGEGATE_REGISTRY_PORT}" \
+  -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
 # Signal that Consul is ready for services blocked waiting on Consul
 /edgex-init/security-bootstrapper --confdir=/edgex-init/res listenTcp \

--- a/cmd/security-bootstrapper/entrypoint-scripts/kong_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/kong_wait_install.sh
@@ -27,18 +27,21 @@ set -e
 echo "Script for waiting security bootstrapping on Kong"
 
 # gating on the ready-to-run port
-echo "$(date) Executing dockerize with waiting on tcp://${STAGEGATE_BOOTSTRAPPER_HOST}:${STAGEGATE_READY_TORUNPORT}"
-/edgex-init/dockerize -wait tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_READY_TORUNPORT}" \
-  -timeout "${SECTY_BOOTSTRAP_GATING_TIMEOUT_DURATION}"
+echo "$(date) Executing waitFor with waiting on tcp://${STAGEGATE_BOOTSTRAPPER_HOST}:${STAGEGATE_READY_TORUNPORT}"
+/edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+  -uri tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_READY_TORUNPORT}" \
+  -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
 echo "$(date) Kong waits on Postgres to be initialized"
-/edgex-init/dockerize -wait tcp://"${STAGEGATE_KONGDB_HOST}":"${STAGEGATE_KONGDB_READYPORT}" \
-  -timeout "${SECTY_BOOTSTRAP_GATING_TIMEOUT_DURATION}"
+/edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+  -uri tcp://"${STAGEGATE_KONGDB_HOST}":"${STAGEGATE_KONGDB_READYPORT}" \
+  -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
 # KONG_PG_PASSWORD_FILE is env used by Kong, it is for kong-db's password file
-echo "$(date) Executing dockerize with waiting on file:${KONG_PG_PASSWORD_FILE}"
-/edgex-init/dockerize -wait file://"${KONG_PG_PASSWORD_FILE}" \
-  -timeout "${SECTY_BOOTSTRAP_GATING_TIMEOUT_DURATION}"
+echo "$(date) Executing waitFor with waiting on file:${KONG_PG_PASSWORD_FILE}"
+/edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+  -uri file://"${KONG_PG_PASSWORD_FILE}" \
+  -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
 # double check and make sure the postgres is setup with that password and ready
 passwd=$(cat "${KONG_PG_PASSWORD_FILE}")

--- a/cmd/security-bootstrapper/entrypoint-scripts/postgres_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/postgres_wait_install.sh
@@ -27,10 +27,11 @@ set -e
 echo "Script for waiting security bootstrapping on Postgres"
 
 # Postgres is waiting for BOOTSTRAP_PORT
-echo "$(date) Executing dockerize on Postgres with waiting on \
+echo "$(date) Executing waitFor on Postgres with waiting on \
   tcp://${STAGEGATE_BOOTSTRAPPER_HOST}:${STAGEGATE_BOOTSTRAPPER_STARTPORT}"
-/edgex-init/dockerize -wait tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_BOOTSTRAPPER_STARTPORT}" \
-  -timeout "${SECTY_BOOTSTRAP_GATING_TIMEOUT_DURATION}"
+/edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+  -uri tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_BOOTSTRAPPER_STARTPORT}" \
+  -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
 echo "$(date) Postgres waits on Vault to be initialized"
 

--- a/cmd/security-bootstrapper/entrypoint-scripts/proxy_setup_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/proxy_setup_wait_install.sh
@@ -27,10 +27,11 @@ set -e
 echo "Script for waiting security bootstrapping on proxy-setup"
 
 # gating on the ready-to-run port
-echo "$(date) Executing dockerize for ${PROXY_SETUP_HOST} with waiting on \
+echo "$(date) Executing waitFor for ${PROXY_SETUP_HOST} with waiting on \
   tcp://${STAGEGATE_BOOTSTRAPPER_HOST}:${STAGEGATE_READY_TORUNPORT}"
-/edgex-init/dockerize -wait tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_READY_TORUNPORT}" \
-  -timeout "${SECTY_BOOTSTRAP_GATING_TIMEOUT_DURATION}"
+/edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+  -uri tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_READY_TORUNPORT}" \
+  -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
 echo "$(date) ${PROXY_SETUP_HOST} waits on Kong to be initialized"
 

--- a/cmd/security-bootstrapper/entrypoint-scripts/ready_to_run_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/ready_to_run_wait_install.sh
@@ -32,9 +32,10 @@ set -e
 echo "Script for waiting on security bootstrapping ready-to-run"
 
 # gating on the ready-to-run port
-echo "$(date) Executing dockerize with $@ waiting on tcp://${STAGEGATE_BOOTSTRAPPER_HOST}:${STAGEGATE_READY_TORUNPORT}"
-/edgex-init/dockerize -wait tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_READY_TORUNPORT}" \
-  -timeout "${SECTY_BOOTSTRAP_GATING_TIMEOUT_DURATION}"
+echo "$(date) Executing waitFor with $@ waiting on tcp://${STAGEGATE_BOOTSTRAPPER_HOST}:${STAGEGATE_READY_TORUNPORT}"
+/edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+  -uri tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_READY_TORUNPORT}" \
+  -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
 echo "$(date) Starting $@ ..."
 exec "$@"

--- a/cmd/security-bootstrapper/entrypoint-scripts/redis_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/redis_wait_install.sh
@@ -27,10 +27,11 @@ set -e
 echo "Script for waiting security bootstrapping on Redis"
 
 # gating on the TokensReadyPort
-echo "$(date) Executing dockerize on Redis with waiting on TokensReadyPort \
+echo "$(date) Executing waitFor on Redis with waiting on TokensReadyPort \
   tcp://${STAGEGATE_SECRETSTORESETUP_HOST}:${STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT}"
-/edgex-init/dockerize -wait tcp://"${STAGEGATE_SECRETSTORESETUP_HOST}":"${STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT}" \
-  -timeout "${SECTY_BOOTSTRAP_GATING_TIMEOUT_DURATION}"
+/edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+  -uri tcp://"${STAGEGATE_SECRETSTORESETUP_HOST}":"${STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT}" \
+  -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
 # the bootstrap-redis needs the connection from Redis db to set it up.
 # Hence, here bootstrap-redis runs in background and then after bootstrap-redis starts,

--- a/cmd/security-bootstrapper/entrypoint-scripts/vault_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/vault_wait_install.sh
@@ -46,11 +46,11 @@ export VAULT_LOCAL_CONFIG
 echo "$(date) VAULT_LOCAL_CONFIG: ${VAULT_LOCAL_CONFIG}"
 
 if [ "$1" = 'server' ]; then
-  echo "$(date) Executing dockerize on vault $* with waiting on \
+  echo "$(date) Executing waitFor on vault $* with \
     tcp://${STAGEGATE_BOOTSTRAPPER_HOST}:${STAGEGATE_BOOTSTRAPPER_STARTPORT}"
-  /edgex-init/dockerize \
-    -wait tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_BOOTSTRAPPER_STARTPORT}" \
-    -timeout "${SECTY_BOOTSTRAP_GATING_TIMEOUT_DURATION}"
+  /edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+    -uri tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_BOOTSTRAPPER_STARTPORT}" \
+    -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
   echo "$(date) Starting edgex-vault..."
   exec /usr/local/bin/docker-entrypoint.sh server -log-level=info

--- a/cmd/security-bootstrapper/res/configuration.toml
+++ b/cmd/security-bootstrapper/res/configuration.toml
@@ -25,3 +25,6 @@ LogLevel = 'INFO'
     Host = "kong-db"
     Port = 5432
     ReadyPort = 54325
+  [StageGate.WaitFor]
+    Timeout = "10s"
+    RetryInterval = "1s"

--- a/internal/security/bootstrapper/command/cmd_dispatcher.go
+++ b/internal/security/bootstrapper/command/cmd_dispatcher.go
@@ -25,6 +25,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/command/gethttpstatus"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/command/listen"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/command/ping"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/command/waitfor"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/interfaces"
 
@@ -43,8 +44,8 @@ func NewCommand(
 	var err error
 
 	if len(args) < 1 {
-		return nil, fmt.Errorf("subcommand required (%s, %s, %s, %s, %s)", gate.CommandName, listen.CommandName,
-			ping.CommandName, gethttpstatus.CommandName, genpassword.CommandName)
+		return nil, fmt.Errorf("subcommand required (%s, %s, %s, %s, %s, %s)", gate.CommandName, listen.CommandName,
+			ping.CommandName, gethttpstatus.CommandName, genpassword.CommandName, waitfor.CommandName)
 	}
 
 	commandName := args[0]
@@ -60,6 +61,8 @@ func NewCommand(
 		command, err = gethttpstatus.NewCommand(ctx, wg, lc, configuration, args[1:])
 	case genpassword.CommandName:
 		command, err = genpassword.NewCommand(ctx, wg, lc, configuration, args[1:])
+	case waitfor.CommandName:
+		command, err = waitfor.NewCommand(ctx, wg, lc, configuration, args[1:])
 	default:
 		command = nil
 		err = fmt.Errorf("unsupported command %s", commandName)

--- a/internal/security/bootstrapper/command/cmd_dispatcher_test.go
+++ b/internal/security/bootstrapper/command/cmd_dispatcher_test.go
@@ -32,7 +32,14 @@ func TestNewCommand(t *testing.T) {
 	ctx := context.Background()
 	wg := &sync.WaitGroup{}
 	lc := logger.MockLogger{}
-	config := &config.ConfigurationStruct{}
+	config := &config.ConfigurationStruct{
+		StageGate: config.StageGateInfo{
+			WaitFor: config.WaitForInfo{
+				Timeout:       "2s",
+				RetryInterval: "1s",
+			},
+		},
+	}
 
 	tests := []struct {
 		name            string
@@ -46,10 +53,12 @@ func TestNewCommand(t *testing.T) {
 		{"Good: listenTcp command", []string{"listenTcp", "--port=55555"}, "listenTcp", false},
 		{"Good: genPassword command", []string{"genPassword"}, "genPassword", false},
 		{"Good: getHttpStatus command", []string{"getHttpStatus", "--url=http://localhost:55555"}, "getHttpStatus", false},
+		{"Good: waitFor command", []string{"waitFor", "--uri=http://localhost:55555"}, "waitFor", false},
 		{"Bad: unknown command", []string{"unknown"}, "", true},
 		{"Bad: empty command", []string{}, "", true},
 		{"Bad: listenTcp command missing required --port", []string{"listenTcp"}, "", true},
 		{"Bad: getHttpStatus command missing required --url", []string{"getHttpStatus"}, "", true},
+		{"Bad: waitFor command missing required --uri", []string{"waitFor"}, "", true},
 	}
 
 	for _, tt := range tests {

--- a/internal/security/bootstrapper/command/flags_common.go
+++ b/internal/security/bootstrapper/command/flags_common.go
@@ -102,6 +102,8 @@ func HelpCallback() {
 			"    listenTcp     Start up a TCP listener\n"+
 			"    pingPgDb      Test Postgres database readiness\n"+
 			"    getHttpStatus Do an HTTP GET call to get the status code\n"+
-			"    genPassword   Generate a random password\n",
+			"    genPassword   Generate a random password\n"+
+			"    waitfor       Wait for the other services with specified URI(s) to connect:\n"+
+			"                  the URI(s) can be communication protocols like tcp/tcp4/tcp6/http/https or files\n",
 		os.Args[0])
 }

--- a/internal/security/bootstrapper/command/waitfor/command.go
+++ b/internal/security/bootstrapper/command/waitfor/command.go
@@ -1,0 +1,251 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package waitfor
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/interfaces"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+)
+
+const (
+	CommandName string = "waitFor"
+)
+
+type cmd struct {
+	waitGroup     *sync.WaitGroup
+	loggingClient logger.LoggingClient
+	configuration *config.ConfigurationStruct
+
+	// options
+	uris          uriFlagsVar
+	timeout       time.Duration
+	retryInterval time.Duration
+
+	// internal states
+	parsedURIs []url.URL
+}
+
+// NewCommand creates a new cmd and parses through options if any
+func NewCommand(
+	_ context.Context,
+	_ *sync.WaitGroup,
+	lc logger.LoggingClient,
+	configuration *config.ConfigurationStruct,
+	args []string) (interfaces.Command, error) {
+
+	// input sanity checks
+	defaultTimeout, err := time.ParseDuration(configuration.StageGate.WaitFor.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse duration for StageGate.WaitFor.Timeout: %s: %w",
+			configuration.StageGate.WaitFor.Timeout, err)
+	} else if defaultTimeout <= 0 {
+		return nil, fmt.Errorf("Expect positive time duration (> 0) for StageGate.WaitFor.Timeout: %s",
+			configuration.StageGate.WaitFor.Timeout)
+	}
+
+	defaultRetryInterval, err := time.ParseDuration(configuration.StageGate.WaitFor.RetryInterval)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse duration for StageGate.WaitFor.RetryInterval: %s: %w",
+			configuration.StageGate.WaitFor.RetryInterval, err)
+	} else if defaultRetryInterval <= 0 {
+		return nil, fmt.Errorf("Expect positive time duration (> 0) for StageGate.WaitFor.RetryInterval: %s",
+			configuration.StageGate.WaitFor.RetryInterval)
+	}
+
+	cmd := cmd{
+		waitGroup:     &sync.WaitGroup{},
+		loggingClient: lc,
+		configuration: configuration,
+	}
+
+	var dummy string
+
+	flagSet := flag.NewFlagSet(CommandName, flag.ContinueOnError)
+	flagSet.StringVar(&dummy, "confdir", "", "") // handled by bootstrap; duplicated here to prevent arg parsing errors
+
+	flagSet.Var(&cmd.uris, "uri", "Service (tcp/tcp4/tcp6/http/https/unix/file) to wait for before this one starts. "+
+		"Can be passed multiple times. e.g. tcp://db:5432")
+
+	flagSet.DurationVar(&cmd.timeout, "timeout", defaultTimeout, "Timeout duration of waiting for services")
+
+	flagSet.DurationVar(&cmd.retryInterval, "retryInterval", defaultRetryInterval, "Duration to pause before retrying")
+
+	err = flagSet.Parse(args)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse command: %s: %w", strings.Join(args, " "), err)
+	}
+
+	if len(cmd.uris) == 0 {
+		return nil, fmt.Errorf("%s %s: argument --uri is required", os.Args[0], CommandName)
+	}
+
+	return &cmd, nil
+}
+
+// GetCommandName returns the name of this command
+func (c *cmd) GetCommandName() string {
+	return CommandName
+}
+
+// Execute implements Command and runs this command
+// command waitFor waits services to be connected and responded
+func (c *cmd) Execute() (int, error) {
+	c.loggingClient.Infof("Security bootstrapper running %s", CommandName)
+
+	for _, rawURI := range c.uris {
+		uri, err := url.Parse(rawURI)
+		if err != nil {
+			return interfaces.StatusCodeExitWithError, err
+		}
+
+		c.parsedURIs = append(c.parsedURIs, *uri)
+	}
+
+	if err := c.waitForDependencies(); err != nil {
+		return interfaces.StatusCodeExitWithError, err
+	}
+
+	return interfaces.StatusCodeExitNormal, nil
+}
+
+// waitForDependencies implements very similar ideas from dockerize
+func (c *cmd) waitForDependencies() error {
+	dependencyChan := make(chan struct{})
+	waitErr := make(chan error, 1)
+
+	go func() {
+		for _, uri := range c.parsedURIs {
+			c.loggingClient.Infof("Waiting for: [%s] with timeout: [%s]", uri.String(), c.timeout.String())
+
+			switch uri.Scheme {
+			case "file":
+				c.waitForFile(uri)
+			case "tcp", "tcp4", "tcp6":
+				c.waitForSocket(uri.Scheme, uri.Host)
+			case "unix":
+				c.waitForSocket(uri.Scheme, uri.Path)
+			case "http", "https":
+				c.waitForHTTP(uri)
+			default:
+				waitErr <- fmt.Errorf("invalid host protocol provided: %s. supported protocols are: file, tcp, tcp4, "+
+					"tcp6, unix and http", uri.Scheme)
+				return
+			}
+		}
+
+		c.waitGroup.Wait()
+		close(dependencyChan)
+	}()
+
+	select {
+	case err := <-waitErr:
+		return err
+	case <-dependencyChan:
+		break
+	case <-time.After(c.timeout):
+		return fmt.Errorf("Timeout after %s waiting on dependencies to become available: %v", c.timeout, c.uris)
+	}
+
+	return nil
+}
+
+func (c *cmd) waitForFile(fileUri url.URL) {
+	c.waitGroup.Add(1)
+	go func(uri url.URL) {
+		defer c.waitGroup.Done()
+		ticker := time.NewTicker(c.retryInterval)
+		defer ticker.Stop()
+		var err error
+		for range ticker.C {
+			if _, err = os.Stat(uri.Path); err == nil {
+				c.loggingClient.Infof("File %s had been generated", uri.String())
+				return
+			} else if os.IsNotExist(err) {
+				// file not exists at this moment
+				c.loggingClient.Infof("Problem with check file %s exist: %v. Sleeping %s",
+					uri.String(), err, c.retryInterval)
+			} else {
+				// file may or may not exist: see err for details
+				c.loggingClient.Infof("Problem with check file %s exist: %v. Sleeping %s",
+					uri.String(), err, c.retryInterval)
+			}
+		}
+	}(fileUri)
+}
+
+func (c *cmd) waitForSocket(scheme, addr string) {
+	c.waitGroup.Add(1)
+	go func(schm, adr string) {
+		defer c.waitGroup.Done()
+		for {
+			conn, err := net.DialTimeout(schm, adr, c.timeout)
+			if err != nil {
+				c.loggingClient.Infof("Problem with dial: %v. Sleeping %s", err.Error(), c.retryInterval)
+				time.Sleep(c.retryInterval)
+			}
+
+			if conn != nil {
+				c.loggingClient.Infof("Connected to %s://%s", schm, adr)
+				return
+			}
+		}
+	}(scheme, addr)
+}
+
+func (c *cmd) waitForHTTP(uri url.URL) {
+	c.waitGroup.Add(1)
+	go func(httpURL url.URL) {
+		client := &http.Client{
+			Timeout: c.timeout,
+		}
+
+		defer c.waitGroup.Done()
+		for {
+			req, err := http.NewRequest(http.MethodGet, httpURL.String(), nil)
+			if err != nil {
+				c.loggingClient.Infof("Problem with dial: %v. Sleeping %s", err.Error(), c.retryInterval)
+				time.Sleep(c.retryInterval)
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				c.loggingClient.Infof("Problem with request: %s. Sleeping %s", err.Error(), c.retryInterval)
+				time.Sleep(c.retryInterval)
+			} else if err == nil && resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+				// dependency is treated as ok if http status code is between 200 and 300
+				c.loggingClient.Infof("Received %d from %s", resp.StatusCode, httpURL.String())
+				return
+			} else {
+				c.loggingClient.Infof("Received %d from %s. Sleeping %s", resp.StatusCode,
+					httpURL.String(), c.retryInterval)
+				time.Sleep(c.retryInterval)
+			}
+		}
+	}(uri)
+}

--- a/internal/security/bootstrapper/command/waitfor/command.go
+++ b/internal/security/bootstrapper/command/waitfor/command.go
@@ -188,7 +188,7 @@ func (c *cmd) waitForFile(fileUri url.URL) {
 				return
 			} else if os.IsNotExist(err) {
 				// file not exists at this moment
-				c.loggingClient.Infof("Problem with check file %s exist: %v. Sleeping %s",
+				c.loggingClient.Infof("File %s not exists: %v. Sleeping %s",
 					uri.String(), err, c.retryInterval)
 			} else {
 				// file may or may not exist: see err for details
@@ -231,6 +231,7 @@ func (c *cmd) waitForHTTP(uri url.URL) {
 			if err != nil {
 				c.loggingClient.Infof("Problem with dial: %v. Sleeping %s", err.Error(), c.retryInterval)
 				time.Sleep(c.retryInterval)
+				continue
 			}
 
 			resp, err := client.Do(req)

--- a/internal/security/bootstrapper/command/waitfor/command_test.go
+++ b/internal/security/bootstrapper/command/waitfor/command_test.go
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package waitfor
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/tcp"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+)
+
+func TestNewCommand(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	wg := &sync.WaitGroup{}
+	lc := logger.MockLogger{}
+	testDefaultTimeout := "10s"
+	testDefaultRetryInterval := "1s"
+
+	tests := []struct {
+		name          string
+		cmdArgs       []string
+		timeout       string
+		retryInterval string
+		expectedErr   bool
+	}{
+		{"Good: waitFor required at least one --uri option", []string{"--uri=http://localhost:11120"},
+			testDefaultTimeout, testDefaultRetryInterval, false},
+		{"Good: waitFor multiple --uri options", []string{"--uri=http://localhost:11120", "--uri=file:///testfile"},
+			testDefaultTimeout, testDefaultRetryInterval, false},
+		{"Good: waitFor --uri with --timeout options", []string{"--uri=http://:11120", "--timeout=1s"},
+			testDefaultTimeout, testDefaultRetryInterval, false},
+		{"Good: waitFor multiple --uri with --timeout options",
+			[]string{"--uri=http://:11120", "--uri=file:///testfile", "--timeout=1s"}, testDefaultTimeout,
+			testDefaultRetryInterval, false},
+		{"Good: waitFor --uri with --retryInterval options", []string{"--uri=http://:11120", "--retryInterval=5s"},
+			testDefaultTimeout, testDefaultRetryInterval, false},
+		{"Good: waitFor multiple --uri with --retryInterval options",
+			[]string{"--uri=http://:11120", "--uri=file:///testfile", "--retryInterval=5s"}, testDefaultTimeout,
+			testDefaultRetryInterval, false},
+		{"Good: waitFor --uri --timeout --retryInterval options",
+			[]string{"--uri=http://:11120", "--timeout=1s", "--retryInterval=5s"}, testDefaultTimeout,
+			testDefaultRetryInterval, false},
+		{"Bad: waitFor invalid option", []string{"--invalid=http://localhost:123"}, testDefaultTimeout,
+			testDefaultRetryInterval, true},
+		{"Bad: waitFor empty option", []string{""}, testDefaultTimeout, testDefaultRetryInterval, true},
+		{"Bad: waitFor interval option parse error", []string{"--uri=http://:11120", "--timeout=100"},
+			testDefaultTimeout, testDefaultRetryInterval, true},
+		{"Bad: waitFor bad syntax timeout config", []string{"--uri=http://localhost:11120"}, "10",
+			testDefaultRetryInterval, true},
+		{"Bad: waitFor bad syntax retryInterval config", []string{"--uri=http://localhost:11120"}, testDefaultTimeout,
+			"1", true},
+		{"Bad: waitFor negative value timeout config", []string{"--uri=http://localhost:11120"}, "-10s",
+			testDefaultRetryInterval, true},
+		{"Bad: waitFor negative value retryInterval config", []string{"--uri=http://localhost:11120"},
+			testDefaultTimeout, "-1m", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := getTestConfig(tt.timeout, tt.retryInterval)
+			command, err := NewCommand(ctx, wg, lc, config, tt.cmdArgs)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, command)
+			}
+		})
+	}
+}
+
+func TestExecute(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	wg := &sync.WaitGroup{}
+	lc := logger.MockLogger{}
+	config := getTestConfig("7s", "1s")
+
+	defaultWaitTimeout, err := time.ParseDuration(config.StageGate.WaitFor.Timeout)
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	testHost := "localhost"
+	testPort := 11122
+	testSrv := net.JoinHostPort(testHost, strconv.Itoa(testPort))
+
+	testFile := "command_test.go"
+	path, err := os.Getwd()
+
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	waitFile := filepath.Join(path, testFile)
+
+	testHttpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer testHttpSrv.Close()
+
+	tests := []struct {
+		name        string
+		cmdArgs     []string
+		testTimeout time.Duration
+		expectedErr bool
+	}{
+		{"Good: waitFor with existing tcp server", []string{"--uri=tcp://" + testSrv}, defaultWaitTimeout, false},
+		{"Good: waitFor with existing tcp server with timeout", []string{"--uri=tcp://" + testSrv, "--timeout=5s"},
+			time.Duration(5 * time.Second), false},
+		{"Good: waitFor with existing tcp server with retryInterval", []string{"--uri=tcp://" + testSrv, "--retryInterval=2s"},
+			time.Duration(6 * time.Second), false},
+		{"Good: waitFor with existing testFile",
+			[]string{"--uri=file://" + waitFile}, defaultWaitTimeout, false},
+		{"Good: waitFor with existing tcp server and testFile",
+			[]string{"--uri=tcp://" + testSrv, "--uri=file://" + waitFile}, defaultWaitTimeout, false},
+		{"Good: waitFor with existing tcp server and testFile and timeout",
+			[]string{"--uri=tcp://" + testSrv, "--uri=file://" + waitFile, "--timeout=5s"}, defaultWaitTimeout, false},
+		{"Good: waitFor with existing tcp server and testFile and retryInterval",
+			[]string{"--uri=tcp://" + testSrv, "--uri=file://" + waitFile, "--retryInterval=2s"}, defaultWaitTimeout, false},
+		{"Good: waitFor with existing http server", []string{"--uri=" + testHttpSrv.URL}, defaultWaitTimeout, false},
+		{"Bad: waitFor with malformed URL", []string{"--uri=_http!@xxxxxx:1111"}, time.Duration(2 * time.Second), true},
+		{"Bad: waitFor with no tcp server response", []string{"--uri=tcp://non-existing:1111", "--timeout=3s"},
+			time.Duration(3 * time.Second), true},
+		{"Bad: waitFor with no http server response", []string{"--uri=http://non-existing:1111", "--timeout=3s"},
+			time.Duration(3 * time.Second), true},
+		{"Bad: waitFor with no file", []string{"--uri=file://non-existing-file", "--timeout=3s"},
+			time.Duration(3 * time.Second), true},
+		{"Bad: waitFor with unsupported protocol", []string{"--uri=chrome://settings", "--timeout=3s"},
+			time.Duration(3 * time.Second), true},
+	}
+
+	type execRet struct {
+		statusCode int
+		execErr    error
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			waitFor, err := NewCommand(ctx, wg, lc, config, tt.cmdArgs)
+			require.NoError(t, err)
+			require.NotNil(t, waitFor)
+			require.Equal(t, "waitFor", waitFor.GetCommandName())
+
+			ret := make(chan execRet, 1)
+			go func() {
+				code, err := waitFor.Execute()
+				ret <- execRet{statusCode: code, execErr: err}
+			}()
+
+			// literally make random delay between 0 to 3 seconds before running the tcp server
+			time.Sleep(time.Duration(rand.Intn(3)) * time.Second)
+
+			tcpSrvErr := make(chan error, 1)
+			go func() {
+				tcpSrvErr <- tcp.NewTcpServer().StartListener(testPort,
+					lc, testHost)
+			}()
+
+			select {
+			case res := <-ret:
+				if tt.expectedErr {
+					require.Error(t, res.execErr)
+					require.Equal(t, interfaces.StatusCodeExitWithError, res.statusCode)
+				} else {
+					require.NoError(t, res.execErr)
+					require.Equal(t, interfaces.StatusCodeExitNormal, res.statusCode)
+				}
+			case <-time.After(tt.testTimeout + time.Second):
+				require.Fail(t, "waitFor failed to get response after test timeout")
+			}
+		})
+	}
+}
+
+func getTestConfig(timeout, retryInterval string) *config.ConfigurationStruct {
+	return &config.ConfigurationStruct{
+		StageGate: config.StageGateInfo{
+			WaitFor: config.WaitForInfo{
+				Timeout:       timeout,
+				RetryInterval: retryInterval,
+			},
+		},
+	}
+}

--- a/internal/security/bootstrapper/command/waitfor/uri_flags.go
+++ b/internal/security/bootstrapper/command/waitfor/uri_flags.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Intel Corp.
+ * Copyright 2021 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,24 +10,20 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  *******************************************************************************/
 
-package main
+package waitfor
 
-import (
-	"context"
-	"os"
+import "fmt"
 
-	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper"
-	"github.com/gorilla/mux"
-)
+type uriFlagsVar []string
 
-func main() {
-	// When running security-bootstrapper's subcommands, we don't want the side effect of
-	// the env var. EDGEX_PROFILE overriding so that unset the env can avoid the TOML's resource
-	// directory path of the security-bootstrapper itself being modified.
-	_ = os.Unsetenv("EDGEX_PROFILE")
+func (uris *uriFlagsVar) String() string {
+	return fmt.Sprint(*uris)
+}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	bootstrapper.Main(ctx, cancel, mux.NewRouter(), nil)
+func (uris *uriFlagsVar) Set(value string) error {
+	*uris = append(*uris, value)
+	return nil
 }

--- a/internal/security/bootstrapper/command/waitfor/uri_flags.go
+++ b/internal/security/bootstrapper/command/waitfor/uri_flags.go
@@ -19,10 +19,13 @@ import "fmt"
 
 type uriFlagsVar []string
 
+// String overrides the Flag.Value interface, method String() string
 func (uris *uriFlagsVar) String() string {
 	return fmt.Sprint(*uris)
 }
 
+// Set overrides the Flag.Value interface, method Set(string) error
+// uriFlagsVar is a slice of string flags and thus we aggregate it over each flag call
 func (uris *uriFlagsVar) Set(value string) error {
 	*uris = append(*uris, value)
 	return nil

--- a/internal/security/bootstrapper/config/types.go
+++ b/internal/security/bootstrapper/config/types.go
@@ -77,4 +77,5 @@ type StageGateInfo struct {
 	Database         DatabaseInfo
 	Registry         RegistryInfo
 	KongDB           KongDBInfo
+	WaitFor          WaitForInfo
 }

--- a/internal/security/bootstrapper/config/waitFor.go
+++ b/internal/security/bootstrapper/config/waitFor.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Intel Corp.
+ * Copyright 2021 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -10,24 +10,14 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  *******************************************************************************/
 
-package main
+package config
 
-import (
-	"context"
-	"os"
-
-	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper"
-	"github.com/gorilla/mux"
-)
-
-func main() {
-	// When running security-bootstrapper's subcommands, we don't want the side effect of
-	// the env var. EDGEX_PROFILE overriding so that unset the env can avoid the TOML's resource
-	// directory path of the security-bootstrapper itself being modified.
-	_ = os.Unsetenv("EDGEX_PROFILE")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	bootstrapper.Main(ctx, cancel, mux.NewRouter(), nil)
+// WaitForInfo defines some fields related to
+// waitFor subcommand of security-bootstrapper
+type WaitForInfo struct {
+	Timeout       string
+	RetryInterval string
 }


### PR DESCRIPTION
- New subcommand **waitFor** is added and it replaces the functionality of the former `dockerize`
- Add waitForInfo for the toml configuration (`Timeout` and `RetryInterval`)
- Building related to `dockerize` in Dockerfile is removed

Fixes: #3100

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently we are using `dockerize` 3rd party lib to do the waiting for other services.

## Issue Number:  #3100 


## What is the new behavior?
Replacing the `dockerize` with internal implemented `waitFor` as part of `security-bootstrapper` subcommand.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
After this merged, need to update the `developer-script` compose files to include newly added env var. overrides used in `waitFor`.
Update PR created: https://github.com/edgexfoundry/developer-scripts/pull/399   