### PR TITLE
feat(security): Implement consul token header in API Gateway

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
@@ -92,6 +92,10 @@ if [ "${ENABLE_REGISTRY_ACL}" == "true" ]; then
   if [ "${setupACL_code}" -ne 0 ]; then
     echo "$(date) failed to set up Consul ACL"
   fi
+
+  # we need to grant the permission for proxy setup to read consul's token path so as to retrieve consul's token from it
+  echo "$(date) Changing ownership of consul token path to ${EDGEX_USER}:${EDGEX_GROUP}"
+  chown -Rh "${EDGEX_USER}":"${EDGEX_GROUP}" "${STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH}"
   set -e
   # no need to wait for Consul's port since it is in ready state after all ACL stuff
 else

--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -1,5 +1,6 @@
 #################################################################################
 # Copyright 2019 Dell Inc.
+# Copyright 2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -20,6 +21,7 @@ LogLevel = "DEBUG"
 SNIS = [""]
 # RequestTimeout for proxy-setup http client caller
 RequestTimeout = 10
+AccessTokenFile = "/tmp/edgex/secrets/consul-acl-token/bootstrap_token.json"
 
 [KongURL]
 Server = "127.0.0.1"
@@ -94,3 +96,9 @@ RetryWaitPeriod = "1s"
   Protocol = "http"
   Host = "localhost"
   Port = 49990
+
+  [Routes.edgex-core-consul]
+  Name = "consul"
+  Protocol = "http"
+  Host = "localhost"
+  Port = 8500

--- a/internal/security/config/command/proxy/adduser/command_test.go
+++ b/internal/security/config/command/proxy/adduser/command_test.go
@@ -9,9 +9,11 @@ package adduser
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"testing"
 
@@ -113,6 +115,9 @@ func TestAddUserJWT(t *testing.T) {
 		"--public_key", publicKey,
 		"--jwt", jwt,
 	})
+
+	defer func() { _ = os.Remove(jwtFile) }()
+
 	require.NoError(t, err)
 
 	// Execute command "addUser w/JWT"
@@ -185,6 +190,9 @@ func TestAddUserOAuth2(t *testing.T) {
 		"--redirect_uris", redirectUris,
 		"--jwt", jwt,
 	})
+
+	defer func() { _ = os.Remove(jwtFile) }()
+
 	require.NoError(t, err)
 
 	// Execute command "addUser w/JWT"
@@ -193,4 +201,11 @@ func TestAddUserOAuth2(t *testing.T) {
 	// Assert execution return
 	require.NoError(t, err)
 	require.Equal(t, interfaces.StatusCodeExitNormal, code)
+}
+
+func prepareJWTFile(t *testing.T, jwtData string) string {
+	jwtFile := "testJwtFile"
+	err := ioutil.WriteFile(jwtFile, []byte(jwtData), 0600)
+	require.NoError(t, err)
+	return jwtFile
 }

--- a/internal/security/config/command/proxy/adduser/command_test.go
+++ b/internal/security/config/command/proxy/adduser/command_test.go
@@ -9,11 +9,9 @@ package adduser
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strconv"
 	"testing"
 
@@ -116,8 +114,6 @@ func TestAddUserJWT(t *testing.T) {
 		"--jwt", jwt,
 	})
 
-	defer func() { _ = os.Remove(jwtFile) }()
-
 	require.NoError(t, err)
 
 	// Execute command "addUser w/JWT"
@@ -191,8 +187,6 @@ func TestAddUserOAuth2(t *testing.T) {
 		"--jwt", jwt,
 	})
 
-	defer func() { _ = os.Remove(jwtFile) }()
-
 	require.NoError(t, err)
 
 	// Execute command "addUser w/JWT"
@@ -201,11 +195,4 @@ func TestAddUserOAuth2(t *testing.T) {
 	// Assert execution return
 	require.NoError(t, err)
 	require.Equal(t, interfaces.StatusCodeExitNormal, code)
-}
-
-func prepareJWTFile(t *testing.T, jwtData string) string {
-	jwtFile := "testJwtFile"
-	err := ioutil.WriteFile(jwtFile, []byte(jwtData), 0600)
-	require.NoError(t, err)
-	return jwtFile
 }

--- a/internal/security/config/command/proxy/oauth2/command.go
+++ b/internal/security/config/command/proxy/oauth2/command.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/config/command/proxy/common"
 	"github.com/edgexfoundry/edgex-go/internal/security/config/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg"
@@ -101,7 +102,7 @@ func (c *cmd) Execute() (statusCode int, err error) {
 	}
 
 	// Add header values
-	req.Header.Add(clients.ContentType, "application/x-www-form-urlencoded")
+	req.Header.Add(clients.ContentType, common.UrlEncodedForm)
 	req.Header.Add(internal.AuthHeaderTitle, internal.BearerLabel+c.jwt)
 
 	// Execute the request

--- a/internal/security/config/interfaces/constants.go
+++ b/internal/security/config/interfaces/constants.go
@@ -15,4 +15,8 @@ const (
 	RS256 string = "RS256"
 	// ES256 JWT Alt ES256
 	ES256 string = "ES256"
+	// Authorization is the standard authorization header for http authentication
+	Authorization = "Authorization"
+	// Bearer is the standard spec. for using token authentication
+	Bearer = "Bearer "
 )

--- a/internal/security/config/interfaces/constants.go
+++ b/internal/security/config/interfaces/constants.go
@@ -15,8 +15,4 @@ const (
 	RS256 string = "RS256"
 	// ES256 JWT Alt ES256
 	ES256 string = "ES256"
-	// Authorization is the standard authorization header for http authentication
-	Authorization = "Authorization"
-	// Bearer is the standard spec. for using token authentication
-	Bearer = "Bearer "
 )

--- a/internal/security/proxy/config/config.go
+++ b/internal/security/proxy/config/config.go
@@ -27,13 +27,14 @@ import (
 )
 
 type ConfigurationStruct struct {
-	LogLevel       string
-	RequestTimeout int
-	SNIS           []string
-	KongURL        KongUrlInfo
-	KongAuth       KongAuthInfo
-	SecretStore    bootstrapConfig.SecretStoreInfo
-	Routes         map[string]models.KongService
+	LogLevel        string
+	RequestTimeout  int
+	SNIS            []string
+	AccessTokenFile string
+	KongURL         KongUrlInfo
+	KongAuth        KongAuthInfo
+	SecretStore     bootstrapConfig.SecretStoreInfo
+	Routes          map[string]models.KongService
 }
 
 type KongUrlInfo struct {

--- a/internal/security/proxy/const.go
+++ b/internal/security/proxy/const.go
@@ -25,4 +25,7 @@ const (
 	VaultToken       = "X-Vault-Token"
 	OAuth2GrantType  = "client_credentials"
 	OAuth2Scopes     = "all"
+	Authorization    = "Authorization"
+	Bearer           = "Bearer "
+	URLEncodedForm   = "application/x-www-form-urlencoded"
 )

--- a/internal/security/proxy/const.go
+++ b/internal/security/proxy/const.go
@@ -25,7 +25,5 @@ const (
 	VaultToken       = "X-Vault-Token"
 	OAuth2GrantType  = "client_credentials"
 	OAuth2Scopes     = "all"
-	Authorization    = "Authorization"
-	Bearer           = "Bearer "
 	URLEncodedForm   = "application/x-www-form-urlencoded"
 )

--- a/internal/security/proxy/resource.go
+++ b/internal/security/proxy/resource.go
@@ -65,7 +65,6 @@ func (r *Resource) Remove(path string) error {
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 		r.loggingClient.Info(fmt.Sprintf("successful to delete %s at %s", r.name, path))
-		break
 	default:
 		e := fmt.Sprintf("failed to delete %s at %s with errocode %d.", r.name, path, resp.StatusCode)
 		r.loggingClient.Error(e)

--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
- * Copyright 2020 Intel Corp.
+ * Copyright 2021 Intel Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -46,6 +46,8 @@ const (
 
 	// AddProxyRoutesEnv is the environment variable name for adding the additional Kong routes for app services
 	AddProxyRoutesEnv = "ADD_PROXY_ROUTE"
+
+	edgeXCoreConsulServiceKey = "edgex-core-consul"
 )
 
 type CertError struct {
@@ -99,7 +101,6 @@ func (s *Service) checkServiceStatus(path string) error {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		s.loggingClient.Info(fmt.Sprintf("the service on %s is up successfully", path))
-		break
 	default:
 		err = fmt.Errorf("unexpected http status %v %s", resp.StatusCode, path)
 		s.loggingClient.Error(err.Error())
@@ -145,11 +146,25 @@ func (s *Service) Init() error {
 
 	mergedRoutes := s.mergeRoutesWith(addRoutesFromEnv)
 
-	for _, route := range mergedRoutes {
+	for serviceKey, route := range mergedRoutes {
 
 		err := s.initKongService(&route)
 		if err != nil {
 			return err
+		}
+
+		// if it is edgex-core-consul service; then we need to enable the request transformer plugin
+		// in order to add the consul token header for that service
+		// see details on https://docs.konghq.com/hub/kong-inc/request-transformer/#enabling-the-plugin-on-a-service
+		if serviceKey == edgeXCoreConsulServiceKey {
+			// s.enableRequestTransformerPlugin(&route)
+			s.loggingClient.Infof("try to enable service plugin for %s", edgeXCoreConsulServiceKey)
+			if err := s.addConsulTokenHeaderTo(&route); err != nil {
+				s.loggingClient.Errorf("failed to enable service plugin for %s: %v", edgeXCoreConsulServiceKey, err)
+				return err
+			}
+
+			s.loggingClient.Infof("service plugin for %s enabled", edgeXCoreConsulServiceKey)
 		}
 
 		routeParams := &models.KongRoute{
@@ -295,7 +310,6 @@ func (s *Service) postCert(cp bootstrapConfig.CertKeyPair) *CertError {
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
 		s.loggingClient.Info("successfully added certificate to the reverse proxy")
-		break
 	default:
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -328,7 +342,7 @@ func (s *Service) initKongService(service *models.KongService) error {
 		return fmt.Errorf("failed to construct http POST form request: %s %s", service.Name, err.Error())
 	}
 	req.Header.Add(internal.AuthHeaderTitle, internal.BearerLabel+s.bearerToken)
-	req.Header.Add(clients.ContentType, "application/x-www-form-urlencoded")
+	req.Header.Add(clients.ContentType, URLEncodedForm)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -341,10 +355,8 @@ func (s *Service) initKongService(service *models.KongService) error {
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated:
 		s.loggingClient.Info(fmt.Sprintf("successful to set up proxy service for `%s` at `%s:%d`", service.Name, service.Host, service.Port))
-		break
 	case http.StatusConflict:
 		s.loggingClient.Info(fmt.Sprintf("proxy service for %s has been set up", service.Name))
-		break
 	default:
 		err = fmt.Errorf("proxy service for %s returned status %d", service.Name, resp.StatusCode)
 		s.loggingClient.Error(err.Error())
@@ -361,6 +373,7 @@ func (s *Service) initKongRoutes(r *models.KongRoute, name string) error {
 	}
 	tokens := []string{s.configuration.KongURL.GetProxyBaseURL(), ServicesPath, name, "routes"}
 
+	// Create routes associated to a specific service
 	req, err := http.NewRequest(http.MethodPost, strings.Join(tokens, "/"), strings.NewReader(string(data)))
 	if err != nil {
 		e := fmt.Sprintf("failed to set up routes for %s with error %s", name, err.Error())
@@ -382,7 +395,6 @@ func (s *Service) initKongRoutes(r *models.KongRoute, name string) error {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
 		s.routes[name] = r
 		s.loggingClient.Info(fmt.Sprintf("successful to set up route for `%s` at `%v`", name, r.Paths))
-		break
 	default:
 		e := fmt.Sprintf("failed to set up route for %s with error %s", name, resp.Status)
 		s.loggingClient.Error(e)
@@ -414,7 +426,7 @@ func (s *Service) initJWTAuth() error {
 		s.loggingClient.Error(e)
 		return err
 	}
-	req.Header.Add(clients.ContentType, "application/x-www-form-urlencoded")
+	req.Header.Add(clients.ContentType, URLEncodedForm)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -427,7 +439,6 @@ func (s *Service) initJWTAuth() error {
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
 		s.loggingClient.Info("successful to set up jwt authentication")
-		break
 	default:
 		e := fmt.Sprintf("failed to set up jwt authentication with errorcode %d", resp.StatusCode)
 		s.loggingClient.Error(e)
@@ -461,7 +472,7 @@ func (s *Service) initOAuth2(ttl int) error {
 		s.loggingClient.Error(e)
 		return err
 	}
-	req.Header.Add(clients.ContentType, "application/x-www-form-urlencoded")
+	req.Header.Add(clients.ContentType, URLEncodedForm)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -474,7 +485,6 @@ func (s *Service) initOAuth2(ttl int) error {
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
 		s.loggingClient.Info("successful to set up oauth2 authentication")
-		break
 	default:
 		e := fmt.Sprintf("failed to set up oauth2 authentication with errorcode %d", resp.StatusCode)
 		s.loggingClient.Error(e)
@@ -506,7 +516,6 @@ func (s *Service) getSvcIDs(path string) (models.DataCollect, error) {
 		if err = json.NewDecoder(resp.Body).Decode(&collection); err != nil {
 			return collection, err
 		}
-		break
 	default:
 		e := fmt.Sprintf("failed to get list of %s with HTTP error code %d", path, resp.StatusCode)
 		s.loggingClient.Error(e)

--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -157,7 +157,6 @@ func (s *Service) Init() error {
 		// in order to add the consul token header for that service
 		// see details on https://docs.konghq.com/hub/kong-inc/request-transformer/#enabling-the-plugin-on-a-service
 		if serviceKey == edgeXCoreConsulServiceKey {
-			// s.enableRequestTransformerPlugin(&route)
 			s.loggingClient.Infof("try to enable service plugin for %s", edgeXCoreConsulServiceKey)
 			if err := s.addConsulTokenHeaderTo(&route); err != nil {
 				s.loggingClient.Errorf("failed to enable service plugin for %s: %v", edgeXCoreConsulServiceKey, err)

--- a/internal/security/proxy/serviceplugin.go
+++ b/internal/security/proxy/serviceplugin.go
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/helper"
+	"github.com/edgexfoundry/edgex-go/internal/security/proxy/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/fileioperformer"
+)
+
+const (
+	requestTransformerPlugin = "request-transformer"
+	consulTokenHeader        = "X-Consul-Token"
+)
+
+// addConsulHeader is to enable request transformer plugin on a service
+// with the given configuration
+func (s *Service) addConsulTokenHeaderTo(kongService *models.KongService) error {
+	// first to get the pluginID for the service
+	// create one if not found
+	servicePluginID, err := s.getServicePluginIDBy(kongService.Name, requestTransformerPlugin)
+	if err != nil {
+		return fmt.Errorf("cannot get service plugin ID: %w", err)
+	}
+
+	if len(servicePluginID) > 0 {
+		// In order to make sure the Consul header always match with the latest one from the file
+		// we want to delete the existing service plugin and re-create one as both Kong and Consul are stateful
+		if err := s.deleteServicePlugin(kongService.Name, servicePluginID); err != nil {
+			return fmt.Errorf("cannot delete service plugin ID: %w", err)
+		}
+	}
+
+	accessToken, err := s.retrieveConsulAccessToken()
+	if err != nil {
+		return fmt.Errorf("cannot retrieve Consul access token: %w", err)
+	}
+
+	if len(accessToken) == 0 {
+		return fmt.Errorf("retrieved access token is empty")
+	}
+
+	return s.createConsulTokenHeaderForServicePlugin(kongService.Name, requestTransformerPlugin, accessToken)
+}
+
+func (s *Service) getServicePluginIDBy(serviceName, pluginName string) (string, error) {
+	servicePluginPath := path.Join(ServicesPath, serviceName, PluginsPath)
+	servicePluginURL := strings.Join([]string{s.configuration.KongURL.GetProxyBaseURL(), servicePluginPath}, "/")
+
+	req, err := http.NewRequest(http.MethodGet, servicePluginURL, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to create get request for %s: %w", servicePluginURL, err)
+	}
+
+	req.Header.Add(Authorization, Bearer+s.bearerToken)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get plugin list for service %s: %w", serviceName, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body to get plugins: %w", err)
+	}
+
+	type ServicePluginInfo struct {
+		PluginID   string `json:"id"`
+		PluginName string `json:"name"`
+	}
+
+	type KongServicePlugins struct {
+		Entries []ServicePluginInfo `json:"data"`
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var plugins KongServicePlugins
+		if err := json.NewDecoder(bytes.NewReader(responseBody)).Decode(&plugins); err != nil {
+			return "", fmt.Errorf("unable to parse response from get service plugins: %w", err)
+		}
+
+		for _, data := range plugins.Entries {
+			if data.PluginName == pluginName {
+				s.loggingClient.Infof("successful to get service pluginID of plugin %s for service %s", pluginName, serviceName)
+
+				return data.PluginID, nil
+			}
+		}
+
+		// no plugin matching pluginName found
+		return "", nil
+	default:
+		return "", fmt.Errorf("unable to get service plugins from Kong's API %s with status code %d: %s", servicePluginURL,
+			resp.StatusCode, string(responseBody))
+	}
+}
+
+func (s *Service) deleteServicePlugin(serviceName, pluginID string) error {
+	deletePluginPath := path.Join(ServicesPath, serviceName, PluginsPath, pluginID)
+	deleteServicePluginURL := strings.Join([]string{s.configuration.KongURL.GetProxyBaseURL(), deletePluginPath}, "/")
+
+	req, err := http.NewRequest(http.MethodDelete, deleteServicePluginURL, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request for %s: %w", deleteServicePluginURL, err)
+	}
+
+	req.Header.Add(Authorization, Bearer+s.bearerToken)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete service plugin for service %s: %w", serviceName, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		s.loggingClient.Infof("successfully deleted service plugin for service %s", serviceName)
+
+		return nil
+	default:
+		responseBody, err := ioutil.ReadAll(resp.Body)
+		var errMsg string
+		if err != nil {
+			errMsg = fmt.Sprintf("failed to read response body for delete service plugin: %v", err)
+		} else {
+			errMsg = string(responseBody)
+		}
+
+		return fmt.Errorf("unable to delete service plugin from Kong's API %s with status code %d: %s", deleteServicePluginURL,
+			resp.StatusCode, errMsg)
+	}
+}
+
+func (s *Service) retrieveConsulAccessToken() (string, error) {
+	if len(s.configuration.AccessTokenFile) == 0 {
+		return "", errors.New("required AccessTokenFile from configuration is empty")
+	}
+
+	tokenFileAbsPath, err := filepath.Abs(s.configuration.AccessTokenFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert tokenFile to absolute path %s: %v", s.configuration.AccessTokenFile, err)
+	}
+
+	if exists := helper.CheckIfFileExists(tokenFileAbsPath); !exists {
+		return "", fmt.Errorf("access token file %s not found", tokenFileAbsPath)
+	}
+
+	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
+	tokenReader, err := fileOpener.OpenFileReader(tokenFileAbsPath, os.O_RDONLY, 0400)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file reader: %v", err)
+	}
+
+	var accessToken map[string]interface{}
+	if err := json.NewDecoder(tokenReader).Decode(&accessToken); err != nil {
+		return "", fmt.Errorf("failed to parse access token JSON data: %v", err)
+	}
+
+	s.loggingClient.Infof("successfully retrieved access token from %s", tokenFileAbsPath)
+
+	return fmt.Sprintf("%s", accessToken["SecretID"]), nil
+}
+
+func (s *Service) createConsulTokenHeaderForServicePlugin(serviceName, pluginName, accessToken string) error {
+	servicePluginPath := path.Join(ServicesPath, serviceName, PluginsPath)
+	servicePluginURL := strings.Join([]string{s.configuration.KongURL.GetProxyBaseURL(), servicePluginPath}, "/")
+
+	form := url.Values{
+		"name":               []string{pluginName},
+		"config.add.headers": []string{consulTokenHeader + ":" + accessToken},
+	}
+
+	formVal := form.Encode()
+	req, err := http.NewRequest(http.MethodPost, servicePluginURL, strings.NewReader(formVal))
+	if err != nil {
+		return fmt.Errorf("failed to create POST request for %s: %w", servicePluginURL, err)
+	}
+
+	req.Header.Add(Authorization, Bearer+s.bearerToken)
+	req.Header.Add(clients.ContentType, URLEncodedForm)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to create Consul token header for service %s: %w", serviceName, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		s.loggingClient.Infof("successfully created Consul token header to service %s", serviceName)
+
+		return nil
+	default:
+		responseBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body for creating Consul token header: %w", err)
+		}
+
+		return fmt.Errorf("unable to create Consul token header from Kong's API %s with status code %d: %s", servicePluginURL,
+			resp.StatusCode, string(responseBody))
+	}
+}

--- a/internal/security/proxy/serviceplugin.go
+++ b/internal/security/proxy/serviceplugin.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/helper"
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
@@ -78,7 +79,7 @@ func (s *Service) getServicePluginIDBy(serviceName, pluginName string) (string, 
 		return "", fmt.Errorf("failed to create get request for %s: %w", servicePluginURL, err)
 	}
 
-	req.Header.Add(Authorization, Bearer+s.bearerToken)
+	req.Header.Add(internal.AuthHeaderTitle, internal.BearerLabel+s.bearerToken)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -133,7 +134,7 @@ func (s *Service) deleteServicePlugin(serviceName, pluginID string) error {
 		return fmt.Errorf("failed to create delete request for %s: %w", deleteServicePluginURL, err)
 	}
 
-	req.Header.Add(Authorization, Bearer+s.bearerToken)
+	req.Header.Add(internal.AuthHeaderTitle, internal.BearerLabel+s.bearerToken)
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -206,7 +207,7 @@ func (s *Service) createConsulTokenHeaderForServicePlugin(serviceName, pluginNam
 		return fmt.Errorf("failed to create POST request for %s: %w", servicePluginURL, err)
 	}
 
-	req.Header.Add(Authorization, Bearer+s.bearerToken)
+	req.Header.Add(internal.AuthHeaderTitle, internal.BearerLabel+s.bearerToken)
 	req.Header.Add(clients.ContentType, URLEncodedForm)
 
 	resp, err := s.client.Do(req)

--- a/internal/security/proxy/serviceplugin_test.go
+++ b/internal/security/proxy/serviceplugin_test.go
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package proxy
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/proxy/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testServiceName = "testService"
+)
+
+func TestAddConsulHeaderTo(t *testing.T) {
+	mockLogger := logger.MockLogger{}
+	kongService := &models.KongService{
+		Name: testServiceName,
+	}
+	// setup access token file
+	tokenData := `{
+		"SecretID":"test-access-token",
+		"Policies": [
+			{
+				"ID": "test-policy-id",
+				"Name":"test-policy-name"
+			}
+		]
+	}
+	`
+
+	tests := []struct {
+		name                         string
+		getPluginIDOkResponse        bool
+		emptyPluginIDResponse        bool
+		deletePluginOkResponse       bool
+		accessTokenFileCreate        bool
+		createHeaderPluginOkResponse bool
+		expectedErr                  bool
+	}{
+		{"Good:add consul header with ok empty pluginID response", true, true, false, true, true, false},
+		{"Good:add consul header with ok some pluginID and delete response", true, false, true, true, true, false},
+		{"Bad:add consul header with ok some pluginID but bad delete response", true, false, false, false, false, true},
+		{"Bad:add consul header with missing access token file", true, false, true, false, false, true},
+		{"Bad:add consul header with bad get pluginID response", false, true, false, true, false, true},
+		{"Bad:add consul header with bad create pluginID response", true, false, true, true, false, true},
+		{"Bad:add consul header with bad create pluginID response- empty pluginID", true, true, true, true, false, true},
+	}
+
+	for _, tt := range tests {
+		test := tt // capture as local copy
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// prepare test
+			if test.accessTokenFileCreate {
+				// use test name as the config name so that it is unique
+				err := ioutil.WriteFile(test.name, []byte(tokenData), 0600)
+				require.NoError(t, err)
+			}
+
+			testSrvOptions := serverOptions{
+				emptyServicePlugin:                  test.emptyPluginIDResponse,
+				getServicePluginIDResponseOk:        test.getPluginIDOkResponse,
+				deleteServicePluginResponseOk:       test.deletePluginOkResponse,
+				createServicePluginHeaderResponseOk: test.createHeaderPluginOkResponse,
+			}
+			testSrv := newKongTestServer(testSrvOptions)
+			defer testSrv.close()
+
+			testConfig := testSrv.getStubKongServerConfig(t)
+			testConfig.AccessTokenFile = test.name
+			service := NewService(NewRequestor(true, 10, "", mockLogger), mockLogger, testConfig)
+			err := service.addConsulTokenHeaderTo(kongService)
+
+			defer func() {
+				_ = os.Remove(test.name)
+			}()
+
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+type kongTestServer struct {
+	serverOptions serverOptions
+	server        *httptest.Server
+}
+
+type serverOptions struct {
+	emptyServicePlugin                  bool
+	getServicePluginIDResponseOk        bool
+	deleteServicePluginResponseOk       bool
+	createServicePluginHeaderResponseOk bool
+}
+
+func newKongTestServer(srvOptions serverOptions) kongTestServer {
+	return kongTestServer{
+		serverOptions: srvOptions,
+	}
+}
+
+func (s kongTestServer) close() {
+	if s.server != nil {
+		s.server.Close()
+	}
+}
+
+func (s kongTestServer) getStubKongServerConfig(t *testing.T) *config.ConfigurationStruct {
+	kongTestConfig := &config.ConfigurationStruct{}
+	testServicePluginID := "test-plugin-id"
+	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.EscapedPath() {
+		case path.Join("/admin", ServicesPath, testServiceName, PluginsPath):
+			switch r.Method {
+			case http.MethodGet:
+				if s.serverOptions.getServicePluginIDResponseOk && s.serverOptions.emptyServicePlugin {
+					w.WriteHeader(http.StatusOK)
+					jsonResponse := map[string]interface{}{
+						"data": []map[string]interface{}{},
+					}
+					err := json.NewEncoder(w).Encode(jsonResponse)
+					require.NoError(t, err)
+				} else if s.serverOptions.getServicePluginIDResponseOk {
+					w.WriteHeader(http.StatusOK)
+					jsonResponse := map[string]interface{}{
+						"data": []map[string]interface{}{
+							{
+								"id":   testServicePluginID,
+								"name": requestTransformerPlugin,
+								"service": map[string]interface{}{
+									"id": "test-service-id",
+								},
+								"config": map[string]interface{}{
+									"add": map[string]interface{}{
+										"querystring": []interface{}{},
+										"headers": []interface{}{
+											"X-Consul-Token:test-access-token",
+										},
+										"body": []interface{}{},
+									},
+								},
+							},
+						},
+					}
+					err := json.NewEncoder(w).Encode(jsonResponse)
+					require.NoError(t, err)
+				} else {
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte("failed to get data for service " + testServiceName))
+				}
+			case http.MethodPost:
+				if s.serverOptions.createServicePluginHeaderResponseOk {
+					w.WriteHeader(http.StatusCreated)
+				} else {
+					w.WriteHeader(http.StatusConflict)
+					_, _ = w.Write([]byte(`{name": "unique constraint violation}`))
+				}
+			default:
+				t.Errorf("Unsupported method %s to URL %s", r.Method, r.URL.EscapedPath())
+			}
+		case path.Join("/admin", ServicesPath, testServiceName, PluginsPath, testServicePluginID):
+			require.Equal(t, http.MethodDelete, r.Method)
+			if s.serverOptions.deleteServicePluginResponseOk {
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("could not find plugin " + testServicePluginID))
+			}
+		default:
+			t.Errorf("Unexpected call to URL %s", r.URL.EscapedPath())
+		}
+	}))
+	tsURL, err := url.Parse(testSrv.URL)
+	require.NoError(t, err)
+	portNum, _ := strconv.Atoi(tsURL.Port())
+	kongTestConfig.KongURL.Server = tsURL.Hostname()
+	kongTestConfig.KongURL.ApplicationPort = portNum
+	s.server = testSrv
+
+	return kongTestConfig
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -176,11 +176,13 @@ apps:
     adapter: none
     after:
       - security-secretstore-setup
+      - security-consul-bootstrapper
       - kong-daemon
     command: bin/security-proxy-setup -confdir $SNAP_DATA/config/security-proxy-setup/res $INIT_ARG
     environment:
       INIT_ARG: "--init=true"
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
+      ACCESSTOKENFILE: $SNAP_DATA/secrets/consul-acl-token/bootstrap_token.json
     daemon: oneshot
     start-timeout: 15m
     plugs: [network]
@@ -344,6 +346,7 @@ apps:
     command: bin/security-proxy-setup
     environment:
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
+      ACCESSTOKENFILE: $SNAP_DATA/secrets/consul-acl-token/bootstrap_token.json
     plugs: [home, removable-media, network]
   secrets-config:
     adapter: none


### PR DESCRIPTION
- Add implementation for enabling request transformer plugin on consul service for Kong's route through proxy-setup
- Fix unit test issues
- Add necessary starting sequence and env. for proxy-setup in snap packaging

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
no consul service available in Kong

## Issue Number: #3368 


## What is the new behavior?
add consul service/route to Kong and enable consul header through kong's request transform plugins on the added consul service.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
Note: This has been `re-based` on top of @beaufrusetta's branch from his PR https://github.com/edgexfoundry/edgex-go/pull/3328
Would need some merging coordination with his PR: until then, made this PR as draft.

Beau's PR has already merged, updated to fit only commits I've now.

## Other information