### PR TITLE
fix(snap): fix redis snapshots

### DIFF
--- a/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
+++ b/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
@@ -11,7 +11,7 @@ diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
 index 4f322fc4..a1dfb449 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
-@@ -75,58 +75,6 @@ confinement: strict
+@@ -75,60 +75,6 @@ confinement: strict
  environment:
    SecretStore_RootCaCertPath: $SNAP_DATA/secrets/ca/ca.pem
  apps:
@@ -24,9 +24,11 @@ index 4f322fc4..a1dfb449 100644
 -  redis:
 -    adapter: full
 -    after: [security-secretstore-setup]
--    command: bin/redis-server --dir $SNAP_DATA/redis $REDIS_SAVE_OPTS
+-    command: bin/redis-server $DIR_OPT $SAVE_OPT1 $SAVE_OPT2
 -    environment:
--      REDIS_SAVE_OPTS: "--save 900 1 --save 300 10"
+-      DIR_OPT: "--dir $SNAP_DATA/redis"
+-      SAVE_OPT1: "--save 900 1"
+-      SAVE_OPT2: "--save 300 10"
 -    daemon: simple
 -    plugs: [network, network-bind]
 -  postgres:

--- a/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
+++ b/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
@@ -358,8 +358,8 @@ index 4f322fc4..a1dfb449 100644
 -      - zip
 -
 -  redis:
--    source: https://github.com/antirez/redis.git
--    source-tag: "6.0.8"
+-    source: https://github.com/redis/redis.git
+-    source-tag: "6.0.9"
 -    source-depth: 1
 -    plugin: make
 -    make-install-var: PREFIX

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -84,9 +84,11 @@ apps:
   redis:
     adapter: full
     after: [security-secretstore-setup]
-    command: bin/redis-server --dir $SNAP_DATA/redis $REDIS_SAVE_OPTS
+    command: bin/redis-server $DIR_OPT $SAVE_OPT1 $SAVE_OPT2
     environment:
-      REDIS_SAVE_OPTS: "--save 900 1 --save 300 10"
+      DIR_OPT: "--dir $SNAP_DATA/redis"
+      SAVE_OPT1: "--save 900 1"
+      SAVE_OPT2: "--save 300 10"
     daemon: simple
     plugs: [network, network-bind]
   postgres:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -593,8 +593,8 @@ parts:
       - zip
 
   redis:
-    source: https://github.com/antirez/redis.git
-    source-tag: "6.0.8"
+    source: https://github.com/redis/redis.git
+    source-tag: "6.0.9"
     source-depth: 1
     plugin: make
     make-install-var: PREFIX


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
The edgexfoundry snap doesn't properly generate redis persistence snapshots.

## Issue Number: 2876

## What is the new behavior?
Snapshots are properly generated.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions

## Other information
This fix has already been applied to master. Also as part of this PR, the snap is also updated to use the latest maintenance release of Redis (6.0.10).