### PR TITLE
feat: Use service keys for Route configuration keys

### DIFF
--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -55,43 +55,43 @@ RetryWaitPeriod = "1s"
   AuthType = "X-Vault-Token"
 
 [Routes]
-  [Routes.CoreData]
+  [Routes.edgex-core-data]
   Name = "coredata"
   Protocol = "http"
   Host = "localhost"
   Port = 48080
 	
-  [Routes.Metadata]
+  [Routes.edgex-core-metadata]
   Name = "metadata"
   Protocol = "http"
   Host = "localhost"
   Port = 48081
 	
-  [Routes.Command]
+  [Routes.edgex-core-command]
   Name = "command"
   Protocol = "http"
   Host = "localhost"
   Port = 48082
 	
-  [Routes.Notifications]
+  [Routes.edgex-support-notifications]
   Name = "notifications"
   Protocol = "http"
   Host = "localhost"
   Port = 48060
 
-  [Routes.Scheduler]
+  [Routes.edgex-support-scheduler]
   Name = "scheduler"
   Protocol = "http"
   Host = "localhost"
   Port = 48085
 
-  [Routes.RulesEngine]
+  [Routes.rules-engine]
   Name = "rulesengine"
   Protocol = "http"
   Host = "localhost"
   Port = 48075
 	
-  [Routes.VirtualDevice]
+  [Routes.device-virtual]
   Name = "virtualdevice"
   Protocol = "http"
   Host = "localhost"

--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -342,7 +342,7 @@ func (s *Service) initKongService(service *models.KongService) error {
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated:
-		s.loggingClient.Info(fmt.Sprintf("successful to set up proxy service for %s", service.Name))
+		s.loggingClient.Info(fmt.Sprintf("successful to set up proxy service for `%s` at `%s:%d`", service.Name, service.Host, service.Port))
 		break
 	case http.StatusConflict:
 		s.loggingClient.Info(fmt.Sprintf("proxy service for %s has been set up", service.Name))
@@ -382,7 +382,7 @@ func (s *Service) initKongRoutes(r *models.KongRoute, name string) error {
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
 		s.routes[name] = r
-		s.loggingClient.Info(fmt.Sprintf("successful to set up route for %s", name))
+		s.loggingClient.Info(fmt.Sprintf("successful to set up route for `%s` at `%v`", name, r.Paths))
 		break
 	default:
 		e := fmt.Sprintf("failed to set up route for %s with error %s", name, resp.Status)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Route configuration map keys are the old random names for the services

## Issue Number: #3246


## What is the new behavior?
Route configuration map keys are now the services' service keys


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information