### PR TITLE
feat(notifications): Implement PATCH /subscription V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -751,6 +751,19 @@ func (c *Client) SubscriptionsByReceiver(offset int, limit int, receiver string)
 	return subscriptions, nil
 }
 
+// SubscriptionById gets a subscription by id
+func (c *Client) SubscriptionById(id string) (subscription model.Subscription, edgexErr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	subscription, edgexErr = subscriptionById(conn, id)
+	if edgexErr != nil {
+		return subscription, errors.NewCommonEdgeX(errors.Kind(edgexErr), fmt.Sprintf("failed to query subscription by id %s", id), edgexErr)
+	}
+
+	return
+}
+
 // SubscriptionByName queries subscription by name
 func (c *Client) SubscriptionByName(name string) (subscription model.Subscription, edgeXerr errors.EdgeX) {
 	conn := c.Pool.Get()

--- a/internal/pkg/v2/infrastructure/redis/subscription.go
+++ b/internal/pkg/v2/infrastructure/redis/subscription.go
@@ -101,6 +101,16 @@ func allSubscriptions(conn redis.Conn, offset, limit int) (subscriptions []model
 	return subscriptions, nil
 }
 
+// subscriptionById query subscription by id from DB
+func subscriptionById(conn redis.Conn, id string) (subscription models.Subscription, edgexErr errors.EdgeX) {
+	edgexErr = getObjectById(conn, subscriptionStoredKey(id), &subscription)
+	if edgexErr != nil {
+		return subscription, errors.NewCommonEdgeXWrapper(edgexErr)
+	}
+
+	return
+}
+
 // subscriptionByName queries subscription by name
 func subscriptionByName(conn redis.Conn, name string) (subscription models.Subscription, edgeXerr errors.EdgeX) {
 	edgeXerr = getObjectByHash(conn, SubscriptionCollectionName, name, &subscription)

--- a/internal/support/notifications/v2/controller/http/subscription.go
+++ b/internal/support/notifications/v2/controller/http/subscription.go
@@ -296,3 +296,51 @@ func (sc *SubscriptionController) DeleteSubscriptionByName(w http.ResponseWriter
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc)
 }
+
+func (sc *SubscriptionController) PatchSubscription(w http.ResponseWriter, r *http.Request) {
+	if r.Body != nil {
+		defer func() { _ = r.Body.Close() }()
+	}
+
+	lc := container.LoggingClientFrom(sc.dic.Get)
+
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	updateSubscriptionDTOs, err := sc.reader.ReadUpdateSubscriptionRequest(r.Body)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		errResponses := commonDTO.NewBaseResponse(
+			"",
+			err.Message(),
+			err.Code())
+		utils.WriteHttpHeader(w, ctx, err.Code())
+		pkg.Encode(errResponses, w, lc)
+		return
+	}
+
+	var updateResponses []interface{}
+	for _, dto := range updateSubscriptionDTOs {
+		var response interface{}
+		reqId := dto.RequestId
+		err := application.PatchSubscription(ctx, dto.Subscription, sc.dic)
+		if err != nil {
+			lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse(
+				reqId,
+				err.Message(),
+				err.Code())
+		} else {
+			response = commonDTO.NewBaseResponse(
+				reqId,
+				"",
+				http.StatusOK)
+		}
+		updateResponses = append(updateResponses, response)
+	}
+
+	utils.WriteHttpHeader(w, ctx, http.StatusMultiStatus)
+	pkg.Encode(updateResponses, w, lc)
+}

--- a/internal/support/notifications/v2/controller/http/subscription_test.go
+++ b/internal/support/notifications/v2/controller/http/subscription_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -91,6 +92,32 @@ func addSubscriptionRequestData() requests.AddSubscriptionRequest {
 	}
 
 	return testAddSubscriptionReq
+}
+
+func updateSubscriptionRequestData() requests.UpdateSubscriptionRequest {
+	testUUID := ExampleUUID
+	testName := testSubscriptionName
+	testDescription := testSubscriptionDescription
+	var testUpdateSubscriptionReq = requests.UpdateSubscriptionRequest{
+		BaseRequest: common.BaseRequest{
+			RequestId:   ExampleUUID,
+			Versionable: common.NewVersionable(),
+		},
+		Subscription: dtos.UpdateSubscription{
+			Versionable: common.NewVersionable(),
+			Id:             &testUUID,
+			Name:           &testName,
+			Channels:    testSubscriptionChannels,
+			Receiver:    &testSubscriptionReceiver,
+			Categories:    testSubscriptionCategories,
+			Labels:     testSubscriptionLabels,
+			Description: &testDescription,
+			ResendLimit:   &testSubscriptionResendLimit,
+			ResendInterval:  &testSubscriptionResendInterval,
+		},
+	}
+
+	return testUpdateSubscriptionReq
 }
 
 func TestAddSubscription(t *testing.T) {
@@ -589,6 +616,134 @@ func TestDeleteSubscriptionByName(t *testing.T) {
 			if testCase.expectedStatusCode == http.StatusNoContent {
 				assert.Empty(t, res.Message, "Message should be empty when it is successful")
 			} else {
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			}
+		})
+	}
+}
+
+func TestPatchSubscription(t *testing.T) {
+	expectedRequestId := ExampleUUID
+	dic := mockDic()
+	dbClientMock := &dbMock.DBClient{}
+	testReq := updateSubscriptionRequestData()
+	subscriptionModel := models.Subscription{
+		Id:                  *testReq.Subscription.Id,
+		Name:                *testReq.Subscription.Name,
+		Channels:            dtos.ToChannelModels(testReq.Subscription.Channels),
+		Receiver:            *testReq.Subscription.Receiver,
+		Categories:          dtos.ToCategoryModels(testReq.Subscription.Categories),
+		Labels:              testReq.Subscription.Labels,
+		Description:         *testReq.Subscription.Description,
+		ResendLimit:         *testReq.Subscription.ResendLimit,
+		ResendInterval:      *testReq.Subscription.ResendInterval,
+	}
+
+	valid := testReq
+	dbClientMock.On("SubscriptionById", *valid.Subscription.Id).Return(subscriptionModel, nil)
+	dbClientMock.On("DeleteSubscriptionByName", *valid.Subscription.Name).Return(nil)
+	dbClientMock.On("AddSubscription", mock.Anything).Return(subscriptionModel, nil)
+	validWithNoReqID := testReq
+	validWithNoReqID.RequestId = ""
+	validWithNoId := testReq
+	validWithNoId.Subscription.Id = nil
+	dbClientMock.On("SubscriptionByName", *validWithNoId.Subscription.Name).Return(subscriptionModel, nil)
+	validWithNoName := testReq
+	validWithNoName.Subscription.Name = nil
+
+	invalidId := testReq
+	invalidUUID := "invalidUUID"
+	invalidId.Subscription.Id = &invalidUUID
+
+	emptyString := ""
+	emptyId := testReq
+	emptyId.Subscription.Id = &emptyString
+	emptyName := testReq
+	emptyName.Subscription.Id = nil
+	emptyName.Subscription.Name = &emptyString
+
+	invalidNoIdAndName := testReq
+	invalidNoIdAndName.Subscription.Id = nil
+	invalidNoIdAndName.Subscription.Name = nil
+
+	invalidNotFoundId := testReq
+	invalidNotFoundId.Subscription.Name = nil
+	notFoundId := "12345678-1111-1234-5678-de9dac3fb9bc"
+	invalidNotFoundId.Subscription.Id = &notFoundId
+	notFoundIdError := errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("%s doesn't exist in the database", notFoundId), nil)
+	dbClientMock.On("SubscriptionById", *invalidNotFoundId.Subscription.Id).Return(subscriptionModel, notFoundIdError)
+
+	invalidNotFoundName := testReq
+	invalidNotFoundName.Subscription.Id = nil
+	notFoundName := "notFoundName"
+	invalidNotFoundName.Subscription.Name = &notFoundName
+	notFoundNameError := errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("%s doesn't exist in the database", notFoundName), nil)
+	dbClientMock.On("SubscriptionByName", *invalidNotFoundName.Subscription.Name).Return(subscriptionModel, notFoundNameError)
+
+	dic.Update(di.ServiceConstructorMap{
+		v2NotificationsContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	controller := NewSubscriptionController(dic)
+	require.NotNil(t, controller)
+	tests := []struct {
+		name                 string
+		request              []requests.UpdateSubscriptionRequest
+		expectedStatusCode   int
+		expectedResponseCode int
+	}{
+		{"Valid", []requests.UpdateSubscriptionRequest{valid}, http.StatusMultiStatus, http.StatusOK},
+		{"Valid - no requestId", []requests.UpdateSubscriptionRequest{validWithNoReqID}, http.StatusMultiStatus, http.StatusOK},
+		{"Valid - no id", []requests.UpdateSubscriptionRequest{validWithNoId}, http.StatusMultiStatus, http.StatusOK},
+		{"Valid - no name", []requests.UpdateSubscriptionRequest{validWithNoName}, http.StatusMultiStatus, http.StatusOK},
+		{"Invalid - invalid id", []requests.UpdateSubscriptionRequest{invalidId}, http.StatusBadRequest, http.StatusBadRequest},
+		{"Invalid - empty id", []requests.UpdateSubscriptionRequest{emptyId}, http.StatusBadRequest, http.StatusBadRequest},
+		{"Invalid - empty name", []requests.UpdateSubscriptionRequest{emptyName}, http.StatusBadRequest, http.StatusBadRequest},
+		{"Invalid - not found id", []requests.UpdateSubscriptionRequest{invalidNotFoundId}, http.StatusMultiStatus, http.StatusNotFound},
+		{"Invalid - not found name", []requests.UpdateSubscriptionRequest{invalidNotFoundName}, http.StatusMultiStatus, http.StatusNotFound},
+		{"Invalid - no id and name", []requests.UpdateSubscriptionRequest{invalidNoIdAndName}, http.StatusBadRequest, http.StatusBadRequest},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			jsonData, err := json.Marshal(testCase.request)
+			require.NoError(t, err)
+
+			reader := strings.NewReader(string(jsonData))
+			req, err := http.NewRequest(http.MethodPost, v2.ApiSubscriptionRoute, reader)
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(controller.PatchSubscription)
+			handler.ServeHTTP(recorder, req)
+
+			if testCase.expectedStatusCode == http.StatusMultiStatus {
+				var res []common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+
+				// Assert
+				assert.Equal(t, http.StatusMultiStatus, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, v2.ApiVersion, res[0].ApiVersion, "API Version not as expected")
+				if res[0].RequestId != "" {
+					assert.Equal(t, expectedRequestId, res[0].RequestId, "RequestID not as expected")
+				}
+				assert.Equal(t, testCase.expectedResponseCode, res[0].StatusCode, "BaseResponse status code not as expected")
+				if testCase.expectedResponseCode == http.StatusOK {
+					assert.Empty(t, res[0].Message, "Message should be empty when it is successful")
+				} else {
+					assert.NotEmpty(t, res[0].Message, "Response message doesn't contain the error message")
+				}
+			} else {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+
+				// Assert
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedResponseCode, res.StatusCode, "BaseResponse status code not as expected")
 				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
 			}
 		})

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -14,6 +14,7 @@ type DBClient interface {
 	CloseSession()
 
 	AddSubscription(e models.Subscription) (models.Subscription, errors.EdgeX)
+	SubscriptionById(id string) (models.Subscription, errors.EdgeX)
 	AllSubscriptions(offset int, limit int) ([]models.Subscription, errors.EdgeX)
 	SubscriptionByName(name string) (models.Subscription, errors.EdgeX)
 	SubscriptionsByCategory(offset, limit int, category string) ([]models.Subscription, errors.EdgeX)

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -84,6 +84,29 @@ func (_m *DBClient) DeleteSubscriptionByName(name string) errors.EdgeX {
 	return r0
 }
 
+// SubscriptionById provides a mock function with given fields: id
+func (_m *DBClient) SubscriptionById(id string) (models.Subscription, errors.EdgeX) {
+	ret := _m.Called(id)
+
+	var r0 models.Subscription
+	if rf, ok := ret.Get(0).(func(string) models.Subscription); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(models.Subscription)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(string) errors.EdgeX); ok {
+		r1 = rf(id)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // SubscriptionByName provides a mock function with given fields: name
 func (_m *DBClient) SubscriptionByName(name string) (models.Subscription, errors.EdgeX) {
 	ret := _m.Called(name)

--- a/internal/support/notifications/v2/io/subscription.go
+++ b/internal/support/notifications/v2/io/subscription.go
@@ -16,6 +16,7 @@ import (
 // SubscriptionReader unmarshals a request body into an array of Subscription type
 type SubscriptionReader interface {
 	ReadAddSubscriptionRequest(reader io.Reader) ([]dtoRequest.AddSubscriptionRequest, errors.EdgeX)
+	ReadUpdateSubscriptionRequest(reader io.Reader) ([]dtoRequest.UpdateSubscriptionRequest, errors.EdgeX)
 }
 
 // NewRequestReader returns a BodyReader capable of processing the request body
@@ -39,4 +40,15 @@ func (jsonSubscriptionReader) ReadAddSubscriptionRequest(reader io.Reader) ([]dt
 		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "subscription json decoding failed", err)
 	}
 	return addSubscriptions, nil
+}
+
+// ReadUpdateSubscriptionRequest reads a request and then converts its JSON data into an array of UpdateSubscriptionRequest struct
+func (jsonSubscriptionReader) ReadUpdateSubscriptionRequest(reader io.Reader) ([]dtoRequest.UpdateSubscriptionRequest, errors.EdgeX) {
+	var updateSubscriptions []dtoRequest.UpdateSubscriptionRequest
+	err := json.NewDecoder(reader).Decode(&updateSubscriptions)
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "subscription json decoding failed", err)
+	}
+
+	return updateSubscriptions, nil
 }

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -34,4 +34,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiSubscriptionByLabelRoute, nc.SubscriptionsByLabel).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiSubscriptionByReceiverRoute, nc.SubscriptionsByReceiver).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiSubscriptionByNameRoute, nc.DeleteSubscriptionByName).Methods(http.MethodDelete)
+	r.HandleFunc(v2Constant.ApiSubscriptionRoute, nc.PatchSubscription).Methods(http.MethodPatch)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## Issue Number: #3140 


## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/patch_subscription, implement PATCH /subscription V2 API.

Close #3140

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Putting this PR on hold/draft until after https://github.com/edgexfoundry/go-mod-core-contracts/pull/498 is merged.