### PR TITLE
fix: Fix unit test failure when using the latest go-mod-bootstrap v31

### DIFF
--- a/internal/core/metadata/v2/controller/http/deviceservice_test.go
+++ b/internal/core/metadata/v2/controller/http/deviceservice_test.go
@@ -121,7 +121,7 @@ func TestAddDeviceService(t *testing.T) {
 		{
 			"Request with duplicate service name",
 			true,
-			buildTestDBClient(dsModels[0], errors.KindDuplicateName, ""),
+			buildTestDBClient(dsModels[0], errors.KindDuplicateName, "duplicate service name error"),
 			[]requests.AddDeviceServiceRequest{validReq},
 			http.StatusConflict,
 		},


### PR DESCRIPTION
fix by adding test error message when calling mock DbClient

Fix: #3346

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
unit test failed on using latest go-mod-bootstrap

## Issue Number: #3346 


## What is the new behavior?
Fix the broken unit test

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information