### PR TITLE
fix: Added Content-Type from REST header to Context

### DIFF
--- a/internal/pkg/correlation/middleware.go
+++ b/internal/pkg/correlation/middleware.go
@@ -15,12 +15,17 @@ var LoggingClient logger.LoggingClient
 
 func ManageHeader(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hdr := r.Header.Get(clients.CorrelationHeader)
-		if hdr == "" {
-			hdr = uuid.New().String()
+		correlationID := r.Header.Get(clients.CorrelationHeader)
+		if correlationID == "" {
+			correlationID = uuid.New().String()
 		}
-		ctx := context.WithValue(r.Context(), clients.CorrelationHeader, hdr)
+		ctx := context.WithValue(r.Context(), clients.CorrelationHeader, correlationID)
+
+		contentType := r.Header.Get(clients.ContentType)
+		ctx = context.WithValue(ctx, clients.ContentType, contentType)
+
 		r = r.WithContext(ctx)
+
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Content-Type not being set in the Context where it is pulled from when setting the Content-Type on the MessageEnevlope.

## Issue Number: #3271


## What is the new behavior?
Now Content-Type is being set in the Context for that set in the  the REST Header when request is first received.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information