### PR TITLE
feat(command): Add parameters field to Core Command V2 API

### DIFF
--- a/internal/core/command/v2/application/command_test.go
+++ b/internal/core/command/v2/application/command_test.go
@@ -6,6 +6,7 @@
 package application
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
@@ -31,12 +32,12 @@ func TestBuildCoreCommands(t *testing.T) {
 	profile := dtos.DeviceProfile{
 		Name: "testProfile",
 		DeviceResources: []dtos.DeviceResource{
-			{Name: resource1, Properties: dtos.ResourceProperties{ReadWrite: v2.ReadWrite_R}},
-			{Name: resource2, Properties: dtos.ResourceProperties{ReadWrite: v2.ReadWrite_W}},
-			{Name: resource3, Properties: dtos.ResourceProperties{ReadWrite: v2.ReadWrite_RW}},
-			{Name: resource4, Properties: dtos.ResourceProperties{ReadWrite: v2.ReadWrite_RW}, IsHidden: true},
-			{Name: resource5, Properties: dtos.ResourceProperties{ReadWrite: v2.ReadWrite_RW}},
-			{Name: resource6, Properties: dtos.ResourceProperties{ReadWrite: v2.ReadWrite_RW}},
+			{Name: resource1, Properties: dtos.ResourceProperties{ValueType: v2.ValueTypeString, ReadWrite: v2.ReadWrite_R}},
+			{Name: resource2, Properties: dtos.ResourceProperties{ValueType: v2.ValueTypeInt16, ReadWrite: v2.ReadWrite_W}},
+			{Name: resource3, Properties: dtos.ResourceProperties{ValueType: v2.ValueTypeBool, ReadWrite: v2.ReadWrite_RW}},
+			{Name: resource4, Properties: dtos.ResourceProperties{ValueType: v2.ValueTypeString, ReadWrite: v2.ReadWrite_RW}, IsHidden: true},
+			{Name: resource5, Properties: dtos.ResourceProperties{ValueType: v2.ValueTypeInt16, ReadWrite: v2.ReadWrite_RW}},
+			{Name: resource6, Properties: dtos.ResourceProperties{ValueType: v2.ValueTypeBool, ReadWrite: v2.ReadWrite_RW}},
 		},
 		DeviceCommands: []dtos.DeviceCommand{
 			{
@@ -60,15 +61,38 @@ func TestBuildCoreCommands(t *testing.T) {
 		},
 	}
 	expectedCoreCommand := []dtos.CoreCommand{
-		{Name: command1, Get: true, Path: commandPath(testDeviceName, command1), Url: testServiceUrl},
-		{Name: resource6, Get: true, Set: true, Path: commandPath(testDeviceName, resource6), Url: testServiceUrl},
-		{Name: resource1, Get: true, Path: commandPath(testDeviceName, resource1), Url: testServiceUrl},
-		{Name: resource2, Set: true, Path: commandPath(testDeviceName, resource2), Url: testServiceUrl},
-		{Name: resource3, Get: true, Set: true, Path: commandPath(testDeviceName, resource3), Url: testServiceUrl},
-		{Name: resource5, Get: true, Set: true, Path: commandPath(testDeviceName, resource5), Url: testServiceUrl},
+		{
+			Name: command1, Get: true, Path: commandPath(testDeviceName, command1), Url: testServiceUrl,
+			Parameters: []dtos.CoreCommandParameter{
+				{ResourceName: resource1, ValueType: v2.ValueTypeString},
+				{ResourceName: resource2, ValueType: v2.ValueTypeInt16},
+				{ResourceName: resource3, ValueType: v2.ValueTypeBool},
+			},
+		},
+		{
+			Name: resource6, Get: true, Set: true, Path: commandPath(testDeviceName, resource6), Url: testServiceUrl,
+			Parameters: []dtos.CoreCommandParameter{{ResourceName: resource6, ValueType: v2.ValueTypeBool}},
+		},
+		{
+			Name: resource1, Get: true, Path: commandPath(testDeviceName, resource1), Url: testServiceUrl,
+			Parameters: []dtos.CoreCommandParameter{{ResourceName: resource1, ValueType: v2.ValueTypeString}},
+		},
+		{
+			Name: resource2, Set: true, Path: commandPath(testDeviceName, resource2), Url: testServiceUrl,
+			Parameters: []dtos.CoreCommandParameter{{ResourceName: resource2, ValueType: v2.ValueTypeInt16}},
+		},
+		{
+			Name: resource3, Get: true, Set: true, Path: commandPath(testDeviceName, resource3), Url: testServiceUrl,
+			Parameters: []dtos.CoreCommandParameter{{ResourceName: resource3, ValueType: v2.ValueTypeBool}},
+		},
+		{
+			Name: resource5, Get: true, Set: true, Path: commandPath(testDeviceName, resource5), Url: testServiceUrl,
+			Parameters: []dtos.CoreCommandParameter{{ResourceName: resource5, ValueType: v2.ValueTypeInt16}},
+		},
 	}
 
-	result := buildCoreCommands(testDeviceName, testServiceUrl, profile)
+	result, err := buildCoreCommands(testDeviceName, testServiceUrl, profile)
+	require.NoError(t, err)
 
 	assert.ElementsMatch(t, expectedCoreCommand, result)
 }

--- a/openapi/v2/core-command.yaml
+++ b/openapi/v2/core-command.yaml
@@ -55,6 +55,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CoreCommand'
+    CoreCommandParameter:
+      description: "Indicate the core command expected readings or parameters. For Get command, it describes the expected readings. For Set command, it describes the parameters in the payload."
+      type: object
+      properties:
+        resourceName:
+          type: string
+        valueType:
+          type: string
     CoreCommand:
       type: object
       properties:
@@ -68,6 +76,10 @@ components:
           type: string
         url:
           type: string
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/CoreCommandParameter'
     DeviceCoreCommandResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -390,10 +402,12 @@ components:
                 get: true
                 path: "/api/v2/device/name/testDevice/command/coolingpoint1"
                 url: "http://localhost:48082"
+                parameters: [ {"resourceName":"resource1","valueType":"Int32"} ]
               - name: "coolingpoint2"
                 set: true
                 path: "/api/v2/device/name/testDevice/command/coolingpoint2"
                 url: "http://localhost:48082"
+                parameters: [ {"resourceName":"resource5","valueType":"String"},{"resourceName":"resource6","valueType":"Bool"}  ]
     MultiDeviceCoreCommandsExample:
       value:
         apiVersion: "v2"
@@ -406,10 +420,12 @@ components:
               get: true
               path: "/api/v2/device/name/testDevice1/command/coolingpoint1"
               url: "http://localhost:48082"
+              parameters: [ {"resourceName":"resource1","valueType":"Int32"} ]
             - name: "coolingpoint2"
               set: true
               path: "/api/v2/device/name/testDevice1/command/coolingpoint2"
               url: "http://localhost:48082"
+              parameters: [ {"resourceName":"resource2","valueType":"Int16"},{"resourceName":"resource3","valueType":"Int32"}  ]
           - deviceName: "testDevice2"
             profileName: "testProfile"
             coreCommands:
@@ -417,10 +433,12 @@ components:
               get: true
               path: "/api/v2/device/name/testDevice2/command/coolingpoint1"
               url: "http://localhost:48082"
+              parameters: [ {"resourceName":"resource4","valueType":"Int32"} ]
             - name: "coolingpoint2"
               set: true
               path: "/api/v2/device/name/testDevice2/command/coolingpoint2"
               url: "http://localhost:48082"
+              parameters: [ {"resourceName":"resource5","valueType":"String"},{"resourceName":"resource6","valueType":"Bool"}  ]
 paths:
   /device/name/{name}/{command}:
     parameters:


### PR DESCRIPTION
Close: #3434

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3434


## What is the new behavior?
Add a field called parameters to Core Command V2 API. For Get command, it describes the expected readings. For Set command, it describes the parameters in the payload.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information