### PR TITLE
fix: Support Scheduler V1 DB credentials not used due to V2 DB Handler side effect

### DIFF
--- a/internal/support/scheduler/main.go
+++ b/internal/support/scheduler/main.go
@@ -72,8 +72,8 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router, re
 		dic,
 		[]interfaces.BootstrapHandler{
 			handlers.SecureProviderBootstrapHandler,
-			v2Handlers.NewDatabase(httpServer, configuration, v2SchedulerContainer.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
 			database.NewDatabase(httpServer, configuration).BootstrapHandler,
+			v2Handlers.NewDatabase(httpServer, configuration, v2SchedulerContainer.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
 			NewBootstrap(router).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Support scheduler unable to access DB due to no credentials

## Issue Number: #3105


## What is the new behavior?
Support scheduler now able access DB

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information