### PR TITLE
feat(security): Add new environment variable to seed Secret Store with known secrets

### DIFF
--- a/internal/security/fileprovider/tokenconfig.go
+++ b/internal/security/fileprovider/tokenconfig.go
@@ -50,6 +50,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/fileioperformer"
 )
 
@@ -107,18 +108,7 @@ func GetTokenConfigFromEnv() (TokenConfFile, error) {
 	// the list of service names is comma-separated
 	tokenConfigFromEnv := make(TokenConfFile)
 	serviceNameList := strings.Split(addTokenList, ",")
-	// regex for valid service name as key
-	// the service name eventually becomes part of the URL to Vault's API call
-	// Based upon the RFC 3986: https://tools.ietf.org/html/rfc3986#page-12,
-	// the following characters are reserved characters for URI's and thus NOT allowed:
-	// gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
-	// sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
-	// backslash (\) also is not allowed due to being as a delimiter for URI directory in Windows
-	// percent symbol (%) also is not allowed due to being used to encode the reserved characters in URI
-	// and the regular alphanumeric characters like A to Z, a to z, 0 to 9, underscore (_),
-	// -, ~, ^,  {, }, |, <, >, . are allowed.
-	// and the the length of the name is upto 512 characters
-	serviceNameRegx := regexp.MustCompile(`^[\w. \~\^\-\|\<\>\{\}]{1,512}$`)
+	serviceNameRegx := regexp.MustCompile(secretstore.ServiceNameValidationRegx)
 
 	for _, name := range serviceNameList {
 		serviceName := strings.TrimSpace(name)

--- a/internal/security/secretstore/constants.go
+++ b/internal/security/secretstore/constants.go
@@ -19,6 +19,19 @@
 package secretstore
 
 const (
+	// ServiceNameValidationRegx is regex string for valid service name as key
+	// the service name eventually becomes part of the URL to Vault's API call
+	// Based upon the RFC 3986: https://tools.ietf.org/html/rfc3986#page-12,
+	// the following characters are reserved characters for URI's and thus NOT allowed:
+	// gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+	// sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+	// backslash (\) also is not allowed due to being as a delimiter for URI directory in Windows
+	// percent symbol (%) also is not allowed due to being used to encode the reserved characters in URI
+	// and the regular alphanumeric characters like A to Z, a to z, 0 to 9, underscore (_),
+	// -, ~, ^,  {, }, |, <, >, . are allowed.
+	// and the the length of the name is upto 512 characters
+	ServiceNameValidationRegx = `^[\w. \~\^\-\|\<\>\{\}]{1,512}$`
+
 	// this is a feature key to indicate whether to enable Registry Consul's ACL or not
 	RegistryACLFeatureFlag = "ENABLE_REGISTRY_ACL"
 

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -48,6 +49,13 @@ import (
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 	"github.com/edgexfoundry/go-mod-secrets/v2/secrets"
 )
+
+const (
+	addKnownSecretsEnv = "ADD_KNOWN_SECRETS"
+	redisSecretName    = "redisdb"
+)
+
+var validKnownSecrets = map[string]bool{redisSecretName: true}
 
 type Bootstrap struct {
 	insecureSkipVerify bool
@@ -324,6 +332,12 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 		os.Exit(1)
 	}
 
+	knownSecretsToAdd, err := getKnownSecretsToAdd()
+	if err != nil {
+		lc.Error(err.Error())
+		os.Exit(1)
+	}
+
 	// credential creation
 	gen := NewPasswordGenerator(lc, secretStoreConfig.PasswordProvider, secretStoreConfig.PasswordProviderArgs)
 	cred := NewCred(httpCaller, rootToken, gen, secretStoreConfig.GetBaseURL(), lc)
@@ -349,6 +363,16 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	redis5Pair := UserPasswordPair{
 		User:     "redis5",
 		Password: redis5Password,
+	}
+
+	// Add any additional services that need the known DB secret
+	services, ok := knownSecretsToAdd[redisSecretName]
+	if ok {
+		for _, service := range services {
+			configuration.Databases[service] = config.Database{
+				Service: service,
+			}
+		}
 	}
 
 	for _, info := range configuration.Databases {
@@ -438,6 +462,61 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	lc.Info("Vault init done successfully")
 	return false
 
+}
+
+func getKnownSecretsToAdd() (map[string][]string, error) {
+	// Process the env var for adding known secrets to the specified services' secret stores.
+	// Format of the env var value is:
+	//   "<secretName>[<serviceName>;<serviceName>; ...], <secretName>[<serviceName>;<serviceName>; ...], ..."
+	knownSecretsToAdd := map[string][]string{}
+
+	addKnownSecretsValue := strings.TrimSpace(os.Getenv(addKnownSecretsEnv))
+	if len(addKnownSecretsValue) == 0 {
+		return knownSecretsToAdd, nil
+	}
+
+	serviceNameRegx := regexp.MustCompile(ServiceNameValidationRegx)
+	knownSecrets := strings.Split(addKnownSecretsValue, ",")
+	for _, secretSpec := range knownSecrets {
+		// each secretSpec has format of "<secretName>[<serviceName>;<serviceName>; ...]"
+		secretItems := strings.Split(secretSpec, "[")
+		if len(secretItems) != 2 {
+			return nil, fmt.Errorf("invalid specification for %s environment vaiable: Format of value '%s' is invalid. Missing or too many '['", addKnownSecretsEnv, secretSpec)
+		}
+
+		secretName := strings.TrimSpace(secretItems[0])
+
+		_, valid := validKnownSecrets[secretName]
+		if !valid {
+			return nil, fmt.Errorf("invalid specification for %s environment vaiable: '%s' is not a known secret", addKnownSecretsEnv, secretName)
+		}
+
+		serviceNameList := secretItems[1]
+		if !strings.Contains(serviceNameList, "]") {
+			return nil, fmt.Errorf("invalid specification for %s environment vaiable: Service list for '%s' missing closing ']'", addKnownSecretsEnv, secretName)
+		}
+
+		serviceNameList = strings.TrimSpace(strings.Replace(serviceNameList, "]", "", 1))
+		if len(serviceNameList) == 0 {
+			return nil, fmt.Errorf("invalid specification for %s environment vaiable: Service name list for '%s' is empty.", addKnownSecretsEnv, secretName)
+		}
+
+		serviceNames := strings.Split(serviceNameList, ";")
+		for index := range serviceNames {
+			serviceNames[index] = strings.TrimSpace(serviceNames[index])
+
+			if !serviceNameRegx.MatchString(serviceNames[index]) {
+				return nil, fmt.Errorf("invalid specification for %s environment vaiable: Service name '%s' has invalid characters.", addKnownSecretsEnv, serviceNames[index])
+			}
+		}
+
+		// This supports listing known secret multiple times.
+		// Same service name listed twice is not an issue since the add logic checks if the secret is already present.
+		existingServices := knownSecretsToAdd[secretName]
+		knownSecretsToAdd[secretName] = append(existingServices, serviceNames...)
+	}
+
+	return knownSecretsToAdd, nil
 }
 
 // XXX Collapse addServiceCredential and addDBCredential together by passing in the path or using

--- a/internal/security/secretstore/init_test.go
+++ b/internal/security/secretstore/init_test.go
@@ -13,12 +13,13 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/fileioperformer/mocks"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const sampleJSON = `
@@ -76,6 +77,50 @@ func TestSaveInitResponse(t *testing.T) {
 	// Assert
 	assert.NoError(t, err)
 	fileOpener.AssertExpectations(t)
+}
+
+func TestGetKnownSecretsToAdd(t *testing.T) {
+	defer os.Clearenv()
+
+	expectedEmpty := map[string][]string{}
+	expectedOneService := map[string][]string{
+		"redisdb": {"service-1"},
+	}
+	expectedMultiServices := map[string][]string{
+		"redisdb": {"service-1", "service-2", "service-3"},
+	}
+
+	tests := []struct {
+		name                  string
+		envValue              string
+		expected              map[string][]string
+		expectedErrorContains string
+	}{
+		{"valid empty", "", expectedEmpty, ""},
+		{"valid one service", "redisdb[service-1]", expectedOneService, ""},
+		{"valid multi services", "redisdb[service-1; service-2; service-3]", expectedMultiServices, ""},
+		{"valid secret listed twice", "redisdb[service-1], redisdb[service-2; service-3]", expectedMultiServices, ""},
+		{"invalid no services", "redisdb[]", nil, "list for 'redisdb' is empty"},
+		{"invalid unknown secret", "messagebus[service-1; service-2; service-3]", nil, "'messagebus' is not a known secret"},
+		{"invalid known & unknown secret", "redisdb[service-1], messagebus[service-1; service-2; service-3]", nil, "'messagebus' is not a known secret"},
+		{"invalid service list, missing ]", "redisdb[service-1; service-2; service-3", nil, "Service list for 'redisdb' missing closing ']'"},
+		{"invalid service list, missing [", "redisdb:service-1; service-2; service-3]", nil, "is invalid. Missing or too many '['"},
+		{"invalid service name", "redisdb[service-%1]", nil, "Service name 'service-%1' has invalid characters"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_ = os.Setenv(addKnownSecretsEnv, test.envValue)
+			actual, err := getKnownSecretsToAdd()
+			if test.expected == nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.expectedErrorContains)
+				return
+			}
+
+			assert.Equal(t, test.expected, actual)
+		})
+	}
 }
 
 //

--- a/internal/security/secretstore/init_test.go
+++ b/internal/security/secretstore/init_test.go
@@ -108,10 +108,12 @@ func TestGetKnownSecretsToAdd(t *testing.T) {
 		{"invalid service name", "redisdb[service-%1]", nil, "Service name 'service-%1' has invalid characters"},
 	}
 
+	b := NewBootstrap(false, 10)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_ = os.Setenv(addKnownSecretsEnv, test.envValue)
-			actual, err := getKnownSecretsToAdd()
+			actual, err := b.getKnownSecretsToAdd()
 			if test.expected == nil {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.expectedErrorContains)

--- a/internal/security/secretstore/init_test.go
+++ b/internal/security/secretstore/init_test.go
@@ -80,7 +80,7 @@ func TestSaveInitResponse(t *testing.T) {
 }
 
 func TestGetKnownSecretsToAdd(t *testing.T) {
-	defer os.Clearenv()
+	defer os.Setenv(addKnownSecretsEnv, "")
 
 	expectedEmpty := map[string][]string{}
 	expectedOneService := map[string][]string{


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
No ability to add known secrets to services which have secret store added via the ADD_SECRETSTORE_TOKENS env var.

## Issue Number:  #2889

## What is the new behavior?
Secret Store Setup now has ADD_KNOWN_SECRETS environment variable to specify known secrets to add to the specified services` secret stores.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information