### PR TITLE
fix(snap): update to kong 2.3.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -670,16 +670,16 @@ parts:
       # note - we specifically don't use arch
       case "$(dpkg --print-architecture)" in
         amd64)
-          FILE_NAME=kong-2.0.5.xenial.amd64.deb
-          FILE_HASH=450223a011dba0d6eeb6a192be368e7bcd45a5dc063c743ed6f3d37eb95237b8
+          FILE_NAME=kong_2.3.3_amd64.deb
+          FILE_HASH=c30cdf5ffac9c0921699c1b3ee549daa032dc8bbbb348a4d1d5aebf5c8c2faa7
           ;;
         arm64)
-          FILE_NAME=kong-2.0.5.xenial.arm64.deb
-          FILE_HASH=15aa5fb2eb0c992afa277b09cb03b3b940df9704ab9e8d93327a72c0cb87eb09
+          FILE_NAME=kong_2.3.3_arm64.deb
+          FILE_HASH=54066ca600dd9873b812ca7e1b98012c23b808c8773a61006d021b3deebbb335
           ;;
       esac
       # download the archive, failing on ssl cert problems
-      curl -L https://bintray.com/kong/kong-deb/download_file?file_path=$FILE_NAME -o $FILE_NAME
+      curl -L https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong/$FILE_NAME -o $FILE_NAME
       echo "$FILE_HASH $FILE_NAME" > sha256
       sha256sum -c sha256 | grep OK
       dpkg -x $FILE_NAME $SNAPCRAFT_PART_INSTALL
@@ -689,6 +689,11 @@ parts:
 
       mkdir -p $SNAPCRAFT_PART_INSTALL/config/security-proxy-setup
       cp $SNAPCRAFT_PART_INSTALL/etc/kong/kong.conf.default $SNAPCRAFT_PART_INSTALL/config/security-proxy-setup/kong.conf
+
+      # kong 2.2.0 change the default user to "kong" which breaks
+      # under confinement so explicitly set user to "root root"
+      sed -i -e 's/#nginx_user = kong kong/nginx_user = root root/' \
+        $SNAPCRAFT_PART_INSTALL/config/security-proxy-setup/kong.conf
 
       # by default the Kong deb contains an absolute symlink @ /usr/local/openresty/bin/openresty which points to /usr/local/openresty/nginx/sbin/nginx
       # because the review-tools for the snap store do not currently allow using absolute symlinks that point outside of the snap


### PR DESCRIPTION
Update to kong 2.3.x as this is required to use the new plugin template version 2.1 needed to secure the kong admin API. This change also updates the snap build to use kong's new download site to pull the debian package.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
See commit message for details

## Issue Number:


## What is the new behavior?
No change in behavior.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
Securing Kong Admin API PR: https://github.com/edgexfoundry/edgex-go/pull/3328
Bintray shutdown notice: https://www.infoq.com/news/2021/02/jfrog-jcenter-bintray-closure/