### PR TITLE
feat(security): Implementation for adding Consul ACL policies, roles

### DIFF
--- a/cmd/security-bootstrapper/res/configuration.toml
+++ b/cmd/security-bootstrapper/res/configuration.toml
@@ -23,11 +23,28 @@ LogLevel = 'INFO'
     [StageGate.Registry.ACL]
       Protocol = "http"
       # this is the filepath for the generated Consul management token from ACL bootstrap
-      BootstrapTokenPath = "/tmp/edgex/secrets/edgex-consul/admin/bootstrap_token.json"
+      BootstrapTokenPath = "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
       # this is the filepath for the Vault token created from secretstore-setup
       SecretsAdminTokenPath = "/tmp/edgex/secrets/edgex-consul/admin/token.json"
       # this is the filepath for the sentinel file to indicate the registry ACL is set up successfully
       SentinelFilePath = "/edgex-init/consul-bootstrapper/consul_acl_done"
+      # this is the filepath for the created Consul management token
+      ManagementTokenPath = "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
+      
+      # this section contains the list of registry roles for EdgeX services
+      # the service keys are the role names
+      [StageGate.Registry.ACL.Roles]
+        [StageGate.Registry.ACL.Roles.edgex-core-data]
+          Description = "role for coredata"
+        [StageGate.Registry.ACL.Roles.edgex-core-metadata]
+          Description = "role for metadata"
+        [StageGate.Registry.ACL.Roles.edgex-core-command]
+          Description = "role for command"
+        [StageGate.Registry.ACL.Roles.edgex-support-notifications]
+          Description = "role for notifications"
+        [StageGate.Registry.ACL.Roles.edgex-support-scheduler]
+          Description = "role for scheduler"
+          
   [StageGate.KongDb]
     Host = "kong-db"
     Port = 5432

--- a/internal/security/bootstrapper/command/setupacl/aclpolicies.go
+++ b/internal/security/bootstrapper/command/setupacl/aclpolicies.go
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package setupacl
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
+)
+
+const (
+	// edgeXPolicyRules are rules for edgex services
+	// in Phase 2, we will use the same policy for all EdgeX services
+	// TODO: phase 3 will have more finer grained policies for each service
+	edgeXPolicyRules = `
+	# HCL definition of server agent policy for EdgeX
+	agent "" {
+		policy = "read"
+	}
+	agent_prefix "edgex" {
+		policy = "write"
+	}
+	node "" {
+  		policy = "read"
+	}
+	node_prefix "edgex" {
+		policy = "write"
+	}
+	service "" {
+  		policy = "read"
+	}
+	service_prefix "edgex" {
+  		policy = "write"
+	}
+	# allow key value store put
+	# once the default_policy is switched to "deny",
+	# this is needed if wants to allow updating Key/Value configuration
+	key "" {
+  		policy = "read"
+	}
+	key_prefix "edgex" {
+		policy = "write"
+	}
+	`
+
+	// edgeXServicePolicyName is the name of the agent policy for edgex
+	edgeXServicePolicyName = "edgex-service-policy"
+
+	consulCreatePolicyAPI     = "/v1/acl/policy"
+	consulReadPolicyByNameAPI = "/v1/acl/policy/name/%s"
+
+	aclNotFoundMessage = "ACL not found"
+)
+
+// getOrCreateRegistryPolicy retrieves or creates a new policy
+// it inserts a new policy if the policy name does not exist and returns a policy
+// it returns the same policy if the policy name already exists
+func (c *cmd) getOrCreateRegistryPolicy(tokenID, policyName, policyRules string) (*Policy, error) {
+	// try to get the policy to see if it exists or not
+	policy, err := c.getPolicyByName(tokenID, policyName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get policy ID by name %s: %v", policyName, err)
+	}
+
+	if policy != nil {
+		// policy exists, return this one
+		return policy, nil
+	}
+
+	createPolicyURL, err := c.getRegistryApiUrl(consulCreatePolicyAPI)
+	if err != nil {
+		return nil, err
+	}
+
+	// payload struct for creating a new policy
+	type CreatePolicy struct {
+		Name        string `json:"Name"`
+		Description string `json:"Description,omitempty"`
+		Rules       string `json:"Rules,omitempty"`
+	}
+
+	createPolicy := &CreatePolicy{
+		Name:        policyName,
+		Description: "agent policy for EdgeX microservices",
+		Rules:       policyRules,
+	}
+
+	jsonPayload, err := json.Marshal(createPolicy)
+	c.loggingClient.Tracef("payload: %v", createPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal CreatePolicy JSON string payload: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPut, createPolicyURL, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare create a new policy request for http URL: %w", err)
+	}
+
+	req.Header.Add(consulTokenHeader, tokenID)
+	req.Header.Add(clients.ContentType, clients.ContentTypeJSON)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to send create a new policy request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	createPolicyResp, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read create a new policy response body: %w", err)
+	}
+
+	var created Policy
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if err := json.NewDecoder(bytes.NewReader(createPolicyResp)).Decode(&created); err != nil {
+			return nil, fmt.Errorf("failed to decode create a new policy response body: %v", err)
+		}
+
+		c.loggingClient.Infof("successfully created a new agent policy with name %s", policyName)
+
+		return &created, nil
+	default:
+		return nil, fmt.Errorf("failed to create a new policy with name %s via URL [%s] and status code= %d: %s",
+			policyName, consulCreatePolicyAPI, resp.StatusCode, string(createPolicyResp))
+	}
+}
+
+// getPolicyByName gets policy by policy name, returns nil if not found
+func (c *cmd) getPolicyByName(tokenID, policyName string) (*Policy, error) {
+	readPolicyByNameURL, err := c.getRegistryApiUrl(fmt.Sprintf(consulReadPolicyByNameAPI, policyName))
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, readPolicyByNameURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to prepare readPolicyByName request for http URL: %w", err)
+	}
+
+	req.Header.Add(consulTokenHeader, tokenID)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to send readPolicyByName request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	readPolicyResp, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read readPolicyByName response body: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var existing Policy
+		if err := json.NewDecoder(bytes.NewReader(readPolicyResp)).Decode(&existing); err != nil {
+			return nil, fmt.Errorf("failed to decode Policy json data: %v", err)
+		}
+
+		return &existing, nil
+	case http.StatusForbidden:
+		// when the policy cannot be found by the name, the body returns "ACL not found"
+		// so we treat it as non-error case
+		if strings.EqualFold(aclNotFoundMessage, string(readPolicyResp)) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to read policy by name with error %s", string(readPolicyResp))
+	default:
+		return nil, fmt.Errorf("failed to read policy by name with status code= %d: %s",
+			resp.StatusCode, string(readPolicyResp))
+	}
+}

--- a/internal/security/bootstrapper/command/setupacl/aclpolicies_test.go
+++ b/internal/security/bootstrapper/command/setupacl/aclpolicies_test.go
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package setupacl
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+)
+
+func TestGetOrCreatePolicy(t *testing.T) {
+	ctx := context.Background()
+	wg := &sync.WaitGroup{}
+	lc := logger.MockLogger{}
+	testBootstrapToken := "test-bootstrap-token"
+	testPolicyName := "test-policy-name"
+
+	tests := []struct {
+		name                    string
+		bootstrapToken          string
+		policyName              string
+		getPolicyOkResponse     bool
+		policyNameAlreadyExists bool
+		createPolicyOkResponse  bool
+		expectedErr             bool
+	}{
+		{"Good:create policy ok with non-existing name yet", testBootstrapToken, testPolicyName, true, false, true, false},
+		{"Good:get or create policy ok with pre-existing name", testBootstrapToken, testPolicyName, true, true, true, false},
+		{"Bad:get policy bad response", testBootstrapToken, testPolicyName, false, false, false, true},
+		{"Bad:create policy bad response", testBootstrapToken, testPolicyName, true, false, false, true},
+		{"Bad:empty bootstrap token", "", testPolicyName, false, false, false, true},
+		{"Bad:empty policy name", testBootstrapToken, "", false, false, false, true},
+	}
+
+	for _, tt := range tests {
+		test := tt // capture as local copy
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// prepare test
+			responseOpts := serverOptions{
+				readPolicyByNameOk:  test.getPolicyOkResponse,
+				policyAlreadyExists: test.policyNameAlreadyExists,
+				createNewPolicyOk:   test.createPolicyOkResponse,
+			}
+			testSrv := newRegistryTestServer(responseOpts)
+			conf := testSrv.getRegistryServerConf(t)
+			defer testSrv.close()
+
+			command, err := NewCommand(ctx, wg, lc, conf, []string{})
+			require.NoError(t, err)
+			require.NotNil(t, command)
+			require.Equal(t, "setupRegistryACL", command.GetCommandName())
+			setupRegistryACL := command.(*cmd)
+			setupRegistryACL.retryTimeout = 2 * time.Second
+
+			policyActual, err := setupRegistryACL.getOrCreateRegistryPolicy(test.bootstrapToken, test.policyName, edgeXPolicyRules)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, policyActual)
+				require.Equal(t, test.policyName, policyActual.Name)
+			}
+		})
+	}
+}

--- a/internal/security/bootstrapper/command/setupacl/aclroles.go
+++ b/internal/security/bootstrapper/command/setupacl/aclroles.go
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package setupacl
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
+)
+
+// RegistryTokenType is the type of registry tokens that will be created when the role is using to call token creds API
+type RegistryTokenType string
+
+const (
+	/*
+	 * The following are available registry token types that can be used for specifying in the role-based tokens
+	 * created via /consul/creds secret engine Vault API.
+	 * For the details, see reference https://www.vaultproject.io/api/secret/consul#create-update-role
+	 */
+	// ManagementType is the type of registry role can be used to create tokens when role-based API /consul/creds is called
+	// the management type of created tokens is automatically granted the built-in global management policy
+	ManagementType RegistryTokenType = "management"
+	// ClientType is the type of registry role that can be used to create tokens when role-based API /consul/creds is called
+	// the regular client type of created tokens is associated with custom policies
+	ClientType RegistryTokenType = "client"
+
+	createConsulRoleVaultAPI = "/v1/consul/roles/%s"
+)
+
+// RegistryRole is the meta definition for creating registry's role
+type RegistryRole struct {
+	RoleName    string   `json:"name"`
+	TokenType   string   `json:"token_type"`
+	PolicyNames []string `json:"policies,omitempty"`
+	Local       bool     `json:"local,omitempty"`
+	TimeToLive  string   `json:"TTL,omitempty"`
+}
+
+// NewRegistryRole instantiates a new RegistryRole with the given inputs
+func NewRegistryRole(name string, tokenType RegistryTokenType, policies []Policy, localUse bool) RegistryRole {
+	// to conform to the payload of the registry create role API,
+	// we convert the slice of policies from type Policy to string and make it unique
+	// as the policy name needs to be unique per API's requirement
+	policyNames := make([]string, 0, len(policies))
+	tempMap := make(map[string]bool)
+	for _, policy := range policies {
+		if _, exists := tempMap[policy.Name]; !exists {
+			policyNames = append(policyNames, policy.Name)
+		}
+	}
+
+	return RegistryRole{
+		RoleName:    strings.TrimSpace(name),
+		TokenType:   string(tokenType),
+		PolicyNames: policyNames,
+		Local:       localUse,
+		// unlimited for now
+		TimeToLive: "0s",
+	}
+}
+
+// createRole creates a secret store role that can be used to generate registry tokens
+// and part of elements for the role ties up with the registry policies in which it dictates
+// the permission of accesses to the registry kv store or agent etc.
+func (c *cmd) createRole(secretStoreToken string, registryRole RegistryRole) error {
+	if len(secretStoreToken) == 0 {
+		return errors.New("required secret store token is empty")
+	}
+
+	if len(registryRole.RoleName) == 0 {
+		return errors.New("required role name cannot be empty")
+	}
+
+	createRoleURL := fmt.Sprintf("%s://%s:%d%s", c.configuration.SecretStore.Protocol,
+		c.configuration.SecretStore.Host, c.configuration.SecretStore.Port,
+		fmt.Sprintf(createConsulRoleVaultAPI, registryRole.RoleName))
+	_, err := url.Parse(createRoleURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse create role URL: %v", err)
+	}
+
+	c.loggingClient.Debugf("createRoleURL: %s", createRoleURL)
+
+	jsonPayload, err := json.Marshal(&registryRole)
+
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON string payload: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, createRoleURL, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return fmt.Errorf("failed to prepare POST request for http URL: %w", err)
+	}
+
+	req.Header.Add("X-Vault-Token", secretStoreToken)
+	req.Header.Add(clients.ContentType, clients.ContentTypeJSON)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		// no response body returned in this case
+		c.loggingClient.Infof("successfully created a role [%s] for secretstore", registryRole.RoleName)
+		return nil
+	default:
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			c.loggingClient.Errorf("cannot read resp.Body: %v", err)
+		}
+		return fmt.Errorf("failed to create a role %s for secretstore via URL [%s] and status code= %d: %s",
+			registryRole.RoleName, createRoleURL, resp.StatusCode, string(body))
+	}
+}

--- a/internal/security/bootstrapper/command/setupacl/aclroles_test.go
+++ b/internal/security/bootstrapper/command/setupacl/aclroles_test.go
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package setupacl
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+)
+
+func TestCreateRole(t *testing.T) {
+	ctx := context.Background()
+	wg := &sync.WaitGroup{}
+	lc := logger.MockLogger{}
+	testSecretStoreToken := "test-secretstore-token"
+	testSinglePolicy := []Policy{
+		{
+			ID:   "test-ID",
+			Name: "test-name",
+		},
+	}
+	testMultiplePolicies := []Policy{
+		{
+			ID:   "test-ID1",
+			Name: "test-name1",
+		},
+		{
+			ID:   "test-ID2",
+			Name: "test-name2",
+		},
+	}
+
+	testRoleWithNilPolicy := NewRegistryRole("testRoleSingle", ClientType, nil, true)
+	testRoleWithEmptyPolicy := NewRegistryRole("testRoleSingle", ClientType, []Policy{}, true)
+	testRoleWithSinglePolicy := NewRegistryRole("testRoleSingle", ClientType, testSinglePolicy, true)
+	testRoleWithMultiplePolicies := NewRegistryRole("testRoleMultiple", ClientType, testMultiplePolicies, true)
+	testEmptyRoleName := NewRegistryRole("", ManagementType, testSinglePolicy, true)
+
+	tests := []struct {
+		name                string
+		secretstoreToken    string
+		registryRole        RegistryRole
+		creatRoleOkResponse bool
+		expectedErr         bool
+	}{
+		{"Good:create role with single policy ok", testSecretStoreToken, testRoleWithSinglePolicy, true, false},
+		{"Good:create role with multiple policies ok", testSecretStoreToken, testRoleWithMultiplePolicies, true, false},
+		{"Good:create role with empty policy ok", testSecretStoreToken, testRoleWithEmptyPolicy, true, false},
+		{"Good:create role with nil policy ok", testSecretStoreToken, testRoleWithNilPolicy, true, false},
+		{"Bad:create role bad response", testSecretStoreToken, testRoleWithSinglePolicy, false, true},
+		{"Bad:empty secretstore token", "", testRoleWithMultiplePolicies, false, true},
+		{"Bad:empty role name", testSecretStoreToken, testEmptyRoleName, false, true},
+	}
+
+	for _, tt := range tests {
+		test := tt // capture as local copy
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// prepare test
+			responseOpts := serverOptions{
+				createRoleOk: test.creatRoleOkResponse,
+			}
+			testSrv := newRegistryTestServer(responseOpts)
+			conf := testSrv.getRegistryServerConf(t)
+			defer testSrv.close()
+
+			command, err := NewCommand(ctx, wg, lc, conf, []string{})
+			require.NoError(t, err)
+			require.NotNil(t, command)
+			require.Equal(t, "setupRegistryACL", command.GetCommandName())
+			setupRegistryACL := command.(*cmd)
+			setupRegistryACL.retryTimeout = 2 * time.Second
+
+			err = setupRegistryACL.createRole(test.secretstoreToken, test.registryRole)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/security/bootstrapper/command/setupacl/acltokens_test.go
+++ b/internal/security/bootstrapper/command/setupacl/acltokens_test.go
@@ -17,19 +17,11 @@ package setupacl
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
@@ -58,12 +50,13 @@ func TestIsACLTokenPersistent(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			// prepare test
-			responseOpts := responseOptions{
+			responseOpts := serverOptions{
 				enablePersistence:  test.enablePersist,
 				consulCheckAgentOk: test.checkAgentOkResponse,
 			}
 			testSrv := newRegistryTestServer(responseOpts)
 			conf := testSrv.getRegistryServerConf(t)
+			defer testSrv.close()
 
 			command, err := NewCommand(ctx, wg, lc, conf, []string{})
 			require.NoError(t, err)
@@ -78,7 +71,7 @@ func TestIsACLTokenPersistent(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, testSrv.responseOptions.enablePersistence, persistent)
+				require.Equal(t, testSrv.serverOptions.enablePersistence, persistent)
 			}
 		})
 	}
@@ -119,13 +112,14 @@ func TestCreateAgentToken(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			// prepare test
-			responseOpts := responseOptions{
+			responseOpts := serverOptions{
 				listTokensOk:  test.listTokensOkResponse,
 				createTokenOk: test.createTokenOkResponse,
 				readTokenOk:   test.readTokenOkResponse,
 			}
 			testSrv := newRegistryTestServer(responseOpts)
 			conf := testSrv.getRegistryServerConf(t)
+			defer testSrv.close()
 
 			command, err := NewCommand(ctx, wg, lc, conf, []string{})
 			require.NoError(t, err)
@@ -191,11 +185,12 @@ func TestSetAgentTokenToAgent(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			// prepare test
-			responseOpts := responseOptions{
+			responseOpts := serverOptions{
 				setAgentTokenOk: test.setAgentTokenOkResponse,
 			}
 			testSrv := newRegistryTestServer(responseOpts)
 			conf := testSrv.getRegistryServerConf(t)
+			defer testSrv.close()
 
 			command, err := NewCommand(ctx, wg, lc, conf, []string{})
 			require.NoError(t, err)
@@ -213,181 +208,4 @@ func TestSetAgentTokenToAgent(t *testing.T) {
 			}
 		})
 	}
-}
-
-type registryTestServer struct {
-	config          *config.ConfigurationStruct
-	responseOptions responseOptions
-}
-
-type responseOptions struct {
-	enablePersistence       bool
-	consulCheckAgentOk      bool
-	listTokensOk            bool
-	listTokensWithRetriesOk bool
-	createTokenOk           bool
-	readTokenOk             bool
-	setAgentTokenOk         bool
-}
-
-func newRegistryTestServer(respOpts responseOptions) *registryTestServer {
-	return &registryTestServer{
-		config:          &config.ConfigurationStruct{},
-		responseOptions: respOpts,
-	}
-}
-
-func (registry *registryTestServer) getRegistryServerConf(t *testing.T) *config.ConfigurationStruct {
-	registryTestConf := registry.config
-	testAgentTokenAccessorID := "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-	tokens := []map[string]interface{}{
-		{
-			"AccessorID":  "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
-			"Description": "some other type of agent token",
-		},
-		{
-			"AccessorID":  "00000000-0000-0000-0000-000000000002",
-			"Description": "Anonymous Token",
-		},
-		{
-			"AccessorID":  "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm",
-			"Description": "Bootstrap Token (Global Management)",
-		},
-	}
-	respCnt := 0
-	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.EscapedPath() {
-		case consulCheckAgentAPI:
-			require.Equal(t, http.MethodGet, r.Method)
-			if registry.responseOptions.consulCheckAgentOk {
-				w.WriteHeader(http.StatusOK)
-				jsonResponse := map[string]interface{}{
-					"DebugConfig": map[string]interface{}{
-						"ACLDatacenter":    "dc1",
-						"ACLDefaultPolicy": "allow",
-						"ACLDisabledTTL":   "2m0s",
-						"ACLTokens": map[string]interface{}{
-							"EnablePersistence": registry.responseOptions.enablePersistence,
-						},
-						"ACLsEnabled": true,
-					},
-				}
-				err := json.NewEncoder(w).Encode(jsonResponse)
-				require.NoError(t, err)
-			} else {
-				w.WriteHeader(http.StatusForbidden)
-				_, _ = w.Write([]byte("permission denied"))
-			}
-		case consulListTokensAPI:
-			require.Equal(t, http.MethodGet, r.Method)
-			if registry.responseOptions.listTokensOk {
-				w.WriteHeader(http.StatusOK)
-				err := json.NewEncoder(w).Encode(tokens)
-				require.NoError(t, err)
-			} else if registry.responseOptions.listTokensWithRetriesOk {
-				if respCnt >= 2 {
-					w.WriteHeader(http.StatusOK)
-					err := json.NewEncoder(w).Encode(tokens)
-					require.NoError(t, err)
-				} else {
-					respCnt++
-					w.WriteHeader(http.StatusInternalServerError)
-					_, _ = w.Write([]byte(consulLegacyACLModeError))
-				}
-			} else if !registry.responseOptions.listTokensWithRetriesOk {
-				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte(consulLegacyACLModeError))
-			} else {
-				w.WriteHeader(http.StatusForbidden)
-				_, _ = w.Write([]byte("permission denied"))
-			}
-		case consulCreateTokenAPI:
-			require.Equal(t, http.MethodPut, r.Method)
-			if registry.responseOptions.createTokenOk {
-				w.WriteHeader(http.StatusOK)
-				jsonResponse := map[string]interface{}{
-					"AccessorID":  testAgentTokenAccessorID,
-					"Description": "edgex-core-consul agent token",
-					"Policies": []map[string]interface{}{
-						{
-							"ID":   "00000000-0000-0000-0000-000000000001",
-							"Name": "global-management",
-						},
-						{
-							"ID":   "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
-							"Name": "node-read policy",
-						},
-					},
-					"Local":       true,
-					"CreateTime":  "2021-03-10T12:25:06.123456-07:00",
-					"Hash":        "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
-					"CreateIndex": 59,
-					"ModifyIndex": 59,
-				}
-
-				err := json.NewEncoder(w).Encode(jsonResponse)
-				require.NoError(t, err)
-				tokens = append(tokens, jsonResponse)
-			} else {
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte("cannot create token"))
-			}
-		case fmt.Sprintf(consulTokenRUDAPI, testAgentTokenAccessorID):
-			if r.Method == http.MethodGet && registry.responseOptions.readTokenOk {
-				w.WriteHeader(http.StatusOK)
-				jsonResponse := map[string]interface{}{
-					"AccessorID":  testAgentTokenAccessorID,
-					"Description": "edgex-core-consul agent token",
-					"Policies": []map[string]interface{}{
-						{
-							"ID":   "00000000-0000-0000-0000-000000000001",
-							"Name": "global-management",
-						},
-						{
-							"ID":   "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
-							"Name": "node-read policy",
-						},
-					},
-					"Local":       false,
-					"CreateTime":  "2021-03-10T12:25:06.123456-07:00",
-					"Hash":        "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
-					"CreateIndex": 59,
-					"ModifyIndex": 59,
-				}
-
-				err := json.NewEncoder(w).Encode(jsonResponse)
-				require.NoError(t, err)
-			} else if r.Method == http.MethodGet {
-				w.WriteHeader(http.StatusForbidden)
-				_, _ = w.Write([]byte("permission denied"))
-			} else {
-				w.WriteHeader(http.StatusInternalServerError)
-				t.Fatal(fmt.Sprintf("Unexpected method %s to URL %s", r.Method, r.URL.EscapedPath()))
-			}
-		case fmt.Sprintf(consulSetAgentTokenAPI, AgentType):
-			require.Equal(t, http.MethodPut, r.Method)
-			if registry.responseOptions.setAgentTokenOk {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte("agent token set successfully"))
-			} else {
-				w.WriteHeader(http.StatusForbidden)
-				_, _ = w.Write([]byte("permission denied"))
-			}
-		default:
-			t.Fatal(fmt.Sprintf("Unexpected call to URL %s", r.URL.EscapedPath()))
-		}
-	}))
-	tsURL, err := url.Parse(testSrv.URL)
-	require.NoError(t, err)
-	portNum, _ := strconv.Atoi(tsURL.Port())
-	registryTestConf.StageGate.Registry.ACL.Protocol = tsURL.Scheme
-	registryTestConf.StageGate.Registry.Host = tsURL.Hostname()
-	registryTestConf.StageGate.Registry.Port = portNum
-	registryTestConf.StageGate.WaitFor.Timeout = "1m"
-	registryTestConf.StageGate.WaitFor.RetryInterval = "1s"
-	// for the sake of simplicity, we use the same test server as the secret store server
-	registryTestConf.SecretStore.Protocol = tsURL.Scheme
-	registryTestConf.SecretStore.Host = tsURL.Hostname()
-	registryTestConf.SecretStore.Port = portNum
-	return registryTestConf
 }

--- a/internal/security/bootstrapper/command/setupacl/stubregistryserver_test.go
+++ b/internal/security/bootstrapper/command/setupacl/stubregistryserver_test.go
@@ -1,0 +1,317 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package setupacl
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
+	"github.com/stretchr/testify/require"
+)
+
+type registryTestServer struct {
+	serverOptions serverOptions
+	server        *httptest.Server
+}
+
+type serverOptions struct {
+	aclBootstrapOkResponse  bool
+	configAccessOkResponse  bool
+	enablePersistence       bool
+	consulCheckAgentOk      bool
+	listTokensOk            bool
+	listTokensWithRetriesOk bool
+	createTokenOk           bool
+	readTokenOk             bool
+	setAgentTokenOk         bool
+	readPolicyByNameOk      bool
+	policyAlreadyExists     bool
+	createNewPolicyOk       bool
+	createRoleOk            bool
+}
+
+func newRegistryTestServer(respOpts serverOptions) *registryTestServer {
+	return &registryTestServer{
+		serverOptions: respOpts,
+	}
+}
+
+func (registry *registryTestServer) close() {
+	if registry.server != nil {
+		registry.server.Close()
+	}
+}
+
+func (registry *registryTestServer) getRegistryServerConf(t *testing.T) *config.ConfigurationStruct {
+	registryTestConf := &config.ConfigurationStruct{}
+	testAgentTokenAccessorID := "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	testEdgeXPolicyID := "eeeeeeeee-eeee-eeee-eeee-eeeeeeeee"
+	tokens := []map[string]interface{}{
+		{
+			"AccessorID":  "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+			"Description": "some other type of agent token",
+		},
+		{
+			"AccessorID":  "00000000-0000-0000-0000-000000000002",
+			"Description": "Anonymous Token",
+		},
+		{
+			"AccessorID":  "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm",
+			"Description": "Bootstrap Token (Global Management)",
+		},
+	}
+	respCnt := 0
+	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pathBase := path.Base(r.URL.Path)
+		switch r.URL.EscapedPath() {
+		case consulGetLeaderAPI:
+			require.Equal(t, http.MethodGet, r.Method)
+			respCnt++
+			w.WriteHeader(http.StatusOK)
+			var err error
+			if respCnt >= 2 {
+				_, err = w.Write([]byte("127.0.0.1:12345"))
+			} else {
+				_, err = w.Write([]byte(""))
+			}
+			require.NoError(t, err)
+		case consulACLBootstrapAPI:
+			require.Equal(t, http.MethodPut, r.Method)
+			if registry.serverOptions.aclBootstrapOkResponse {
+				w.WriteHeader(http.StatusOK)
+				jsonResponse := map[string]interface{}{
+					"AccessorID":  "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					"SecretID":    "22222222-bbbb-3333-cccc-444444444444",
+					"Description": "Bootstrap Token (Global Management)",
+					"Policies": []map[string]interface{}{
+						{
+							"ID":   "00000000-0000-0000-0000-000000000001",
+							"Name": "global-management",
+						},
+					},
+					"Local":      false,
+					"CreateTime": "2021-03-01T10:34:20.843397-07:00",
+				}
+				err := json.NewEncoder(w).Encode(jsonResponse)
+				require.NoError(t, err)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("The ACL system is currently in legacy mode."))
+			}
+		case consulConfigAccessVaultAPI:
+			require.Equal(t, http.MethodPost, r.Method)
+			if registry.serverOptions.configAccessOkResponse {
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+			}
+		case fmt.Sprintf(createConsulRoleVaultAPI, pathBase):
+			require.Equal(t, http.MethodPost, r.Method)
+			if registry.serverOptions.createRoleOk {
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+			}
+		case consulCheckAgentAPI:
+			require.Equal(t, http.MethodGet, r.Method)
+			if registry.serverOptions.consulCheckAgentOk {
+				w.WriteHeader(http.StatusOK)
+				jsonResponse := map[string]interface{}{
+					"DebugConfig": map[string]interface{}{
+						"ACLDatacenter":    "dc1",
+						"ACLDefaultPolicy": "allow",
+						"ACLDisabledTTL":   "2m0s",
+						"ACLTokens": map[string]interface{}{
+							"EnablePersistence": registry.serverOptions.enablePersistence,
+						},
+						"ACLsEnabled": true,
+					},
+				}
+				err := json.NewEncoder(w).Encode(jsonResponse)
+				require.NoError(t, err)
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("permission denied"))
+			}
+		case consulListTokensAPI:
+			require.Equal(t, http.MethodGet, r.Method)
+			if registry.serverOptions.listTokensOk {
+				w.WriteHeader(http.StatusOK)
+				err := json.NewEncoder(w).Encode(tokens)
+				require.NoError(t, err)
+			} else if registry.serverOptions.listTokensWithRetriesOk {
+				if respCnt >= 2 {
+					w.WriteHeader(http.StatusOK)
+					err := json.NewEncoder(w).Encode(tokens)
+					require.NoError(t, err)
+				} else {
+					respCnt++
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(consulLegacyACLModeError))
+				}
+			} else if !registry.serverOptions.listTokensWithRetriesOk {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(consulLegacyACLModeError))
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("permission denied"))
+			}
+		case consulCreateTokenAPI:
+			require.Equal(t, http.MethodPut, r.Method)
+			if registry.serverOptions.createTokenOk {
+				w.WriteHeader(http.StatusOK)
+				jsonResponse := map[string]interface{}{
+					"AccessorID":  testAgentTokenAccessorID,
+					"Description": "edgex-core-consul agent token",
+					"Policies": []map[string]interface{}{
+						{
+							"ID":   "00000000-0000-0000-0000-000000000001",
+							"Name": "global-management",
+						},
+						{
+							"ID":   "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+							"Name": "node-read policy",
+						},
+					},
+					"Local":       true,
+					"CreateTime":  "2021-03-10T12:25:06.123456-07:00",
+					"Hash":        "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+					"CreateIndex": 59,
+					"ModifyIndex": 59,
+				}
+
+				err := json.NewEncoder(w).Encode(jsonResponse)
+				require.NoError(t, err)
+				tokens = append(tokens, jsonResponse)
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("cannot create token"))
+			}
+		case fmt.Sprintf(consulTokenRUDAPI, testAgentTokenAccessorID):
+			if r.Method == http.MethodGet && registry.serverOptions.readTokenOk {
+				w.WriteHeader(http.StatusOK)
+				jsonResponse := map[string]interface{}{
+					"AccessorID":  testAgentTokenAccessorID,
+					"Description": "edgex-core-consul agent token",
+					"Policies": []map[string]interface{}{
+						{
+							"ID":   "00000000-0000-0000-0000-000000000001",
+							"Name": "global-management",
+						},
+						{
+							"ID":   "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+							"Name": "node-read policy",
+						},
+					},
+					"Local":       false,
+					"CreateTime":  "2021-03-10T12:25:06.123456-07:00",
+					"Hash":        "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+					"CreateIndex": 59,
+					"ModifyIndex": 59,
+				}
+
+				err := json.NewEncoder(w).Encode(jsonResponse)
+				require.NoError(t, err)
+			} else if r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("permission denied"))
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Fatal(fmt.Sprintf("Unexpected method %s to URL %s", r.Method, r.URL.EscapedPath()))
+			}
+		case fmt.Sprintf(consulSetAgentTokenAPI, AgentType):
+			require.Equal(t, http.MethodPut, r.Method)
+			if registry.serverOptions.setAgentTokenOk {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("agent token set successfully"))
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("permission denied"))
+			}
+		case fmt.Sprintf(consulReadPolicyByNameAPI, ""):
+			require.Equal(t, http.MethodGet, r.Method)
+			// the policy name is empty
+			w.WriteHeader(http.StatusBadRequest)
+		case fmt.Sprintf(consulReadPolicyByNameAPI, pathBase):
+			require.Equal(t, http.MethodGet, r.Method)
+			if registry.serverOptions.readPolicyByNameOk && registry.serverOptions.policyAlreadyExists {
+				w.WriteHeader(http.StatusOK)
+				jsonResponse := map[string]interface{}{
+					"ID":          testEdgeXPolicyID,
+					"Name":        pathBase,
+					"Description": "test edgex policy",
+					"Rules":       edgeXPolicyRules,
+				}
+
+				err := json.NewEncoder(w).Encode(jsonResponse)
+				require.NoError(t, err)
+			} else if registry.serverOptions.readPolicyByNameOk {
+				// no existing policy
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(aclNotFoundMessage))
+			} else {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte("permission denied"))
+			}
+		case consulCreatePolicyAPI:
+			require.Equal(t, http.MethodPut, r.Method)
+			if registry.serverOptions.createNewPolicyOk {
+				w.WriteHeader(http.StatusOK)
+				reqBody, err := ioutil.ReadAll(r.Body)
+				require.NoError(t, err)
+				var policyMap map[string]interface{}
+				err = json.Unmarshal(reqBody, &policyMap)
+				require.NoError(t, err)
+				jsonResponse := map[string]interface{}{
+					"ID":          testEdgeXPolicyID,
+					"Name":        policyMap["Name"],
+					"Description": "test edgex policy",
+					"Rules":       policyMap["Rules"],
+				}
+
+				err = json.NewEncoder(w).Encode(jsonResponse)
+				require.NoError(t, err)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("Invalid Policy: A Policy with Name " + edgeXServicePolicyName + " already exists"))
+			}
+		default:
+			t.Fatal(fmt.Sprintf("Unexpected call to URL %s", r.URL.EscapedPath()))
+		}
+	}))
+	tsURL, err := url.Parse(testSrv.URL)
+	require.NoError(t, err)
+	portNum, _ := strconv.Atoi(tsURL.Port())
+	registryTestConf.StageGate.Registry.ACL.Protocol = tsURL.Scheme
+	registryTestConf.StageGate.Registry.Host = tsURL.Hostname()
+	registryTestConf.StageGate.Registry.Port = portNum
+	registryTestConf.StageGate.WaitFor.Timeout = "1m"
+	registryTestConf.StageGate.WaitFor.RetryInterval = "1s"
+	// for the sake of simplicity, we use the same test server as the secret store server
+	registryTestConf.SecretStore.Protocol = tsURL.Scheme
+	registryTestConf.SecretStore.Host = tsURL.Hostname()
+	registryTestConf.SecretStore.Port = portNum
+	registry.server = testSrv
+	return registryTestConf
+}

--- a/internal/security/bootstrapper/config/config.go
+++ b/internal/security/bootstrapper/config/config.go
@@ -16,6 +16,8 @@
 package config
 
 import (
+	"strings"
+
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 )
 
@@ -70,4 +72,14 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 // GetInsecureSecrets returns the service's InsecureSecrets.
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return nil
+}
+
+// GetRoleNames gets the slice of the keys (i.e. the service keys) from map Roles as ACL role names
+func (acl ACLInfo) GetACLRoleNames() []string {
+	roleNames := make([]string, 0, len(acl.Roles))
+	for serviceKey := range acl.Roles {
+		// always converts to lower cases by design
+		roleNames = append(roleNames, strings.ToLower(serviceKey))
+	}
+	return roleNames
 }

--- a/internal/security/bootstrapper/config/types.go
+++ b/internal/security/bootstrapper/config/types.go
@@ -69,6 +69,16 @@ type ACLInfo struct {
 	SecretsAdminTokenPath string
 	// filepath for the sentinel file to indicate the registry ACL is set up successfully
 	SentinelFilePath string
+	// filepath to save the registry's token created for management purposes
+	ManagementTokenPath string
+	// the roles for registry role-based access control list
+	Roles map[string]ACLRoleInfo
+}
+
+// ACLRoleInfo defines the fields related to Registry's ACL roles
+type ACLRoleInfo struct {
+	// the details about the role
+	Description string
 }
 
 // KongDBInfo defines the fields related to

--- a/internal/security/fileprovider/defaults.go
+++ b/internal/security/fileprovider/defaults.go
@@ -17,10 +17,18 @@
 package fileprovider
 
 func makeDefaultTokenPolicy(serviceName string) map[string]interface{} {
+	// protected path for secret/
 	protectedPath := "secret/edgex/" + serviceName + "/*"
 	capabilities := []string{"create", "update", "delete", "list", "read"}
 	acl := map[string]interface{}{"capabilities": capabilities}
-	pathObject := map[string]interface{}{protectedPath: acl}
+	// path for consul tokens
+	registryCredsPath := "consul/creds/" + serviceName
+	registryCredsCapabilities := []string{"read"}
+	registryCredsACL := map[string]interface{}{"capabilities": registryCredsCapabilities}
+	pathObject := map[string]interface{}{
+		protectedPath:     acl,
+		registryCredsPath: registryCredsACL,
+	}
 	retval := map[string]interface{}{"path": pathObject}
 	return retval
 
@@ -29,9 +37,12 @@ func makeDefaultTokenPolicy(serviceName string) map[string]interface{} {
 			"path": {
 			  "secret/edgex/service-name/*": {
 				"capabilities": [ "create", "update", "delete", "list", "read" ]
+			  },
+			  "consul/creds/service-name": {
+				"capabilities": [ "read" ]
 			  }
 			}
-		  }
+		}
 	*/
 }
 

--- a/internal/security/fileprovider/defaults_test.go
+++ b/internal/security/fileprovider/defaults_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultTokenPolicy(t *testing.T) {
@@ -28,11 +28,21 @@ func TestDefaultTokenPolicy(t *testing.T) {
 
 	// Assert
 	bytes, err := json.Marshal(policies)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NotEmpty(t, bytes)
 
-	expected := `{"path":{"secret/edgex/service-name/*":{"capabilities":["create","update","delete","list","read"]}}}`
-	actual := string(bytes)
-	assert.Equal(t, expected, actual)
+	expected := map[string]interface{}{
+		"path": map[string]interface{}{
+			"secret/edgex/service-name/*": map[string]interface{}{
+				"capabilities": []string{"create", "update", "delete", "list", "read"},
+			},
+			"consul/creds/service-name": map[string]interface{}{
+				"capabilities": []string{"read"},
+			},
+		},
+	}
+
+	require.Equal(t, expected, policies)
 }
 
 func TestDefaultTokenParameters(t *testing.T) {
@@ -41,9 +51,9 @@ func TestDefaultTokenParameters(t *testing.T) {
 
 	// Assert
 	bytes, err := json.Marshal(parameters)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := `{"display_name":"service-name","no_parent":true,"period":"1h","policies":["edgex-service-service-name"],"ttl":"1h"}`
 	actual := string(bytes)
-	assert.Equal(t, expected, actual)
+	require.Equal(t, expected, actual)
 }

--- a/internal/security/fileprovider/provider.go
+++ b/internal/security/fileprovider/provider.go
@@ -105,6 +105,10 @@ func (p *fileTokenProvider) Run() error {
 		if serviceConfig.UseDefaults {
 			p.logger.Info(fmt.Sprintf("using policy/token defaults for service %s", serviceName))
 			servicePolicy = makeDefaultTokenPolicy(serviceName)
+			defaultPolicyPaths := servicePolicy["path"].(map[string]interface{})
+			for pathKey, policy := range defaultPolicyPaths {
+				servicePolicy["path"].(map[string]interface{})[pathKey] = policy
+			}
 			createTokenParameters = makeDefaultTokenParameters(serviceName)
 		}
 
@@ -195,15 +199,8 @@ func (p *fileTokenProvider) Run() error {
 			}
 		}
 
-		encoder := json.NewEncoder(writeCloser)
-		if encoder == nil {
-			_ = writeCloser.Close()
-			err = fmt.Errorf("unable to create JSON output encoder")
-			return err
-		}
-
 		// Write resulting token
-		if err := encoder.Encode(createTokenResponse); err != nil {
+		if err := json.NewEncoder(writeCloser).Encode(createTokenResponse); err != nil {
 			_ = writeCloser.Close()
 			p.logger.Error(fmt.Sprintf("failed to write token file: %s", err.Error()))
 			return err


### PR DESCRIPTION
New addition for implementing for Consul's ACL policies creation and roles for Consul tokens generated later on via `go-mod-secret`
 - Add logic to check whether the ACL policy is already per-existing before creation of new policy
 - Add implementation to create a new ACL policy
 - Add implementation to create a role for EdgeX's services via Vault's /consul/roles/* APIs: this sets the stage for creating role-based Consul tokens used by EdgeX services
 - Add logic for creating token roles based on EdgeX service keys from configuration file
 - Update token-file-provider on Edgex's default policy to add the permission for calling `/consul/creds/"service-key"` endpoint

Closes: #3254, #3160

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
this is a new feature, no ACL policies and roles existing yet.

## Issue Number: #3254 


## What is the new behavior?
Add Consul's ACL policies for EdgeX services and management token.
Add roles for Vault so that we can utilize the /consul/creds/rolename api to create Consul tokens for services later.
Add consul management token
Augment the Vault's ACL policy of /consul/creds/servicekey on file-token-provider

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
With this PR and run the docker compose,  `docker logs edgex-core-consul` should give successful logging messages like the following:
```

level=INFO ts=2021-03-18T21:13:05.744452978Z app=edgex-security-bootstrapper source=command.go:486 msg="successfully retrieved secretstore management token from /tmp/edgex/secrets/edgex-consul/admin/token.json"
level=INFO ts=2021-03-18T21:13:05.744465707Z app=edgex-security-bootstrapper source=command.go:163 msg="successfully get secretstore token and configuring the registry access for secretestore"
level=INFO ts=2021-03-18T21:13:05.746086231Z app=edgex-security-bootstrapper source=command.go:538 msg="successfully configure Consul access for secretstore"
    2021-03-18T21:13:05.747Z [ERROR] agent.http: Request error: method=GET url=/v1/acl/policy/name/edgex-service-policy from=192.168.48.7:58514 error="ACL not found"
level=INFO ts=2021-03-18T21:13:05.758003985Z app=edgex-security-bootstrapper source=aclpolicies.go:150 msg="successfully created a new agent policy with name edgex-service-policy"
level=INFO ts=2021-03-18T21:13:05.759230928Z app=edgex-security-bootstrapper source=aclroles.go:127 msg="successfully create a role [edgex-security-proxy-setup] for secretstore"
level=INFO ts=2021-03-18T21:13:05.760299764Z app=edgex-security-bootstrapper source=aclroles.go:127 msg="successfully create a role [edgex-support-notifications] for secretstore"
level=INFO ts=2021-03-18T21:13:05.76133305Z app=edgex-security-bootstrapper source=aclroles.go:127 msg="successfully create a role [edgex-support-scheduler] for secretstore"
level=INFO ts=2021-03-18T21:13:05.762399343Z app=edgex-security-bootstrapper source=aclroles.go:127 msg="successfully create a role [edgex-application-service] for secretstore"
level=INFO ts=2021-03-18T21:13:05.763350181Z app=edgex-security-bootstrapper source=aclroles.go:127 msg="successfully create a role [edgex-core-command] for secretstore"
level=INFO ts=2021-03-18T21:13:05.764296028Z app=edgex-security-bootstrapper source=aclroles.go:127 msg="successfully create a role [edgex-core-data] for secretstore"
level=INFO ts=2021-03-18T21:13:05.765305796Z app=edgex-security-bootstrapper source=aclroles.go:127 msg="successfully create a role [edgex-core-metadata] for secretstore"
level=INFO ts=2021-03-18T21:13:05.768771663Z app=edgex-security-bootstrapper source=acltokens.go:166 msg="internal Consul ACL system is ready"
level=INFO ts=2021-03-18T21:13:05.779467636Z app=edgex-security-bootstrapper source=acltokens.go:423 msg="successfully created a new registry token"
level=INFO ts=2021-03-18T21:13:05.779711338Z app=edgex-security-bootstrapper source=acltokens.go:316 msg="successfully created a new agent token"
    2021-03-18T21:13:05.788Z [INFO]  agent: Updated agent's ACL token: token=agent
level=INFO ts=2021-03-18T21:13:05.789274373Z app=edgex-security-bootstrapper source=acltokens.go:368 msg="agent token is set with type [agent]"
level=INFO ts=2021-03-18T21:13:05.789381234Z app=edgex-security-bootstrapper source=command.go:345 msg="successfully set up agent token into agent"
    2021-03-18T21:13:05.790Z [ERROR] agent.http: Request error: method=GET url=/v1/acl/policy/name/edgex-management-policy from=192.168.48.7:58514 error="ACL not found"
level=INFO ts=2021-03-18T21:13:05.804597835Z app=edgex-security-bootstrapper source=aclpolicies.go:150 msg="successfully created a new agent policy with name edgex-management-policy"
level=INFO ts=2021-03-18T21:13:05.81879284Z app=edgex-security-bootstrapper source=acltokens.go:423 msg="successfully created a new registry token"
level=INFO ts=2021-03-18T21:13:05.819110185Z app=edgex-security-bootstrapper source=command.go:306 msg="token is written to /tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
level=INFO ts=2021-03-18T21:13:05.819189022Z app=edgex-security-bootstrapper source=command.go:272 msg="successfully created and saved registry management token with policy name edgex-management-policy"
level=INFO ts=2021-03-18T21:13:05.819399123Z app=edgex-security-bootstrapper source=command.go:197 msg="setupRegistryACL successfully done"

```

## Other information