### PR TITLE
fix(security): Fix local security-proxy-setup startup issue

### DIFF
--- a/internal/security/proxy/main.go
+++ b/internal/security/proxy/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/flags"
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/handlers"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
@@ -75,7 +74,6 @@ func Main(ctx context.Context, cancel context.CancelFunc, _ *mux.Router, _ chan<
 		startupTimer,
 		dic,
 		[]interfaces.BootstrapHandler{
-			handlers.SecureProviderBootstrapHandler,
 			NewBootstrap(
 				insecureSkipVerify,
 				initNeeded,


### PR DESCRIPTION
- Remove unused handlers.SecureProviderBootstrapHandler as it is no longer in use

Fix: #3204

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Local built executable/binary cannot start up due to empty configure type from go-mod-bootstrap.

## Issue Number: #3204 


## What is the new behavior?
Remove unused `handlers.SecureProviderBootstrapHandler` from bootstrapping Run.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
This fix also resolves the snap's security-proxy-setup startup issue.

## Other information