### PR TITLE
feat(notifications): Implement GET /subscription/name{name} V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -750,3 +750,16 @@ func (c *Client) SubscriptionsByReceiver(offset int, limit int, receiver string)
 	}
 	return subscriptions, nil
 }
+
+// SubscriptionByName queries subscription by name
+func (c *Client) SubscriptionByName(name string) (subscription model.Subscription, edgeXerr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	subscription, edgeXerr = subscriptionByName(conn, name)
+	if edgeXerr != nil {
+		return subscription, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
+			fmt.Sprintf("fail to query subscription by name %s", name), edgeXerr)
+	}
+	return subscription, nil
+}

--- a/internal/pkg/v2/infrastructure/redis/subscription.go
+++ b/internal/pkg/v2/infrastructure/redis/subscription.go
@@ -101,6 +101,15 @@ func allSubscriptions(conn redis.Conn, offset, limit int) (subscriptions []model
 	return subscriptions, nil
 }
 
+// subscriptionByName queries subscription by name
+func subscriptionByName(conn redis.Conn, name string) (subscription models.Subscription, edgeXerr errors.EdgeX) {
+	edgeXerr = getObjectByHash(conn, SubscriptionCollectionName, name, &subscription)
+	if edgeXerr != nil {
+		return subscription, errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+	return
+}
+
 // subscriptionsByCategory queries subscriptions by offset, limit, and category
 func subscriptionsByCategory(conn redis.Conn, offset int, limit int, category string) (subscriptions []models.Subscription, edgeXerr errors.EdgeX) {
 	end := offset + limit - 1

--- a/internal/support/notifications/v2/application/subscription.go
+++ b/internal/support/notifications/v2/application/subscription.go
@@ -51,6 +51,20 @@ func AllSubscriptions(offset, limit int, dic *di.Container) (subscriptions []dto
 	return subscriptions, nil
 }
 
+// SubscriptionByName queries subscription by name
+func SubscriptionByName(name string, dic *di.Container) (subscription dtos.Subscription, err errors.EdgeX) {
+	if name == "" {
+		return subscription, errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
+	}
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+	subscriptionModel, err := dbClient.SubscriptionByName(name)
+	if err != nil {
+		return subscription, errors.NewCommonEdgeXWrapper(err)
+	}
+	subscription = dtos.FromSubscriptionModelToDTO(subscriptionModel)
+	return subscription, nil
+}
+
 // SubscriptionsByCategory queries subscriptions with offset, limit, and category
 func SubscriptionsByCategory(offset, limit int, category string, dic *di.Container) (subscriptions []dtos.Subscription, err errors.EdgeX) {
 	if category == "" {

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -15,6 +15,7 @@ type DBClient interface {
 
 	AddSubscription(e models.Subscription) (models.Subscription, errors.EdgeX)
 	AllSubscriptions(offset int, limit int) ([]models.Subscription, errors.EdgeX)
+	SubscriptionByName(name string) (models.Subscription, errors.EdgeX)
 	SubscriptionsByCategory(offset, limit int, category string) ([]models.Subscription, errors.EdgeX)
 	SubscriptionsByLabel(offset, limit int, label string) ([]models.Subscription, errors.EdgeX)
 	SubscriptionsByReceiver(offset, limit int, receiver string) ([]models.Subscription, errors.EdgeX)

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -68,6 +68,29 @@ func (_m *DBClient) CloseSession() {
 	_m.Called()
 }
 
+// SubscriptionByName provides a mock function with given fields: name
+func (_m *DBClient) SubscriptionByName(name string) (models.Subscription, errors.EdgeX) {
+	ret := _m.Called(name)
+
+	var r0 models.Subscription
+	if rf, ok := ret.Get(0).(func(string) models.Subscription); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Get(0).(models.Subscription)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(string) errors.EdgeX); ok {
+		r1 = rf(name)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // SubscriptionsByCategory provides a mock function with given fields: offset, limit, category
 func (_m *DBClient) SubscriptionsByCategory(offset int, limit int, category string) ([]models.Subscription, errors.EdgeX) {
 	ret := _m.Called(offset, limit, category)

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -29,6 +29,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	nc := notificationsController.NewSubscriptionController(dic)
 	r.HandleFunc(v2Constant.ApiSubscriptionRoute, nc.AddSubscription).Methods(http.MethodPost)
 	r.HandleFunc(v2Constant.ApiAllSubscriptionRoute, nc.AllSubscriptions).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiSubscriptionByNameRoute, nc.SubscriptionByName).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiSubscriptionByCategoryRoute, nc.SubscriptionsByCategory).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiSubscriptionByLabelRoute, nc.SubscriptionsByLabel).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiSubscriptionByReceiverRoute, nc.SubscriptionsByReceiver).Methods(http.MethodGet)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## Issue Number: #3135


## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/get_subscription_name__name_, implemented GET /subscription/name{name} V2 API.

Close #3135 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No