### PR TITLE
feat(notifications): Implement GET /subscription/all V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -697,3 +697,17 @@ func (c *Client) AddSubscription(subscription model.Subscription) (model.Subscri
 
 	return addSubscription(conn, subscription)
 }
+
+// AllSubscriptions returns multiple subscriptions per query criteria, including
+// offset: The number of items to skip before starting to collect the result set.
+// limit: The maximum number of items to return.
+func (c *Client) AllSubscriptions(offset int, limit int) ([]model.Subscription, errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	subscriptions, edgeXerr := allSubscriptions(conn, offset, limit)
+	if edgeXerr != nil {
+		return subscriptions, errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+	return subscriptions, nil
+}

--- a/internal/support/notifications/v2/application/subscription.go
+++ b/internal/support/notifications/v2/application/subscription.go
@@ -15,6 +15,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 )
 
@@ -34,4 +35,18 @@ func AddSubscription(d models.Subscription, ctx context.Context, dic *di.Contain
 		correlation.FromContext(ctx))
 
 	return addedSubscription.Id, nil
+}
+
+// AllSubscriptions queries subscriptions by offset and limit
+func AllSubscriptions(offset, limit int, dic *di.Container) (subscriptions []dtos.Subscription, err errors.EdgeX) {
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+	subs, err := dbClient.AllSubscriptions(offset, limit)
+	if err != nil {
+		return subscriptions, errors.NewCommonEdgeXWrapper(err)
+	}
+	subscriptions = make([]dtos.Subscription, len(subs))
+	for i, sub := range subs {
+		subscriptions[i] = dtos.FromSubscriptionModelToDTO(sub)
+	}
+	return subscriptions, nil
 }

--- a/internal/support/notifications/v2/controller/http/subscription.go
+++ b/internal/support/notifications/v2/controller/http/subscription.go
@@ -6,11 +6,13 @@
 package http
 
 import (
+	"math"
 	"net/http"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/v2/utils"
+	notificationContainer "github.com/edgexfoundry/edgex-go/internal/support/notifications/container"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications/v2/application"
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications/v2/io"
 
@@ -18,8 +20,10 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
 	requestDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
+	responseDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
 )
 
 type SubscriptionController struct {
@@ -83,4 +87,39 @@ func (sc *SubscriptionController) AddSubscription(w http.ResponseWriter, r *http
 
 	utils.WriteHttpHeader(w, ctx, http.StatusMultiStatus)
 	pkg.Encode(addResponses, w, lc)
+}
+
+func (sc *SubscriptionController) AllSubscriptions(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(sc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+	config := notificationContainer.ConfigurationFrom(sc.dic.Get)
+
+	var response interface{}
+	var statusCode int
+
+	// parse URL query string for offset and limit
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxUint32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		subscriptions, err := application.AllSubscriptions(offset, limit, sc.dic)
+		if err != nil {
+			if errors.Kind(err) != errors.KindEntityDoesNotExist {
+				lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			}
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+			statusCode = err.Code()
+		} else {
+			response = responseDTO.NewMultiSubscriptionsResponse("", "", http.StatusOK, subscriptions)
+			statusCode = http.StatusOK
+		}
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
 }

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -14,4 +14,5 @@ type DBClient interface {
 	CloseSession()
 
 	AddSubscription(e models.Subscription) (models.Subscription, errors.EdgeX)
+	AllSubscriptions(offset int, limit int) ([]models.Subscription, errors.EdgeX)
 }

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -38,6 +38,31 @@ func (_m *DBClient) AddSubscription(e models.Subscription) (models.Subscription,
 	return r0, r1
 }
 
+// AllSubscriptions provides a mock function with given fields: offset, limit
+func (_m *DBClient) AllSubscriptions(offset int, limit int) ([]models.Subscription, errors.EdgeX) {
+	ret := _m.Called(offset, limit)
+
+	var r0 []models.Subscription
+	if rf, ok := ret.Get(0).(func(int, int) []models.Subscription); ok {
+		r0 = rf(offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Subscription)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int) errors.EdgeX); ok {
+		r1 = rf(offset, limit)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // CloseSession provides a mock function with given fields:
 func (_m *DBClient) CloseSession() {
 	_m.Called()

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -28,4 +28,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	// Subscription
 	nc := notificationsController.NewSubscriptionController(dic)
 	r.HandleFunc(v2Constant.ApiSubscriptionRoute, nc.AddSubscription).Methods(http.MethodPost)
+	r.HandleFunc(v2Constant.ApiAllSubscriptionRoute, nc.AllSubscriptions).Methods(http.MethodGet)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## Issue Number: #3106 

## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/get_subscription_all, implemented GET /subscription/all V2 API.

Close #3106 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

