### PR TITLE
fix: Update docker file location 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ They can be launched easily with **docker-compose**.
 The simplest way to get started is to fetch the latest docker-compose.yml and start the EdgeX containers:
 
 ```sh
+release="pre-release" # or "hanoi" for latest
 wget -O docker-compose.yml \
-https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files/docker-compose-nexus-redis.yml
+https://raw.githubusercontent.com/edgexfoundry/edgex-compose/master/releases/${release}/docker-compose-${release}.yml
 docker-compose up -d
 ```
 


### PR DESCRIPTION
Current path is no more available,
I am assuming it has been relocated to this new repo:

https://github.com/edgexfoundry/edgex-compose/
Signed-off-by: Philippe Coval <rzr@users.sf.net>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information