### PR TITLE
build(snap): Enable secure Kong Admin APIs in snap build

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -36,6 +36,12 @@ for service in security-file-token-provider security-proxy-setup security-secret
     fi
 done
 
+# install the template config yaml file for securing Kong's admin APIs in security-secretstore-setup service
+if [ ! -f "$SNAP_DATA/config/security-secretstore-setup/res/kong-admin-config.template.yml" ]; then
+    cp "$SNAP/config/security-secretstore-setup/res/kong-admin-config.template.yml" \
+        "$SNAP_DATA/config/security-secretstore-setup/res/kong-admin-config.template.yml"
+fi
+
 # handle app-service-configurable's various profiles:
 # 1. ensure all the directories from app-service-configurable exist
 # 2. copy the config files from $SNAP into $SNAP_DATA

--- a/snap/local/runtime-helpers/bin/kong-daemon.sh
+++ b/snap/local/runtime-helpers/bin/kong-daemon.sh
@@ -12,7 +12,7 @@ until "$KONG" migrations bootstrap --conf "$KONG_CONF"; do
 done
 
 # set up Kong's admin API plugins via kong.yml:
-"$KONG" config db_import "$KONGADMIN_CONFIGFILEPATH"
+"$KONG" config db_import "$KONGADMIN_CONFIGFILEPATH" || true
 
 # now start kong normally
 "$KONG" start --conf "$KONG_CONF" --v

--- a/snap/local/runtime-helpers/bin/kong-daemon.sh
+++ b/snap/local/runtime-helpers/bin/kong-daemon.sh
@@ -11,5 +11,8 @@ until "$KONG" migrations bootstrap --conf "$KONG_CONF"; do
     sleep 5
 done
 
+# set up Kong's admin API plugins via kong.yml:
+"$KONG" config db_import "$KONGADMIN_CONFIGFILEPATH"
+
 # now start kong normally
 "$KONG" start --conf "$KONG_CONF" --v

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -656,7 +656,9 @@ parts:
       done
 
       # For securing Kong's admin APIs, we also need to install kong-admin-config's template yml
-      # into secretstore-setup service
+      # into secretstore-setup service because secretstore-setup uses it to create a JWT file that
+      # proxy-setup can later on enable Kong's JWT plugin on admin API route hence secure it with
+      # JWT authentication and authorization
       install -DT "./cmd/security-secretstore-setup/res/kong-admin-config.template.yml" \
         "$SNAPCRAFT_PART_INSTALL/config/security-secretstore-setup/res/kong-admin-config.template.yml"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -124,7 +124,15 @@ apps:
       KONG_PROXY_ERROR_LOG: $SNAP_COMMON/logs/kong-proxy-error.log
       KONG_ADMIN_ERROR_LOG: $SNAP_COMMON/logs/kong-admin-error.log
       KONG_ADMIN_LISTEN: "localhost:8001, localhost:8444 ssl"
-      KONG_STATUS_LISTEN: "0.0.0.0:8100"
+      KONG_STATUS_LISTEN: "localhost:8100"
+      # The DNS order was modified because of an issue with a Windows based host DNS issue.
+      # Keeping the default order would cause the first API request to Kong's admin API much longer time to connect for
+      # taking something minimum of 20 seconds to complete, and then others would complete as expected.
+      # Moreover, changing the DNS order did not impact those non-Windows based systems,
+      # so implementing it across the board seemed pretty low risk.
+      # The work-around that was found in one of the documented issues was to remove the SRV record check
+      # by manipulating the Kong DNS checking order via environment variable. Once we did that,
+      # the prolonged connecting issue went away.
       KONG_DNS_ORDER: "LAST,A,CNAME"
       LC_ALL: C.UTF-8
       LANG: C.UTF-8

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -108,6 +108,8 @@ apps:
     adapter: full
     after:
       - postgres
+      # to ensure kong.yml is ready for kong to process as the file is set up from security-secretstore-setup
+      - security-secretstore-setup
     command: bin/kong-daemon.sh
     command-chain:
       - bin/perl5lib-launch.sh
@@ -115,12 +117,15 @@ apps:
     daemon: forking
     environment:
       KONG_CONF: $SNAP_DATA/config/security-proxy-setup/kong.conf
+      KONGADMIN_CONFIGFILEPATH: $SNAP_DATA/config/kong.yml
       KONG_LOGS_DIR: $SNAP_COMMON/logs
       KONG_PROXY_ACCESS_LOG: $SNAP_COMMON/logs/kong-proxy-access.log
       KONG_ADMIN_ACCESS_LOG: $SNAP_COMMON/logs/kong-admin-access.log
       KONG_PROXY_ERROR_LOG: $SNAP_COMMON/logs/kong-proxy-error.log
       KONG_ADMIN_ERROR_LOG: $SNAP_COMMON/logs/kong-admin-error.log
       KONG_ADMIN_LISTEN: "localhost:8001, localhost:8444 ssl"
+      KONG_STATUS_LISTEN: "0.0.0.0:8100"
+      KONG_DNS_ORDER: "LAST,A,CNAME"
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     start-timeout: 15m
@@ -170,6 +175,11 @@ apps:
       TOKENFILEPROVIDER_CONFIGFILE: $SNAP_DATA/config/security-file-token-provider/res/token-config.json
       TOKENFILEPROVIDER_OUTPUTDIR: $SNAP_DATA/secrets
 
+      # securing Kong's admin API plugin related environment variables:
+      KONGADMIN_CONFIGTEMPLATEPATH: $SNAP_DATA/config/security-secretstore-setup/res/kong-admin-config.template.yml
+      KONGADMIN_CONFIGFILEPATH: $SNAP_DATA/config/kong.yml
+      KONGADMIN_CONFIGJWTPATH: $SNAP_DATA/secrets/edgex-security-proxy-setup/kong-admin-jwt
+
     start-timeout: 15m
     plugs: [network]
   security-proxy-setup:
@@ -183,6 +193,7 @@ apps:
       INIT_ARG: "--init=true"
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
       ACCESSTOKENFILE: $SNAP_DATA/secrets/consul-acl-token/bootstrap_token.json
+      KONGAUTH_JWTFILE: $SNAP_DATA/secrets/edgex-security-proxy-setup/kong-admin-jwt
     daemon: oneshot
     start-timeout: 15m
     plugs: [network]
@@ -347,6 +358,7 @@ apps:
     environment:
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/edgex-security-proxy-setup/secrets-token.json
       ACCESSTOKENFILE: $SNAP_DATA/secrets/consul-acl-token/bootstrap_token.json
+      KONGAUTH_JWTFILE: $SNAP_DATA/secrets/edgex-security-proxy-setup/kong-admin-jwt
     plugs: [home, removable-media, network]
   secrets-config:
     adapter: none
@@ -642,6 +654,11 @@ parts:
           esac
 
       done
+
+      # For securing Kong's admin APIs, we also need to install kong-admin-config's template yml
+      # into secretstore-setup service
+      install -DT "./cmd/security-secretstore-setup/res/kong-admin-config.template.yml" \
+        "$SNAPCRAFT_PART_INSTALL/config/security-secretstore-setup/res/kong-admin-config.template.yml"
 
       install -DT "./Attribution.txt" "$SNAPCRAFT_PART_INSTALL/usr/share/doc/github.com/edgexfoundry/Attribution.txt"
       install -DT "./LICENSE" "$SNAPCRAFT_PART_INSTALL/usr/share/doc/github.com/edgexfoundry/LICENSE"


### PR DESCRIPTION
- Add installation of Kong's Admin plugins template yaml to enable Admin JWT, ACL plugins etc.
- Update the Kong daemon startup shell script to import the plugins into database
- Update the snapcraft yml to integrate the secure Kong's Admin API features

Closes: #3403

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
kong's admin APIs at 8001 are wide open without authentication and ACLs in snap

## Issue Number: #3403 


## What is the new behavior?
Kong's admin APIs are now protected with required JWT authentication with ACLs in snap

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

In Draft PR mode until other dependent PRs for this snap to be working:
- Feature of [securing Kong's Admin APIs from this PR](https://github.com/edgexfoundry/edgex-go/pull/3328)  MERGED
- Kong's binary upgrade to new version 2.3.x PR (https://github.com/edgexfoundry/edgex-go/pull/3415)  MERGED

Now this PR is ready.

## Other information