### PR TITLE
feat(security)!: Switch Consul's default_policy to deny

### DIFF
--- a/cmd/security-bootstrapper/consul-acl/config_consul_acl.json
+++ b/cmd/security-bootstrapper/consul-acl/config_consul_acl.json
@@ -1,7 +1,7 @@
 {
     "acl": {
       "enabled": true,
-      "default_policy": "allow",
+      "default_policy": "deny",
       "enable_token_persistence": true
     }
 }

--- a/internal/security/bootstrapper/command/setupacl/acltokens.go
+++ b/internal/security/bootstrapper/command/setupacl/acltokens.go
@@ -301,8 +301,19 @@ func (c *cmd) readTokenIDBy(bootstrapACLToken BootStrapACLTokenInfo, accessorID 
 // insertNewAgentToken creates a new Consul token
 // it returns the token's ID and error if any error occurs
 func (c *cmd) insertNewAgentToken(bootstrapACLToken BootStrapACLTokenInfo) (string, error) {
+	// get a policy for this agent token to associate with
+	edgexAgentPolicy, err := c.getOrCreateRegistryPolicy(bootstrapACLToken.SecretID,
+		"edgex-agent-policy",
+		edgeXPolicyRules)
+	if err != nil {
+		return share.EmptyToken, fmt.Errorf("failed to create edgex agent policy: %v", err)
+	}
+
 	unlimitedDuration := "0s"
-	createToken := NewCreateRegistryToken("edgex-core-consul agent token", bootstrapACLToken.Policies, true, &unlimitedDuration)
+	createToken := NewCreateRegistryToken("edgex-core-consul agent token",
+		[]Policy{
+			*edgexAgentPolicy,
+		}, true, &unlimitedDuration)
 	newTokenInfo, err := c.createNewToken(bootstrapACLToken.SecretID, createToken)
 	if err != nil {
 		return share.EmptyToken, fmt.Errorf("failed to insert new edgex agent token: %v", err)

--- a/internal/security/bootstrapper/command/setupacl/acltokens_test.go
+++ b/internal/security/bootstrapper/command/setupacl/acltokens_test.go
@@ -98,13 +98,15 @@ func TestCreateAgentToken(t *testing.T) {
 		listTokensRetriesOkResponse bool
 		createTokenOkResponse       bool
 		readTokenOkResponse         bool
+		policyAlreadyExists         bool
 		expectedErr                 bool
 	}{
-		{"Good:agent token ok response", testBootstrapToken, true, true, true, true, false},
-		{"Bad:list tokens bad response", testBootstrapToken, false, false, true, true, true},
-		{"Bad:create token bad response", testBootstrapToken, true, true, false, true, true},
-		{"Bad:read token bad response", testBootstrapToken, true, true, true, false, true},
-		{"Bad:empty bootstrap token", BootStrapACLTokenInfo{}, false, false, false, true, true},
+		{"Good:agent token ok response 1st time", testBootstrapToken, true, true, true, true, false, false},
+		{"Good:agent token ok response 2nd time or later", testBootstrapToken, true, true, true, true, true, false},
+		{"Bad:list tokens bad response", testBootstrapToken, false, false, true, true, false, true},
+		{"Bad:create token bad response", testBootstrapToken, true, true, false, true, false, true},
+		{"Bad:read token bad response", testBootstrapToken, true, true, true, false, false, true},
+		{"Bad:empty bootstrap token", BootStrapACLTokenInfo{}, false, false, false, true, false, true},
 	}
 
 	for _, tt := range tests {
@@ -113,9 +115,12 @@ func TestCreateAgentToken(t *testing.T) {
 			t.Parallel()
 			// prepare test
 			responseOpts := serverOptions{
-				listTokensOk:  test.listTokensOkResponse,
-				createTokenOk: test.createTokenOkResponse,
-				readTokenOk:   test.readTokenOkResponse,
+				listTokensOk:        test.listTokensOkResponse,
+				createTokenOk:       test.createTokenOkResponse,
+				readTokenOk:         test.readTokenOkResponse,
+				policyAlreadyExists: test.policyAlreadyExists,
+				readPolicyByNameOk:  true,
+				createNewPolicyOk:   true,
 			}
 			testSrv := newRegistryTestServer(responseOpts)
 			conf := testSrv.getRegistryServerConf(t)


### PR DESCRIPTION
- turn on Consul's "deny" default_policy
- use more restricted policy rules for Consul's agent token than the original global policy rules

Note: After this switch is on, Consul's GUI access like http://localhost:8500/ui
will be automatically locked with authentication required.  Any direct accesses
to Consul require a legit token.

Closes: #3256

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently the default policy of Consul's server agent is "allow"

## Issue Number: #3256 


## What is the new behavior?
Switch the default policy of Consul to "deny"

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x ] Yes
- [ ] No

    Note: After this switch is on, Consul's GUI access like http://localhost:8500/ui
    will be automatically locked with authentication required.  Any direct accesses
    to Consul require a legit token.


## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information