### PR TITLE
feat(security): Implementation for generating and storing Consul tokens for EdgeX services

### DIFF
--- a/cmd/security-bootstrapper/res/configuration.toml
+++ b/cmd/security-bootstrapper/res/configuration.toml
@@ -28,6 +28,13 @@ LogLevel = 'INFO'
       SecretsAdminTokenPath = "/tmp/edgex/secrets/edgex-consul/admin/token.json"
       # this is the filepath for the sentinel file to indicate the registry ACL is set up successfully
       SentinelFilePath = "/edgex-init/consul-bootstrapper/consul_acl_done"
+
+      # this is the output base directory for generated consul tokens
+      # the token is actually put underneath each service key's subdirectory like "edgex-core-data/"
+      TokenBaseDir = "/tmp/edgex/secrets"
+      # the access token file name for all services
+      TokenFileName = "consul-token"
+
       # this is the filepath for the created Consul management token
       ManagementTokenPath = "/tmp/edgex/secrets/consul-acl-token/mgmt_token.json"
       

--- a/internal/security/bootstrapper/command/setupacl/aclpolicies.go
+++ b/internal/security/bootstrapper/command/setupacl/aclpolicies.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/command/setupacl/share"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 )
 
@@ -114,7 +115,7 @@ func (c *cmd) getOrCreateRegistryPolicy(tokenID, policyName, policyRules string)
 		return nil, fmt.Errorf("failed to prepare create a new policy request for http URL: %w", err)
 	}
 
-	req.Header.Add(consulTokenHeader, tokenID)
+	req.Header.Add(share.ConsulTokenHeader, tokenID)
 	req.Header.Add(clients.ContentType, clients.ContentTypeJSON)
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -159,7 +160,7 @@ func (c *cmd) getPolicyByName(tokenID, policyName string) (*Policy, error) {
 		return nil, fmt.Errorf("Failed to prepare readPolicyByName request for http URL: %w", err)
 	}
 
-	req.Header.Add(consulTokenHeader, tokenID)
+	req.Header.Add(share.ConsulTokenHeader, tokenID)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to send readPolicyByName request for http URL: %w", err)

--- a/internal/security/bootstrapper/command/setupacl/command_test.go
+++ b/internal/security/bootstrapper/command/setupacl/command_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -134,6 +135,7 @@ func TestExecute(t *testing.T) {
 				policyAlreadyExists:     true,
 				createNewPolicyOk:       true,
 				createRoleOk:            true,
+				consulCredsApiCallOk:    true,
 			}
 			conf, testServer := test.prepare(testSrvOptions, t)
 			defer testServer.Close()
@@ -142,6 +144,8 @@ func TestExecute(t *testing.T) {
 			conf.StageGate.Registry.ACL.BootstrapTokenPath = filepath.Join(test.adminDir, "bootstrap_token.json")
 			conf.StageGate.Registry.ACL.SentinelFilePath = filepath.Join(test.adminDir, "sentinel_test_file")
 			conf.StageGate.Registry.ACL.ManagementTokenPath = filepath.Join(test.adminDir, "mgmt_token.json")
+			conf.StageGate.Registry.ACL.TokenBaseDir = test.adminDir
+			conf.StageGate.Registry.ACL.TokenFileName = "consul-token"
 
 			setupRegistryACL, err := NewCommand(ctx, wg, lc, conf, []string{})
 			require.NoError(t, err)
@@ -165,6 +169,10 @@ func TestExecute(t *testing.T) {
 				if test.adminDir == "" {
 					// empty test dir case don't have the directory to clean up
 					_ = os.Remove(conf.StageGate.Registry.ACL.BootstrapTokenPath)
+					for roleName := range conf.StageGate.Registry.ACL.Roles {
+						curDir, _ := os.Getwd()
+						_ = os.Remove(filepath.Join(curDir, strings.ToLower(roleName)))
+					}
 				} else {
 					_ = os.RemoveAll(test.adminDir)
 				}
@@ -221,6 +229,7 @@ func TestMultipleExecuteCalls(t *testing.T) {
 				policyAlreadyExists:     true,
 				createNewPolicyOk:       true,
 				createRoleOk:            true,
+				consulCredsApiCallOk:    true,
 			}
 			conf, testServer := test.prepare(testSrvOptions, t)
 			defer testServer.Close()
@@ -229,6 +238,8 @@ func TestMultipleExecuteCalls(t *testing.T) {
 			conf.StageGate.Registry.ACL.BootstrapTokenPath = filepath.Join(test.adminDir, "bootstrap_token.json")
 			conf.StageGate.Registry.ACL.SentinelFilePath = filepath.Join(test.adminDir, "sentinel_test_file")
 			conf.StageGate.Registry.ACL.ManagementTokenPath = filepath.Join(test.adminDir, "mgmt_token.json")
+			conf.StageGate.Registry.ACL.TokenBaseDir = test.adminDir
+			conf.StageGate.Registry.ACL.TokenFileName = "test-consul-token"
 
 			setupRegistryACL, err := NewCommand(ctx, wg, lc, conf, []string{})
 			require.NoError(t, err)
@@ -253,6 +264,10 @@ func TestMultipleExecuteCalls(t *testing.T) {
 				if test.adminDir == "" {
 					// empty test dir case don't have the directory to clean up
 					_ = os.Remove(conf.StageGate.Registry.ACL.BootstrapTokenPath)
+					for roleName := range conf.StageGate.Registry.ACL.Roles {
+						curDir, _ := os.Getwd()
+						_ = os.Remove(filepath.Join(curDir, strings.ToLower(roleName)))
+					}
 				} else {
 					_ = os.RemoveAll(test.adminDir)
 				}

--- a/internal/security/bootstrapper/command/setupacl/share/constant.go
+++ b/internal/security/bootstrapper/command/setupacl/share/constant.go
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package share
+
+const (
+	// ConsulTokenHeader is the HTTP header for Consul token access
+	ConsulTokenHeader = "X-Consul-Token"
+	// EmptyToken represents an empty token
+	EmptyToken = ""
+)

--- a/internal/security/bootstrapper/command/setupacl/tokencleaner/tokencleaner.go
+++ b/internal/security/bootstrapper/command/setupacl/tokencleaner/tokencleaner.go
@@ -1,0 +1,256 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package tokencleaner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/command/setupacl/share"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/fileioperformer"
+)
+
+const (
+	consulReadSelfTokenAPI = "/v1/acl/token/self"
+	// require bootstrap token or acl:write permission to delete tokens, %s is token's accessorID
+	consulDeleteTokenAPI = "/v1/acl/token/%s"
+)
+
+// TokenCleaner cleans up the old consul tokens from Consul server agent
+// based on the tokenID stored under the token base directory and token file name
+type TokenCleaner struct {
+	tokenApiUrlBase string
+	tokenBaseDirAbs string
+	tokenFileName   string
+	lc              logger.LoggingClient
+	httpCaller      internal.HttpCaller
+}
+
+// SelfTokenInfo is the token information about its token ID and accessor ID
+type SelfTokenInfo struct {
+	AccessorID string `json:"AccessorID"`
+	SecretID   string `json:"SecretID"`
+}
+
+// NewTokenCleaner returns a new instance of TokenCleaner
+// the tokenFileName cannot be empty
+func NewTokenCleaner(tokenApiUrlBase string,
+	tokenBaseDir string,
+	tokenFileName string,
+	lc logger.LoggingClient,
+	caller internal.HttpCaller) (*TokenCleaner, error) {
+	tokenBaseDirAbs, err := filepath.Abs(tokenBaseDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path for tokenBaseDir: %v", err)
+	}
+
+	if len(tokenFileName) == 0 {
+		return nil, errors.New("token file name is empty")
+	}
+
+	return &TokenCleaner{
+		tokenApiUrlBase: tokenApiUrlBase,
+		tokenBaseDirAbs: tokenBaseDirAbs,
+		tokenFileName:   tokenFileName,
+		lc:              lc,
+		httpCaller:      caller,
+	}, nil
+}
+
+// ScrubOldTokens walks through the directories underneath the access token base directory, finds the matching token file name,
+// and deletes the old token from registry agent server based on the tokenID read from the token file if any
+// the deletion requires the ACL write permission and hence using bootstrap ACL token
+// the caller should calls this to clean up the old tokens before creating new tokens, and the caller could ingore
+// the returned error from the Scrubber as it is not that critical if unable to delete the old tokens
+func (tr *TokenCleaner) ScrubOldTokens(bootstrapACLToken string) error {
+	// if the base directory to clean does not even exist, nothing to be cleaned
+	if !tr.isBaseDirExist() {
+		tr.lc.Infof("the token base directory %s does not exist, skip scrubbing old tokens", tr.tokenBaseDirAbs)
+		return nil
+	}
+
+	if len(bootstrapACLToken) == 0 {
+		return errors.New("required bootstrap token is empty")
+	}
+
+	// walk through the base directory and found the matched token file names and
+	// read the token out of it and delete the token from Consul
+	walkErr := filepath.Walk(tr.tokenBaseDirAbs, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("found error while walking through token base directory %s: %v", tr.tokenBaseDirAbs, err)
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		fileName := filepath.Base(path)
+		if fileName != tr.tokenFileName {
+			return nil
+		}
+
+		token, err := tr.readTokenFromFile(path)
+		if err != nil {
+			tr.lc.Warnf("found read token from file error: %v", err)
+			return err
+		}
+
+		// need to lookup self to obtain the token's accessor as Consul's delete token API
+		// only take accessor ID
+		tokenSelf, err := tr.retrieveSelfToken(path, token)
+		if err != nil {
+			tr.lc.Warnf("found read self token error: %v", err)
+			return err
+		} else if tokenSelf == nil {
+			return nil
+		}
+
+		// purge Consul token from agent server
+		if err := tr.deleteToken(path, tokenSelf.AccessorID, bootstrapACLToken); err != nil {
+			tr.lc.Warnf("found delete token error: %v", err)
+			// ignore the delete error as it will return status code 500 internal server errors if the token to delete
+			// doesn't exist, hence here we return nil so that the filepath.WalkFunc will ignore the error and continue
+			// in the best effort to delete tokens
+			return nil
+		}
+
+		tr.lc.Infof("successfully scrubbed old token for %s from server", path)
+
+		return nil
+	})
+
+	return walkErr
+}
+
+func (tr *TokenCleaner) readTokenFromFile(filePath string) (string, error) {
+	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
+	reader, err := fileOpener.OpenFileReader(filePath, os.O_RDONLY, 0400)
+	if err != nil {
+		return share.EmptyToken, fmt.Errorf("failed to open file reader: %v", err)
+	}
+
+	token, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return share.EmptyToken, fmt.Errorf("failed to read token from reader: %v", err)
+	}
+
+	return strings.TrimSpace(string(token)), nil
+}
+
+func (tr *TokenCleaner) retrieveSelfToken(filepath, token string) (*SelfTokenInfo, error) {
+	if len(token) == 0 {
+		tr.lc.Infof("tokenID is empty for path %s, skip readTokenSelf", filepath)
+		return nil, nil
+	}
+
+	readTokenSelfURL := tr.tokenApiUrlBase + consulReadSelfTokenAPI
+	req, err := http.NewRequest(http.MethodGet, readTokenSelfURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to prepare readTokenSelfURL request for http URL: %w", err)
+	}
+
+	req.Header.Add(share.ConsulTokenHeader, token)
+	resp, err := tr.httpCaller.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to send readTokenSelfURL request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	tokenSelfResp, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read readTokenSelfURL response body: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var tokenSelf SelfTokenInfo
+		if err := json.NewDecoder(bytes.NewReader(tokenSelfResp)).Decode(&tokenSelf); err != nil {
+			return nil, fmt.Errorf("failed to decode ConsulToken json data: %v", err)
+		}
+
+		return &tokenSelf, nil
+	case http.StatusForbidden:
+		// in this case, the self token is not found, so we just return nil
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("failed to read self token for path %s with status code= %d: %s",
+			filepath, resp.StatusCode, string(tokenSelfResp))
+	}
+}
+
+func (tr *TokenCleaner) deleteToken(path, tokenAccessorID, bootstrapACLToken string) error {
+	if len(tokenAccessorID) == 0 {
+		tr.lc.Infof("tokenAccessorID is empty for path %s, skip deleteToken", path)
+		return nil
+	}
+
+	delateTokenURL := tr.tokenApiUrlBase + fmt.Sprintf(consulDeleteTokenAPI, tokenAccessorID)
+	req, err := http.NewRequest(http.MethodDelete, delateTokenURL, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("Failed to prepare delateTokenURL request for http URL: %w", err)
+	}
+
+	req.Header.Add(share.ConsulTokenHeader, bootstrapACLToken)
+	resp, err := tr.httpCaller.Do(req)
+	if err != nil {
+		return fmt.Errorf("Failed to send delateTokenURL request for http URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	tokenSelfResp, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Failed to read delateTokenURL response body: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		if "true" == string(tokenSelfResp) {
+			return nil
+		}
+		return fmt.Errorf("unable to delete old token for service filepath %s", path)
+	default:
+		return fmt.Errorf("failed to delete old token for service filepath %s with status code= %d: %s",
+			path, resp.StatusCode, string(tokenSelfResp))
+	}
+}
+
+func (tr *TokenCleaner) isBaseDirExist() bool {
+	statInfo, err := os.Stat(tr.tokenBaseDirAbs)
+	if err == nil {
+		return statInfo.IsDir()
+	}
+
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	return false
+}

--- a/internal/security/bootstrapper/command/setupacl/tokencleaner/tokencleaner_test.go
+++ b/internal/security/bootstrapper/command/setupacl/tokencleaner/tokencleaner_test.go
@@ -1,0 +1,394 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package tokencleaner
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/command/setupacl/share"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/helper"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg"
+)
+
+func TestNewTokenCleaner(t *testing.T) {
+	lc := logger.MockLogger{}
+	httpCaller := pkg.NewRequester(lc).Insecure()
+	testTokenBaseDir := "test-base-dir"
+	testTokenFileName := "test-token"
+
+	tests := []struct {
+		name          string
+		tokenBaseDir  string
+		tokenFileName string
+		expectedErr   bool
+	}{
+		{"Good:new token cleaner ok", testTokenBaseDir, testTokenFileName, false},
+		{"Bad:new token cleaner with empty token file name", testTokenBaseDir, "", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tokenCleaner, err := NewTokenCleaner("http://localhost:18500", test.tokenBaseDir, test.tokenFileName, lc, httpCaller)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, tokenCleaner)
+			}
+		})
+	}
+}
+
+func TestScrubOldToken(t *testing.T) {
+	lc := logger.MockLogger{}
+	testTokenBaseDir := "test-base-dir"
+	testServiceKey := "service-test"
+	testTokenFileName := "test-token"
+	testToken := "token-x"
+	testBootstrapToken := "test-bootstrap-token"
+
+	// prepare test
+	serviceDir := filepath.Join(testTokenBaseDir, testServiceKey)
+	err := helper.CreateDirectoryIfNotExists(serviceDir)
+	require.NoError(t, err)
+	additionalDir := filepath.Join(testTokenBaseDir, "another")
+	err = helper.CreateDirectoryIfNotExists(additionalDir)
+	require.NoError(t, err)
+
+	// write a token into service directory
+	tokenFilePath := filepath.Join(serviceDir, testTokenFileName)
+	err = ioutil.WriteFile(tokenFilePath, []byte(testToken), 0600)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(filepath.Join(serviceDir, "anotherFile"), []byte("testingAnother"), 0600)
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(testTokenBaseDir)
+	}()
+
+	tests := []struct {
+		name           string
+		tokenBaseDir   string
+		tokenFileName  string
+		bootstrapToken string
+		clientCaller   internal.HttpCaller
+		expectedErr    bool
+	}{
+		{"Good:scrubOldToken ok with skipping non-existing base dir", "non-exist", testTokenFileName, testBootstrapToken, nil, false},
+		{"Good:scrubOldToken ok with existing token", testTokenBaseDir, testTokenFileName, testBootstrapToken, &mockAuthHttpCaller{
+			authTokenHeader:  share.ConsulTokenHeader,
+			authToken:        "token-x",
+			getStatusCode:    200,
+			returnError:      false,
+			getResponse:      `{"AccessorID":"xxxx", "SecretID":"token-x"}`,
+			deleteStatusCode: 200,
+			deleteResponse:   "true",
+		}, false},
+		{"Bad:scrubOldToken with empty bootstrap token", testTokenBaseDir, testTokenFileName, share.EmptyToken, nil, true},
+		{"Bad:scrubOldToken read self token error", testTokenBaseDir, testTokenFileName, testBootstrapToken, &mockAuthHttpCaller{
+			authTokenHeader: share.ConsulTokenHeader,
+			authToken:       "token-y",
+			getStatusCode:   403,
+			returnError:     false,
+			getResponse:     "permission denied",
+		}, true},
+		// ignore the error and thus treat it as good case in the best effort to delete the tokens
+		{"Good:scrubOldToken delete token error", testTokenBaseDir, testTokenFileName, "token-z", &mockAuthHttpCaller{
+			authTokenHeader:  share.ConsulTokenHeader,
+			authToken:        "token-x",
+			getStatusCode:    200,
+			returnError:      false,
+			getResponse:      `{"AccessorID":"xxxx", "SecretID":"token-x"}`,
+			deleteStatusCode: 403,
+			deleteResponse:   "false",
+		}, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tokenCleaner, err := NewTokenCleaner("http://localhost:18500", test.tokenBaseDir, test.tokenFileName, lc, test.clientCaller)
+			require.NoError(t, err)
+			require.NotNil(t, tokenCleaner)
+			err = tokenCleaner.ScrubOldTokens(test.bootstrapToken)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReadTokenFromFile(t *testing.T) {
+	lc := logger.MockLogger{}
+	httpCaller := pkg.NewRequester(lc).Insecure()
+	testServiceKey := "test-service-key"
+	testTokenBaseDir := "test-base-dir"
+	testTokenFileName := "test-token"
+
+	// prepare test
+	serviceDir := filepath.Join(testTokenBaseDir, testServiceKey)
+	err := helper.CreateDirectoryIfNotExists(serviceDir)
+	require.NoError(t, err)
+	testToken := "token-x"
+	// write a token into service directory
+	tokenFilePath := filepath.Join(serviceDir, testTokenFileName)
+	err = ioutil.WriteFile(tokenFilePath, []byte(testToken), 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		tokenBaseDir  string
+		tokenFileName string
+		expectedErr   bool
+	}{
+		{"Good:token file path exists", testTokenBaseDir, testTokenFileName, false},
+		{"Bad:token file path not exists ", testTokenBaseDir, "not-exists", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			defer func() {
+				_ = os.RemoveAll(test.tokenBaseDir)
+			}()
+
+			tokenCleaner, err := NewTokenCleaner("http://localhost:18500", test.tokenBaseDir, test.tokenFileName, lc, httpCaller)
+			require.NoError(t, err)
+			require.NotNil(t, tokenCleaner)
+			testFilePath := filepath.Join(serviceDir, test.tokenFileName)
+			actualToken, err := tokenCleaner.readTokenFromFile(testFilePath)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, "token-x", actualToken)
+			}
+		})
+	}
+}
+
+func TestRetrieveTokenSelf(t *testing.T) {
+	lc := logger.MockLogger{}
+	testServiceKey := "test-service-key"
+	testTokenBaseDir := "test-base-dir"
+	testTokenFileName := "test-token"
+
+	// prepare test
+	serviceDir := filepath.Join(testTokenBaseDir, testServiceKey)
+	err := helper.CreateDirectoryIfNotExists(serviceDir)
+	require.NoError(t, err)
+	testToken := "token-x"
+	// write a token into service directory
+	tokenFilePath := filepath.Join(serviceDir, testTokenFileName)
+	err = ioutil.WriteFile(tokenFilePath, []byte(testToken), 0600)
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(testTokenBaseDir)
+	}()
+
+	tests := []struct {
+		name         string
+		token        string
+		statusCode   int
+		callerClient internal.HttpCaller
+		expectedErr  bool
+	}{
+		{"Good:read self token resp ok", testToken, 200, &mockAuthHttpCaller{
+			authTokenHeader: share.ConsulTokenHeader,
+			authToken:       testToken,
+			getStatusCode:   200,
+			returnError:     false,
+			getResponse:     `{"AccessorID":"xxxx", "SecretID":"` + testToken + `"}`,
+		}, false},
+		{"Good:read self token with empty token", share.EmptyToken, 404, &mockAuthHttpCaller{}, false},
+		{"Good:read self token with token not found", testToken, 403, &mockAuthHttpCaller{
+			authTokenHeader: share.ConsulTokenHeader,
+			authToken:       testToken,
+			getStatusCode:   403,
+			returnError:     false,
+			getResponse:     "ACL not found",
+		}, false},
+		{"Bad:read self token with internal server error", testToken, 500, &mockAuthHttpCaller{
+			authTokenHeader: share.ConsulTokenHeader,
+			authToken:       testToken,
+			getStatusCode:   500,
+			returnError:     false,
+			getResponse:     "internal server error",
+		}, true},
+		{"Bad:read self token req not ok", testToken, 500, &mockAuthHttpCaller{
+			returnError: true,
+			getResponse: "EOF",
+		}, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tokenCleaner, err := NewTokenCleaner("http://localhost:18500", testTokenBaseDir, testTokenFileName, lc, test.callerClient)
+			require.NoError(t, err)
+			require.NotNil(t, tokenCleaner)
+			tokenInfo, err := tokenCleaner.retrieveSelfToken(tokenFilePath, test.token)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if test.token == share.EmptyToken {
+					return
+				}
+
+				if test.statusCode == http.StatusForbidden {
+					// means no self token found
+					require.Nil(t, tokenInfo)
+				} else {
+					require.NotNil(t, tokenInfo)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleteToken(t *testing.T) {
+	lc := logger.MockLogger{}
+	testServiceKey := "test-service-key"
+	testTokenBaseDir := "test-base-dir"
+	testTokenFileName := "test-token"
+	bootstrapToken := "bootstrap-token"
+	accessorID := "xxxxxx"
+
+	// prepare test
+	serviceDir := filepath.Join(testTokenBaseDir, testServiceKey)
+	err := helper.CreateDirectoryIfNotExists(serviceDir)
+	require.NoError(t, err)
+	testToken := "token-x"
+	// write a token into service directory
+	tokenFilePath := filepath.Join(serviceDir, testTokenFileName)
+	err = ioutil.WriteFile(tokenFilePath, []byte(testToken), 0600)
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(testTokenBaseDir)
+	}()
+
+	tests := []struct {
+		name           string
+		bootstrapToken string
+		accessorID     string
+		callerClient   internal.HttpCaller
+		expectedErr    bool
+	}{
+		{"Good:delete token resp ok", testToken, accessorID, &mockAuthHttpCaller{
+			authTokenHeader:  share.ConsulTokenHeader,
+			authToken:        bootstrapToken,
+			deleteStatusCode: 200,
+			returnError:      false,
+			deleteResponse:   "true",
+		}, false},
+		{"Good:delete token accessorID is empty", testToken, "", &mockAuthHttpCaller{}, false},
+		{"Bad:delete token resp status not ok", testToken, accessorID, &mockAuthHttpCaller{
+			authTokenHeader:  share.ConsulTokenHeader,
+			authToken:        testToken,
+			deleteStatusCode: 403,
+			returnError:      false,
+			deleteResponse:   "permission denied",
+		}, true},
+		{"Bad:delete token resp status ok but returned not true", testToken, accessorID, &mockAuthHttpCaller{
+			authTokenHeader:  share.ConsulTokenHeader,
+			authToken:        testToken,
+			deleteStatusCode: 200,
+			returnError:      false,
+			deleteResponse:   "false",
+		}, true},
+		{"Bad:delete token req not ok", testToken, accessorID, &mockAuthHttpCaller{
+			returnError:    true,
+			deleteResponse: "EOF",
+		}, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tokenCleaner, err := NewTokenCleaner("http://localhost:18500", testTokenBaseDir, testTokenFileName, lc, test.callerClient)
+			require.NoError(t, err)
+			require.NotNil(t, tokenCleaner)
+			err = tokenCleaner.deleteToken(tokenFilePath, test.accessorID, test.bootstrapToken)
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+type mockAuthHttpCaller struct {
+	authTokenHeader  string
+	authToken        string
+	getStatusCode    int
+	returnError      bool
+	getResponse      string
+	deleteStatusCode int
+	deleteResponse   string
+}
+
+func (smhc *mockAuthHttpCaller) Do(req *http.Request) (*http.Response, error) {
+	switch req.Method {
+	case http.MethodGet:
+		if smhc.returnError {
+			return &http.Response{
+				StatusCode: smhc.getStatusCode,
+			}, errors.New("http request Method Get error")
+		}
+
+		if req.Header.Get(smhc.authTokenHeader) != smhc.authToken {
+			return nil, fmt.Errorf("auth header %s is expected but not present in request", smhc.authTokenHeader)
+		}
+
+		return &http.Response{
+			StatusCode: smhc.getStatusCode,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(smhc.getResponse))),
+		}, nil
+
+	case http.MethodDelete:
+		if smhc.returnError {
+			return &http.Response{
+				StatusCode: 500,
+			}, errors.New("http request Method DELETE error")
+		}
+
+		return &http.Response{
+			StatusCode: smhc.deleteStatusCode,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(smhc.deleteResponse))),
+		}, nil
+
+	default:
+		return nil, errors.New("unsupported HTTP method")
+	}
+
+}

--- a/internal/security/bootstrapper/config/types.go
+++ b/internal/security/bootstrapper/config/types.go
@@ -69,6 +69,10 @@ type ACLInfo struct {
 	SecretsAdminTokenPath string
 	// filepath for the sentinel file to indicate the registry ACL is set up successfully
 	SentinelFilePath string
+	// output base directory for the consul tokens
+	TokenBaseDir string
+	// output token file name
+	TokenFileName string
 	// filepath to save the registry's token created for management purposes
 	ManagementTokenPath string
 	// the roles for registry role-based access control list

--- a/internal/security/secretstore/tokenfilewriter/tokenfilewriter.go
+++ b/internal/security/secretstore/tokenfilewriter/tokenfilewriter.go
@@ -136,6 +136,11 @@ path "` + secretsengine.ConsulSecretEngineMountPoint + `/roles/*" {
     capabilities = ["create", "read", "update", "delete", "list"]
 }
 
+# allow to create consul token based on role name
+path "` + secretsengine.ConsulSecretEngineMountPoint + `/creds/*" {
+    capabilities = ["read"]
+}
+
 `
 
 	if err := w.secretClient.InstallPolicy(rootToken,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -214,6 +214,7 @@ apps:
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: $SNAP_DATA/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_SECRETSADMINTOKENPATH: $SNAP_DATA/secrets/edgex-consul/admin/token.json
       STAGEGATE_REGISTRY_ACL_SENTINELFILEPATH: $SNAP_DATA/consul/config/consul_acl_done
+      STAGEGATE_REGISTRY_ACL_TOKENBASEDIR: $SNAP_DATA/secrets
     daemon: oneshot
     plugs: [network]
   core-data:


### PR DESCRIPTION
changes for `security-bootstrapper` on setupRegitrsyACL
 - add logic for deleting consul tokens for the 2nd time or later based on the consul-token files
 - add logic for generating consul tokens with go-mod-secret's API
 - add logic for re-set up the consul tokens for the 2nd time or later
 - add env. override `STAGEGATE_REGISTRY_ACL_TOKENBASEDIR` for snap on consul token base directory

Closes: #3306

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
N/A, this is new feature.

## Issue Number: #3306 


## What is the new behavior?
New feature added for generating and storing Consul tokens for EdgeX services to access Consul later on.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
To test this locally, follows the steps below:
1. git clone this PR, build a local `dev` version of docker images via `make docker`.  
2. Then, in `edgex-compose`, under compose builder generate the compose file and update the docker-compose file to add `/tmp/edgex/secrets` on `consul` service as writable like:

```yaml
   consul:
      entrypoint: ["/edgex-init/consul_wait_install.sh"]
    .........
    volumes:
      - edgex-init:/edgex-init:ro,z
      # make secrets directories writable as Consul tokens are saved underneath this base directory
      - /tmp/edgex/secrets:/tmp/edgex/secrets:z
     .........
```
3. do a `docker-compose up`.   One should observe that consul tokens are generated underneath `/tmp/edgex/secrets` directory with their service-key as sub-folder something like this logging messages:
```
......
level=INFO ts=2021-03-30T16:13:01.589955906Z app=edgex-security-bootstrapper source=acltokens.go:166 msg="internal Consul ACL system is ready"
    2021-03-30T16:13:01.590Z [INFO]  agent: Synced check: check=AppService-rules-engine
level=INFO ts=2021-03-30T16:13:01.600544874Z app=edgex-security-bootstrapper source=acltokens.go:423 msg="successfully created a new registry token"
level=INFO ts=2021-03-30T16:13:01.600833693Z app=edgex-security-bootstrapper source=acltokens.go:316 msg="successfully created a new agent token"
    2021-03-30T16:13:01.603Z [INFO]  agent: Updated agent's ACL token: token=agent
level=INFO ts=2021-03-30T16:13:01.603826539Z app=edgex-security-bootstrapper source=acltokens.go:368 msg="agent token is set with type [agent]"
level=INFO ts=2021-03-30T16:13:01.603908166Z app=edgex-security-bootstrapper source=command.go:538 msg="successfully set up agent token into agent"
level=INFO ts=2021-03-30T16:13:01.604227728Z app=edgex-security-bootstrapper source=aclbootstrap.go:109 msg="bootstrap token is written to /tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
level=INFO ts=2021-03-30T16:13:01.604297113Z app=edgex-security-bootstrapper source=command.go:200 msg="SecretStoreClient created"
level=INFO ts=2021-03-30T16:13:01.604362357Z app=edgex-security-bootstrapper source=command.go:440 msg="successfully got unique role names, total size=5"
level=INFO ts=2021-03-30T16:13:01.625375988Z app=edgex-security-bootstrapper source=command.go:307 msg="successfully saved access token for service [edgex-core-command]"
level=INFO ts=2021-03-30T16:13:01.639097506Z app=edgex-security-bootstrapper source=command.go:307 msg="successfully saved access token for service [edgex-core-data]"
level=INFO ts=2021-03-30T16:13:01.65802044Z app=edgex-security-bootstrapper source=command.go:307 msg="successfully saved access token for service [edgex-core-metadata]"
level=INFO ts=2021-03-30T16:13:01.671018684Z app=edgex-security-bootstrapper source=command.go:307 msg="successfully saved access token for service [edgex-support-notifications]"
level=INFO ts=2021-03-30T16:13:01.681975965Z app=edgex-security-bootstrapper source=command.go:307 msg="successfully saved access token for service [edgex-support-scheduler]"
level=INFO ts=2021-03-30T16:13:01.682209615Z app=edgex-security-bootstrapper source=command.go:276 msg="successfully set up EdgeX access tokens"
level=INFO ts=2021-03-30T16:13:01.682468128Z app=edgex-security-bootstrapper source=command.go:177 msg="setupRegistryACL successfully done"

......

```