### PR TITLE
docs: Remove RequestId from the example of swagger doc

### DIFF
--- a/openapi/v2/core-command.yaml
+++ b/openapi/v2/core-command.yaml
@@ -366,27 +366,22 @@ components:
     400Example:
       value:
         apiVersion: "v2"
-        requestId: ""
         statusCode: 400
         message: "Bad Request"
     416Example:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 416
         message: "Range Not Satisfiable"
     500Example:
       value:
         apiVersion: "v2"
-        requestId: ""
         statusCode: 500
         message: "Internal Server Error"
     DeviceCoreCommandExample:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 200
-        message: ""
         deviceCoreCommand:
           - deviceName: "testDevice"
             profileName: "testProfile"
@@ -401,10 +396,8 @@ components:
                 url: "http://localhost:48082"
     MultiDeviceCoreCommandsExample:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 200
-        message: ""
         deviceCoreCommands:
           - deviceName: "testDevice1"
             profileName: "testProfile"

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -309,52 +309,41 @@ components:
   examples:
     200Example:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 200
-        message: ""
     202Example:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 202
-        message: ""
     400Example:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 400
         message: "Bad Request" 
     404Example:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 404
         message: "Not Found"
     409Example:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 409
         message: "Data Duplicate"
     416Example:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 416
         message: "Range Not Satisfiable"
     500Example:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 500
         message: "Interval Server Error" 
     EventExample:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 200
-        message: ""
         event:
           apiVersion: "v2"
           id: "040bd523-ec33-440d-9d72-e5813a465f37"
@@ -385,10 +374,8 @@ components:
               value: "75"
     AllEventsExample:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 200
-        message: ""
         events: 
           - apiVersion: "v2"
             id: "040bd523-ec33-440d-9d72-e5813a465f37"
@@ -448,10 +435,8 @@ components:
                 value: "12.2"
     AllReadingsExample:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 200
-        message: ""
         readings:
           - deviceName: "device-001"
             resourceName: "resource-001"
@@ -484,10 +469,8 @@ components:
             value: "12.2"
     CountExample:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 200
-        message: ""
         count: 3
 paths:
   /event/{profileName}/{deviceName}/{sourceName}:
@@ -551,10 +534,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/BaseWithIdResponse'
               example:
-                requestId: ""
                 apiVersion: "v2"
                 statusCode: 201
-                message: ""
                 id: "d5471d59-2810-419a-8744-18eb8fa03465"
         '400':
           description: "Request is in an invalid state"

--- a/openapi/v2/core-metadata.yaml
+++ b/openapi/v2/core-metadata.yaml
@@ -1037,8 +1037,7 @@ components:
           message: "Internal Server Error"
     AddDeviceRequest:
       value:
-        - requestId: "e6e8a2f4-eb14-4649-9e2b-175247911369"
-          apiVersion: v2
+        - apiVersion: v2
           device:
             name: AWS IOT Button1
             description: Home automation system
@@ -1061,6 +1060,24 @@ components:
                 port: '1234'
                 unitID: '1'
             notify: false
+    UpdateDeviceRequest:
+      value:
+        - apiVersion: v2
+          device:
+            - id: "edaa7c0f-05c6-4368-89f1-3be5e197cf6a"
+              name: "AWS IOT Button1"
+              operatingState: "DOWN"
+              labels:
+                - "home"
+              autoEvents:
+                - frequency: "100ms"
+                  onChange: true
+                  sourceName: "CurrentHumidity"
+            - id: "771de9f4-b5a3-4eba-b5e7-ec6e14fa3de7"
+              name: "AWS IOT Button2"
+              description: "Home automation system"
+              adminState: "LOCKED"
+              operatingState: "UP"
     AddDeviceServiceRequest:
       value:
         - requestId: "e6e8a2f4-eb14-4649-9e2b-175247911369"
@@ -1334,25 +1351,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateDeviceRequest'
-            example:
-              requestId: "d3367878-c46b-4263-b0af-1ccac37aab6e"
-              apiVersion: v2
-              device:
-                - id: "edaa7c0f-05c6-4368-89f1-3be5e197cf6a"
-                  name: "AWS IOT Button1"
-                  operatingState: "DOWN"
-                  labels:
-                    - "home"
-                  autoEvents:
-                    - frequency: "100ms"
-                      onChange: true
-                      sourceName: "CurrentHumidity"
-                - id: "771de9f4-b5a3-4eba-b5e7-ec6e14fa3de7"
-                  name: "AWS IOT Button2"
-                  description: "Home automation system"
-                  adminState: "LOCKED"
-                  operatingState: "UP"
+              type: array
+              items:
+                $ref: '#/components/schemas/UpdateDeviceRequest'
+            examples:
+              UpdateDeviceRequest:
+                $ref: '#/components/examples/UpdateDeviceRequest'
       responses:
         '207':
           description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."

--- a/openapi/v2/support-notifications.yaml
+++ b/openapi/v2/support-notifications.yaml
@@ -509,37 +509,30 @@ components:
     200Example:
       value:
         apiVersion: "v2"
-        requestId: ""
         statusCode: 200
-        message: ""
     400Example:
       value:
         apiVersion: "v2"
-        requestId: ""
         statusCode: 400
         message: "Bad Request"
     404Example:
       value:
         apiVersion: "v2"
-        requestId: ""
         statusCode: 404
         message: "Not Found"
     416Example:
       value:
-        requestId: ""
         apiVersion: "v2"
         statusCode: 416
         message: "Range Not Satisfiable"
     500Example:
       value:
         apiVersion: "v2"
-        requestId: ""
         statusCode: 500
         message: "Internal Server Error"
     SubscriptionRequestExample:
       value:
         - apiVersion: "v2"
-          requestId: "6f52dc3c-5548-4142-baa6-052ac4bece93"
           subscription:
             name: subscriptionA
             channels:
@@ -561,48 +554,36 @@ components:
     AddSubscriptionsExample:
       value:
         - apiVersion: "v2"
-          requestId: ""
           statusCode: 201
           id: "6f52dc3c-5548-4142-baa6-052ac4bece93"
-          message: ""
         - apiVersion: "v2"
-          requestId: ""
           statusCode: 409
           message: "Duplicated"
         - apiVersion: "v2"
-          requestId: ""
           statusCode: 500
           message: "Internal Server Error"
     UpdateSubscriptionsExample:
       value:
         - apiVersion: "v2"
-          requestId: ""
           statusCode: 200
-          message: ""
         - apiVersion: "v2"
-          requestId: ""
           statusCode: 404
           message: "Not Found"
         - apiVersion: "v2"
-          requestId: ""
           statusCode: 500
           message: "Internal Server Error"
     AddNotificationsExample:
       value:
         - apiVersion: "v2"
-          requestId: ""
           statusCode: 201
           id: "e77c6ca4-46e9-4b11-b0e9-4bbfe5e8420e"
           message: ""
         - apiVersion: "v2"
-          requestId: ""
           statusCode: 500
           message: "Internal Server Error"
     SubscriptionResponseExample:
       value:
         apiVersion: v2
-        requestId: ''
-        message: ''
         statusCode: 200
         subscription:
           id: 25d4a9d3-0a9b-469f-8ce0-4a5ba1f7b152
@@ -627,8 +608,6 @@ components:
     MultiSubscriptionsResponseExample:
       value:
         apiVersion: "v2"
-        requestId: ""
-        message: ""
         statusCode: 200
         subscriptions:
             - id: 25d4a9d3-0a9b-469f-8ce0-4a5ba1f7b152

--- a/openapi/v2/support-scheduler.yaml
+++ b/openapi/v2/support-scheduler.yaml
@@ -479,13 +479,11 @@ components:
     400Example:
       value:
         apiVersion: "v2"
-        requestId: ""
         statusCode: 400
         message: "Bad Request"
     500Example:
       value:
         apiVersion: "v2"
-        requestId: ""
         statusCode: 500
         message: "Internal Server Error"
 paths:

--- a/openapi/v2/system-agent.yaml
+++ b/openapi/v2/system-agent.yaml
@@ -68,7 +68,7 @@ components:
           type: object
           title: service
           description: "Map of service(key) and configuration(value)"
-      example: { "apiVersion":"v2", "requestId": "e6e8a2f4-eb14-4649-9e2b-175247911369","statusCode": 200, "message": "",
+      example: { "apiVersion":"v2","statusCode": 200,
                  "edgex-core-data" : {"Clients" : {"Logging" : {"Host" : "localhost", "Port" : "48061" , "Protocol":"http"}}}}
       required:
         - config
@@ -290,7 +290,6 @@ components:
     500Example:
       value:
         apiVersion: "v2"
-        requestId: ""
         statusCode: 500
         message: "Internal Server Error"
 paths:


### PR DESCRIPTION
Close #3312

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3312 


## What is the new behavior?
- Since the RequestId is optional and the user don't need to provide the RequestId for the REST API, so we can remove RequestId from the example of swagger doc.
- And the message can be omitted when it was empty.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information