### PR TITLE
ci: update minimal-snap-build.sh script

### DIFF
--- a/snap/local/build-helpers/bin/minimal-snap-build.sh
+++ b/snap/local/build-helpers/bin/minimal-snap-build.sh
@@ -13,24 +13,27 @@
 # work with the patch applied). This further reduces the build
 # time.
 
-sudo snap install yq --channel=v4/stable
+# get the 4.6.2 release of yq from github
+curl -L --output yq.tar.gz https://github.com/mikefarah/yq/releases/download/v4.6.2/yq_linux_amd64.tar.gz
+tar -xvf yq.tar.gz
+mv yq_linux_amd64 yq
 
 CURRDIR=$(pwd)
 SNAPCRAFT_YAML="$CURRDIR/snap/snapcraft.yaml"
 
 # remove first chunk of apps
-yq e -P -i 'del(.apps.consul,.apps.redis,.apps.postgres,.apps.kong-daemon,.apps.vault,.apps.vault-cli)' "$SNAPCRAFT_YAML"
+$CURRDIR/yq e -P -i 'del(.apps.consul,.apps.redis,.apps.postgres,.apps.kong-daemon,.apps.vault,.apps.vault-cli)' "$SNAPCRAFT_YAML"
 
 # remove second chunk of apps
-yq e -P -i 'del(.apps.device-virtual,.apps.app-service-configurable)' "$SNAPCRAFT_YAML"
+$CURRDIR/yq e -P -i 'del(.apps.device-virtual,.apps.app-service-configurable)' "$SNAPCRAFT_YAML"
 
 # remove third chunk of apps
-yq e -P -i 'del(.apps.redis-cli,.apps.consul-cli)' "$SNAPCRAFT_YAML"
+$CURRDIR/yq e -P -i 'del(.apps.redis-cli,.apps.consul-cli)' "$SNAPCRAFT_YAML"
 
 # remove fourth chunk of apps
-yq e -P -i 'del(.apps.kong,.apps.psql,.apps.psql-any,.apps.createdb,.apps.kuiper,.apps.kuiper-cli)' "$SNAPCRAFT_YAML"
+$CURRDIR/yq e -P -i 'del(.apps.kong,.apps.psql,.apps.psql-any,.apps.createdb,.apps.kuiper,.apps.kuiper-cli)' "$SNAPCRAFT_YAML"
 
 # remove unwanted parts
-yq e -P -i 'del(.parts.snapcraft-preload,.parts.postgres,.parts.consul,.parts.redis,.parts.kong,.parts.vault,.parts.device-virtual-go,.parts.kuiper)' "$SNAPCRAFT_YAML"
+$CURRDIR/yq e -P -i 'del(.parts.snapcraft-preload,.parts.postgres,.parts.consul,.parts.redis,.parts.kong,.parts.vault,.parts.device-virtual-go,.parts.kuiper)' "$SNAPCRAFT_YAML"
 
 


### PR DESCRIPTION
The yq snap is confined and can only work in the user's home directory.
As the Jenkins pipeline builds the snap outside the homedir, yq is not
able to update the file. This PR changes the script to use the yq binary
from github.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
yq fails to modify snapcraft.yaml and the minimal edgexfoundry snap build fails.

## Issue Number:


## What is the new behavior?
yq is able modify snapcraft.yaml and the minimal edgexfoundry snap build succeeds.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information