### PR TITLE
feat: Implement API to retrieve Resource by profile and resource name

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -191,5 +191,8 @@ https://github.com/mattn/go-isatty/blob/master/LICENSE
 golang.org/x/sys (Unspecified) https://github.com/golang/sys
 https://github.com/golang/sys/blob/master/LICENSE
 
+golang.org/x/text (Unspecified) https://github.com/golang/text
+https://github.com/golang/text/blob/master/LICENSE
+
 github.com/gorilla/websocket (BSD-2) https://github.com/gorilla/websocket
 https://github.com/gorilla/websocket/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.34
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.6
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.71
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.8
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.4
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.14

--- a/internal/core/metadata/v2/application/deviceresource.go
+++ b/internal/core/metadata/v2/application/deviceresource.go
@@ -1,0 +1,48 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+import (
+	"fmt"
+
+	v2MetadataContainer "github.com/edgexfoundry/edgex-go/internal/core/metadata/v2/bootstrap/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
+)
+
+// DeviceResourceByProfileNameAndResourceName query the device resource by profileName and resourceName
+func DeviceResourceByProfileNameAndResourceName(profileName string, resourceName string, dic *di.Container) (resource dtos.DeviceResource, err errors.EdgeX) {
+	if profileName == "" {
+		return resource, errors.NewCommonEdgeX(errors.KindContractInvalid, "profile name is empty", nil)
+	}
+	if resourceName == "" {
+		return resource, errors.NewCommonEdgeX(errors.KindContractInvalid, "resource name is empty", nil)
+	}
+	dbClient := v2MetadataContainer.DBClientFrom(dic.Get)
+	profile, err := dbClient.DeviceProfileByName(profileName)
+	if err != nil {
+		return resource, errors.NewCommonEdgeXWrapper(err)
+	}
+	r, err := resourceByName(profile.DeviceResources, resourceName)
+	if err != nil {
+		return resource, errors.NewCommonEdgeXWrapper(err)
+	}
+
+	resource = dtos.FromDeviceResourceModelToDTO(r)
+	return resource, nil
+}
+
+func resourceByName(resources []models.DeviceResource, resourceName string) (models.DeviceResource, errors.EdgeX) {
+	for _, r := range resources {
+		if r.Name == resourceName {
+			return r, nil
+		}
+	}
+	return models.DeviceResource{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("resource %s not exists", resourceName), nil)
+}

--- a/internal/core/metadata/v2/controller/http/deviceresource.go
+++ b/internal/core/metadata/v2/controller/http/deviceresource.go
@@ -1,0 +1,69 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/v2/application"
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/v2/io"
+	"github.com/edgexfoundry/edgex-go/internal/pkg"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/v2/utils"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	responseDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
+
+	"github.com/gorilla/mux"
+)
+
+type DeviceResourceController struct {
+	reader io.DeviceProfileReader
+	dic    *di.Container
+}
+
+// NewDeviceResourceController creates and initializes an DeviceResourceController
+func NewDeviceResourceController(dic *di.Container) *DeviceResourceController {
+	return &DeviceResourceController{
+		dic: dic,
+	}
+}
+
+// DeviceResourceByProfileNameAndResourceName query the device resource by profileName and resourceName
+func (dc *DeviceResourceController) DeviceResourceByProfileNameAndResourceName(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(dc.dic.Get)
+	ctx := r.Context()
+	correlationId := correlation.FromContext(ctx)
+
+	// URL parameters
+	vars := mux.Vars(r)
+	profileName := vars[v2.ProfileName]
+	resourceName := vars[v2.ResourceName]
+
+	var response interface{}
+	var statusCode int
+
+	resource, err := application.DeviceResourceByProfileNameAndResourceName(profileName, resourceName, dc.dic)
+	if err != nil {
+		if errors.Kind(err) != errors.KindEntityDoesNotExist {
+			lc.Error(err.Error(), clients.CorrelationHeader, correlationId)
+		}
+		lc.Debug(err.DebugMessages(), clients.CorrelationHeader, correlationId)
+		response = commonDTO.NewBaseResponse("", err.Message(), err.Code())
+		statusCode = err.Code()
+	} else {
+		response = responseDTO.NewDeviceResourceResponse("", "", http.StatusOK, resource)
+		statusCode = http.StatusOK
+	}
+
+	utils.WriteHttpHeader(w, ctx, statusCode)
+	pkg.Encode(response, w, lc)
+}

--- a/internal/core/metadata/v2/controller/http/deviceresource_test.go
+++ b/internal/core/metadata/v2/controller/http/deviceresource_test.go
@@ -1,0 +1,94 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v2MetadataContainer "github.com/edgexfoundry/edgex-go/internal/core/metadata/v2/bootstrap/container"
+	dbMock "github.com/edgexfoundry/edgex-go/internal/core/metadata/v2/infrastructure/interfaces/mocks"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	responseDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceResourceByProfileNameAndResourceName(t *testing.T) {
+	deviceProfile := dtos.ToDeviceProfileModel(buildTestDeviceProfileRequest().Profile)
+	emptyName := ""
+	profileNotFoundName := "profileNotFoundName"
+	resourceNotFoundName := "resourceNotFoundName"
+
+	dic := mockDic()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("DeviceProfileByName", deviceProfile.Name).Return(deviceProfile, nil)
+	dbClientMock.On("DeviceProfileByName", profileNotFoundName).Return(models.DeviceProfile{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "device profile doesn't exist in the database", nil))
+	dic.Update(di.ServiceConstructorMap{
+		v2MetadataContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+
+	controller := NewDeviceResourceController(dic)
+	assert.NotNil(t, controller)
+
+	tests := []struct {
+		name               string
+		profileName        string
+		resourceName       string
+		errorExpected      bool
+		expectedStatusCode int
+	}{
+		{"Valid - find device resource by profileName and resourceName", deviceProfile.Name, TestDeviceResourceName, false, http.StatusOK},
+		{"Invalid - profile name is empty", emptyName, TestDeviceResourceName, true, http.StatusBadRequest},
+		{"Invalid - profile name is empty", deviceProfile.Name, emptyName, true, http.StatusBadRequest},
+		{"Invalid - device profile not", profileNotFoundName, TestDeviceResourceName, true, http.StatusNotFound},
+		{"Invalid - resource not found", deviceProfile.Name, resourceNotFoundName, true, http.StatusNotFound},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, v2.ApiDeviceResourceByProfileAndResourceRoute, http.NoBody)
+			req = mux.SetURLVars(req, map[string]string{v2.ProfileName: testCase.profileName, v2.ResourceName: testCase.resourceName})
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(controller.DeviceResourceByProfileNameAndResourceName)
+			handler.ServeHTTP(recorder, req)
+
+			// Assert
+			if testCase.errorExpected {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res responseDTO.DeviceResourceResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
+				assert.Equal(t, testCase.resourceName, res.Resource.Name, "Resource name not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}

--- a/internal/core/metadata/v2/router.go
+++ b/internal/core/metadata/v2/router.go
@@ -40,6 +40,10 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiDeviceProfileByManufacturerRoute, dc.DeviceProfilesByManufacturer).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiDeviceProfileByManufacturerAndModelRoute, dc.DeviceProfilesByManufacturerAndModel).Methods(http.MethodGet)
 
+	// Device Resource
+	dr := metadataController.NewDeviceResourceController(dic)
+	r.HandleFunc(v2Constant.ApiDeviceResourceByProfileAndResourceRoute, dr.DeviceResourceByProfileNameAndResourceName).Methods(http.MethodGet)
+
 	// Device Service
 	ds := metadataController.NewDeviceServiceController(dic)
 	r.HandleFunc(v2Constant.ApiDeviceServiceRoute, ds.AddDeviceService).Methods(http.MethodPost)

--- a/openapi/v2/core-metadata.yaml
+++ b/openapi/v2/core-metadata.yaml
@@ -399,6 +399,13 @@ components:
             type: string
       required:
         - name
+    DeviceResourceResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+      type: object
+      properties:
+        resource:
+          $ref: '#/components/schemas/DeviceResource'
     DeviceResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -2053,7 +2060,7 @@ paths:
                   - description: "Generate random float32 value"
                     name: "Float32"
                     properties:
-                      type: "Float32"
+                      valueType: "Float32"
                       readWrite: "RW"
                       defaultValue: "0"
                 deviceCommands:
@@ -2292,6 +2299,78 @@ paths:
               examples:
                 400Example:
                   $ref: '#/components/examples/400Example'
+        '500':
+          description: "Internal Server Error"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
+  /deviceresource/profile/{profileName}/resource/{resourceName}:
+    parameters:
+      - $ref: '#/components/parameters/correlatedRequestHeader'
+      - name: profileName
+        in: path
+        required: true
+        schema:
+          type: string
+        description: "The unique name of a device profile"
+      - name: resourceName
+        in: path
+        required: true
+        schema:
+          type: string
+        description: "The unique name of a device resource"
+    get:
+      summary: "Returns a device resource for the given profileName and resourceName."
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceResourceResponse'
+              example:
+                apiVersion: "v2"
+                statusCode: 200
+                resource:
+                  name: "float32-value"
+                  description: "random float32 value"
+                  properties:
+                    valueType: "Float32"
+                    readWrite: "R"
+        '400':
+          description: "Request is in an invalid state"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '404':
+          description: "The requested resource does not exist"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                404Example:
+                  $ref: '#/components/examples/404Example'
         '500':
           description: "Internal Server Error"
           headers:


### PR DESCRIPTION
Close #3229

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3229


## What is the new behavior?
Implement the GET method to retrieve a Resource by name from specified Profile
GET/deviceresource/profile/{profileName}/resource/{resourceName}

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information