### PR TITLE
feat(security): Implementation for setting up agent token

### DIFF
--- a/internal/security/bootstrapper/command/setupacl/acltokens.go
+++ b/internal/security/bootstrapper/command/setupacl/acltokens.go
@@ -1,0 +1,413 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package setupacl
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
+)
+
+// AgentTokenType is the type of token to be set on the Consul agent
+type AgentTokenType string
+
+const (
+	/*
+	 * The following are available agent token types that can be used for setting the token to Consul's agent
+	 * For the details for each type, see reference https://www.consul.io/commands/acl/set-agent-token#token-types
+	 */
+	// DefaultType is agent token type "default" to be set
+	DefaultType AgentTokenType = "default"
+	// AgentType is agent token type "agent" to be set
+	AgentType AgentTokenType = "agent"
+	// MasterType is agent token type "master" to be set
+	MasterType AgentTokenType = "master"
+	// ReplicationType is agent token type "replication" to be set
+	ReplicationType AgentTokenType = "replication"
+
+	// consul API related:
+	consulTokenHeader      = "X-Consul-Token"
+	consulCheckAgentAPI    = "/v1/agent/self"
+	consulSetAgentTokenAPI = "/v1/agent/token/%s"
+	consulListTokensAPI    = "/v1/acl/tokens"
+	consulCreateTokenAPI   = "/v1/acl/token"
+	// RUD: Read Update Delete
+	consulTokenRUDAPI = "/v1/acl/token/%s"
+)
+
+// isACLTokenPersistent checks Consul agent's configuration property for EnablePersistence of ACLTokens
+// it returns true if the token persistence is enabled; false otherwise
+// once ACL rules are enforced, this call requires at least agent read permission and hence we use
+// the bootstrap ACL token as that's the only token available before creating an agent token
+// this determines whether we need to re-set the agent token every time Consul agent is restarted
+func (c *cmd) isACLTokenPersistent(bootstrapACLToken *string) (bool, error) {
+	if bootstrapACLToken == nil || len(*bootstrapACLToken) == 0 {
+		return false, errors.New("bootstrap ACL token is required for checking agent properties")
+	}
+
+	checkAgentURL, err := c.getRegistryApiUrl(consulCheckAgentAPI)
+	if err != nil {
+		return false, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, checkAgentURL, http.NoBody)
+	if err != nil {
+		return false, fmt.Errorf("Failed to prepare checkAgent request for http URL: %w", err)
+	}
+
+	req.Header.Add(consulTokenHeader, *bootstrapACLToken)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("Failed to send checkAgent request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	checkAgentResp, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("Failed to read checkAgent response body: %w", err)
+	}
+
+	type AgentProperties struct {
+		AgentDebugConfig struct {
+			AgentACLTokens struct {
+				EnablePersistence bool `json:"EnablePersistence"`
+			} `json:"ACLTokens"`
+		} `json:"DebugConfig"`
+	}
+
+	var agentProp AgentProperties
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if err := json.NewDecoder(bytes.NewReader(checkAgentResp)).Decode(&agentProp); err != nil {
+			return false, fmt.Errorf("failed to decode AgentProperties json data: %v", err)
+		}
+
+		c.loggingClient.Debugf("got AgentProperties: %v", agentProp)
+
+		return agentProp.AgentDebugConfig.AgentACLTokens.EnablePersistence, nil
+	default:
+		return false, fmt.Errorf("failed to check agent ACL token persistence property with status code= %d: %s",
+			resp.StatusCode, string(checkAgentResp))
+	}
+}
+
+// createAgentToken uses bootstrapped ACL token to create an agent token
+// this call requires ACL read/write permission and hence we use the bootstrap ACL token
+// it checks whether there is an agent token already existing and re-uses it if so
+// otherwise creates a new agent token
+func (c *cmd) createAgentToken(bootstrapACLToken *BootStrapACLTokenInfo) (string, error) {
+	if bootstrapACLToken == nil {
+		return emptyToken, errors.New("bootstrap ACL token is required for creating agent token")
+	}
+
+	// list tokens and search for the "edgex-core-consul" agent token if any
+	// Note: the internal Consul ACL system may not be ready yet, hence we need to retry it as to
+	// error on ACL in legacy mode until timed out otherwise
+	timeoutInSec := int(c.retryTimeout.Seconds())
+	timer := startup.NewTimer(timeoutInSec, 1)
+	var agentToken string
+	var err error
+	for timer.HasNotElapsed() {
+		agentToken, err = c.getEdgeXAgentToken(bootstrapACLToken)
+
+		if err != nil && !strings.Contains(err.Error(), consulLegacyACLModeError) {
+			// other type of request error, cannot continue
+			return emptyToken, fmt.Errorf("Failed to retrieve EdgeX agent token: %v", err)
+		} else if err != nil {
+			c.loggingClient.Warnf("found Consul still in ACL legacy mode, will retry once again: %v", err)
+			timer.SleepForInterval()
+			continue
+		}
+
+		// once reach here, Consul ACL system is ready
+		c.loggingClient.Info("internal Consul ACL system is ready")
+		break
+	}
+
+	// retries reached timeout, aborting
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to retrieve EdgeX agent token: %v", err)
+	}
+
+	if len(agentToken) == 0 {
+		// need to create a new agent token as there is no matched one found
+		agentToken, err = c.insertNewAgentToken(bootstrapACLToken)
+		if err != nil {
+			return emptyToken, fmt.Errorf("Failed to insert a new EdgeX agent token: %v", err)
+		}
+	}
+	return agentToken, nil
+}
+
+// getEdgeXAgentToken lists tokens and find the matched agent token by the expected key pattern
+// it returns the first matched agent token if many tokens actually are matched
+// it returns empty token if no matching found
+func (c *cmd) getEdgeXAgentToken(bootstrapACLToken *BootStrapACLTokenInfo) (string, error) {
+	listTokensURL, err := c.getRegistryApiUrl(consulListTokensAPI)
+	if err != nil {
+		return emptyToken, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, listTokensURL, http.NoBody)
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to prepare getEdgeXAgentToken request for http URL: %w", err)
+	}
+
+	req.Header.Add(consulTokenHeader, bootstrapACLToken.SecretID)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to send getEdgeXAgentToken request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	listTokensResp, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to read getEdgeXAgentToken response body: %w", err)
+	}
+
+	type ListTokensInfo []struct {
+		AccessorID  string `json:"AccessorID"`
+		Description string `json:"Description"`
+	}
+
+	var listTokens ListTokensInfo
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if err := json.NewDecoder(bytes.NewReader(listTokensResp)).Decode(&listTokens); err != nil {
+			return emptyToken, fmt.Errorf("failed to decode ListTokensInfo json data: %v", err)
+		}
+
+		edgexAgentToken := emptyToken // initial value
+		// use Description to match the substring to search for EdgeX's agent token
+		// we cannot use policy to search yet as the agent token is created with the global policy
+		// matching anything contains pattern "edgex[alphanumeric_with_space_or_dash] agent token" with case insensitive
+		pattern := regexp.MustCompile(`(?i)edgex([0-9a-z\- ]+)agent token`)
+		for _, token := range listTokens {
+			if pattern.MatchString(token.Description) {
+				tokenID, err := c.readTokenIDBy(bootstrapACLToken, strings.TrimSpace(token.AccessorID))
+				if err != nil {
+					return emptyToken, err
+				}
+				edgexAgentToken = tokenID
+				break
+			}
+		}
+
+		return edgexAgentToken, nil
+	default:
+		return emptyToken, fmt.Errorf("failed to list tokens with status code= %d: %s", resp.StatusCode,
+			string(listTokensResp))
+	}
+}
+
+// readTokenID reads the tokenID (i.e. SecretID) by given accessorID
+// it returns the token's SecretID if found, otherwise empty string
+func (c *cmd) readTokenIDBy(bootstrapACLToken *BootStrapACLTokenInfo, accessorID string) (string, error) {
+	if len(accessorID) == 0 {
+		return emptyToken, errors.New("accessorID is required and cannot be empty")
+	}
+
+	readTokenURL, err := c.getRegistryApiUrl(fmt.Sprintf(consulTokenRUDAPI, accessorID))
+	if err != nil {
+		return emptyToken, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, readTokenURL, http.NoBody)
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to prepare readTokenID request for http URL: %w", err)
+	}
+
+	req.Header.Add(consulTokenHeader, bootstrapACLToken.SecretID)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to send readTokenID request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	readTokenResp, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to read readTokenID response body: %w", err)
+	}
+
+	type TokenReadInfo struct {
+		ID string `json:"SecretID"`
+	}
+
+	var tokenRead TokenReadInfo
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if err := json.NewDecoder(bytes.NewReader(readTokenResp)).Decode(&tokenRead); err != nil {
+			return emptyToken, fmt.Errorf("failed to decode TokenReadInfo json data: %v", err)
+		}
+
+		return tokenRead.ID, nil
+	default:
+		return emptyToken, fmt.Errorf("failed to read token ID with status code= %d: %s", resp.StatusCode,
+			string(readTokenResp))
+	}
+}
+
+// insertNewAgentToken creates a new Consul token
+// it returns the token's ID and error if any error occurs
+func (c *cmd) insertNewAgentToken(bootstrapACLToken *BootStrapACLTokenInfo) (string, error) {
+	createTokenURL, err := c.getRegistryApiUrl(consulCreateTokenAPI)
+	if err != nil {
+		return emptyToken, err
+	}
+
+	// payload struct for creating a new token
+	type CreateToken struct {
+		Description string   `json:"Description"`
+		Policies    []Policy `json:"Policies"`
+		Local       bool     `json:"Local"`
+		TTL         *string  `json:"ExpirationTTL,omitempty"`
+	}
+
+	unlimitedDuration := "0s"
+	createToken := &CreateToken{
+		Description: "edgex-core-consul agent token",
+		// uses global mgmt policy in Phase 1
+		Policies: bootstrapACLToken.Policies,
+		// only applies to the local agent as of today's use cases (no need to be replicated to other agents)
+		Local: true,
+		// never expired, based on Phase 1 or 2 from ADR
+		TTL: &unlimitedDuration,
+	}
+
+	jsonPayload, err := json.Marshal(createToken)
+	c.loggingClient.Tracef("payload: %v", createToken)
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to marshal CreatToken JSON string payload: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPut, createTokenURL, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to prepare creat a new token request for http URL: %w", err)
+	}
+
+	req.Header.Add(consulTokenHeader, bootstrapACLToken.SecretID)
+	req.Header.Add(clients.ContentType, clients.ContentTypeJSON)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to send create a new token request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	createTokenResp, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return emptyToken, fmt.Errorf("Failed to read create a new token response body: %w", err)
+	}
+
+	var parsedTokenResponse map[string]interface{}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if err := json.NewDecoder(bytes.NewReader(createTokenResp)).Decode(&parsedTokenResponse); err != nil {
+			return emptyToken, fmt.Errorf("Failed to decode create token response body: %v", err)
+		}
+
+		c.loggingClient.Info("successfully created a new agent token")
+
+		return fmt.Sprintf("%s", parsedTokenResponse["SecretID"]), nil
+	default:
+		return emptyToken, fmt.Errorf("failed to create a new token via URL [%s] and status code= %d: %s",
+			consulCreateTokenAPI, resp.StatusCode, string(createTokenResp))
+	}
+}
+
+// setAgentToken sets the ACL token currently in use by the agent
+func (c *cmd) setAgentToken(bootstrapACLToken *BootStrapACLTokenInfo, agentTokenID *string,
+	tokenType AgentTokenType) error {
+	if bootstrapACLToken == nil {
+		return errors.New("bootstrap ACL token is required for setting agent token")
+	}
+
+	if agentTokenID == nil || len(*agentTokenID) == 0 {
+		return errors.New("agent token ID is required for setting agent token")
+	}
+
+	setAgentTokenURL, err := c.getRegistryApiUrl(fmt.Sprintf(consulSetAgentTokenAPI, tokenType))
+	if err != nil {
+		return err
+	}
+
+	type SetAgentToken struct {
+		Token string `json:"Token"`
+	}
+
+	setToken := &SetAgentToken{
+		Token: *agentTokenID,
+	}
+	jsonPayload, err := json.Marshal(setToken)
+	if err != nil {
+		return fmt.Errorf("Failed to marshal SetAgentToken JSON string payload: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPut, setAgentTokenURL, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return fmt.Errorf("Failed to prepare SetAgentToken request for http URL: %w", err)
+	}
+
+	req.Header.Add(consulTokenHeader, bootstrapACLToken.SecretID)
+	req.Header.Add(clients.ContentType, clients.ContentTypeJSON)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Failed to send SetAgentToken request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// no response body returned in this case
+		c.loggingClient.Infof("agent token is set with type [%s]", tokenType)
+	default:
+		setAgentTokenResp, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("Failed to read SetAgentToken response body with status code=%d: %w", resp.StatusCode, err)
+		}
+
+		return fmt.Errorf("failed to set agent token with type %s via URL [%s] and status code= %d: %s",
+			tokenType, setAgentTokenURL, resp.StatusCode, string(setAgentTokenResp))
+	}
+
+	return nil
+}

--- a/internal/security/bootstrapper/command/setupacl/acltokens_test.go
+++ b/internal/security/bootstrapper/command/setupacl/acltokens_test.go
@@ -1,0 +1,393 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package setupacl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+)
+
+func TestIsACLTokenPersistent(t *testing.T) {
+	ctx := context.Background()
+	wg := &sync.WaitGroup{}
+	lc := logger.MockLogger{}
+	testBootstrapToken := "test-bootstrap-token"
+
+	tests := []struct {
+		name                 string
+		bootstrapToken       *string
+		enablePersist        bool
+		checkAgentOkResponse bool
+		expectedErr          bool
+	}{
+		{"Good:persist enabled ok response", &testBootstrapToken, true, true, false},
+		{"Good:persist disabled ok response", &testBootstrapToken, false, true, false},
+		{"Bad:persist check bad response", &testBootstrapToken, false, false, true},
+		{"Bad:nil bootstrap token", nil, false, false, true},
+	}
+
+	for _, tt := range tests {
+		test := tt // capture as local copy
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// prepare test
+			responseOpts := responseOptions{
+				enablePersistence:  test.enablePersist,
+				consulCheckAgentOk: test.checkAgentOkResponse,
+			}
+			testSrv := newRegistryTestServer(responseOpts)
+			conf := testSrv.getRegistryServerConf(t)
+
+			command, err := NewCommand(ctx, wg, lc, conf, []string{})
+			require.NoError(t, err)
+			require.NotNil(t, command)
+			require.Equal(t, "setupRegistryACL", command.GetCommandName())
+			setupRegistryACL := command.(*cmd)
+			setupRegistryACL.retryTimeout = 3 * time.Second
+
+			persistent, err := setupRegistryACL.isACLTokenPersistent(test.bootstrapToken)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, testSrv.responseOptions.enablePersistence, persistent)
+			}
+		})
+	}
+}
+
+func TestCreateAgentToken(t *testing.T) {
+	ctx := context.Background()
+	wg := &sync.WaitGroup{}
+	lc := logger.MockLogger{}
+	testBootstrapToken := BootStrapACLTokenInfo{
+		SecretID: "test-bootstrap-token",
+		Policies: []Policy{
+			{
+				ID:   "00000000-0000-0000-0000-000000000001",
+				Name: "global-management",
+			},
+		},
+	}
+
+	tests := []struct {
+		name                        string
+		bootstrapToken              *BootStrapACLTokenInfo
+		listTokensOkResponse        bool
+		listTokensRetriesOkResponse bool
+		createTokenOkResponse       bool
+		readTokenOkResponse         bool
+		expectedErr                 bool
+	}{
+		{"Good:agent token ok response", &testBootstrapToken, true, true, true, true, false},
+		{"Bad:list tokens bad response", &testBootstrapToken, false, false, true, true, true},
+		{"Bad:create token bad response", &testBootstrapToken, true, true, false, true, true},
+		{"Bad:read token bad response", &testBootstrapToken, true, true, true, false, true},
+		{"Bad:nil bootstrap token", nil, false, false, false, true, true},
+	}
+
+	for _, tt := range tests {
+		test := tt // capture as local copy
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// prepare test
+			responseOpts := responseOptions{
+				listTokensOk:  test.listTokensOkResponse,
+				createTokenOk: test.createTokenOkResponse,
+				readTokenOk:   test.readTokenOkResponse,
+			}
+			testSrv := newRegistryTestServer(responseOpts)
+			conf := testSrv.getRegistryServerConf(t)
+
+			command, err := NewCommand(ctx, wg, lc, conf, []string{})
+			require.NoError(t, err)
+			require.NotNil(t, command)
+			require.Equal(t, "setupRegistryACL", command.GetCommandName())
+			setupRegistryACL := command.(*cmd)
+			setupRegistryACL.retryTimeout = 3 * time.Second
+
+			// first time we don't have the agent token yet
+			agentToken1, err := setupRegistryACL.createAgentToken(test.bootstrapToken)
+
+			// readToken only being executed only on the second time, so the first time should not expected an error
+			if test.expectedErr && test.readTokenOkResponse {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotEmpty(t, agentToken1)
+			}
+
+			// re-run create to test the existing token route
+			agentToken2, err := setupRegistryACL.createAgentToken(test.bootstrapToken)
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotEmpty(t, agentToken2)
+				require.Equal(t, agentToken1, agentToken2)
+			}
+		})
+	}
+}
+
+func TestSetAgentTokenToAgent(t *testing.T) {
+	ctx := context.Background()
+	wg := &sync.WaitGroup{}
+	lc := logger.MockLogger{}
+	testBootstrapToken := BootStrapACLTokenInfo{
+		SecretID: "test-bootstrap-token",
+		Policies: []Policy{
+			{
+				ID:   "00000000-0000-0000-0000-000000000001",
+				Name: "global-management",
+			},
+		},
+	}
+	testAgentToken := "test-agent-token"
+
+	tests := []struct {
+		name                    string
+		bootstrapToken          *BootStrapACLTokenInfo
+		agentToken              *string
+		setAgentTokenOkResponse bool
+		expectedErr             bool
+	}{
+		{"Good:set agent token ok response", &testBootstrapToken, &testAgentToken, true, false},
+		{"Bad:set agent token bad response", &testBootstrapToken, &testAgentToken, false, true},
+		{"Bad:nil bootstrap token", nil, &testAgentToken, false, true},
+		{"Bad:nil agent token", &testBootstrapToken, nil, false, true},
+	}
+
+	for _, tt := range tests {
+		test := tt // capture as local copy
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// prepare test
+			responseOpts := responseOptions{
+				setAgentTokenOk: test.setAgentTokenOkResponse,
+			}
+			testSrv := newRegistryTestServer(responseOpts)
+			conf := testSrv.getRegistryServerConf(t)
+
+			command, err := NewCommand(ctx, wg, lc, conf, []string{})
+			require.NoError(t, err)
+			require.NotNil(t, command)
+			require.Equal(t, "setupRegistryACL", command.GetCommandName())
+			setupRegistryACL := command.(*cmd)
+			setupRegistryACL.retryTimeout = 3 * time.Second
+
+			err = setupRegistryACL.setAgentToken(test.bootstrapToken, test.agentToken, AgentType)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+type registryTestServer struct {
+	config          *config.ConfigurationStruct
+	responseOptions responseOptions
+}
+
+type responseOptions struct {
+	enablePersistence       bool
+	consulCheckAgentOk      bool
+	listTokensOk            bool
+	listTokensWithRetriesOk bool
+	createTokenOk           bool
+	readTokenOk             bool
+	setAgentTokenOk         bool
+}
+
+func newRegistryTestServer(respOpts responseOptions) *registryTestServer {
+	return &registryTestServer{
+		config:          &config.ConfigurationStruct{},
+		responseOptions: respOpts,
+	}
+}
+
+func (registry *registryTestServer) getRegistryServerConf(t *testing.T) *config.ConfigurationStruct {
+	registryTestConf := registry.config
+	testAgentTokenAccessorID := "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	tokens := []map[string]interface{}{
+		{
+			"AccessorID":  "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+			"Description": "some other type of agent token",
+		},
+		{
+			"AccessorID":  "00000000-0000-0000-0000-000000000002",
+			"Description": "Anonymous Token",
+		},
+		{
+			"AccessorID":  "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm",
+			"Description": "Bootstrap Token (Global Management)",
+		},
+	}
+	respCnt := 0
+	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.EscapedPath() {
+		case consulCheckAgentAPI:
+			require.Equal(t, http.MethodGet, r.Method)
+			if registry.responseOptions.consulCheckAgentOk {
+				w.WriteHeader(http.StatusOK)
+				jsonResponse := map[string]interface{}{
+					"DebugConfig": map[string]interface{}{
+						"ACLDatacenter":    "dc1",
+						"ACLDefaultPolicy": "allow",
+						"ACLDisabledTTL":   "2m0s",
+						"ACLTokens": map[string]interface{}{
+							"EnablePersistence": registry.responseOptions.enablePersistence,
+						},
+						"ACLsEnabled": true,
+					},
+				}
+				err := json.NewEncoder(w).Encode(jsonResponse)
+				require.NoError(t, err)
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("permission denied"))
+			}
+		case consulListTokensAPI:
+			require.Equal(t, http.MethodGet, r.Method)
+			if registry.responseOptions.listTokensOk {
+				w.WriteHeader(http.StatusOK)
+				err := json.NewEncoder(w).Encode(tokens)
+				require.NoError(t, err)
+			} else if registry.responseOptions.listTokensWithRetriesOk {
+				if respCnt >= 2 {
+					w.WriteHeader(http.StatusOK)
+					err := json.NewEncoder(w).Encode(tokens)
+					require.NoError(t, err)
+				} else {
+					respCnt++
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(consulLegacyACLModeError))
+				}
+			} else if !registry.responseOptions.listTokensWithRetriesOk {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(consulLegacyACLModeError))
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("permission denied"))
+			}
+		case consulCreateTokenAPI:
+			require.Equal(t, http.MethodPut, r.Method)
+			if registry.responseOptions.createTokenOk {
+				w.WriteHeader(http.StatusOK)
+				jsonResponse := map[string]interface{}{
+					"AccessorID":  testAgentTokenAccessorID,
+					"Description": "edgex-core-consul agent token",
+					"Policies": []map[string]interface{}{
+						{
+							"ID":   "00000000-0000-0000-0000-000000000001",
+							"Name": "global-management",
+						},
+						{
+							"ID":   "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+							"Name": "node-read policy",
+						},
+					},
+					"Local":       true,
+					"CreateTime":  "2021-03-10T12:25:06.123456-07:00",
+					"Hash":        "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+					"CreateIndex": 59,
+					"ModifyIndex": 59,
+				}
+
+				err := json.NewEncoder(w).Encode(jsonResponse)
+				require.NoError(t, err)
+				tokens = append(tokens, jsonResponse)
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("cannot create token"))
+			}
+		case fmt.Sprintf(consulTokenRUDAPI, testAgentTokenAccessorID):
+			if r.Method == http.MethodGet && registry.responseOptions.readTokenOk {
+				w.WriteHeader(http.StatusOK)
+				jsonResponse := map[string]interface{}{
+					"AccessorID":  testAgentTokenAccessorID,
+					"Description": "edgex-core-consul agent token",
+					"Policies": []map[string]interface{}{
+						{
+							"ID":   "00000000-0000-0000-0000-000000000001",
+							"Name": "global-management",
+						},
+						{
+							"ID":   "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+							"Name": "node-read policy",
+						},
+					},
+					"Local":       false,
+					"CreateTime":  "2021-03-10T12:25:06.123456-07:00",
+					"Hash":        "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+					"CreateIndex": 59,
+					"ModifyIndex": 59,
+				}
+
+				err := json.NewEncoder(w).Encode(jsonResponse)
+				require.NoError(t, err)
+			} else if r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("permission denied"))
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Fatal(fmt.Sprintf("Unexpected method %s to URL %s", r.Method, r.URL.EscapedPath()))
+			}
+		case fmt.Sprintf(consulSetAgentTokenAPI, AgentType):
+			require.Equal(t, http.MethodPut, r.Method)
+			if registry.responseOptions.setAgentTokenOk {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("agent token set successfully"))
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("permission denied"))
+			}
+		default:
+			t.Fatal(fmt.Sprintf("Unexpected call to URL %s", r.URL.EscapedPath()))
+		}
+	}))
+	tsURL, err := url.Parse(testSrv.URL)
+	require.NoError(t, err)
+	portNum, _ := strconv.Atoi(tsURL.Port())
+	registryTestConf.StageGate.Registry.ACL.Protocol = tsURL.Scheme
+	registryTestConf.StageGate.Registry.Host = tsURL.Hostname()
+	registryTestConf.StageGate.Registry.Port = portNum
+	registryTestConf.StageGate.WaitFor.Timeout = "1m"
+	registryTestConf.StageGate.WaitFor.RetryInterval = "1s"
+	// for the sake of simplicity, we use the same test server as the secret store server
+	registryTestConf.SecretStore.Protocol = tsURL.Scheme
+	registryTestConf.SecretStore.Host = tsURL.Hostname()
+	registryTestConf.SecretStore.Port = portNum
+	return registryTestConf
+}

--- a/internal/security/bootstrapper/command/setupacl/acltokens_test.go
+++ b/internal/security/bootstrapper/command/setupacl/acltokens_test.go
@@ -42,15 +42,15 @@ func TestIsACLTokenPersistent(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		bootstrapToken       *string
+		bootstrapToken       string
 		enablePersist        bool
 		checkAgentOkResponse bool
 		expectedErr          bool
 	}{
-		{"Good:persist enabled ok response", &testBootstrapToken, true, true, false},
-		{"Good:persist disabled ok response", &testBootstrapToken, false, true, false},
-		{"Bad:persist check bad response", &testBootstrapToken, false, false, true},
-		{"Bad:nil bootstrap token", nil, false, false, true},
+		{"Good:persist enabled ok response", testBootstrapToken, true, true, false},
+		{"Good:persist disabled ok response", testBootstrapToken, false, true, false},
+		{"Bad:persist check bad response", testBootstrapToken, false, false, true},
+		{"Bad:empty bootstrap token", "", false, false, true},
 	}
 
 	for _, tt := range tests {
@@ -100,18 +100,18 @@ func TestCreateAgentToken(t *testing.T) {
 
 	tests := []struct {
 		name                        string
-		bootstrapToken              *BootStrapACLTokenInfo
+		bootstrapToken              BootStrapACLTokenInfo
 		listTokensOkResponse        bool
 		listTokensRetriesOkResponse bool
 		createTokenOkResponse       bool
 		readTokenOkResponse         bool
 		expectedErr                 bool
 	}{
-		{"Good:agent token ok response", &testBootstrapToken, true, true, true, true, false},
-		{"Bad:list tokens bad response", &testBootstrapToken, false, false, true, true, true},
-		{"Bad:create token bad response", &testBootstrapToken, true, true, false, true, true},
-		{"Bad:read token bad response", &testBootstrapToken, true, true, true, false, true},
-		{"Bad:nil bootstrap token", nil, false, false, false, true, true},
+		{"Good:agent token ok response", testBootstrapToken, true, true, true, true, false},
+		{"Bad:list tokens bad response", testBootstrapToken, false, false, true, true, true},
+		{"Bad:create token bad response", testBootstrapToken, true, true, false, true, true},
+		{"Bad:read token bad response", testBootstrapToken, true, true, true, false, true},
+		{"Bad:empty bootstrap token", BootStrapACLTokenInfo{}, false, false, false, true, true},
 	}
 
 	for _, tt := range tests {
@@ -175,15 +175,15 @@ func TestSetAgentTokenToAgent(t *testing.T) {
 
 	tests := []struct {
 		name                    string
-		bootstrapToken          *BootStrapACLTokenInfo
-		agentToken              *string
+		bootstrapToken          BootStrapACLTokenInfo
+		agentToken              string
 		setAgentTokenOkResponse bool
 		expectedErr             bool
 	}{
-		{"Good:set agent token ok response", &testBootstrapToken, &testAgentToken, true, false},
-		{"Bad:set agent token bad response", &testBootstrapToken, &testAgentToken, false, true},
-		{"Bad:nil bootstrap token", nil, &testAgentToken, false, true},
-		{"Bad:nil agent token", &testBootstrapToken, nil, false, true},
+		{"Good:set agent token ok response", testBootstrapToken, testAgentToken, true, false},
+		{"Bad:set agent token bad response", testBootstrapToken, testAgentToken, false, true},
+		{"Bad:empty bootstrap token", BootStrapACLTokenInfo{}, testAgentToken, false, true},
+		{"Bad:empty agent token", testBootstrapToken, "", false, true},
 	}
 
 	for _, tt := range tests {

--- a/internal/security/bootstrapper/command/setupacl/command.go
+++ b/internal/security/bootstrapper/command/setupacl/command.go
@@ -95,8 +95,8 @@ func NewCommand(
 }
 
 // Execute implements Command and runs this command
-// command setupRegistryACL sets up the ACL system of the registry, Consul in this case, preparing for generating
-// Consul's agent tokens later on
+// command setupRegistryACL sets up the ACL system of the registry, Consul in this case, bootstrap ACL system,
+// configure Consul access for the secret store, create agent token, and set up the agent token to agent
 func (c *cmd) Execute() (statusCode int, err error) {
 	c.loggingClient.Infof("Security bootstrapper running %s", CommandName)
 
@@ -108,13 +108,22 @@ func (c *cmd) Execute() (statusCode int, err error) {
 		return interfaces.StatusCodeExitWithError, fmt.Errorf("failed to get the absolute path of the sentinel file: %v", err)
 	}
 
-	if helper.CheckIfFileExists(sentinelFileAbsPath) {
-		c.loggingClient.Info("Registry ACL had been setup successfully already, skip")
-		return
-	}
-
+	// a non-empty leader is a prerequisite for any agent related API operations
 	if err := c.waitForNonEmptyConsulLeader(); err != nil {
 		return interfaces.StatusCodeExitWithError, fmt.Errorf("failed to wait for Consul leader: %v", err)
+	}
+
+	if helper.CheckIfFileExists(sentinelFileAbsPath) {
+		// although we may have done setup ACL successfully already previous times,
+		// if token persistence is not enabled, we have to re-set agent token every time agent is restarted,
+		// i.e., when this subcommand is called every time, regardless whether it is first time or not
+		if err := c.setupAgentToken(nil); err != nil {
+			return interfaces.StatusCodeExitWithError, fmt.Errorf("on 2nd time or later, failed to set up agent token: %v", err)
+		}
+
+		c.loggingClient.Info("setupRegistryACL successfully done")
+
+		return
 	}
 
 	var bootstrapACLToken *BootStrapACLTokenInfo
@@ -164,6 +173,11 @@ func (c *cmd) Execute() (statusCode int, err error) {
 		return interfaces.StatusCodeExitWithError, fmt.Errorf("failed to write sentinel file: %v", err)
 	}
 
+	// set up agent token to agent for the first time
+	if err := c.setupAgentToken(bootstrapACLToken); err != nil {
+		return interfaces.StatusCodeExitWithError, fmt.Errorf("failed to set up agent token: %v", err)
+	}
+
 	c.loggingClient.Info("setupRegistryACL successfully done")
 
 	return
@@ -172,6 +186,81 @@ func (c *cmd) Execute() (statusCode int, err error) {
 // GetCommandName returns the name of this command
 func (c *cmd) GetCommandName() string {
 	return CommandName
+}
+
+// setupAgentToken is to set up the agent token to the running agent if haven't set up yet
+func (c *cmd) setupAgentToken(inputToken *BootStrapACLTokenInfo) error {
+	var err error
+	setupAlreadyPrevious := false
+	bootstrapACLToken := inputToken
+	if inputToken == nil {
+		// this may be the case that re-run with a different configuration like token persistence is changed
+		// reconstruct the bootstrapACLToken from the file
+		bootstrapACLToken, err = c.reconstructBootstrapACLToken()
+		if err != nil {
+			return fmt.Errorf("failed to reconstruct bootstrap ACL token: %v", err)
+		}
+		setupAlreadyPrevious = true
+	}
+
+	persistent, err := c.isACLTokenPersistent(&bootstrapACLToken.SecretID)
+	if err != nil {
+		return fmt.Errorf("failed to check the agent token persistence: %v", err)
+	}
+
+	// if property token persistence is not enabled, we have to re-set agent token every time agent is restarted
+	// i.e., when this subcommand is called, regardless whether it is first time or not
+	// furthermore, we also need to set agent token if it is the first time to set up the registry ACL
+	if !persistent || !setupAlreadyPrevious {
+		agentToken, err := c.createAgentToken(bootstrapACLToken)
+		if err != nil {
+			return fmt.Errorf("setupAgentToken failed: %v", err)
+		}
+		err = c.setAgentToken(bootstrapACLToken, &agentToken, AgentType)
+		if err != nil {
+			return fmt.Errorf("failed to set agent token: %v", err)
+		}
+
+		c.loggingClient.Info("successfully set up agent token into agent")
+	} else {
+		// we had already done all necessary setups
+		c.loggingClient.Info("setupAgentToken had been done before and agent token is persistent, skip")
+	}
+
+	return nil
+}
+
+// reconstructBootstrapACLToken reads bootstrap ACL token from the saved file and reconstruct it into BootStrapACLTokenInfo
+func (c *cmd) reconstructBootstrapACLToken() (*BootStrapACLTokenInfo, error) {
+	bootstrapTokenFilePath := strings.TrimSpace(c.configuration.StageGate.Registry.ACL.BootstrapTokenPath)
+	if len(bootstrapTokenFilePath) == 0 {
+		return nil, errors.New("required StageGate_Registry_ACL_BootstrapTokenPath from configuration is empty")
+	}
+
+	tokenFileAbsPath, err := filepath.Abs(bootstrapTokenFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert tokenFile to absolute path %s: %v", bootstrapTokenFilePath, err)
+	}
+
+	// make sure we have the file
+	if exists := helper.CheckIfFileExists(tokenFileAbsPath); !exists {
+		return nil, fmt.Errorf("registry bootstrap ACL token file %s not found", tokenFileAbsPath)
+	}
+
+	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
+	tokenReader, err := fileOpener.OpenFileReader(tokenFileAbsPath, os.O_RDONLY, 0400)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file reader: %v", err)
+	}
+
+	var bootstrapACLToken BootStrapACLTokenInfo
+	if err := json.NewDecoder(tokenReader).Decode(&bootstrapACLToken); err != nil {
+		return nil, fmt.Errorf("failed to parse token data into BootStrapACLTokenInfo: %v", err)
+	}
+
+	c.loggingClient.Infof("successfully reconstructed bootstrap ACL token from %s", bootstrapTokenFilePath)
+
+	return &bootstrapACLToken, nil
 }
 
 func (c *cmd) getRegistryApiUrl(api string) (string, error) {
@@ -196,7 +285,7 @@ func (c *cmd) waitForNonEmptyConsulLeader() error {
 			timer.SleepForInterval()
 			continue
 		}
-		c.loggingClient.Info("found Consul leader to bootstrap ACL")
+		c.loggingClient.Info("found Consul leader to set up ACL")
 		return nil
 	}
 
@@ -252,7 +341,7 @@ func (c *cmd) getNonEmptyConsulLeader() error {
 func (c *cmd) getSecretStoreTokenFromFile() (string, error) {
 	trimmedFilePath := strings.TrimSpace(c.configuration.StageGate.Registry.ACL.SecretsAdminTokenPath)
 	if len(trimmedFilePath) == 0 {
-		return emptyToken, errors.New("required StageGate_Registry_SecretsAdminTokenPath from configuration is empty")
+		return emptyToken, errors.New("required StageGate_Registry_ACL_SecretsAdminTokenPath from configuration is empty")
 	}
 
 	tokenFileAbsPath, err := filepath.Abs(trimmedFilePath)

--- a/internal/security/bootstrapper/command/setupacl/command.go
+++ b/internal/security/bootstrapper/command/setupacl/command.go
@@ -188,7 +188,8 @@ func (c *cmd) GetCommandName() string {
 	return CommandName
 }
 
-// setupAgentToken is to set up the agent token to the running agent if haven't set up yet
+// setupAgentToken is to set up the agent token using the inputToken to the running agent if haven't set up yet
+// if the inputToken is nil then it will try to reconstruct from the saved file
 func (c *cmd) setupAgentToken(inputToken *BootStrapACLTokenInfo) error {
 	var err error
 	setupAlreadyPrevious := false
@@ -203,7 +204,7 @@ func (c *cmd) setupAgentToken(inputToken *BootStrapACLTokenInfo) error {
 		setupAlreadyPrevious = true
 	}
 
-	persistent, err := c.isACLTokenPersistent(&bootstrapACLToken.SecretID)
+	persistent, err := c.isACLTokenPersistent(bootstrapACLToken.SecretID)
 	if err != nil {
 		return fmt.Errorf("failed to check the agent token persistence: %v", err)
 	}
@@ -212,11 +213,11 @@ func (c *cmd) setupAgentToken(inputToken *BootStrapACLTokenInfo) error {
 	// i.e., when this subcommand is called, regardless whether it is first time or not
 	// furthermore, we also need to set agent token if it is the first time to set up the registry ACL
 	if !persistent || !setupAlreadyPrevious {
-		agentToken, err := c.createAgentToken(bootstrapACLToken)
+		agentToken, err := c.createAgentToken(*bootstrapACLToken)
 		if err != nil {
 			return fmt.Errorf("setupAgentToken failed: %v", err)
 		}
-		err = c.setAgentToken(bootstrapACLToken, &agentToken, AgentType)
+		err = c.setAgentToken(*bootstrapACLToken, agentToken, AgentType)
 		if err != nil {
 			return fmt.Errorf("failed to set agent token: %v", err)
 		}


### PR DESCRIPTION
Part of Securing Consul Phase 1 stories, add new implementation and changes to `security-bootstrapper` setupRegistryACL:
 - Add Create agent token logic with using global policy
 - Add Agent checking logic to determine whether we should set agent token every time on agent restarting
 - Add re-use created agent token logic in the case of re-start and re-set scenarios
 - Add set agent token implementation
 - Add re-set agent token logic in the case of re-starting and non-persistent token case if needed

Closes: #3157

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
N/A this is new feature

## Issue Number: #3157 


## What is the new behavior?
Now Consul is set with a agent token

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
To test this locally, git clone this PR and build the dev. version of `security-bootstrapper`:
`make docker_security_bootstrapper `
(make sure to clean up your local volume or image cache first, in case it still uses cached docker image), 
and then use compose-builder to run docker stack in dev mode: `make run dev`
Observe the docker log message on `edgex-core-consul` and you should see successfully set up message like the following:

```
......
level=INFO ts=2021-03-11T22:11:05.372083311Z app=edgex-security-bootstrapper source=command.go:101 msg="Security bootstrapper running setupRegistryACL"
level=INFO ts=2021-03-11T22:11:05.374514548Z app=edgex-security-bootstrapper source=command.go:329 msg="leader [\"192.168.160.5:8300\"] is elected"
level=INFO ts=2021-03-11T22:11:05.374604792Z app=edgex-security-bootstrapper source=command.go:285 msg="found Consul leader to set up ACL"
    2021-03-11T22:11:05.375Z [WARN]  agent.server.acl: failed to remove bootstrap file: error="remove /consul/data/acl-bootstrap-reset: no such file or directory"
    2021-03-11T22:11:05.378Z [INFO]  agent.server.acl: ACL bootstrap completed
level=INFO ts=2021-03-11T22:11:05.379855616Z app=edgex-security-bootstrapper source=command.go:149 msg="successfully bootstrap registry ACL"
level=INFO ts=2021-03-11T22:11:05.380457374Z app=edgex-security-bootstrapper source=aclbootstrap.go:109 msg="bootstrap token is written to /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
level=INFO ts=2021-03-11T22:11:05.380849652Z app=edgex-security-bootstrapper source=command.go:362 msg="successfully retrieved secretstore management token from /tmp/edgex/secrets/edgex-consul/admin/token.json"
level=INFO ts=2021-03-11T22:11:05.380912348Z app=edgex-security-bootstrapper source=command.go:162 msg="successfully get secretstore token and configuring the registry access for secretestore"
level=INFO ts=2021-03-11T22:11:05.39776416Z app=edgex-security-bootstrapper source=command.go:414 msg="successfully configure Consul access for secretstore"
level=INFO ts=2021-03-11T22:11:05.415093814Z app=edgex-security-bootstrapper source=acltokens.go:148 msg="internal Consul ACL system is ready"
level=INFO ts=2021-03-11T22:11:05.419369993Z app=edgex-security-bootstrapper source=acltokens.go:345 msg="successfully created a new agent token"
    2021-03-11T22:11:05.423Z [INFO]  agent: Updated agent's ACL token: token=agent
level=INFO ts=2021-03-11T22:11:05.423787697Z app=edgex-security-bootstrapper source=acltokens.go:401 msg="agent token is set with type [agent]"
level=INFO ts=2021-03-11T22:11:05.423888036Z app=edgex-security-bootstrapper source=command.go:221 msg="successfully set up agent token into agent"
level=INFO ts=2021-03-11T22:11:05.423934179Z app=edgex-security-bootstrapper source=command.go:179 msg="setupRegistryACL successfully done"
...............
```