### PR TITLE
feat(notifications): Implement GET /notification/start/{start}/end/{end} V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -908,3 +908,16 @@ func (c *Client) NotificationsByStatus(offset int, limit int, status string) (no
 	}
 	return notifications, nil
 }
+
+// NotificationsByTimeRange query notifications by time range, offset, and limit
+func (c *Client) NotificationsByTimeRange(start int, end int, offset int, limit int) (notifications []model.Notification, edgeXerr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	notifications, edgeXerr = notificationsByTimeRange(conn, start, end, offset, limit)
+	if edgeXerr != nil {
+		return notifications, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
+			fmt.Sprintf("fail to query notifications by time range %v ~ %v, offset %d, and limit %d", start, end, offset, limit), edgeXerr)
+	}
+	return notifications, nil
+}

--- a/internal/support/notifications/v2/application/notification.go
+++ b/internal/support/notifications/v2/application/notification.go
@@ -109,3 +109,17 @@ func NotificationsByStatus(offset, limit int, status string, dic *di.Container) 
 	}
 	return notifications, nil
 }
+
+// NotificationsByTimeRange query notifications with offset, limit and time range
+func NotificationsByTimeRange(start int, end int, offset int, limit int, dic *di.Container) (notifications []dtos.Notification, err errors.EdgeX) {
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+	notificationModels, err := dbClient.NotificationsByTimeRange(start, end, offset, limit)
+	if err != nil {
+		return notifications, errors.NewCommonEdgeXWrapper(err)
+	}
+	notifications = make([]dtos.Notification, len(notificationModels))
+	for i, e := range notificationModels {
+		notifications[i] = dtos.FromNotificationModelToDTO(e)
+	}
+	return notifications, nil
+}

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -27,4 +27,5 @@ type DBClient interface {
 	NotificationsByCategory(offset, limit int, category string) ([]models.Notification, errors.EdgeX)
 	NotificationsByLabel(offset, limit int, label string) ([]models.Notification, errors.EdgeX)
 	NotificationsByStatus(offset, limit int, status string) ([]models.Notification, errors.EdgeX)
+	NotificationsByTimeRange(start int, end int, offset int, limit int) ([]models.Notification, errors.EdgeX)
 }

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -205,6 +205,31 @@ func (_m *DBClient) NotificationsByStatus(offset int, limit int, status string) 
 	return r0, r1
 }
 
+// NotificationsByTimeRange provides a mock function with given fields: start, end, offset, limit
+func (_m *DBClient) NotificationsByTimeRange(start int, end int, offset int, limit int) ([]models.Notification, errors.EdgeX) {
+	ret := _m.Called(start, end, offset, limit)
+
+	var r0 []models.Notification
+	if rf, ok := ret.Get(0).(func(int, int, int, int) []models.Notification); ok {
+		r0 = rf(start, end, offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Notification)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, int, int) errors.EdgeX); ok {
+		r1 = rf(start, end, offset, limit)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // SubscriptionById provides a mock function with given fields: id
 func (_m *DBClient) SubscriptionById(id string) (models.Subscription, errors.EdgeX) {
 	ret := _m.Called(id)

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -43,4 +43,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiNotificationByCategoryRoute, nc.NotificationsByCategory).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiNotificationByLabelRoute, nc.NotificationsByLabel).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiNotificationByStatusRoute, nc.NotificationsByStatus).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiNotificationByTimeRangeRoute, nc.NotificationsByTimeRange).Methods(http.MethodGet)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3239


## What is the new behavior?
Per https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/get_notification_start__start__end__end_, implemented GET /notification/start/{start}/end/{end} V2 API.

Close #3239 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No
