### PR TITLE
feat(security): Add renewal mechanism for Vault management token in security Consul bootstrapper

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/redis_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/redis_wait_install.sh
@@ -48,7 +48,7 @@ fi
 
 # make sure the config file is present before redis server starts up
 if [ ! -f "${DATABASECONFIG_PATH}"/"${DATABASECONFIG_NAME}" ]; then
-  ehco "$(date) Error: conf file ${DATABASECONFIG_PATH}/${DATABASECONFIG_NAME} not exists"
+  echo "$(date) Error: conf file ${DATABASECONFIG_PATH}/${DATABASECONFIG_NAME} not exists"
   exit 1
 else
   # before using the generated config file we need to change the ownership to redis:redis

--- a/snap/local/runtime-helpers/bin/renew_mgmt_token.sh
+++ b/snap/local/runtime-helpers/bin/renew_mgmt_token.sh
@@ -1,0 +1,71 @@
+#!/bin/bash -e
+#
+# This is a service using a shell script for renewing the Vault's management token that is used to generate the Consul tokens
+# for EdgeX services.  The life cycle of those Consul tokens are governed by Vault and hence if the Vault token
+# is expired, then all these Consul tokens will be revoked from Consul as well. In order for EdgeX services keeping
+# using the valid Consul tokens, we need to renew the management token periodically while it is running.
+#
+
+# function to self-renew Consul secrets engine's Vault management token
+# the self-renew occurs after its TTL < 10% of its period
+renewToken()
+{
+    mgmt_token="$1"
+
+    lookup_url="http://${SECRETSTORE_HOST}:${SECRETSTORE_PORT}/v1/auth/token/lookup-self"
+    renew_url="http://${SECRETSTORE_HOST}:${SECRETSTORE_PORT}/v1/auth/token/renew-self"
+
+    # loop forever for token-renewal process
+    while true; do
+        echo "checking Vault management token's TTL with ${lookup_url} ..."
+        # self lookup token's period and remaining life (ttl)
+        response=$(curl -s -w "__STATUS_CODE__=%{http_code}" -H "Cache-Control: no-cache" \
+            -H "X-Vault-Token:${mgmt_token}" "${lookup_url}")
+        status_code="${response#*__STATUS_CODE__=}"
+        json_data="${response%__STATUS_CODE__=*}"
+        if [ "${status_code}" -eq 200 ]; then
+            # caluclate the amount of time to sleep before renew the token
+            # the self-renew will occur when its TTL < 10% of its period
+            wait_time=$(echo "${json_data}" | jq -r '.data.ttl-.data.period/10')
+            if [ "${wait_time}" -gt 0 ]; then
+                echo "management token will be renewed after ${wait_time} seconds"
+                sleep "${wait_time}"
+            else
+                # alredy below the threshold: no wait, just renew it if hasn't expired yet
+                echo "management token's TTL is lower than 10%"
+            fi
+            echo "try to renew management token with ${renew_url}:"
+            renew_status_code=$(curl -X POST -s -o /dev/null -w "%{http_code}" -H "X-Vault-Token:${mgmt_token}" "${renew_url}")
+            if [ "${renew_status_code}" -eq 200 ]; then
+              echo "  successfully renewed management token"
+            else
+              echo "  ERROR: unable to renew management token, status code = ${renew_status_code}"
+            fi
+        else
+            echo "ERROR: failed to lookup-self for management token due to token already expired or insufficient permission, cannot renew it. Please re-generate a new management token."
+            return 1
+        fi
+    done
+
+    echo "renewToken process done"
+}
+
+echo "in renew_mgmt_token.sh: ENABLE_REGISTRY_ACL = ${ENABLE_REGISTRY_ACL}"
+
+if [ "${ENABLE_REGISTRY_ACL}" == "true" ]; then
+    # kick off the token renewal process
+    echo "launching vault management token renewal process:"
+    if [ -f "${STAGEGATE_REGISTRY_ACL_SECRETSADMINTOKENPATH}" ]; then
+        mgmt_token=$("${SNAP}"/usr/bin/jq -r '.auth.client_token' "${STAGEGATE_REGISTRY_ACL_SECRETSADMINTOKENPATH}")
+        parsing_token_ret_code=$?
+        if [ "${parsing_token_ret_code}" -eq 0 ]; then
+            renewToken "${mgmt_token}"
+        else
+            "ERROR: cannot parse token from file ${STAGEGATE_REGISTRY_ACL_SECRETSADMINTOKENPATH}, unexpected JSON schema"
+        fi
+    else
+        echo "ERROR: token file ${STAGEGATE_REGISTRY_ACL_SECRETSADMINTOKENPATH} does not exist, cannot renew token"
+    fi
+else
+    echo "Consul ACL not enabled, skip renewing management token"
+fi

--- a/snap/local/runtime-helpers/bin/start-consul.sh
+++ b/snap/local/runtime-helpers/bin/start-consul.sh
@@ -52,3 +52,5 @@ until [ -n "$(curl -s $CONSUL_URL | jq -r '. | length')" ] &&
     [ "$(curl -s $CONSUL_URL | jq -r '. | length')" -gt "0" ] ; do
     sleep 1
 done
+
+echo "Consul started successfully"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -217,6 +217,20 @@ apps:
       STAGEGATE_REGISTRY_ACL_TOKENBASEDIR: $SNAP_DATA/secrets
     daemon: oneshot
     plugs: [network]
+  # this is a long-running service/process to renew Vault's management token that is used to generate Consul tokens
+  # for EdgeX services
+  security-mgmt-token-renewer:
+    adapter: full
+    after:
+      - security-consul-bootstrapper
+    command: bin/renew_mgmt_token.sh
+    environment:
+      ENABLE_REGISTRY_ACL: "true"
+      SECRETSTORE_HOST: localhost
+      SECRETSTORE_PORT: 8200
+      STAGEGATE_REGISTRY_ACL_SECRETSADMINTOKENPATH: $SNAP_DATA/secrets/edgex-consul/admin/token.json
+    daemon: simple
+    plugs: [network, network-bind]
   core-data:
     adapter: full
     after:


### PR DESCRIPTION
Changes made:
 - add renewal process in security-bootstrapper's consul entrypoint
 - add renewal process in snap package as a new simple service using script

The renewal process will be kicked off once the Consul ACLs setup is successfully done and is running as long-running process.
The Vault token renewal happens when its TTL is less than 10% of its original period if it is not expired yet.

Closes: #3335

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
No renewal of token

## Issue Number: #3335 


## What is the new behavior?
Renewal for token process added

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
Locally tested and observed logging message something like `"successfully renewed"`:
```
......
Mon Apr  5 16:16:22 UTC 2021 try to renew management token with http://edgex-vault:8200/v1/auth/token/renew-self:
Mon Apr  5 16:16:22 UTC 2021   successfully renewed management token
Mon Apr  5 16:16:22 UTC 2021 checking Vault management token's TTL with http://edgex-vault:8200/v1/auth/token/lookup-self ...
Mon Apr  5 16:16:23 UTC 2021 management token will be renewed after 161 seconds
......
```
