### PR TITLE
refactor: Replace use of BurntSushi/toml with pelletier/go-toml

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -41,9 +41,6 @@ https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
 mattn/go-xmpp (BSD-3) https://github.com/mattn/go-xmpp
 https://github.com/mattn/go-xmpp/blob/master/LICENSE
 
-BurntSushi/toml (MIT) https://github.com/BurntSushi/toml
-https://github.com/BurntSushi/toml/blob/master/COPYING
-
 mitchellh/consulstructure (MIT) https://github.com/mitchellh/consulstructure
 https://github.com/mitchellh/consulstructure/blob/master/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,9 @@ module github.com/edgexfoundry/edgex-go
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
-	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.32
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.34
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.5
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.8
@@ -17,6 +16,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/imdario/mergo v0.3.12
 	github.com/lib/pq v1.9.0
+	github.com/pelletier/go-toml v1.9.0
 	github.com/pkg/errors v0.8.1
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
 	github.com/stretchr/testify v1.7.0

--- a/internal/security/proxy/service_test.go
+++ b/internal/security/proxy/service_test.go
@@ -35,7 +35,7 @@ import (
 
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 )
 
 func TestPostCertExists(t *testing.T) {


### PR DESCRIPTION
Close #3354

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3354


## What is the new behavior?
Upgrade the go-mod-bootstrap to v2.0.0-dev.34 and replace use of BurntSushi/toml with pelletier/go-toml


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
use pelletier/go-toml to be consistent across EdgexFoundry go project, also BurntSushi/toml is unmaintained.

- [x] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information