### PR TITLE
feat(notifications): Implement GET /notification/status/{status} V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -895,3 +895,16 @@ func (c *Client) NotificationById(id string) (notification model.Notification, e
 	}
 	return
 }
+
+// NotificationsByStatus queries notifications by offset, limit and status
+func (c *Client) NotificationsByStatus(offset int, limit int, status string) (notifications []model.Notification, edgeXerr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	notifications, edgeXerr = notificationsByStatus(conn, offset, limit, status)
+	if edgeXerr != nil {
+		return notifications, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
+			fmt.Sprintf("fail to query notifications by offset %d, limit %d and status %s", offset, limit, status), edgeXerr)
+	}
+	return notifications, nil
+}

--- a/internal/pkg/v2/infrastructure/redis/notification.go
+++ b/internal/pkg/v2/infrastructure/redis/notification.go
@@ -122,3 +122,17 @@ func notificationById(conn redis.Conn, id string) (notification models.Notificat
 	}
 	return
 }
+
+// notificationsByStatus queries notifications by offset, limit, and status
+func notificationsByStatus(conn redis.Conn, offset int, limit int, status string) (notifications []models.Notification, edgeXerr errors.EdgeX) {
+	end := offset + limit - 1
+	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
+		end = limit
+	}
+	objects, err := getObjectsByRevRange(conn, CreateKey(NotificationCollectionStatus, status), offset, end)
+	if err != nil {
+		return notifications, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return convertObjectsToNotifications(objects)
+}

--- a/internal/support/notifications/v2/application/notification.go
+++ b/internal/support/notifications/v2/application/notification.go
@@ -92,3 +92,20 @@ func NotificationById(id string, dic *di.Container) (notification dtos.Notificat
 	notification = dtos.FromNotificationModelToDTO(notificationModel)
 	return notification, nil
 }
+
+// NotificationsByStatus queries notifications with offset, limit, and status
+func NotificationsByStatus(offset, limit int, status string, dic *di.Container) (notifications []dtos.Notification, err errors.EdgeX) {
+	if status == "" {
+		return notifications, errors.NewCommonEdgeX(errors.KindContractInvalid, "status is empty", nil)
+	}
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+	notificationModels, err := dbClient.NotificationsByStatus(offset, limit, status)
+	if err != nil {
+		return notifications, errors.NewCommonEdgeXWrapper(err)
+	}
+	notifications = make([]dtos.Notification, len(notificationModels))
+	for i, n := range notificationModels {
+		notifications[i] = dtos.FromNotificationModelToDTO(n)
+	}
+	return notifications, nil
+}

--- a/internal/support/notifications/v2/controller/http/notification.go
+++ b/internal/support/notifications/v2/controller/http/notification.go
@@ -196,3 +196,41 @@ func (nc *NotificationController) NotificationsByLabel(w http.ResponseWriter, r 
 	utils.WriteHttpHeader(w, ctx, statusCode)
 	pkg.Encode(response, w, lc)
 }
+
+func (nc *NotificationController) NotificationsByStatus(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(nc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+	config := notificationContainer.ConfigurationFrom(nc.dic.Get)
+
+	vars := mux.Vars(r)
+	status := vars[v2.Status]
+
+	var response interface{}
+	var statusCode int
+
+	// parse URL query string for offset, limit
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		notifications, err := application.NotificationsByStatus(offset, limit, status, nc.dic)
+		if err != nil {
+			if errors.Kind(err) != errors.KindEntityDoesNotExist {
+				lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+			}
+			lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+			response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+			statusCode = err.Code()
+		} else {
+			response = responseDTO.NewMultiNotificationsResponse("", "", http.StatusOK, notifications)
+			statusCode = http.StatusOK
+		}
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -26,4 +26,5 @@ type DBClient interface {
 	NotificationById(id string) (models.Notification, errors.EdgeX)
 	NotificationsByCategory(offset, limit int, category string) ([]models.Notification, errors.EdgeX)
 	NotificationsByLabel(offset, limit int, label string) ([]models.Notification, errors.EdgeX)
+	NotificationsByStatus(offset, limit int, status string) ([]models.Notification, errors.EdgeX)
 }

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -180,6 +180,31 @@ func (_m *DBClient) NotificationsByLabel(offset int, limit int, label string) ([
 	return r0, r1
 }
 
+// NotificationsByStatus provides a mock function with given fields: offset, limit, status
+func (_m *DBClient) NotificationsByStatus(offset int, limit int, status string) ([]models.Notification, errors.EdgeX) {
+	ret := _m.Called(offset, limit, status)
+
+	var r0 []models.Notification
+	if rf, ok := ret.Get(0).(func(int, int, string) []models.Notification); ok {
+		r0 = rf(offset, limit, status)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Notification)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, string) errors.EdgeX); ok {
+		r1 = rf(offset, limit, status)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // SubscriptionById provides a mock function with given fields: id
 func (_m *DBClient) SubscriptionById(id string) (models.Subscription, errors.EdgeX) {
 	ret := _m.Called(id)

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -42,4 +42,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiNotificationByIdRoute, nc.NotificationById).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiNotificationByCategoryRoute, nc.NotificationsByCategory).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiNotificationByLabelRoute, nc.NotificationsByLabel).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiNotificationByStatusRoute, nc.NotificationsByStatus).Methods(http.MethodGet)
 }

--- a/openapi/v2/support-notifications.yaml
+++ b/openapi/v2/support-notifications.yaml
@@ -486,12 +486,58 @@ components:
         requestId: ""
         statusCode: 404
         message: "Not Found"
+    416Example:
+      value:
+        requestId: ""
+        apiVersion: "v2"
+        statusCode: 416
+        message: "Range Not Satisfiable"
     500Example:
       value:
         apiVersion: "v2"
         requestId: ""
         statusCode: 500
         message: "Internal Server Error"
+    AddSubscriptionsExample:
+      value:
+        - apiVersion: "v2"
+          requestId: ""
+          statusCode: 201
+          id: "6f52dc3c-5548-4142-baa6-052ac4bece93"
+          message: ""
+        - apiVersion: "v2"
+          requestId: ""
+          statusCode: 409
+          message: "Duplicated"
+        - apiVersion: "v2"
+          requestId: ""
+          statusCode: 500
+          message: "Internal Server Error"
+    UpdateSubscriptionsExample:
+      value:
+        - apiVersion: "v2"
+          requestId: ""
+          statusCode: 200
+          message: ""
+        - apiVersion: "v2"
+          requestId: ""
+          statusCode: 404
+          message: "Not Found"
+        - apiVersion: "v2"
+          requestId: ""
+          statusCode: 500
+          message: "Internal Server Error"
+    AddNotificationsExample:
+      value:
+        - apiVersion: "v2"
+          requestId: ""
+          statusCode: 201
+          id: "e77c6ca4-46e9-4b11-b0e9-4bbfe5e8420e"
+          message: ""
+        - apiVersion: "v2"
+          requestId: ""
+          statusCode: 500
+          message: "Internal Server Error"
 paths:
   /cleanup:
     parameters:
@@ -513,6 +559,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /cleanup/age/{age}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -539,6 +588,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /notification:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -566,6 +618,9 @@ paths:
                   anyOf:
                     - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/BaseWithIdResponse'
+              examples:
+                AddNotificationsExample:
+                  $ref: '#/components/examples/AddNotificationsExample'
         '400':
           description: "Request is in an invalid state"
           headers:
@@ -627,9 +682,22 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -638,9 +706,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /notification/age/{age}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -667,6 +736,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -676,6 +748,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                404Example:
+                  $ref: '#/components/examples/404Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -685,6 +760,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /notification/category/{category}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -708,17 +786,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiNotificationsResponse'
-        '404':
-          description: "The requested resource does not exist"
+        '400':
+          description: "Request is in an invalid state"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -727,9 +818,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /notification/label/{label}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -753,17 +845,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiNotificationsResponse'
-        '404':
-          description: "The requested resource does not exist"
+        '400':
+          description: "Request is in an invalid state"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -772,9 +877,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /notification/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -852,6 +958,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -861,6 +970,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                404Example:
+                  $ref: '#/components/examples/404Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -870,6 +982,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /notification/status/{status}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -893,17 +1008,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiNotificationsResponse'
-        '404':
-          description: "The requested resource does not exist"
+        '400':
+          description: "Request is in an invalid state"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -912,9 +1040,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /notification/subscription/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -938,8 +1067,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiNotificationsResponse'
-        '404':
-          description: "The requested resource does not exist"
+        '400':
+          description: "Request is in an invalid state"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -947,6 +1076,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -956,6 +1088,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /subscription:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -983,6 +1118,9 @@ paths:
                   anyOf:
                     - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/BaseWithIdResponse'
+              examples:
+                AddSubscriptionsExample:
+                  $ref: '#/components/examples/AddSubscriptionsExample'
         '400':
           description: "Request is in an invalid state"
           headers:
@@ -1031,6 +1169,9 @@ paths:
                   anyOf:
                     - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/BaseWithIdResponse'
+              examples:
+                UpdateSubscriptionsExample:
+                  $ref: '#/components/examples/UpdateSubscriptionsExample'
         '400':
           description: "Request is in an invalid state"
           headers:
@@ -1072,6 +1213,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiSubscriptionsResponse'
+        '400':
+          description: "Request is in an invalid state"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1080,9 +1245,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /subscription/category/{category}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1106,17 +1272,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiSubscriptionsResponse'
-        '404':
-          description: "The requested resource does not exist"
+        '400':
+          description: "Request is in an invalid state"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1125,9 +1304,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /subscription/label/{label}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1151,17 +1331,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiSubscriptionsResponse'
-        '404':
-          description: "The requested resource does not exist"
+        '400':
+          description: "Request is in an invalid state"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1170,9 +1363,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /subscription/receiver/{receiver}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1196,17 +1390,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiSubscriptionsResponse'
-        '404':
-          description: "The requested resource does not exist"
+        '400':
+          description: "Request is in an invalid state"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1215,9 +1422,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /subscription/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1248,6 +1456,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                404Example:
+                  $ref: '#/components/examples/404Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1257,6 +1468,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
     delete:
       summary: "Deletes a subscription according to the given name."
       responses:
@@ -1283,6 +1497,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /transmission/id/{id}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1313,6 +1530,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                404Example:
+                  $ref: '#/components/examples/404Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1322,6 +1542,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /transmission/age/{age}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1348,6 +1571,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
         '404':
           description: "The requested resource does not exist"
           headers:
@@ -1366,6 +1592,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /transmission/all:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1383,6 +1612,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiTransmissionsResponse'
+        '400':
+          description: "Request is in an invalid state"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1391,9 +1644,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /transmission/subscription/name/{name}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1417,8 +1671,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiTransmissionsResponse'
-        '404':
-          description: "The requested resource does not exist"
+        '400':
+          description: "Request is in an invalid state"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -1426,6 +1680,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1435,6 +1704,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /transmission/start/{start}/end/{end}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1472,9 +1744,22 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1483,9 +1768,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /transmission/status/{status}:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -1509,8 +1795,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MultiTransmissionsResponse'
-        '404':
-          description: "The requested resource does not exist"
+        '400':
+          description: "Request is in an invalid state"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
@@ -1518,6 +1804,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
         '500':
           description: "An unexpected error occurred on the server"
           headers:
@@ -1527,6 +1828,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /config:
     get:
       summary: "Returns the current configuration of the service."


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3218 


## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/get_notification_status__status_, implemented GET /notification/status/{status} V2 API.

Also revised the Swagger file:
- Added HTTP status code 416 as a possible response to the APIs with query strings `offset` and `limit`.
- Added example responses: 400, 404, 416, 500, AddSubscriptions, UpdateSubscriptions, AddNotifications
- For the APIs used to query multiple data, e.g. /notification/status/{status}, changed the possible response 404 to 400. Because when there are no records in the DB, the current Redis infrastructure will return an empty slice instead of a NotFound error. (Refer to https://github.com/edgexfoundry/edgex-go/commit/08b8cf9d8f91aff2f776525b0898b6ad28dc73db#diff-c279e55dbe08fa2d79b96071b5860ee5e8d7b8f2955298f724dd65d994462328R60-R63)

Close #3218 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No
