### PR TITLE
feat(security): Make separate redis ACL conf file and use hashed pwd in config

### DIFF
--- a/internal/security/bootstrapper/redis/Developer-notes.md
+++ b/internal/security/bootstrapper/redis/Developer-notes.md
@@ -3,10 +3,10 @@
 Currently, the `security-bootstrapper` configureRedis produces the ACL configuration file for Redis' default user.
 Should using different ACL rules call for a debugging needs, developers could override this built-in configuration behavior as follows:
 
- 1. A developer can provide his own config file containing the ACL rules for add some `dangerous` commands like `INFO, MONITOR, BGSAVE, and FLUSHD` inside his own config file using `+` directive. eg.:
+ 1. Currently, the default ACL file path inside the redis.conf is pointing to the path with the file name `edgex_redis_acl.conf`.  A developer can always provide his own redis config file containing the different file name (eg. developer-acl.conf) for ACL rules like adding some `dangerous` commands such as `INFO, MONITOR, BGSAVE, and FLUSHD` inside his own ACL file using `+` directive. eg.:
 
 ```text
-    user default on allkeys +@all -@dangerous >_{{.RedisPwd}}_ +INFO +MONITOR +BGSAVE + FLUSHDB
+    user default on allkeys +@all -@dangerous #_{{.HashedRedisPwd}}_ +INFO +MONITOR +BGSAVE + FLUSHDB
 ```
 
   and use his own config file on developer modified redis' entrypoint script to start the redis server like:
@@ -17,6 +17,8 @@ Should using different ACL rules call for a debugging needs, developers could ov
 
   on `database` service of a docker-compose file.
 
-  Note that the RedisPwd still needs to be come from the original dynamically created redis.conf file as it is read from secretstore Vault.
+  Note that the HashedRedisPwd still needs to be come from the original dynamically created redis.conf file as it is read from secretstore Vault.
+
+  A developer can also just modified the ACL file `edgex_redis_acl.conf` directly and then use `ACL LOAD` or `ACL SAVE` commands to change ACL rules assuming he/she has the right permissions to update that file.
 
  2. For snap, a developer can just change `CONFIG_FILE` environment variable of snap `redis` service to point to his own above-mentioned configuration file, `developer_redis.conf` (assuming developer is putting his configuration file under the same directory eg. `$SNAP_DATA/redis/conf`; creating a new mounted file system and directory inside snapcraft is beyond the scope of this topic).

--- a/internal/security/bootstrapper/redis/configure.go
+++ b/internal/security/bootstrapper/redis/configure.go
@@ -66,7 +66,7 @@ func Configure(ctx context.Context,
 		[]interfaces.BootstrapHandler{
 			handlers.SecureProviderBootstrapHandler,
 			redisBootstrapHdl.GetCredentials,
-			redisBootstrapHdl.SetupConfFile,
+			redisBootstrapHdl.SetupConfFiles,
 		},
 	)
 


### PR DESCRIPTION
- Separate out ACL rule config into a different config file
- Use hashed password in the ACL config file
- Remove requirepass since it is using hashed pwd now

Fixes: #3161

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently clear text pwd from Vault can be observed in `redis.conf` file and acl rules are also in the same config file.

## Issue Number: #3161 


## What is the new behavior?
Hashed pwd in config file and ACL rule config in a separate file.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information