### PR TITLE
fix(snap): use go 1.15.x snap for builds

### DIFF
--- a/snap/local/build-helpers/bin/go-build-helper.sh
+++ b/snap/local/build-helpers/bin/go-build-helper.sh
@@ -1,22 +1,20 @@
 #!/bin/bash
 #
 # $1 - go import path
-# $2 - maj/min version of go; must correspond to a go part in the snap
 #
 # example usage:
-# $ gopartbootstrap github.com/edgexfoundry/edgex-go 1.15
+# $ gopartbootstrap github.com/edgexfoundry/edgex-go
 gopartbootstrap() 
 {
     # first set the GOPATH to be in the current directory and in ".gopath"
     GOPATH="$(pwd)/.gopath"
     export GOPATH
+
     # setup path to include both $SNAPCRAFT_STAGE/bin and $GOPATH/bin
     # the former is for the go tools, as well as things like glide, etc.
     # while the later is for govendor, etc. and other go tools that might need to be installed
-    export PATH="$SNAPCRAFT_STAGE/go$2/bin:$GOPATH/bin:$PATH"
-    # set GOROOT to be whatever the go tool from SNAPCRAFT_STAGE/bin is
-    GOROOT=$(go env GOROOT)
-    export GOROOT
+    export PATH="$GOPATH/bin:$PATH"
+
     # now setup the GOPATH for this part using the import path
     export GOIMPORTPATH="$GOPATH/src/$1"
     mkdir -p "$GOIMPORTPATH"

--- a/snap/local/build-helpers/bin/minimal-snap-build.sh
+++ b/snap/local/build-helpers/bin/minimal-snap-build.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# This script is used by the LF's CI/CD build pipeline to
+# optimize the snap CI check run for pull requests. When
+# run, it essentially strips out everything (apps and
+# parts) from the snapcraft.yaml file except those required
+# to build edgex-go, as the whole idea of the CI check is to
+# catch changes to edgex-go that break the snap build.
+#
+# Note - in addition to applying this patch, the pipeline also
+# only primes the snap (e.g. `snapcraft prime`), as there's no
+# need to build the finally binary .snap file (and it won't
+# work with the patch applied). This further reduces the build
+# time.
+
+sudo snap install yq --channel=v4/stable
+
+CURRDIR=$(pwd)
+SNAPCRAFT_YAML="$CURRDIR/snap/snapcraft.yaml"
+
+# remove first chunk of apps
+yq e -P -i 'del(.apps.consul,.apps.redis,.apps.postgres,.apps.kong-daemon,.apps.vault,.apps.vault-cli)' "$SNAPCRAFT_YAML"
+
+# remove second chunk of apps
+yq e -P -i 'del(.apps.device-virtual,.apps.app-service-configurable)' "$SNAPCRAFT_YAML"
+
+# remove third chunk of apps
+yq e -P -i 'del(.apps.redis-cli,.apps.consul-cli)' "$SNAPCRAFT_YAML"
+
+# remove fourth chunk of apps
+yq e -P -i 'del(.apps.kong,.apps.psql,.apps.psql-any,.apps.createdb,.apps.kuiper,.apps.kuiper-cli)' "$SNAPCRAFT_YAML"
+
+# remove unwanted parts
+yq e -P -i 'del(.parts.snapcraft-preload,.parts.postgres,.parts.consul,.parts.redis,.parts.kong,.parts.vault,.parts.device-virtual-go,.parts.kuiper)' "$SNAPCRAFT_YAML"
+
+

--- a/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
+++ b/snap/local/patches/0001-optimize-build-for-pipeline-CI-check.patch
@@ -1,6 +1,6 @@
 From 0510531350ba940eafa289c8b699567ab358c449 Mon Sep 17 00:00:00 2001
 From: Tony Espy <espy@canonical.com>
-Date: Wed, 16 Dec 2020 16:34:55 -0500
+Date: Tue, 9 Mar 2021 19:05:15 -0500
 Subject: [PATCH] optimize snap build for pipeline CI check
 
 This patch is used by the EdgeX CI pipeline builds to
@@ -21,11 +21,11 @@ need to build the finally binary .snap file (and it won't
 work with the patch applied). This further reduces the build
 time.
 ---
- snap/snapcraft.yaml | 461 +-------------------------------------------
- 1 file changed, 2 insertions(+), 459 deletions(-)
+ snap/snapcraft.yaml | 452 +-------------------------------------------
+ 1 file changed, 1 insertion(+), 451 deletions(-)
 
 diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
-index 1e537489..faf42425 100644
+index d8bc12bc..5a5f5fbb 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
 @@ -73,78 +73,6 @@ confinement: strict
@@ -107,8 +107,8 @@ index 1e537489..faf42425 100644
    security-secretstore-setup:
      adapter: full
      after: [vault]
-@@ -271,29 +202,6 @@ apps:
-       ExecutorPath: $SNAP/bin/sys-mgmt-agent-snap-executor.sh
+@@ -277,29 +205,6 @@ apps:
+       EXECUTORPATH: $SNAP/bin/sys-mgmt-agent-snap-executor.sh
      daemon: simple
      plugs: [network, network-bind]
 -  device-virtual:
@@ -137,7 +137,7 @@ index 1e537489..faf42425 100644
    # helper commands the snap exposes
    security-proxy-setup-cmd:
      adapter: none
-@@ -309,14 +214,6 @@ apps:
+@@ -312,14 +217,6 @@ apps:
      # not a mistake--secrets-config re-uses security-proxy-setup's configuration.toml
      command: bin/secrets-config -confdir $SNAP_DATA/config/security-proxy-setup/res
      plugs: [home, removable-media, network]
@@ -152,7 +152,7 @@ index 1e537489..faf42425 100644
    curl:
      adapter: full
      command: usr/bin/curl
-@@ -325,76 +222,6 @@ apps:
+@@ -328,76 +225,6 @@ apps:
      adapter: full
      command: usr/bin/jq
      plugs: [home, removable-media]
@@ -229,7 +229,7 @@ index 1e537489..faf42425 100644
  
  parts:
    version:
-@@ -402,6 +229,7 @@ parts:
+@@ -405,6 +232,7 @@ parts:
      # as with static-packages part, the source dir is unrelated to this part and is used
      # since it changes rarely and therefore will not trigger a new pull
      source: snap/local/build-helpers
@@ -237,7 +237,7 @@ index 1e537489..faf42425 100644
      override-pull: |
        cd $SNAPCRAFT_PROJECT_DIR
        if [ -f VERSION ]; then
-@@ -428,59 +256,6 @@ parts:
+@@ -431,59 +259,6 @@ parts:
        # setpriv with snapd 2.45 + can be used to drop privileges
        - setpriv
  
@@ -297,14 +297,12 @@ index 1e537489..faf42425 100644
    go-build-helper:
      plugin: dump
      # see comment for static-packages part about specifying a source part here
-@@ -515,70 +290,7 @@ parts:
-       tar -C $SNAPCRAFT_STAGE/go1.15 -xf "$FILE_NAME" --strip-components=1
-     prime:
-       - "-*"
--    after: [go-build-helper]
--
+@@ -496,69 +271,6 @@ parts:
+     plugin: dump
+     source: snap/local/runtime-helpers
+ 
 -  consul:
--    after: [go115]
+-    after: [go-build-helper]
 -    plugin: make
 -    source: https://github.com/hashicorp/consul.git
 -    source-tag: v1.8.4
@@ -326,7 +324,7 @@ index 1e537489..faf42425 100644
 -      fi
 -
 -      . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
--      gopartbootstrap github.com/hashicorp/consul 1.15
+-      gopartbootstrap github.com/hashicorp/consul
 -      export GO111MODULES=off
 -      go get -u github.com/kardianos/govendor
 -      govendor install
@@ -365,11 +363,11 @@ index 1e537489..faf42425 100644
 -    source-depth: 1
 -    plugin: make
 -    make-install-var: PREFIX
-+    after: [go-build-helper, static-packages]
- 
+-
    edgex-go:
      source: .
-@@ -629,172 +341,3 @@ parts:
+     plugin: make
+@@ -615,165 +327,3 @@ parts:
        - pkg-config
      stage-packages:
        - libzmq5
@@ -421,14 +419,14 @@ index 1e537489..faf42425 100644
 -
 -  # SECURITY SERVICES PARTS
 -  vault:
--    after: [go115]
+-    after: [go-build-helper]
 -    plugin: make
 -    source: https://github.com/hashicorp/vault.git
 -    source-tag: v1.5.4
 -    source-depth: 1
 -    override-build: |
 -      . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
--      gopartbootstrap github.com/hashicorp/vault 1.15
+-      gopartbootstrap github.com/hashicorp/vault
 -      export GO111MODULES=off
 -      make bootstrap
 -      make dev
@@ -471,10 +469,8 @@ index 1e537489..faf42425 100644
 -    source-depth: 1
 -    source-tag: v1.2.1
 -    plugin: make
--    after: [go115]
+-    after: [go-build-helper]
 -    override-build: |
--      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
--      cd $SNAPCRAFT_PART_SRC
 -      # create VERSION file (supposed to be created by jenkins pipeline...)
 -      echo "1.2.1" > ./VERSION
 -      make build
@@ -500,10 +496,8 @@ index 1e537489..faf42425 100644
 -    plugin: make
 -    build-packages: [gcc, git, libzmq3-dev, pkg-config]
 -    stage-packages: [libzmq5]
--    after: [go115]
+-    after: [go-build-helper]
 -    override-build: |
--      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
--      cd $SNAPCRAFT_PART_SRC
 -      make build
 -
 -      # install the service binary, configuration, and license files
@@ -520,11 +514,8 @@ index 1e537489..faf42425 100644
 -    source: https://github.com/emqx/kuiper.git
 -    source-tag: 0.4.1
 -    plugin: make
--    after: [go115]
+-    after: [go-build-helper]
 -    override-build: |
--      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
--
--      cd $SNAPCRAFT_PART_SRC
 -      export BUILD_PATH=$SNAPCRAFT_PART_BUILD
 -      export PACKAGES_PATH=$SNAPCRAFT_PART_INSTALL
 -      make build_with_edgex
@@ -544,3 +535,4 @@ index 1e537489..faf42425 100644
 -      - libzmq5
 -- 
 2.17.1
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -488,40 +488,16 @@ parts:
     plugin: dump
     # see comment for static-packages part about specifying a source part here
     source: snap/local/build-helpers
+    build-snaps:
+      - go/1.15/stable
     prime: [-*]
 
   config-common:
     plugin: dump
     source: snap/local/runtime-helpers
 
-  go115:
-    plugin: nil
-    source: snap/local/build-helpers
-    override-build: |
-      # use dpkg architecture to figure out our target arch
-      # note - we specifically don't use arch
-      case "$(dpkg --print-architecture)" in
-        amd64)
-          FILE_NAME=go1.15.2.linux-amd64.tar.gz
-          FILE_HASH=b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552
-          ;;
-        arm64)
-          FILE_NAME=go1.15.2.linux-arm64.tar.gz
-          FILE_HASH=c8ec460cc82d61604b048f9439c06bd591722efce5cd48f49e19b5f6226bd36d
-          ;;
-      esac
-      # download the archive, failing on ssl cert problems
-      curl https://dl.google.com/go/$FILE_NAME -O
-      echo "$FILE_HASH $FILE_NAME" > sha256
-      sha256sum -c sha256 | grep OK
-      mkdir -p $SNAPCRAFT_STAGE/go1.15
-      tar -C $SNAPCRAFT_STAGE/go1.15 -xf "$FILE_NAME" --strip-components=1
-    prime:
-      - "-*"
-    after: [go-build-helper]
-
   consul:
-    after: [go115]
+    after: [go-build-helper]
     plugin: make
     source: https://github.com/hashicorp/consul.git
     source-tag: v1.8.4
@@ -543,7 +519,7 @@ parts:
       fi
 
       . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
-      gopartbootstrap github.com/hashicorp/consul 1.15
+      gopartbootstrap github.com/hashicorp/consul
       export GO111MODULES=off
       go get -u github.com/kardianos/govendor
       govendor install
@@ -586,9 +562,8 @@ parts:
   edgex-go:
     source: .
     plugin: make
-    after: [go115]
+    after: [go-build-helper]
     override-build: |
-      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
       cd $SNAPCRAFT_PART_SRC
 
       make build
@@ -688,14 +663,14 @@ parts:
 
   # SECURITY SERVICES PARTS
   vault:
-    after: [go115]
+    after: [go-build-helper]
     plugin: make
     source: https://github.com/hashicorp/vault.git
     source-tag: v1.5.4
     source-depth: 1
     override-build: |
       . $SNAPCRAFT_STAGE/bin/go-build-helper.sh
-      gopartbootstrap github.com/hashicorp/vault 1.15
+      gopartbootstrap github.com/hashicorp/vault
       export GO111MODULES=off
       make bootstrap
       make dev
@@ -738,10 +713,8 @@ parts:
     source-depth: 1
     source-tag: v1.2.1
     plugin: make
-    after: [go115]
+    after: [go-build-helper]
     override-build: |
-      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
-      cd $SNAPCRAFT_PART_SRC
       # create VERSION file (supposed to be created by jenkins pipeline...)
       echo "1.2.1" > ./VERSION
       make build
@@ -767,10 +740,8 @@ parts:
     plugin: make
     build-packages: [gcc, git, libzmq3-dev, pkg-config]
     stage-packages: [libzmq5]
-    after: [go115]
+    after: [go-build-helper]
     override-build: |
-      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
-      cd $SNAPCRAFT_PART_SRC
       make build
 
       # install the service binary, configuration, and license files
@@ -787,11 +758,8 @@ parts:
     source: https://github.com/emqx/kuiper.git
     source-tag: 0.4.1
     plugin: make
-    after: [go115]
+    after: [go-build-helper]
     override-build: |
-      export PATH="$SNAPCRAFT_STAGE/go1.15/bin:$GOPATH/bin:$PATH"
-
-      cd $SNAPCRAFT_PART_SRC
       export BUILD_PATH=$SNAPCRAFT_PART_BUILD
       export PACKAGES_PATH=$SNAPCRAFT_PART_INSTALL
       make build_with_edgex


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
The snap build downloads prebuilt release tarballs of go 1.15.2 from Google's download site in order to build edgex-go, and the other Go-based parts in the snap.

## Issue Number:


## What is the new behavior?
This change updates the snap build to use the go snap instead of downloading the prebuilt go release tarballs from google's download site. This also means the snap builds are always using the latest go 1.15 stable release.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
This PR also provides a new script called `minimal-snap-build.sh` (found in `/snap/local/build-helpers/bin`) which is meant to replace the existing snap build optimization patch used by the CI/CD pipeline for PRs. The script approach (thanks @bnevis-i) is much more resilient to changes to `snapcraft.yaml`, so in general will be more or less maintenance free.
