### PR TITLE
feat(scheduler): Use v2 API for default scrub event intervalAction

### DIFF
--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -40,16 +40,6 @@ Type = 'consul'
     Frequency = '24h'
 
 [IntervalActions]
-    [IntervalActions.ScrubPushed]
-    Name = 'scrub-pushed-events'
-    Host = 'localhost'
-    Port = 48080
-    Protocol = 'http'
-    Method = 'DELETE'
-    Target = 'core-data'
-    Path = '/api/v1/event/scrub'
-    Interval = 'midnight'
-
     [IntervalActions.ScrubAged]
     Name = 'scrub-aged-events'
     Host = 'localhost'
@@ -57,7 +47,7 @@ Type = 'consul'
     Protocol = 'http'
     Method = 'DELETE'
     Target = 'core-data'
-    Path = '/api/v1/event/removeold/age/604800000'
+    Path = '/api/v2/event/age/604800000000000' # Remove events older than 7 days
     Interval = 'midnight'
 
 [SecretStore]


### PR DESCRIPTION
Close #3383

Signed-off-by: weichou <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3383 


## What is the new behavior?
Modify the scheduler config to use V2 API for removing the events


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information