### PR TITLE
fix: Enable proper configuration for SecretStore initialization

### DIFF
--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -17,6 +17,7 @@
 # This is a TOML config file for edgexsecurity service.
 
 LogLevel = "DEBUG"
+SNIS = [""]
 # RequestTimeout for proxy-setup http client caller
 RequestTimeout = 10
 
@@ -42,11 +43,16 @@ Type = "vault"
 Protocol = "http"
 Host = "localhost"
 Port = 8200
-HealthCheckPath = "v1/sys/health"
-TokenPath = "res/resp-init.json"
-CertPath = ""
-CACertPath = ""
-SNIS = [""]
+Path = "/v1/secret/edgex/edgex-security-proxy-setup/"
+TokenFile = "/tmp/edgex/secrets/edgex-security-proxy-setup/secrets-token.json"
+RootCaCertPath = ""
+ServerName = ""
+# Number of attempts to retry retrieving secrets before failing to start the service.
+AdditionalRetryAttempts = 10
+# Amount of time to wait before attempting another retry
+RetryWaitPeriod = "1s"
+  [SecretStore.Authentication]
+  AuthType = "X-Vault-Token"
 
 [Clients]
   [Clients.CoreData]

--- a/internal/security/proxy/config/config.go
+++ b/internal/security/proxy/config/config.go
@@ -26,10 +26,11 @@ import (
 type ConfigurationStruct struct {
 	LogLevel       string
 	RequestTimeout int
+	SNIS           []string
 	KongURL        KongUrlInfo
 	KongAuth       KongAuthInfo
 	KongACL        KongAclInfo
-	SecretStore    SecretStoreInfo
+	SecretStore    bootstrapConfig.SecretStoreInfo
 	Clients        map[string]bootstrapConfig.ClientInfo
 }
 
@@ -69,23 +70,6 @@ type KongAclInfo struct {
 	WhiteList string
 }
 
-type SecretStoreInfo struct {
-	Type            string
-	Protocol        string
-	Host            string
-	Port            int
-	HealthCheckPath string
-	CertPath        string
-	TokenPath       string
-	CACertPath      string
-	SNIS            []string
-}
-
-// GetBaseURL builds and returns the base URL for the SecretStore service
-func (s SecretStoreInfo) GetBaseURL() string {
-	return fmt.Sprintf("%s://%s:%d", s.Protocol, s.Host, s.Port)
-}
-
 // UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct
 // Not needed for this service, so just return false
 func (c *ConfigurationStruct) UpdateFromRaw(_ interface{}) bool {
@@ -107,7 +91,9 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(_ interface{}) bool {
 // GetBootstrap returns the configuration elements required by the bootstrap.
 // Not needed for this service, so return empty struct
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
-	return bootstrapConfig.BootstrapConfiguration{}
+	return bootstrapConfig.BootstrapConfiguration{
+		SecretStore: c.SecretStore,
+	}
 }
 
 // GetLogLevel returns the current ConfigurationStruct's log level.

--- a/internal/security/proxy/init.go
+++ b/internal/security/proxy/init.go
@@ -66,11 +66,11 @@ func (b *Bootstrap) BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ sta
 	configuration := container.ConfigurationFrom(dic.Get)
 
 	var req internal.HttpCaller
-	if len(configuration.SecretStore.CACertPath) > 0 {
+	if len(configuration.SecretStore.RootCaCertPath) > 0 {
 		req = NewRequestor(
 			b.insecureSkipVerify,
 			configuration.RequestTimeout,
-			configuration.SecretStore.CACertPath,
+			configuration.SecretStore.RootCaCertPath,
 			lc)
 	} else {
 		req = NewRequestor(

--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -83,9 +83,9 @@ func (s *Service) CheckProxyServiceStatus() error {
 	return s.checkServiceStatus(s.configuration.KongURL.GetProxyBaseURL())
 }
 
-func (s *Service) CheckSecretServiceStatus() error {
-	return s.checkServiceStatus(s.configuration.SecretStore.GetBaseURL())
-}
+//func (s *Service) CheckSecretServiceStatus() error {
+//	return s.checkServiceStatus(s.configuration.SecretStore.GetBaseURL())
+//}
 
 func (s *Service) checkServiceStatus(path string) error {
 	req, err := http.NewRequest(http.MethodGet, path, nil)
@@ -282,7 +282,7 @@ func (s *Service) postCert(cp bootstrapConfig.CertKeyPair) *CertError {
 	body := &CertInfo{
 		Cert: cp.Cert,
 		Key:  cp.Key,
-		Snis: s.configuration.SecretStore.SNIS,
+		Snis: s.configuration.SNIS,
 	}
 	s.loggingClient.Debug("trying to upload cert to proxy server")
 	data, err := json.Marshal(body)

--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -83,10 +83,6 @@ func (s *Service) CheckProxyServiceStatus() error {
 	return s.checkServiceStatus(s.configuration.KongURL.GetProxyBaseURL())
 }
 
-//func (s *Service) CheckSecretServiceStatus() error {
-//	return s.checkServiceStatus(s.configuration.SecretStore.GetBaseURL())
-//}
-
 func (s *Service) checkServiceStatus(path string) error {
 	req, err := http.NewRequest(http.MethodGet, path, nil)
 	if err != nil {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -175,7 +175,7 @@ apps:
     command: bin/security-proxy-setup -confdir $SNAP_DATA/config/security-proxy-setup/res $INIT_ARG
     environment:
       INIT_ARG: "--init=true"
-      SECRETSTORE_TOKENPATH: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
+      SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
     daemon: oneshot
     start-timeout: 15m
     plugs: [network]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Empty SecretStore configuration passed to bootstrap so initialization fails when SecretStore is enabled, which is the case for Snap

## Issue Number: #3204 

## What is the new behavior?

Configuration now properly passed to bootstrap which allows for the SecretStore to be properly initialized

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information