### PR TITLE
feat(sma): implement v2 GET /health/{services} API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.42
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.8
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.78
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.80
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.13
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.20

--- a/internal/system/agent/v2/application/health.go
+++ b/internal/system/agent/v2/application/health.go
@@ -1,0 +1,38 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+import (
+	"fmt"
+
+	"github.com/edgexfoundry/go-mod-registry/v2/registry"
+)
+
+const healthy string = "healthy"
+
+func GetHealth(services []string, registryClient registry.Client) map[string]string {
+	health := make(map[string]string)
+	for _, service := range services {
+		if registryClient == nil {
+			health[service] = "registry is required to obtain service health status."
+			continue
+		}
+
+		// the registry service returns nil for a healthy service
+		ok, err := registryClient.IsServiceAvailable(service)
+		if err != nil {
+			health[service] = err.Error()
+			continue
+		}
+		if !ok {
+			health[service] = fmt.Sprintf("service %s is not available", service)
+			continue
+		}
+		health[service] = healthy
+	}
+
+	return health
+}

--- a/internal/system/agent/v2/application/health_test.go
+++ b/internal/system/agent/v2/application/health_test.go
@@ -1,0 +1,46 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-registry/v2/registry"
+	"github.com/edgexfoundry/go-mod-registry/v2/registry/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHealth(t *testing.T) {
+
+	rcMock := &mocks.Client{}
+	rcMock.On("IsServiceAvailable", "edgex-core-data").Return(true, nil)
+	rcMock.On("IsServiceAvailable", "edgex-core-metadata").Return(true, nil)
+	rcMock.On("IsServiceAvailable", "edgex-core-command").Return(false, errors.New(""))
+
+	tests := []struct {
+		name            string
+		services        []string
+		rc              registry.Client
+		expectedHealthy bool
+	}{
+		{"healthy", []string{"edgex-core-data", "edgex-core-metadata"}, rcMock, true},
+		{"unhealthy - RegisterClient not running", []string{"edgex-core-data", "edgex-core-metadata"}, nil, false},
+		{"unhealthy - service not running", []string{"edgex-core-command"}, rcMock, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := GetHealth(tt.services, tt.rc)
+			for _, v := range res {
+				if tt.expectedHealthy {
+					assert.Equal(t, v, healthy)
+				} else {
+					assert.NotEqual(t, v, healthy)
+				}
+			}
+		})
+	}
+}

--- a/internal/system/agent/v2/controller/http/controller.go
+++ b/internal/system/agent/v2/controller/http/controller.go
@@ -1,0 +1,39 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/gorilla/mux"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/v2/application"
+)
+
+type AgentController struct {
+	dic *di.Container
+}
+
+func NewAgentController(dic *di.Container) *AgentController {
+	return &AgentController{dic: dic}
+}
+
+func (c *AgentController) GetHealth(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(c.dic.Get)
+
+	vars := mux.Vars(r)
+	services := strings.Split(vars["services"], ",")
+
+	health := application.GetHealth(services, container.RegistryFrom(c.dic.Get))
+	res := responses.NewHealthResponse("", "", http.StatusOK, health)
+	pkg.Encode(res, w, lc)
+}

--- a/internal/system/agent/v2/router.go
+++ b/internal/system/agent/v2/router.go
@@ -9,11 +9,13 @@ import (
 	"net/http"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/gorilla/mux"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	commonController "github.com/edgexfoundry/edgex-go/internal/pkg/v2/controller/http"
+	smaController "github.com/edgexfoundry/edgex-go/internal/system/agent/v2/controller/http"
 )
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container) {
@@ -24,6 +26,9 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
 	r.HandleFunc(v2.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
 	r.HandleFunc(v2.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
+
+	ac := smaController.NewAgentController(dic)
+	r.HandleFunc(v2.ApiHealthRoute, ac.GetHealth).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/openapi/v2/system-agent.yaml
+++ b/openapi/v2/system-agent.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Edgex Foundry - System Management Agent API
   description: This is the definition of the API for the System Management Agent service in the EdgeX Foundry IOT microservice platform. System Management Agent is responsible for management of EdgeX microservices and supported infrastructure.
-  version: "2.0"
+  version: 2.x
 
 servers:
   - url: "http://localhost:48090/api/v2"
@@ -82,15 +82,16 @@ components:
           example: "edgex-core-data"
     HealthResponse:
       allOf:
-        - $ref: '#/components/schemas/BaseRequest'
+        - $ref: '#/components/schemas/BaseResponse'
       type: object
-      description: "Response containing the health status for the targeted service."
+      description: "Response containing the health status for the targeted services."
       properties:
-        service:
-          type: string
-          example: "edgex-core-data"
         health:
-          type: string
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            edgex-core-data: healthy
     MetricsRequest:
       allOf:
         - $ref: '#/components/schemas/BaseRequest'
@@ -348,19 +349,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /health:
-    post:
+  /health/{services}:
+    get:
       summary: "Obtain health information from the targeted service."
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              anyOf:
-                - $ref: '#/components/schemas/HealthRequest'
-                - type: array
-                  items:
-                    $ref: '#/components/schemas/HealthRequest'
+      parameters:
+        - name: services
+          in: path
+          description: A comma-separated list of EdgeX service names to query for health.
+          required: true
+          schema:
+            type: string
       responses:
         '200':
           description: OK
@@ -371,19 +369,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthResponse'
-        '207':
-          description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  anyOf:
-                    - $ref: '#/components/schemas/ErrorResponse'
-                    - $ref: '#/components/schemas/HealthResponse'
         '400':
           description: "Bad request"
           headers:


### PR DESCRIPTION
- separate controller layer and application layer
- the application layer logic is similar to v1
- update health status from boolean true(v1) to string healthy
- update HealthResponse in SwaggerDoc

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #3418 


## What is the new behavior?
```
$ curl http://localhost:48090/api/v2/health/edgex-core-data,edgex-core-metadata
{"apiVersion":"v2","statusCode":200,"health":{"edgex-core-data":"healthy","edgex-core-metadata":"healthy"}}
```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information

There's no mock for RegistryClient, do we need to create on for testing ?
@lenny-intel @cloudxxx8 