### PR TITLE
fix: MaxResultCount limit the maximum number of returned objects

### DIFF
--- a/internal/core/data/v2/application/event.go
+++ b/internal/core/data/v2/application/event.go
@@ -205,9 +205,9 @@ func EventsByDeviceName(offset int, limit int, name string, dic *di.Container) (
 }
 
 // EventsByTimeRange query events with offset, limit and time range
-func EventsByTimeRange(start int, end int, offset int, limit int, dic *di.Container) (events []dtos.Event, err errors.EdgeX) {
+func EventsByTimeRange(startTime int, endTime int, offset int, limit int, dic *di.Container) (events []dtos.Event, err errors.EdgeX) {
 	dbClient := v2DataContainer.DBClientFrom(dic.Get)
-	eventModels, err := dbClient.EventsByTimeRange(start, end, offset, limit)
+	eventModels, err := dbClient.EventsByTimeRange(startTime, endTime, offset, limit)
 	if err != nil {
 		return events, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -484,14 +484,14 @@ func (c *Client) EventsByDeviceName(offset int, limit int, name string) (events 
 }
 
 // EventsByTimeRange query events by time range, offset, and limit
-func (c *Client) EventsByTimeRange(start int, end int, offset int, limit int) (events []model.Event, edgeXerr errors.EdgeX) {
+func (c *Client) EventsByTimeRange(startTime int, endTime int, offset int, limit int) (events []model.Event, edgeXerr errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	events, edgeXerr = eventsByTimeRange(conn, start, end, offset, limit)
+	events, edgeXerr = eventsByTimeRange(conn, startTime, endTime, offset, limit)
 	if edgeXerr != nil {
 		return events, errors.NewCommonEdgeX(errors.Kind(edgeXerr),
-			fmt.Sprintf("fail to query events by time range %v ~ %v, offset %d, and limit %d", start, end, offset, limit), edgeXerr)
+			fmt.Sprintf("fail to query events by time range %v ~ %v, offset %d, and limit %d", startTime, endTime, offset, limit), edgeXerr)
 	}
 	return events, nil
 }

--- a/internal/pkg/v2/infrastructure/redis/device.go
+++ b/internal/pkg/v2/infrastructure/redis/device.go
@@ -172,11 +172,7 @@ func deleteDevice(conn redis.Conn, device models.Device) errors.EdgeX {
 
 // devicesByServiceName query devices by offset, limit and name
 func devicesByServiceName(conn redis.Conn, offset int, limit int, name string) (devices []models.Device, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(DeviceCollectionServiceName, name), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(DeviceCollectionServiceName, name), offset, limit)
 	if err != nil {
 		return devices, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -195,11 +191,7 @@ func devicesByServiceName(conn redis.Conn, offset int, limit int, name string) (
 
 // devicesByLabels query devices with offset, limit and labels
 func devicesByLabels(conn redis.Conn, offset int, limit int, labels []string) (devices []models.Device, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, edgeXerr := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, DeviceCollection, labels, offset, end)
+	objects, edgeXerr := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, DeviceCollection, labels, offset, limit)
 	if edgeXerr != nil {
 		return devices, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -218,11 +210,7 @@ func devicesByLabels(conn redis.Conn, offset int, limit int, labels []string) (d
 
 // devicesByProfileName query devices by offset, limit and profile name
 func devicesByProfileName(conn redis.Conn, offset int, limit int, profileName string) (devices []models.Device, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(DeviceCollectionProfileName, profileName), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(DeviceCollectionProfileName, profileName), offset, limit)
 	if err != nil {
 		return devices, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/pkg/v2/infrastructure/redis/device_profile.go
+++ b/internal/pkg/v2/infrastructure/redis/device_profile.go
@@ -208,11 +208,7 @@ func deleteDeviceProfileByName(conn redis.Conn, name string) errors.EdgeX {
 
 // deviceProfilesByLabels query device profile with offset and limit
 func deviceProfilesByLabels(conn redis.Conn, offset int, limit int, labels []string) (deviceProfiles []models.DeviceProfile, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, edgeXerr := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, DeviceProfileCollection, labels, offset, end)
+	objects, edgeXerr := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, DeviceProfileCollection, labels, offset, limit)
 	if edgeXerr != nil {
 		return deviceProfiles, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -231,11 +227,7 @@ func deviceProfilesByLabels(conn redis.Conn, offset int, limit int, labels []str
 
 // deviceProfilesByModel query device profiles by offset, limit and model
 func deviceProfilesByModel(conn redis.Conn, offset int, limit int, model string) (deviceProfiles []models.DeviceProfile, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(DeviceProfileCollectionModel, model), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(DeviceProfileCollectionModel, model), offset, limit)
 	if err != nil {
 		return deviceProfiles, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -254,11 +246,7 @@ func deviceProfilesByModel(conn redis.Conn, offset int, limit int, model string)
 
 // deviceProfilesByManufacturer query device profiles by offset, limit and manufacturer
 func deviceProfilesByManufacturer(conn redis.Conn, offset int, limit int, manufacturer string) (deviceProfiles []models.DeviceProfile, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(DeviceProfileCollectionManufacturer, manufacturer), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(DeviceProfileCollectionManufacturer, manufacturer), offset, limit)
 	if err != nil {
 		return deviceProfiles, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -277,6 +265,9 @@ func deviceProfilesByManufacturer(conn redis.Conn, offset int, limit int, manufa
 
 // deviceProfilesByManufacturerAndModel query device profiles by offset, limit, manufacturer and model
 func deviceProfilesByManufacturerAndModel(conn redis.Conn, offset int, limit int, manufacturer string, model string) (deviceProfiles []models.DeviceProfile, edgeXerr errors.EdgeX) {
+	if limit == 0 {
+		return
+	}
 	end := offset + limit - 1
 	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
 		end = limit

--- a/internal/pkg/v2/infrastructure/redis/device_service.go
+++ b/internal/pkg/v2/infrastructure/redis/device_service.go
@@ -166,11 +166,7 @@ func deleteDeviceServiceByName(conn redis.Conn, name string) errors.EdgeX {
 
 // deviceServicesByLabels query multiple device services from DB per labels
 func deviceServicesByLabels(conn redis.Conn, offset int, limit int, labels []string) (deviceServices []models.DeviceService, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, DeviceServiceCollection, labels, offset, end)
+	objects, err := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, DeviceServiceCollection, labels, offset, limit)
 	if err != nil {
 		return deviceServices, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/pkg/v2/infrastructure/redis/event.go
+++ b/internal/pkg/v2/infrastructure/redis/event.go
@@ -257,11 +257,7 @@ func eventById(conn redis.Conn, id string) (event models.Event, edgeXerr errors.
 }
 
 func (c *Client) allEvents(conn redis.Conn, offset int, limit int) (events []models.Event, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, EventsCollection, offset, end)
+	objects, err := getObjectsByRevRange(conn, EventsCollection, offset, limit)
 	if err != nil {
 		return events, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -270,11 +266,7 @@ func (c *Client) allEvents(conn redis.Conn, offset int, limit int) (events []mod
 
 // eventsByDeviceName query events by offset, limit and device name
 func eventsByDeviceName(conn redis.Conn, offset int, limit int, name string) (events []models.Event, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(EventsCollectionDeviceName, name), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(EventsCollectionDeviceName, name), offset, limit)
 	if err != nil {
 		return events, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -282,8 +274,8 @@ func eventsByDeviceName(conn redis.Conn, offset int, limit int, name string) (ev
 }
 
 // eventsByTimeRange query events by time range, offset, and limit
-func eventsByTimeRange(conn redis.Conn, start int, end int, offset int, limit int) (events []models.Event, edgeXerr errors.EdgeX) {
-	objects, edgeXerr := getObjectsByScoreRange(conn, EventsCollectionOrigin, start, end, offset, limit)
+func eventsByTimeRange(conn redis.Conn, startTime int, endTime int, offset int, limit int) (events []models.Event, edgeXerr errors.EdgeX) {
+	objects, edgeXerr := getObjectsByScoreRange(conn, EventsCollectionOrigin, startTime, endTime, offset, limit)
 	if edgeXerr != nil {
 		return events, edgeXerr
 	}

--- a/internal/pkg/v2/infrastructure/redis/interval.go
+++ b/internal/pkg/v2/infrastructure/redis/interval.go
@@ -96,11 +96,7 @@ func intervalById(conn redis.Conn, id string) (interval models.Interval, edgeXer
 
 // allIntervals queries intervals by offset and limit
 func allIntervals(conn redis.Conn, offset, limit int) (intervals []models.Interval, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, edgeXerr := getObjectsByRevRange(conn, IntervalCollection, offset, end)
+	objects, edgeXerr := getObjectsByRevRange(conn, IntervalCollection, offset, limit)
 	if edgeXerr != nil {
 		return intervals, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}

--- a/internal/pkg/v2/infrastructure/redis/intervalaction.go
+++ b/internal/pkg/v2/infrastructure/redis/intervalaction.go
@@ -81,11 +81,7 @@ func addIntervalAction(conn redis.Conn, action models.IntervalAction) (models.In
 
 // allIntervalActions queries intervalActions by offset and limit
 func allIntervalActions(conn redis.Conn, offset, limit int) (intervalActions []models.IntervalAction, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, edgeXerr := getObjectsByRevRange(conn, IntervalActionCollection, offset, end)
+	objects, edgeXerr := getObjectsByRevRange(conn, IntervalActionCollection, offset, limit)
 	if edgeXerr != nil {
 		return intervalActions, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -168,11 +164,7 @@ func updateIntervalAction(conn redis.Conn, action models.IntervalAction) errors.
 
 // intervalActionsByIntervalName query actions by offset, limit and intervalName
 func intervalActionsByIntervalName(conn redis.Conn, offset int, limit int, intervalName string) (actions []models.IntervalAction, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(IntervalActionCollectionIntervalName, intervalName), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(IntervalActionCollectionIntervalName, intervalName), offset, limit)
 	if err != nil {
 		return actions, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/pkg/v2/infrastructure/redis/notification.go
+++ b/internal/pkg/v2/infrastructure/redis/notification.go
@@ -77,11 +77,7 @@ func addNotification(conn redis.Conn, notification models.Notification) (models.
 
 // notificationsByCategory queries notifications by offset, limit, and category
 func notificationsByCategory(conn redis.Conn, offset int, limit int, category string) (notifications []models.Notification, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(NotificationCollectionCategory, category), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(NotificationCollectionCategory, category), offset, limit)
 	if err != nil {
 		return notifications, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -104,11 +100,7 @@ func convertObjectsToNotifications(objects [][]byte) (notifications []models.Not
 
 // notificationsByLabel queries notifications by offset, limit, and label
 func notificationsByLabel(conn redis.Conn, offset int, limit int, label string) (notifications []models.Notification, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(NotificationCollectionLabel, label), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(NotificationCollectionLabel, label), offset, limit)
 	if err != nil {
 		return notifications, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -127,11 +119,7 @@ func notificationById(conn redis.Conn, id string) (notification models.Notificat
 
 // notificationsByStatus queries notifications by offset, limit, and status
 func notificationsByStatus(conn redis.Conn, offset int, limit int, status string) (notifications []models.Notification, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(NotificationCollectionStatus, status), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(NotificationCollectionStatus, status), offset, limit)
 	if err != nil {
 		return notifications, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -140,8 +128,8 @@ func notificationsByStatus(conn redis.Conn, offset int, limit int, status string
 }
 
 // notificationsByTimeRange query notifications by time range, offset, and limit
-func notificationsByTimeRange(conn redis.Conn, start int, end int, offset int, limit int) (notifications []models.Notification, edgeXerr errors.EdgeX) {
-	objects, edgeXerr := getObjectsByScoreRange(conn, NotificationCollectionCreated, start, end, offset, limit)
+func notificationsByTimeRange(conn redis.Conn, startTime int, endTime int, offset int, limit int) (notifications []models.Notification, edgeXerr errors.EdgeX) {
+	objects, edgeXerr := getObjectsByScoreRange(conn, NotificationCollectionCreated, startTime, endTime, offset, limit)
 	if edgeXerr != nil {
 		return notifications, edgeXerr
 	}
@@ -176,6 +164,9 @@ func deleteNotificationById(conn redis.Conn, id string) errors.EdgeX {
 }
 
 func notificationsByCategoriesAndLabels(conn redis.Conn, offset int, limit int, categories []string, labels []string) (notifications []models.Notification, edgeXerr errors.EdgeX) {
+	if limit == 0 {
+		return
+	}
 	end := offset + limit - 1
 	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
 		end = limit

--- a/internal/pkg/v2/infrastructure/redis/provisionwatcher.go
+++ b/internal/pkg/v2/infrastructure/redis/provisionwatcher.go
@@ -104,11 +104,7 @@ func provisionWatcherByName(conn redis.Conn, name string) (provisionWatcher mode
 
 // provisionWatchersByServiceName query provision watchers by offset, limit and service name
 func provisionWatchersByServiceName(conn redis.Conn, offset int, limit int, name string) (provisionWatchers []models.ProvisionWatcher, edgexErr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { // -1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(ProvisionWatcherCollectionServiceName, name), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(ProvisionWatcherCollectionServiceName, name), offset, limit)
 	if err != nil {
 		return provisionWatchers, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -128,11 +124,7 @@ func provisionWatchersByServiceName(conn redis.Conn, offset int, limit int, name
 
 // provisionWatchersByProfileName query provision watchers by offset, limit and profile name
 func provisionWatchersByProfileName(conn redis.Conn, offset int, limit int, name string) (provisionWatchers []models.ProvisionWatcher, edgexErr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { // -1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(ProvisionWatcherCollectionProfileName, name), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(ProvisionWatcherCollectionProfileName, name), offset, limit)
 	if err != nil {
 		return []models.ProvisionWatcher{}, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -152,11 +144,7 @@ func provisionWatchersByProfileName(conn redis.Conn, offset int, limit int, name
 
 // provisionWatchersByLabels query provision watchers by offset, limit and labels
 func provisionWatchersByLabels(conn redis.Conn, offset int, limit int, labels []string) (provisionWatchers []models.ProvisionWatcher, edgexErr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { // -1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, ProvisionWatcherCollection, labels, offset, end)
+	objects, err := getObjectsByLabelsAndSomeRange(conn, ZREVRANGE, ProvisionWatcherCollection, labels, offset, limit)
 	if err != nil {
 		return provisionWatchers, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/pkg/v2/infrastructure/redis/reading.go
+++ b/internal/pkg/v2/infrastructure/redis/reading.go
@@ -177,11 +177,7 @@ func readingsByEventId(conn redis.Conn, eventId string) (readings []models.Readi
 }
 
 func allReadings(conn redis.Conn, offset int, limit int) (readings []models.Reading, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsBySomeRange(conn, ZREVRANGE, ReadingsCollectionOrigin, offset, end)
+	objects, err := getObjectsByRevRange(conn, ReadingsCollectionOrigin, offset, limit)
 	if err != nil {
 		return readings, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -191,11 +187,7 @@ func allReadings(conn redis.Conn, offset int, limit int) (readings []models.Read
 
 // readingsByResourceName query readings by offset, limit, and resource name
 func readingsByResourceName(conn redis.Conn, offset int, limit int, resourceName string) (readings []models.Reading, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(ReadingsCollectionResourceName, resourceName), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(ReadingsCollectionResourceName, resourceName), offset, limit)
 	if err != nil {
 		return readings, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -205,11 +197,7 @@ func readingsByResourceName(conn redis.Conn, offset int, limit int, resourceName
 
 // readingsByDeviceName query readings by offset, limit, and device name
 func readingsByDeviceName(conn redis.Conn, offset int, limit int, name string) (readings []models.Reading, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(ReadingsCollectionDeviceName, name), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(ReadingsCollectionDeviceName, name), offset, limit)
 	if err != nil {
 		return readings, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -218,8 +206,8 @@ func readingsByDeviceName(conn redis.Conn, offset int, limit int, name string) (
 }
 
 // readingsByTimeRange query readings by time range, offset, and limit
-func readingsByTimeRange(conn redis.Conn, start int, end int, offset int, limit int) (readings []models.Reading, edgeXerr errors.EdgeX) {
-	objects, edgeXerr := getObjectsByScoreRange(conn, ReadingsCollectionOrigin, start, end, offset, limit)
+func readingsByTimeRange(conn redis.Conn, startTime int, endTime int, offset int, limit int) (readings []models.Reading, edgeXerr errors.EdgeX) {
+	objects, edgeXerr := getObjectsByScoreRange(conn, ReadingsCollectionOrigin, startTime, endTime, offset, limit)
 	if edgeXerr != nil {
 		return readings, edgeXerr
 	}

--- a/internal/pkg/v2/infrastructure/redis/subscription.go
+++ b/internal/pkg/v2/infrastructure/redis/subscription.go
@@ -88,11 +88,7 @@ func addSubscription(conn redis.Conn, subscription models.Subscription) (models.
 
 // allSubscriptions queries subscriptions by offset and limit
 func allSubscriptions(conn redis.Conn, offset, limit int) (subscriptions []models.Subscription, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, edgeXerr := getObjectsBySomeRange(conn, ZREVRANGE, SubscriptionCollection, offset, end)
+	objects, edgeXerr := getObjectsByRevRange(conn, SubscriptionCollection, offset, limit)
 	if edgeXerr != nil {
 		return subscriptions, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -130,11 +126,7 @@ func subscriptionByName(conn redis.Conn, name string) (subscription models.Subsc
 
 // subscriptionsByCategory queries subscriptions by offset, limit, and category
 func subscriptionsByCategory(conn redis.Conn, offset int, limit int, category string) (subscriptions []models.Subscription, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(SubscriptionCollectionCategory, category), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(SubscriptionCollectionCategory, category), offset, limit)
 	if err != nil {
 		return subscriptions, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -144,11 +136,7 @@ func subscriptionsByCategory(conn redis.Conn, offset int, limit int, category st
 
 // subscriptionsByLabel queries subscriptions by offset, limit, and label
 func subscriptionsByLabel(conn redis.Conn, offset int, limit int, label string) (subscriptions []models.Subscription, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(SubscriptionCollectionLabel, label), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(SubscriptionCollectionLabel, label), offset, limit)
 	if err != nil {
 		return subscriptions, errors.NewCommonEdgeXWrapper(err)
 	}
@@ -158,11 +146,7 @@ func subscriptionsByLabel(conn redis.Conn, offset int, limit int, label string) 
 
 // subscriptionsByReceiver queries subscriptions by offset, limit, and receiver
 func subscriptionsByReceiver(conn redis.Conn, offset int, limit int, receiver string) (subscriptions []models.Subscription, edgeXerr errors.EdgeX) {
-	end := offset + limit - 1
-	if limit == -1 { //-1 limit means that clients want to retrieve all remaining records after offset from DB, so specifying -1 for end
-		end = limit
-	}
-	objects, err := getObjectsByRevRange(conn, CreateKey(SubscriptionCollectionReceiver, receiver), offset, end)
+	objects, err := getObjectsByRevRange(conn, CreateKey(SubscriptionCollectionReceiver, receiver), offset, limit)
 	if err != nil {
 		return subscriptions, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/pkg/v2/utils/http_test.go
+++ b/internal/pkg/v2/utils/http_test.go
@@ -1,0 +1,71 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGetAllObjectsRequestQueryString(t *testing.T) {
+	testLabel := "testLabel"
+	tests := []struct {
+		name              string
+		offset            string
+		limit             string
+		labels            string
+		maxLimit          int
+		expectedOffset    int
+		expectedLimit     int
+		expectedLabels    []string
+		expectedErrorKind errors.ErrKind
+	}{
+		{"valid", "0", "2", testLabel, 10, 0, 2, []string{testLabel}, ""},
+		{"valid - labels is empty", "0", "2", "", 10, 0, 2, nil, ""},
+		{"valid - offset and limit is empty", "", "", testLabel, 50, v2.DefaultOffset, v2.DefaultLimit, []string{testLabel}, ""},
+		{"valid - limit is empty and default value is greater then the maximum", "", "", testLabel, 5, v2.DefaultOffset, 5, []string{testLabel}, ""},
+		{"invalid - offset exceeds the minimum ", "-1", "2", testLabel, 50, 0, 2, []string{testLabel}, errors.KindContractInvalid},
+		{"invalid - offset exceeds the maximum ", strconv.Itoa(math.MaxUint32), "2", testLabel, 10, 0, 2, []string{testLabel}, errors.KindContractInvalid},
+		{"invalid - limit exceeds the minimum ", "0", "-2", testLabel, 50, 0, 2, []string{testLabel}, errors.KindContractInvalid},
+		{"invalid - limit exceeds the maximum ", "0", "100", testLabel, 50, 0, 2, []string{testLabel}, errors.KindContractInvalid},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, v2.ApiAllEventRoute, http.NoBody)
+			require.NoError(t, err)
+			query := req.URL.Query()
+			if testCase.offset != "" {
+				query.Add(v2.Offset, testCase.offset)
+			}
+			if testCase.limit != "" {
+				query.Add(v2.Limit, testCase.limit)
+			}
+			if testCase.labels != "" {
+				query.Add(v2.Labels, testCase.labels)
+			}
+			req.URL.RawQuery = query.Encode()
+
+			offset, limit, labels, err := ParseGetAllObjectsRequestQueryString(req, 0, math.MaxInt32, -1, testCase.maxLimit)
+			if testCase.expectedErrorKind != "" {
+				assert.Equal(t, testCase.expectedErrorKind, errors.Kind(err))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedOffset, offset)
+			assert.Equal(t, testCase.expectedLimit, limit)
+			assert.Equal(t, testCase.expectedLabels, labels)
+		})
+	}
+
+}


### PR DESCRIPTION
Fix: #3409

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3409 


## What is the new behavior?
- Use MaxResultCount to limit the maximum number of returned objects
- Return empty array when limit is zero

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information