### PR TITLE
feat(notifications): Implement DELETE /subscription/name/{name} V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -763,3 +763,16 @@ func (c *Client) SubscriptionByName(name string) (subscription model.Subscriptio
 	}
 	return subscription, nil
 }
+
+// DeleteSubscriptionByName deletes a subscription by name
+func (c *Client) DeleteSubscriptionByName(name string) errors.EdgeX {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	edgeXerr := deleteSubscriptionByName(conn, name)
+	if edgeXerr != nil {
+		return errors.NewCommonEdgeX(errors.Kind(edgeXerr), fmt.Sprintf("fail to delete the subscription with name %s", name), edgeXerr)
+	}
+
+	return nil
+}

--- a/internal/support/notifications/v2/application/subscription.go
+++ b/internal/support/notifications/v2/application/subscription.go
@@ -115,3 +115,16 @@ func SubscriptionsByReceiver(offset, limit int, receiver string, dic *di.Contain
 	}
 	return subscriptions, nil
 }
+
+// DeleteSubscriptionByName deletes the subscription by name
+func DeleteSubscriptionByName(name string, ctx context.Context, dic *di.Container) errors.EdgeX {
+	if name == "" {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
+	}
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+	err := dbClient.DeleteSubscriptionByName(name)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}

--- a/internal/support/notifications/v2/controller/http/subscription.go
+++ b/internal/support/notifications/v2/controller/http/subscription.go
@@ -269,3 +269,30 @@ func (sc *SubscriptionController) SubscriptionsByReceiver(w http.ResponseWriter,
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc)
 }
+
+func (sc *SubscriptionController) DeleteSubscriptionByName(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(sc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	// URL parameters
+	vars := mux.Vars(r)
+	name := vars[v2.Name]
+
+	var response interface{}
+	var statusCode int
+
+	err := application.DeleteSubscriptionByName(name, ctx, sc.dic)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		response = commonDTO.NewBaseResponse("", "", http.StatusNoContent)
+		statusCode = http.StatusNoContent
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -19,4 +19,5 @@ type DBClient interface {
 	SubscriptionsByCategory(offset, limit int, category string) ([]models.Subscription, errors.EdgeX)
 	SubscriptionsByLabel(offset, limit int, label string) ([]models.Subscription, errors.EdgeX)
 	SubscriptionsByReceiver(offset, limit int, receiver string) ([]models.Subscription, errors.EdgeX)
+	DeleteSubscriptionByName(name string) errors.EdgeX
 }

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -68,6 +68,22 @@ func (_m *DBClient) CloseSession() {
 	_m.Called()
 }
 
+// DeleteSubscriptionByName provides a mock function with given fields: name
+func (_m *DBClient) DeleteSubscriptionByName(name string) errors.EdgeX {
+	ret := _m.Called(name)
+
+	var r0 errors.EdgeX
+	if rf, ok := ret.Get(0).(func(string) errors.EdgeX); ok {
+		r0 = rf(name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(errors.EdgeX)
+		}
+	}
+
+	return r0
+}
+
 // SubscriptionByName provides a mock function with given fields: name
 func (_m *DBClient) SubscriptionByName(name string) (models.Subscription, errors.EdgeX) {
 	ret := _m.Called(name)

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -33,4 +33,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiSubscriptionByCategoryRoute, nc.SubscriptionsByCategory).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiSubscriptionByLabelRoute, nc.SubscriptionsByLabel).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiSubscriptionByReceiverRoute, nc.SubscriptionsByReceiver).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiSubscriptionByNameRoute, nc.DeleteSubscriptionByName).Methods(http.MethodDelete)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## Issue Number: #3140 


## What is the new behavior?
Per [https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/delete_subscription_name__name_](https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/delete_subscription_name__name_), implemented DELETE /subscription/name/{name} V2 API.

Close #3140

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions

Putting this PR on hold/draft until after PR #3139 is merged.