### PR TITLE
fix(notifications): Match Specific Subscriptions

### DIFF
--- a/internal/pkg/db/redis/notifications.go
+++ b/internal/pkg/db/redis/notifications.go
@@ -437,7 +437,7 @@ func (c Client) GetSubscriptionByCategoriesLabels(categories []string, labels []
 		args = append(args, db.Subscription+":label:"+label)
 	}
 
-	objects, err := getUnionObjectsByValues(conn, args...)
+	objects, err := getObjectsByValues(conn, args...)
 	if err != nil {
 		return s, err
 	}


### PR DESCRIPTION
Fix 'oversending' of subscriptions by using the intersection of
category/label sets instead of union.

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?

Notifications are sent to any subscription that matches 1 or more category/label on the notificiation. 


## Issue Number:
#3225 

## What is the new behavior?

Notifications are sent to any subscription that matches all category/labels on the notification.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

I did not look at mongo behavior.

## Other information