### PR TITLE
feat(notifications): Implement GET /subscription/receiver/{receiver} V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -737,3 +737,16 @@ func (c *Client) SubscriptionsByLabel(offset int, limit int, label string) (subs
 	}
 	return subscriptions, nil
 }
+
+// SubscriptionsByReceiver queries subscriptions by offset, limit and receiver
+func (c *Client) SubscriptionsByReceiver(offset int, limit int, receiver string) (subscriptions []model.Subscription, edgeXerr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	subscriptions, edgeXerr = subscriptionsByReceiver(conn, offset, limit, receiver)
+	if edgeXerr != nil {
+		return subscriptions, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
+			fmt.Sprintf("fail to query subscriptions by offset %d, limit %d and receiver %s", offset, limit, receiver), edgeXerr)
+	}
+	return subscriptions, nil
+}

--- a/internal/pkg/v2/infrastructure/redis/subscription.go
+++ b/internal/pkg/v2/infrastructure/redis/subscription.go
@@ -129,6 +129,20 @@ func subscriptionsByLabel(conn redis.Conn, offset int, limit int, label string) 
 	return convertObjectsToSubscriptions(objects)
 }
 
+// subscriptionsByReceiver queries subscriptions by offset, limit, and receiver
+func subscriptionsByReceiver(conn redis.Conn, offset int, limit int, receiver string) (subscriptions []models.Subscription, edgeXerr errors.EdgeX) {
+	end := offset + limit - 1
+	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
+		end = limit
+	}
+	objects, err := getObjectsByRevRange(conn, CreateKey(SubscriptionCollectionReceiver, receiver), offset, end)
+	if err != nil {
+		return subscriptions, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return convertObjectsToSubscriptions(objects)
+}
+
 func convertObjectsToSubscriptions(objects [][]byte) (subscriptions []models.Subscription, edgeXerr errors.EdgeX) {
 	subscriptions = make([]models.Subscription, len(objects))
 	for i, o := range objects {

--- a/internal/support/notifications/v2/application/subscription.go
+++ b/internal/support/notifications/v2/application/subscription.go
@@ -84,3 +84,20 @@ func SubscriptionsByLabel(offset, limit int, label string, dic *di.Container) (s
 	}
 	return subscriptions, nil
 }
+
+// SubscriptionsByReceiver queries subscriptions with offset, limit, and receiver
+func SubscriptionsByReceiver(offset, limit int, receiver string, dic *di.Container) (subscriptions []dtos.Subscription, err errors.EdgeX) {
+	if receiver == "" {
+		return subscriptions, errors.NewCommonEdgeX(errors.KindContractInvalid, "receiver is empty", nil)
+	}
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+	subscriptionModels, err := dbClient.SubscriptionsByReceiver(offset, limit, receiver)
+	if err != nil {
+		return subscriptions, errors.NewCommonEdgeXWrapper(err)
+	}
+	subscriptions = make([]dtos.Subscription, len(subscriptionModels))
+	for i, s := range subscriptionModels {
+		subscriptions[i] = dtos.FromSubscriptionModelToDTO(s)
+	}
+	return subscriptions, nil
+}

--- a/internal/support/notifications/v2/controller/http/subscription.go
+++ b/internal/support/notifications/v2/controller/http/subscription.go
@@ -202,3 +202,41 @@ func (sc *SubscriptionController) SubscriptionsByLabel(w http.ResponseWriter, r 
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc)
 }
+
+func (sc *SubscriptionController) SubscriptionsByReceiver(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(sc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+	config := notificationContainer.ConfigurationFrom(sc.dic.Get)
+
+	vars := mux.Vars(r)
+	receiver := vars[v2.Receiver]
+
+	var response interface{}
+	var statusCode int
+
+	// parse URL query string for offset, limit
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		subscriptions, err := application.SubscriptionsByReceiver(offset, limit, receiver, sc.dic)
+		if err != nil {
+			if errors.Kind(err) != errors.KindEntityDoesNotExist {
+				lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			}
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+			statusCode = err.Code()
+		} else {
+			response = responseDTO.NewMultiSubscriptionsResponse("", "", http.StatusOK, subscriptions)
+			statusCode = http.StatusOK
+		}
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}

--- a/internal/support/notifications/v2/controller/http/subscription_test.go
+++ b/internal/support/notifications/v2/controller/http/subscription_test.go
@@ -406,3 +406,71 @@ func TestSubscriptionsByLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestSubscriptionsByReceiver(t *testing.T) {
+	testReceiver := "receiver"
+	dic := mockDic()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("SubscriptionsByReceiver", 0, 20, testReceiver).Return([]models.Subscription{}, nil)
+	dbClientMock.On("SubscriptionsByReceiver", 0, 1, testReceiver).Return([]models.Subscription{}, nil)
+	dic.Update(di.ServiceConstructorMap{
+		v2NotificationsContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	controller := NewSubscriptionController(dic)
+	require.NotNil(t, controller)
+
+	tests := []struct {
+		name               string
+		offset             string
+		limit              string
+		receiver           string
+		errorExpected      bool
+		expectedStatusCode int
+	}{
+		{"Valid - get subscriptions without offset, and limit", "", "", testReceiver, false, http.StatusOK},
+		{"Valid - get subscriptions with offset, and limit", "0", "1", testReceiver, false, http.StatusOK},
+		{"Invalid - invalid offset format", "aaa", "1", testReceiver, true, http.StatusBadRequest},
+		{"Invalid - invalid limit format", "1", "aaa", testReceiver, true, http.StatusBadRequest},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, v2.ApiSubscriptionByReceiverRoute, http.NoBody)
+			query := req.URL.Query()
+			if testCase.offset != "" {
+				query.Add(v2.Offset, testCase.offset)
+			}
+			if testCase.limit != "" {
+				query.Add(v2.Limit, testCase.limit)
+			}
+			req.URL.RawQuery = query.Encode()
+			req = mux.SetURLVars(req, map[string]string{v2.Receiver: testCase.receiver})
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(controller.SubscriptionsByReceiver)
+			handler.ServeHTTP(recorder, req)
+
+			// Assert
+			if testCase.errorExpected {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res responseDTO.MultiSubscriptionsResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -17,4 +17,5 @@ type DBClient interface {
 	AllSubscriptions(offset int, limit int) ([]models.Subscription, errors.EdgeX)
 	SubscriptionsByCategory(offset, limit int, category string) ([]models.Subscription, errors.EdgeX)
 	SubscriptionsByLabel(offset, limit int, label string) ([]models.Subscription, errors.EdgeX)
+	SubscriptionsByReceiver(offset, limit int, receiver string) ([]models.Subscription, errors.EdgeX)
 }

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -117,3 +117,28 @@ func (_m *DBClient) SubscriptionsByLabel(offset int, limit int, label string) ([
 
 	return r0, r1
 }
+
+// SubscriptionsByReceiver provides a mock function with given fields: offset, limit, receiver
+func (_m *DBClient) SubscriptionsByReceiver(offset int, limit int, receiver string) ([]models.Subscription, errors.EdgeX) {
+	ret := _m.Called(offset, limit, receiver)
+
+	var r0 []models.Subscription
+	if rf, ok := ret.Get(0).(func(int, int, string) []models.Subscription); ok {
+		r0 = rf(offset, limit, receiver)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Subscription)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, receiver)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -31,4 +31,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiAllSubscriptionRoute, nc.AllSubscriptions).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiSubscriptionByCategoryRoute, nc.SubscriptionsByCategory).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiSubscriptionByLabelRoute, nc.SubscriptionsByLabel).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiSubscriptionByReceiverRoute, nc.SubscriptionsByReceiver).Methods(http.MethodGet)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3129 


## What is the new behavior?
Per [https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/get_subscription_receiver__receiver_](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/get_subscription_receiver__receiver_), implemented GET /subscription/receiver/{receiver} V2 API.

Close #3129

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No
