### PR TITLE
refactor(meta): Rename PropertyValue's Type field to ValueType

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.7
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.1
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.22
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.23
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.1
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.1
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.3

--- a/internal/core/metadata/v2/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/v2/controller/http/deviceprofile_test.go
@@ -51,7 +51,7 @@ func buildTestDeviceProfileRequest() requests.DeviceProfileRequest {
 		Tag:         TestTag,
 		Attributes:  testAttributes,
 		Properties: dtos.PropertyValue{
-			Type:      contractsV2.ValueTypeInt16,
+			ValueType: contractsV2.ValueTypeInt16,
 			ReadWrite: "RW",
 		},
 	}}
@@ -209,7 +209,7 @@ func TestAddDeviceProfile_BadRequest(t *testing.T) {
 		Tag:         TestTag,
 		Attributes:  testAttributes,
 		Properties: dtos.PropertyValue{
-			Type:      "INT16",
+			ValueType: "INT16",
 			ReadWrite: "RW",
 		},
 	}}
@@ -352,7 +352,7 @@ func TestUpdateDeviceProfile(t *testing.T) {
 		Tag:         TestTag,
 		Attributes:  testAttributes,
 		Properties: dtos.PropertyValue{
-			Type:      "INT16",
+			ValueType: "INT16",
 			ReadWrite: "RW",
 		},
 	}}
@@ -511,7 +511,7 @@ func TestAddDeviceProfileByYaml_BadRequest(t *testing.T) {
 		Tag:         TestTag,
 		Attributes:  testAttributes,
 		Properties: dtos.PropertyValue{
-			Type:      "INT16",
+			ValueType: "INT16",
 			ReadWrite: "RW",
 		},
 	}}
@@ -657,7 +657,7 @@ func TestUpdateDeviceProfileByYaml(t *testing.T) {
 		Tag:         TestTag,
 		Attributes:  testAttributes,
 		Properties: dtos.PropertyValue{
-			Type:      "INT16",
+			ValueType: "INT16",
 			ReadWrite: "RW",
 		},
 	}}

--- a/internal/core/metadata/v2/io/deviceprofile.go
+++ b/internal/core/metadata/v2/io/deviceprofile.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 	dto "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
 )
@@ -69,10 +68,6 @@ func (jsonDeviceProfileReader) ReadDeviceProfileYaml(r *http.Request) (dtos.Devi
 	err = yaml.Unmarshal(data, &dp)
 	if err != nil {
 		return dtos.DeviceProfile{}, errors.NewCommonEdgeX(errors.KindContractInvalid, "fail to unmarshal yaml file", err)
-	}
-	err = v2.Validate(dp)
-	if err != nil {
-		return dtos.DeviceProfile{}, errors.NewCommonEdgeXWrapper(err)
 	}
 
 	return dp, nil

--- a/openapi/v2/core-metadata.yaml
+++ b/openapi/v2/core-metadata.yaml
@@ -777,7 +777,7 @@ components:
       description: "Defines constraints with regard to the range of acceptable values assigned to an event reading and defined as a property within a device profile."
       type: object
       properties:
-        type:
+        valueType:
           type: string
           description: "ValueDescriptor Type of property after transformations. Optional: uint8, uint16, uint32, uint64, int8, int16, int32, int64, float32, float64, bool, string, binary, uint8array, uint16array, uint32array, uint64array, int8array, int16array, int32array, int64array, float32array, float64array, boolarray."
         readWrite:
@@ -1108,7 +1108,7 @@ components:
               - name: "SwitchButton"
                 description: "Switch On/Off."
                 properties:
-                  type: "String"
+                  valueType: "String"
                   readWrite: "RW"
                   defaultValue: "On"
                   units: "On/Off"


### PR DESCRIPTION
Close #3137

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3137 


## What is the new behavior?
Rename PropertyValue's Type field to ValueType and remove the redundant Validate invoke

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information