### PR TITLE
feat(security): Create a Vault mgmt token for Consul Secrets API Operations

### DIFF
--- a/cmd/security-secretstore-setup/res/configuration.toml
+++ b/cmd/security-secretstore-setup/res/configuration.toml
@@ -38,6 +38,7 @@ TokenProviderAdminTokenPath = "/run/edgex/secrets/tokenprovider/secrets-token.js
 PasswordProvider = ""
 PasswordProviderArgs = [ ]
 RevokeRootTokens = true
+ConsulSecretsAdminTokenPath = "/tmp/edgex/secrets/edgex-consul/admin/token.json"
 
 [Databases]
   [Databases.admin]

--- a/internal/security/secretstore/config/config.go
+++ b/internal/security/secretstore/config/config.go
@@ -53,6 +53,7 @@ type SecretStoreInfo struct {
 	PasswordProvider            string
 	PasswordProviderArgs        []string
 	RevokeRootTokens            bool
+	ConsulSecretsAdminTokenPath string
 }
 
 // GetBaseURL builds and returns the base URL for the SecretStore service

--- a/internal/security/secretstore/constants.go
+++ b/internal/security/secretstore/constants.go
@@ -19,10 +19,8 @@
 package secretstore
 
 const (
-	// KVSecretsEngineMountPoint is the name of the mount point base for Vault's key-value secrets engine
-	KVSecretsEngineMountPoint = "secret"
-	// ConsulSecretEngineMountPoint is the name of the mount point base for Vault's Consul secrets engine
-	ConsulSecretEngineMountPoint = "consul"
+	// this is a feature key to indicate whether to enable Registry Consul's ACL or not
+	RegistryACLFeatureFlag = "ENABLE_REGISTRY_ACL"
 
 	VaultToken             = "X-Vault-Token"
 	TokenCreatorPolicyName = "privileged-token-creator"

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -35,6 +35,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/secretsengine"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenfilewriter"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
@@ -223,13 +224,11 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	healthOkCh := make(chan struct{})
 	go func() {
 		for {
-			select {
-			case <-ticker.C:
-				if sCode, _ := client.HealthCheck(); sCode == http.StatusOK {
-					close(healthOkCh)
-					ticker.Stop()
-					return
-				}
+			<-ticker.C
+			if sCode, _ := client.HealthCheck(); sCode == http.StatusOK {
+				close(healthOkCh)
+				ticker.Stop()
+				return
 			}
 		}
 	}()
@@ -290,9 +289,10 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 
 	// If configured to do so, create a token issuing token
 	if secretStoreConfig.TokenProviderAdminTokenPath != "" {
-		revokeIssuingTokenFuc, err := makeTokenIssuingToken(lc, configuration, tokenMaintenance, fileOpener, rootToken)
+		revokeIssuingTokenFuc, err := tokenfilewriter.NewWriter(lc, client, fileOpener).
+			CreateAndWrite(rootToken, secretStoreConfig.TokenProviderAdminTokenPath, tokenMaintenance.CreateTokenIssuingToken)
 		if err != nil {
-			lc.Errorf("failed to create token issuing token %s", err.Error())
+			lc.Errorf("failed to create token issuing token: %s", err.Error())
 			os.Exit(1)
 		}
 		if secretStoreConfig.TokenProviderType == OneShotProvider {
@@ -318,14 +318,14 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	}
 
 	// Enable KV secret engine
-	if err := secretsengine.New(KVSecretsEngineMountPoint, secretsengine.KeyValue).
+	if err := secretsengine.New(secretsengine.KVSecretsEngineMountPoint, secretsengine.KeyValue).
 		Enable(&rootToken, lc, client); err != nil {
 		lc.Errorf("failed to enable KV secrets engine: %s", err.Error())
 		os.Exit(1)
 	}
 
 	// Enable Consul secret engine
-	if err := secretsengine.New(ConsulSecretEngineMountPoint, secretsengine.Consul).
+	if err := secretsengine.New(secretsengine.ConsulSecretEngineMountPoint, secretsengine.Consul).
 		Enable(&rootToken, lc, client); err != nil {
 		lc.Errorf("failed to enable Consul secrets engine: %s", err.Error())
 		os.Exit(1)
@@ -422,6 +422,19 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 		lc.Info("proxy certificate pair upload was skipped because cert secretStore value(s) were blank")
 	}
 
+	// If Registry Consul ACL feature is enabled, then we need to create and save a Vault token to configure
+	// Consul secret engine access, role operations, and managing Consul agent tokens.
+	registryACLEnabled := os.Getenv(RegistryACLFeatureFlag)
+	if registryACLEnabled == "true" {
+		// generate a management token for Consul secrets engine operations:
+		tokenFileWriter := tokenfilewriter.NewWriter(lc, client, fileOpener)
+		if _, err := tokenFileWriter.CreateAndWrite(rootToken, configuration.SecretStore.ConsulSecretsAdminTokenPath,
+			tokenFileWriter.CreateMgmtTokenForConsulSecretsEngine); err != nil {
+			lc.Errorf("failed to create and write the token for Consul secret management: %s", err.Error())
+			os.Exit(1)
+		}
+	}
+
 	lc.Info("Vault init done successfully")
 	return false
 
@@ -467,74 +480,6 @@ func addDBCredential(lc logger.LoggingClient, db string, cred Cred, service stri
 	}
 
 	return err
-}
-
-func makeTokenIssuingToken(
-	lc logger.LoggingClient,
-	configuration *config.ConfigurationStruct,
-	tokenMaintenance *TokenMaintenance,
-	fileOpener fileioperformer.FileIoPerformer,
-	rootToken string) (RevokeFunc, error) {
-
-	configAdminTokenPath := configuration.SecretStore.TokenProviderAdminTokenPath
-	if configAdminTokenPath == "" {
-		err := fmt.Errorf("TokenProviderAdminTokenPath is a required configuration setting")
-		lc.Error(err.Error())
-		return nil, err
-	}
-
-	// Create delegate credential for use by the token provider
-	tokenIssuingToken, revokeIssuingTokenFuc, err := tokenMaintenance.CreateTokenIssuingToken(rootToken)
-	if err != nil {
-		lc.Errorf("failed to create token issuing token %s", err.Error())
-		return nil, err
-	}
-	lc.Info("created token issuing token")
-
-	// Write the token issuing token to disk to pass it to the token provider
-	adminTokenPath, err := filepath.Abs(configAdminTokenPath)
-	if err != nil {
-		lc.Errorf("failed to convert to absolute path %s: %s", configAdminTokenPath, err.Error())
-		revokeIssuingTokenFuc()
-		return nil, err
-	}
-	dirOfAdminToken := filepath.Dir(adminTokenPath)
-	err = fileOpener.MkdirAll(dirOfAdminToken, 0700)
-	if err != nil {
-		lc.Errorf("failed to create tokenpath base dir: %s", err.Error())
-		revokeIssuingTokenFuc()
-		return nil, err
-	}
-	tokenWriter, err := fileOpener.OpenFileWriter(adminTokenPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
-	if err != nil {
-		lc.Errorf("failed to create token issuing file %s: %s", adminTokenPath, err.Error())
-		revokeIssuingTokenFuc()
-		return nil, err
-	}
-
-	encoder := json.NewEncoder(tokenWriter)
-	if encoder == nil {
-		err := fmt.Errorf("failed to create token encoder")
-		lc.Error(err.Error())
-		_ = tokenWriter.Close()
-		revokeIssuingTokenFuc()
-		return nil, err
-	}
-
-	if err = encoder.Encode(tokenIssuingToken); err != nil {
-		lc.Errorf("failed to write token issuing token: %s", err.Error())
-		_ = tokenWriter.Close()
-		revokeIssuingTokenFuc()
-		return nil, err
-	}
-
-	if err = tokenWriter.Close(); err != nil {
-		lc.Errorf("failed to close token issuing file: %s", err.Error())
-		revokeIssuingTokenFuc()
-		return nil, err
-	}
-
-	return revokeIssuingTokenFuc, nil
 }
 
 func loadInitResponse(

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -324,13 +324,6 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 		os.Exit(1)
 	}
 
-	// Enable Consul secret engine
-	if err := secretsengine.New(secretsengine.ConsulSecretEngineMountPoint, secretsengine.Consul).
-		Enable(&rootToken, lc, client); err != nil {
-		lc.Errorf("failed to enable Consul secrets engine: %s", err.Error())
-		os.Exit(1)
-	}
-
 	// credential creation
 	gen := NewPasswordGenerator(lc, secretStoreConfig.PasswordProvider, secretStoreConfig.PasswordProviderArgs)
 	cred := NewCred(httpCaller, rootToken, gen, secretStoreConfig.GetBaseURL(), lc)
@@ -426,6 +419,13 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	// Consul secret engine access, role operations, and managing Consul agent tokens.
 	registryACLEnabled := os.Getenv(RegistryACLFeatureFlag)
 	if registryACLEnabled == "true" {
+		// Enable Consul secret engine
+		if err := secretsengine.New(secretsengine.ConsulSecretEngineMountPoint, secretsengine.Consul).
+			Enable(&rootToken, lc, client); err != nil {
+			lc.Errorf("failed to enable Consul secrets engine: %s", err.Error())
+			os.Exit(1)
+		}
+
 		// generate a management token for Consul secrets engine operations:
 		tokenFileWriter := tokenfilewriter.NewWriter(lc, client, fileOpener)
 		if _, err := tokenFileWriter.CreateAndWrite(rootToken, configuration.SecretStore.ConsulSecretsAdminTokenPath,

--- a/internal/security/secretstore/secretsengine/enabler.go
+++ b/internal/security/secretstore/secretsengine/enabler.go
@@ -23,6 +23,11 @@ import (
 )
 
 const (
+	// KVSecretsEngineMountPoint is the name of the mount point base for Vault's key-value secrets engine
+	KVSecretsEngineMountPoint = "secret"
+	// ConsulSecretEngineMountPoint is the name of the mount point base for Vault's Consul secrets engine
+	ConsulSecretEngineMountPoint = "consul"
+
 	// Vault's secrets engine type related constants
 	KeyValue = "kv"
 	Consul   = "consul"

--- a/internal/security/secretstore/tokencreatable/tokencreatable.go
+++ b/internal/security/secretstore/tokencreatable/tokencreatable.go
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package tokencreatable
+
+// RevokeFunc is a function to revoke a token
+type RevokeFunc func()
+
+// CreateTokenFunc is a function to create a token with optional revoke function in return
+type CreateTokenFunc func(rootToken string) (createResponse map[string]interface{}, revokeFunc RevokeFunc, err error)

--- a/internal/security/secretstore/tokenfilewriter/tokenfilewriter.go
+++ b/internal/security/secretstore/tokenfilewriter/tokenfilewriter.go
@@ -81,7 +81,7 @@ func (w TokenFileWriter) CreateAndWrite(rootToken string, tokenFilePath string,
 		}
 	}()
 
-	// Write the token issuing token to disk to pass it to the token provider
+	// Write the created token to the specified file
 	tokenFileAbsPath, fileErr := filepath.Abs(tokenFilePath)
 	if fileErr != nil {
 		return nil, fmt.Errorf("failed to convert tokenFile to absolute path %s: %s", tokenFilePath, fileErr.Error())
@@ -107,7 +107,7 @@ func (w TokenFileWriter) CreateAndWrite(rootToken string, tokenFilePath string,
 		return nil, fmt.Errorf("failed to close token file: %s", fileErr.Error())
 	}
 
-	w.logClient.Infof("token's written to %s", tokenFilePath)
+	w.logClient.Infof("token is written to %s", tokenFilePath)
 
 	return revokeTokenFunc, nil
 }
@@ -118,8 +118,9 @@ func (w TokenFileWriter) CreateAndWrite(rootToken string, tokenFilePath string,
 // the purpose of Consul ACL's bootstrapping as part of securing Consul process.
 //
 // Requires a root token to create, and returns data/information containing the token,
-// keeping the token without revoking it and hence always returning nil RevokeFunc;
-// also returns non-nil error if anything goes wrong during the creation.
+// keeping the token without revoking it and hence always returning nil RevokeFunc in order to conform to the
+// input type tokencreatable.CreateTokenFunc as its function argument;
+// this function returns non-nil error if anything goes wrong during the creation.
 // this function conforms to the signature of the tokencreatable.CreateTokenFunc type
 // so that it can be passed to CreateAndWrite()
 func (w TokenFileWriter) CreateMgmtTokenForConsulSecretsEngine(rootToken string) (map[string]interface{},

--- a/internal/security/secretstore/tokenfilewriter/tokenfilewriter.go
+++ b/internal/security/secretstore/tokenfilewriter/tokenfilewriter.go
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package tokenfilewriter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/secretsengine"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokencreatable"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/fileioperformer"
+	"github.com/edgexfoundry/go-mod-secrets/v2/secrets"
+)
+
+const (
+	consulSecretsEngineOpsPolicyName = "consul_secrets_engine_management_policy"
+)
+
+// TokenFileWriter is a mechanism to generates a token and writes it into a file specified by configuration
+type TokenFileWriter struct {
+	logClient    logger.LoggingClient
+	secretClient secrets.SecretStoreClient
+	fileOpener   fileioperformer.FileIoPerformer
+}
+
+// NewWriter instantiates a TokenFileWriter instance
+func NewWriter(lc logger.LoggingClient,
+	sc secrets.SecretStoreClient,
+	fileOpener fileioperformer.FileIoPerformer) TokenFileWriter {
+	return TokenFileWriter{
+		logClient:    lc,
+		secretClient: sc,
+		fileOpener:   fileOpener,
+	}
+}
+
+// CreateAndWrite generates a new token and writes it to the file specified by tokenFilePath
+// the generation of the token requires root token privilege
+// it overwrites the file if already exists
+// returns error if anything fails during the whole process
+func (w TokenFileWriter) CreateAndWrite(rootToken string, tokenFilePath string,
+	createTokenFunc tokencreatable.CreateTokenFunc) (tokencreatable.RevokeFunc, error) {
+	if len(rootToken) == 0 {
+		return nil, fmt.Errorf("rootToken is required")
+	}
+
+	// creates the token
+	createTokenFuncName := getFunctionName(createTokenFunc)
+	tokenCreated, revokeTokenFunc, createErr := createTokenFunc(rootToken)
+	if createErr != nil {
+		return nil, fmt.Errorf("failed to create token with %s: %s", createTokenFuncName, createErr.Error())
+	}
+
+	w.logClient.Infof("created token with %s", createTokenFuncName)
+
+	var fileErr error
+	defer func() {
+		// call revokeTokenFunc if there is some fileErr and revokeTokenFunc itself is not nil
+		if fileErr != nil && revokeTokenFunc != nil {
+			revokeTokenFunc()
+		}
+	}()
+
+	// Write the token issuing token to disk to pass it to the token provider
+	tokenFileAbsPath, fileErr := filepath.Abs(tokenFilePath)
+	if fileErr != nil {
+		return nil, fmt.Errorf("failed to convert tokenFile to absolute path %s: %s", tokenFilePath, fileErr.Error())
+	}
+
+	dirOfCreatedToken := filepath.Dir(tokenFileAbsPath)
+	fileErr = w.fileOpener.MkdirAll(dirOfCreatedToken, 0700)
+	if fileErr != nil {
+		return nil, fmt.Errorf("failed to create tokenpath base dir: %s", fileErr.Error())
+	}
+
+	fileWriter, fileErr := w.fileOpener.OpenFileWriter(tokenFileAbsPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if fileErr != nil {
+		return nil, fmt.Errorf("failed to create token file %s: %s", tokenFileAbsPath, fileErr.Error())
+	}
+
+	if fileErr = json.NewEncoder(fileWriter).Encode(tokenCreated); fileErr != nil {
+		_ = fileWriter.Close()
+		return nil, fmt.Errorf("failed to write created token: %s", fileErr.Error())
+	}
+
+	if fileErr = fileWriter.Close(); fileErr != nil {
+		return nil, fmt.Errorf("failed to close token file: %s", fileErr.Error())
+	}
+
+	w.logClient.Infof("token's written to %s", tokenFilePath)
+
+	return revokeTokenFunc, nil
+}
+
+// CreateMgmtTokenForConsulSecretsEngine creates a new Vault token that
+// allows the Consul bootstrapper to operate on managing Vault's Consul secrets engine related APIs (see reference:
+// https://www.vaultproject.io/api-docs/secret/consul). The created Vault token is meant for serving
+// the purpose of Consul ACL's bootstrapping as part of securing Consul process.
+//
+// Requires a root token to create, and returns data/information containing the token,
+// keeping the token without revoking it and hence always returning nil RevokeFunc;
+// also returns non-nil error if anything goes wrong during the creation.
+// this function conforms to the signature of the tokencreatable.CreateTokenFunc type
+// so that it can be passed to CreateAndWrite()
+func (w TokenFileWriter) CreateMgmtTokenForConsulSecretsEngine(rootToken string) (map[string]interface{},
+	tokencreatable.RevokeFunc, error) {
+	consulSecretsEngineOpsPolicyDocument := `
+# allow to configure the access information for Consul
+path "` + secretsengine.ConsulSecretEngineMountPoint + `/config/access" {
+    capabilities = ["create", "update"]
+}
+
+# allow to create, update, read, list, or delete the Consul role definition
+path "` + secretsengine.ConsulSecretEngineMountPoint + `/roles/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+`
+
+	if err := w.secretClient.InstallPolicy(rootToken,
+		consulSecretsEngineOpsPolicyName,
+		consulSecretsEngineOpsPolicyDocument); err != nil {
+		return nil, nil, fmt.Errorf("failed to install Consul secrets engine operations policy: %v", err)
+	}
+
+	// setup new token's properties
+	tokenParams := make(map[string]interface{})
+	tokenParams["type"] = "service"
+	tokenParams["display_name"] = "managing with policy name " + consulSecretsEngineOpsPolicyName
+	tokenParams["no_parent"] = true
+	tokenParams["period"] = "1h"
+	tokenParams["policies"] = []string{consulSecretsEngineOpsPolicyName}
+	tokenParams["meta"] = map[string]interface{}{
+		"description": "Consul secrets engine management token",
+	}
+	response, err := w.secretClient.CreateToken(rootToken, tokenParams)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create token for Consul secrets engine operations: %v", err)
+	}
+
+	return response, nil, nil
+}
+
+func getFunctionName(f interface{}) string {
+	createTokenFuncName := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+	// On runtime, this will get us something like:
+	// github.com/edgexfoundry/edgex-go/internal/security/secretstore.(TokenFileWriter).CreateMgmtTokenForConsulSecretsEngine-fm
+	// but we only want to get the last part of string after last "/",
+	// i.e. secretstore.(TokenFileWriter).CreateMgmtTokenForConsulSecretsEngine-fm
+	elementName := strings.Split(createTokenFuncName, "/")
+	return elementName[len(elementName)-1]
+}

--- a/internal/security/secretstore/tokenfilewriter/tokenfilewriter.go
+++ b/internal/security/secretstore/tokenfilewriter/tokenfilewriter.go
@@ -147,7 +147,8 @@ path "` + secretsengine.ConsulSecretEngineMountPoint + `/roles/*" {
 	// setup new token's properties
 	tokenParams := make(map[string]interface{})
 	tokenParams["type"] = "service"
-	tokenParams["display_name"] = "managing with policy name " + consulSecretsEngineOpsPolicyName
+	// Vault prefixes "token" in front of display_name
+	tokenParams["display_name"] = "for Consul ACL bootstrap"
 	tokenParams["no_parent"] = true
 	tokenParams["period"] = "1h"
 	tokenParams["policies"] = []string{consulSecretsEngineOpsPolicyName}

--- a/internal/security/secretstore/tokenfilewriter/tokenfilewriter_test.go
+++ b/internal/security/secretstore/tokenfilewriter/tokenfilewriter_test.go
@@ -36,7 +36,8 @@ var lc logger.LoggingClient
 var flOpener fileioperformer.FileIoPerformer
 
 func TestMain(m *testing.M) {
-	lc, flOpener = setup()()
+	lc = logger.MockLogger{}
+	flOpener = fileioperformer.NewDefaultFileIoPerformer()
 	os.Exit(m.Run())
 }
 
@@ -172,14 +173,6 @@ func TestFileWriteErrorForConsulSecretEngine(t *testing.T) {
 	_, err := fileWriter.CreateAndWrite(testRootToken, testTokenFilePath,
 		fileWriter.CreateMgmtTokenForConsulSecretsEngine)
 	require.Error(t, err)
-}
-
-func setup() func() (logger.LoggingClient, fileioperformer.FileIoPerformer) {
-	return func() (logger.LoggingClient, fileioperformer.FileIoPerformer) {
-		lc := logger.MockLogger{}
-		flOpener := fileioperformer.NewDefaultFileIoPerformer()
-		return lc, flOpener
-	}
 }
 
 func getCreateTokenResultStub() map[string]interface{} {

--- a/internal/security/secretstore/tokenfilewriter/tokenfilewriter_test.go
+++ b/internal/security/secretstore/tokenfilewriter/tokenfilewriter_test.go
@@ -32,17 +32,21 @@ import (
 	"github.com/edgexfoundry/go-mod-secrets/v2/secrets/mocks"
 )
 
-func TestNewTokenFileWriter(t *testing.T) {
-	lc, flOpener := setup()()
+var lc logger.LoggingClient
+var flOpener fileioperformer.FileIoPerformer
 
+func TestMain(m *testing.M) {
+	lc, flOpener = setup()()
+	os.Exit(m.Run())
+}
+
+func TestNewTokenFileWriter(t *testing.T) {
 	sc := &mocks.SecretStoreClient{}
 	tokenFileWriter := NewWriter(lc, sc, flOpener)
 	require.NotEmpty(t, tokenFileWriter)
 }
 
 func TestCreateMgmtTokenForConsulSecretsEngine(t *testing.T) {
-	lc, flOpener := setup()()
-
 	createTokenResult := getCreateTokenResultStub()
 
 	testRootToken := "testRootToken"
@@ -86,8 +90,6 @@ func TestCreateMgmtTokenForConsulSecretsEngine(t *testing.T) {
 }
 
 func TestCreateAndWriteForConsulSecretEngine(t *testing.T) {
-	lc, flOpener := setup()()
-
 	createTokenResult := getCreateTokenResultStub()
 
 	testInstallPolicyErr := errors.New("install policy error")
@@ -146,10 +148,9 @@ func TestFileWriteErrorForConsulSecretEngine(t *testing.T) {
 	curUser, _ := user.Current()
 	if curUser != nil && curUser.Uid == "0" {
 		// it is root user then we skip this test as root can have permission to write everything
+		t.Log("Skipping this test as it is running as root user")
 		t.Skip()
 	}
-
-	lc, flOpener := setup()()
 
 	createTokenResult := getCreateTokenResultStub()
 

--- a/internal/security/secretstore/tokenfilewriter/tokenfilewriter_test.go
+++ b/internal/security/secretstore/tokenfilewriter/tokenfilewriter_test.go
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package tokenfilewriter
+
+import (
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/fileioperformer"
+	"github.com/edgexfoundry/go-mod-secrets/v2/secrets/mocks"
+)
+
+func TestNewTokenFileWriter(t *testing.T) {
+	lc, flOpener := setup()()
+
+	sc := &mocks.SecretStoreClient{}
+	tokenFileWriter := NewWriter(lc, sc, flOpener)
+	require.NotEmpty(t, tokenFileWriter)
+}
+
+func TestCreateMgmtTokenForConsulSecretsEngine(t *testing.T) {
+	lc, flOpener := setup()()
+
+	createTokenResult := getCreateTokenResultStub()
+
+	testRootToken := "testRootToken"
+	testInstallPolicyErr := errors.New("install policy error")
+	testCreateTokenErr := errors.New("create token error")
+
+	tests := []struct {
+		name               string
+		installPolicyError error
+		createTokenError   error
+	}{
+		{"Ok:create token ok", nil, nil},
+		{"Bad:install policy error", testInstallPolicyErr, nil},
+		{"Bad:create token error", nil, testCreateTokenErr},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup mock secretclient and expected return values for this test
+			secretClient := &mocks.SecretStoreClient{}
+
+			secretClient.On("InstallPolicy", testRootToken,
+				consulSecretsEngineOpsPolicyName, mock.Anything).
+				Return(test.installPolicyError).Once()
+
+			secretClient.On("CreateToken", testRootToken, mock.Anything).
+				Return(createTokenResult, test.createTokenError).Once()
+
+			token, _, err := NewWriter(lc, secretClient, flOpener).
+				CreateMgmtTokenForConsulSecretsEngine(testRootToken)
+
+			if test.installPolicyError != nil || test.createTokenError != nil {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, "createdTestToken", token["auth"].(map[string]interface{})["client_token"])
+				secretClient.AssertExpectations(t)
+			}
+		})
+	}
+}
+
+func TestCreateAndWriteForConsulSecretEngine(t *testing.T) {
+	lc, flOpener := setup()()
+
+	createTokenResult := getCreateTokenResultStub()
+
+	testInstallPolicyErr := errors.New("install policy error")
+	testCreateTokenErr := errors.New("create token error")
+	testTokenFileDir := "test"
+	testRootToken := "testRootToken"
+
+	tests := []struct {
+		name                 string
+		rootToken            string
+		installPolicyCallErr error
+		createTokenCallErr   error
+	}{
+		{"Ok:CreateAndWrite with client call ok", testRootToken, nil, nil},
+		{"Bad:CreateAndWrite with empty token", "", nil, nil},
+		{"Bad:CreateAndWrite with install policy call error", testRootToken, testInstallPolicyErr, nil},
+		{"Bad:CreateAndWrite with create token call error", testRootToken, nil, testCreateTokenErr},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup mock secretclient and expected return values for this test
+			secretClient := &mocks.SecretStoreClient{}
+
+			secretClient.On("InstallPolicy", testRootToken,
+				consulSecretsEngineOpsPolicyName, mock.Anything).
+				Return(test.installPolicyCallErr).Once()
+
+			secretClient.On("CreateToken", testRootToken, mock.Anything).
+				Return(createTokenResult, test.createTokenCallErr).Once()
+
+			testTokenFilePath := filepath.Join(testTokenFileDir,
+				"mgmt-token.json"+"_"+strconv.FormatInt(time.Now().UnixNano(), 10))
+			fileWriter := NewWriter(lc, secretClient, flOpener)
+			_, err := fileWriter.CreateAndWrite(test.rootToken, testTokenFilePath,
+				fileWriter.CreateMgmtTokenForConsulSecretsEngine)
+			defer func() {
+				_ = os.RemoveAll(filepath.Dir(testTokenFilePath))
+			}()
+
+			expectError := test.installPolicyCallErr != nil ||
+				test.createTokenCallErr != nil ||
+				len(test.rootToken) == 0
+
+			if expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.FileExists(t, testTokenFilePath)
+			}
+		})
+	}
+}
+
+func TestFileWriteErrorForConsulSecretEngine(t *testing.T) {
+	curUser, _ := user.Current()
+	if curUser != nil && curUser.Uid == "0" {
+		// it is root user then we skip this test as root can have permission to write everything
+		t.Skip()
+	}
+
+	lc, flOpener := setup()()
+
+	createTokenResult := getCreateTokenResultStub()
+
+	secretClient := &mocks.SecretStoreClient{}
+	testRootToken := "testRootToken"
+
+	secretClient.On("InstallPolicy", testRootToken,
+		consulSecretsEngineOpsPolicyName, mock.Anything).
+		Return(nil).Once()
+
+	secretClient.On("CreateToken", testRootToken, mock.Anything).
+		Return(createTokenResult, nil).Once()
+
+	// literally set to the /root/ directory so that there is no write permission
+	// as only the root user can perform this
+	testTokenFileDir := "/root/test"
+	testTokenFilePath := filepath.Join(testTokenFileDir, "mgmt-token.json")
+	fileWriter := NewWriter(lc, secretClient, flOpener)
+	_, err := fileWriter.CreateAndWrite(testRootToken, testTokenFilePath,
+		fileWriter.CreateMgmtTokenForConsulSecretsEngine)
+	require.Error(t, err)
+}
+
+func setup() func() (logger.LoggingClient, fileioperformer.FileIoPerformer) {
+	return func() (logger.LoggingClient, fileioperformer.FileIoPerformer) {
+		lc := logger.MockLogger{}
+		flOpener := fileioperformer.NewDefaultFileIoPerformer()
+		return lc, flOpener
+	}
+}
+
+func getCreateTokenResultStub() map[string]interface{} {
+	createTokenResult := make(map[string]interface{})
+	createTokenResult["auth"] = make(map[string]interface{})
+	createTokenResult["auth"].(map[string]interface{})["client_token"] = "createdTestToken"
+	return createTokenResult
+}

--- a/internal/security/secretstore/tokenmaintenance.go
+++ b/internal/security/secretstore/tokenmaintenance.go
@@ -36,12 +36,12 @@ For Fuji.DOT/Geneva, all root tokens will be revoked.
 import (
 	"fmt"
 
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokencreatable"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 
 	"github.com/edgexfoundry/go-mod-secrets/v2/secrets"
 )
-
-type RevokeFunc func()
 
 type TokenMaintenance struct {
 	logging      logger.LoggingClient
@@ -60,7 +60,8 @@ func NewTokenMaintenance(logging logger.LoggingClient, secretClient secrets.Secr
 // allows the holder to create per-service tokens an policies.
 // Requires a root token, returns a function that,
 // if called, with revoke the token
-func (tm *TokenMaintenance) CreateTokenIssuingToken(rootToken string) (map[string]interface{}, RevokeFunc, error) {
+func (tm *TokenMaintenance) CreateTokenIssuingToken(rootToken string) (map[string]interface{},
+	tokencreatable.RevokeFunc, error) {
 
 	err := tm.secretClient.InstallPolicy(rootToken, TokenCreatorPolicyName, TokenCreatorPolicy)
 	if err != nil {
@@ -74,8 +75,7 @@ func (tm *TokenMaintenance) CreateTokenIssuingToken(rootToken string) (map[strin
 	createTokenParameters["period"] = "1h"
 	createTokenParameters["policies"] = []string{TokenCreatorPolicyName}
 	createTokenParameters["ttl"] = "1h"
-	createTokenResponse := make(map[string]interface{})
-	createTokenResponse, err = tm.secretClient.CreateToken(rootToken, createTokenParameters)
+	createTokenResponse, err := tm.secretClient.CreateToken(rootToken, createTokenParameters)
 	if err != nil {
 		tm.logging.Error(fmt.Sprintf("failed creation of token-issuing-token: %s", err.Error()))
 		return nil, nil, err


### PR DESCRIPTION
Part of Phase 1 Securing Consul stories: Create a Vault token to configure consul access

Changes in `secretstore-setup`:
 - add token file writer implementation for creating and writing Vault's Consul secrets admin token
 - add Consul ACL feature flag `"ENABLE_REGISTRY_ACL"`
 - add configuration setting for `ConsulSecretAdminTokenPath` for specifying token file location
 - refactor TokenMaintenance to share code with token file writer's implementation

Closes: #3155

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
N/A

## Issue Number: #3155 


## What is the new behavior?
New Vault token created for special purpose of management Consul Secrets APIs operations policy: configure access / create update roles later on.  This token will be later used by Consul's bootstrapper.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
To verify this locally, one can git clone this PR and build a dev version of `docker_secretstore_setup` and then add the following environment variables to docker-compose file of `secretstore-setup`:
```yaml
 environment:
      ENABLE_REGISTRY_ACL: "true"
```
so that the ACL feature is turned on.  Run `make run dev` and then observe the following docker logs from `edgex-secretstore-setup`:
`docker logs edgex-secretstore-setup | grep "edgex-consul/admin/token"`

```

jim@jim-NUC7i5DNHE:~/go/src/github.com/edgexfoundry/edgex-compose/compose-builder$ docker logs edgex-secretstore-setup | grep "edgex-consul/admin/token"
level=INFO ts=2021-02-24T22:47:57.466345924Z app=edgex-security-secretstore-setup source=tokenfilewriter.go:110 msg="token's written to /tmp/edgex/secrets/edgex-consul/admin/token.json"
jim@jim-NUC7i5DNHE:~/go/src/github.com/edgexfoundry/edgex-compose/compose-builder$ 

```
And also list the file, too:
`$ sudo ls -al /tmp/edgex/secrets/edgex-consul/admin/`
```
[sudo] password for jim: 
total 12
drwx------ 2 2002 2001 4096 Feb 24 12:56 .
drwx------ 3 2002 2001 4096 Feb 24 12:56 ..
-rw------- 1 2002 2001  536 Feb 24 15:47 token.json
```