### PR TITLE
refactor: Rework Proxy Setup to use KongRoute struct for configuration

### DIFF
--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -54,38 +54,45 @@ RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = "X-Vault-Token"
 
-[Clients]
-  [Clients.CoreData]
+[Routes]
+  [Routes.CoreData]
+  Name = "coredata"
   Protocol = "http"
   Host = "localhost"
   Port = 48080
 	
-  [Clients.Metadata]
+  [Routes.Metadata]
+  Name = "metadata"
   Protocol = "http"
   Host = "localhost"
   Port = 48081
 	
-  [Clients.Command]
+  [Routes.Command]
+  Name = "command"
   Protocol = "http"
   Host = "localhost"
   Port = 48082
 	
-  [Clients.Notifications]
+  [Routes.Notifications]
+  Name = "notifications"
   Protocol = "http"
   Host = "localhost"
   Port = 48060
 
-  [Clients.Scheduler]
+  [Routes.Scheduler]
+  Name = "scheduler"
   Protocol = "http"
   Host = "localhost"
   Port = 48085
 
-  [Clients.RulesEngine]
+  [Routes.RulesEngine]
+  Name = "rulesengine"
   Protocol = "http"
   Host = "localhost"
   Port = 48075
 	
-  [Clients.VirtualDevice]
+  [Routes.VirtualDevice]
+  Name = "virtualdevice"
   Protocol = "http"
   Host = "localhost"
   Port = 49990

--- a/internal/security/proxy/config/config.go
+++ b/internal/security/proxy/config/config.go
@@ -21,6 +21,8 @@ import (
 	"net/url"
 
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/proxy/models"
 )
 
 type ConfigurationStruct struct {
@@ -31,7 +33,7 @@ type ConfigurationStruct struct {
 	KongAuth       KongAuthInfo
 	KongACL        KongAclInfo
 	SecretStore    bootstrapConfig.SecretStoreInfo
-	Clients        map[string]bootstrapConfig.ClientInfo
+	Routes         map[string]models.KongService
 }
 
 type KongUrlInfo struct {

--- a/internal/security/proxy/container/config.go
+++ b/internal/security/proxy/container/config.go
@@ -17,9 +17,9 @@
 package container
 
 import (
-	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
-
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
 )
 
 // ConfigurationName contains the name of the config.ConfigurationStruct implementation in the DIC.

--- a/internal/security/proxy/models/kongParameters.go
+++ b/internal/security/proxy/models/kongParameters.go
@@ -13,7 +13,7 @@
  *
  * @author: Tingyu Zeng, Dell
  *******************************************************************************/
-package proxy
+package models
 
 type KongService struct {
 	Name     string `url:"name,omitempty"`

--- a/internal/security/proxy/service_test.go
+++ b/internal/security/proxy/service_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/proxy/models"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -325,7 +327,7 @@ func TestInitKongService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tk := &KongService{tt.serviceId, "test", 80, "http"}
+			tk := &models.KongService{tt.serviceId, "test", 80, "http"}
 			svc := NewService(&http.Client{}, logger.MockLogger{}, &tt.config)
 			err = svc.initKongService(tk)
 
@@ -384,7 +386,7 @@ func TestInitKongRoutes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewService(&http.Client{}, logger.MockLogger{}, &tt.config)
-			err = svc.initKongRoutes(&KongRoute{}, tt.path)
+			err = svc.initKongRoutes(&models.KongRoute{}, tt.path)
 			if err != nil && !tt.expectError {
 				t.Error(err)
 			}

--- a/internal/security/proxy/service_test.go
+++ b/internal/security/proxy/service_test.go
@@ -327,7 +327,12 @@ func TestInitKongService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tk := &models.KongService{tt.serviceId, "test", 80, "http"}
+			tk := &models.KongService{
+				Name:     tt.serviceId,
+				Protocol: "http",
+				Host:     "test",
+				Port:     80,
+			}
 			svc := NewService(&http.Client{}, logger.MockLogger{}, &tt.config)
 			err = svc.initKongService(tk)
 

--- a/internal/security/proxy/testdata/configuration.toml
+++ b/internal/security/proxy/testdata/configuration.toml
@@ -47,38 +47,45 @@ TokenPath = "res/resp-init.json"
 CACertPath = "res/EdgeXFoundryCA/EdgeXFoundryCA.pem"
 SNIS = ["edgex-kong"]
 
-[Clients]
-  [Clients.CoreData]
+[Routes]
+  [Routes.CoreData]
+  Name = "coredata"
   Protocol = "http"
-  Host = "edgex-core-data"
+  Host = "localhost"
   Port = 48080
-	
-  [Clients.Metadata]
+
+  [Routes.Metadata]
+  Name = "metadata"
   Protocol = "http"
-  Host = "edgex-core-metadata"
+  Host = "localhost"
   Port = 48081
-	
-  [Clients.Command]
+
+  [Routes.Command]
+  Name = "command"
   Protocol = "http"
-  Host = "edgex-core-command"
+  Host = "localhost"
   Port = 48082
-	
-  [Clients.Notifications]
+
+  [Routes.Notifications]
+  Name = "notifications"
   Protocol = "http"
-  Host = "edgex-support-notifications"
+  Host = "localhost"
   Port = 48060
 
-  [Clients.Scheduler]
-  Protocol = 'http'
-  Host = 'edgex-support-scheduler'
+  [Routes.Scheduler]
+  Name = "scheduler"
+  Protocol = "http"
+  Host = "localhost"
   Port = 48085
 
-  [Clients.Rulesengine]
+  [Routes.RulesEngine]
+  Name = "rules"
   Protocol = "http"
-  Host = "edgex-support-rulesengine"
+  Host = "localhost"
   Port = 48075
-	
-  [Clients.Virtualdevice]
+
+  [Routes.VirtualDevice]
+  Name = "ds-virtual"
   Protocol = "http"
-  Host = "edgex-device-virtual"
+  Host = "localhost"
   Port = 49990


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Proxy Setup uses repurposed ClientInfo struct for the Route configuration which has become an issue once the standards keys changed to service keys. This is because the key name is also used for the route name

## Issue Number: #3220


## What is the new behavior?
Now Proxy Setup uses existing KongRoute struct that has extra name property for the route name. The Route configuration is properly named `Routes`, no longer `Clients`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x ] Yes
- [ ] No

BREAKING CHANGE: Names for Route configuration has changed

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information