### PR TITLE
refactor: Rework entry point scripts to run 'listenTcp' command as non-root

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
@@ -70,7 +70,7 @@ echo "$(date) ENABLE_REGISTRY_ACL = ${ENABLE_REGISTRY_ACL}"
 
 if [ "${ENABLE_REGISTRY_ACL}" == "true" ]; then
   echo "$(date) Starting edgex-core-consul with ACL enabled ..."
-  docker-entrypoint.sh agent \
+  exec docker-entrypoint.sh agent \
     -ui \
     -bootstrap \
     -server \
@@ -96,7 +96,7 @@ if [ "${ENABLE_REGISTRY_ACL}" == "true" ]; then
   # no need to wait for Consul's port since it is in ready state after all ACL stuff
 else
   echo "$(date) Starting edgex-core-consul with ACL disabled ..."
-  docker-entrypoint.sh agent \
+  exec docker-entrypoint.sh agent \
     -ui \
     -bootstrap \
     -server \
@@ -111,7 +111,7 @@ else
 fi
 
 # Signal that Consul is ready for services blocked waiting on Consul
-/edgex-init/security-bootstrapper --confdir=/edgex-init/res listenTcp \
+exec su-exec consul /edgex-init/security-bootstrapper --confdir=/edgex-init/res listenTcp \
   --port="${STAGEGATE_REGISTRY_READYPORT}" --host="${STAGEGATE_REGISTRY_HOST}"
 if [ $? -ne 0 ]; then
     echo "$(date) failed to gating the consul ready port, exits"

--- a/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
@@ -70,7 +70,7 @@ echo "$(date) ENABLE_REGISTRY_ACL = ${ENABLE_REGISTRY_ACL}"
 
 if [ "${ENABLE_REGISTRY_ACL}" == "true" ]; then
   echo "$(date) Starting edgex-core-consul with ACL enabled ..."
-  exec docker-entrypoint.sh agent \
+  docker-entrypoint.sh agent \
     -ui \
     -bootstrap \
     -server \
@@ -96,7 +96,7 @@ if [ "${ENABLE_REGISTRY_ACL}" == "true" ]; then
   # no need to wait for Consul's port since it is in ready state after all ACL stuff
 else
   echo "$(date) Starting edgex-core-consul with ACL disabled ..."
-  exec docker-entrypoint.sh agent \
+  docker-entrypoint.sh agent \
     -ui \
     -bootstrap \
     -server \

--- a/cmd/security-bootstrapper/entrypoint-scripts/postgres_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/postgres_wait_install.sh
@@ -93,7 +93,7 @@ done
 echo "$(date) ${STAGEGATE_KONGDB_HOST} is initialized"
 
 # Signal that Postgres is ready for services blocked waiting on Postgres
-/edgex-init/security-bootstrapper --confdir=/edgex-init/res listenTcp \
+exec su-exec postgres /edgex-init/security-bootstrapper --confdir=/edgex-init/res listenTcp \
   --port="${STAGEGATE_KONGDB_READYPORT}" --host="${STAGEGATE_KONGDB_HOST}"
 if [ $? -ne 0 ]; then
   echo "$(date) failed to gating the postgres ready port, exits"

--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -36,7 +36,7 @@ RUN make cmd/security-file-token-provider/security-file-token-provider \
 
 FROM alpine:3.12
 
-RUN apk add --update --no-cache ca-certificates dumb-init curl
+RUN apk add --update --no-cache ca-certificates dumb-init curl su-exec
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Dell Technologies, Inc.'

--- a/cmd/security-secretstore-setup/entrypoint.sh
+++ b/cmd/security-secretstore-setup/entrypoint.sh
@@ -36,7 +36,7 @@ echo "$(date) Changing ownership of secrets to ${EDGEX_USER}:${EDGEX_GROUP}"
 chown -Rh ${EDGEX_USER}:${EDGEX_GROUP} /tmp/edgex/secrets
 
 # Signal tokens ready port for other services waiting on
-/edgex-init/security-bootstrapper --confdir=/edgex-init/res listenTcp \
+exec su-exec ${EDGEX_USER} /edgex-init/security-bootstrapper --confdir=/edgex-init/res listenTcp \
   --port="${STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT}" --host="${STAGEGATE_SECRETSTORESETUP_HOST}"
 if [ $? -ne 0 ]; then
   echo "$(date) failed to gating the tokens ready port"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
'listenTcp' command runs as root everywhere it is used.

## Issue Number: #3221

## What is the new behavior?
'listenTcp' command now runs as non-root everywhere it is used.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information