### PR TITLE
feat: Switch to Redis as the default MessageBus

### DIFF
--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -44,10 +44,10 @@ Type = 'consul'
   Type = 'redisdb'
 
 [MessageQueue]
-Protocol = 'tcp'
-Host = '*'
-Port = 5563
-Type = 'zero'
+Protocol = 'redis'
+Host = 'localhost'
+Port = 6379
+Type = 'redisstreams'
 Topic = 'events'
 PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name> will be added to this Publish Topic prefix
 [MessageQueue.Optional]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
ZMQ is the default MessageBus

## Issue Number: #3411


## What is the new behavior?
Redis is now the default MessageBus

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes
- [ ] No

BREAKING CHANGE: All service receiving Event must now be configured to use Redis as the MessageBus

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information