### PR TITLE
refactor: combine and improve http LoggingMiddleware

### DIFF
--- a/internal/core/command/router.go
+++ b/internal/core/command/router.go
@@ -63,8 +63,7 @@ func loadRestRoutes(r *mux.Router, dic *di.Container) {
 	loadDeviceRoutes(b, dic)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(bootstrapContainer.LoggingClientFrom(dic.Get)))
 }
 
 func loadDeviceRoutes(b *mux.Router, dic *di.Container) {

--- a/internal/core/command/v2/router.go
+++ b/internal/core/command/v2/router.go
@@ -8,31 +8,32 @@ package v2
 import (
 	"net/http"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/gorilla/mux"
+
 	commandController "github.com/edgexfoundry/edgex-go/internal/core/command/v2/controller/http"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	commonController "github.com/edgexfoundry/edgex-go/internal/pkg/v2/controller/http"
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	v2Constant "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
-	"github.com/gorilla/mux"
 )
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	// v2 API routes
 	// Common
 	cc := commonController.NewV2CommonController(dic)
-	r.HandleFunc(v2Constant.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
 
 	// Command
 	cmd := commandController.NewCommandController(dic)
-	r.HandleFunc(v2Constant.ApiAllDeviceRoute, cmd.AllCommands).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceByNameRoute, cmd.CommandsByDeviceName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceNameCommandNameRoute, cmd.IssueGetCommandByName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceNameCommandNameRoute, cmd.IssueSetCommandByName).Methods(http.MethodPut)
+	r.HandleFunc(v2.ApiAllDeviceRoute, cmd.AllCommands).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceByNameRoute, cmd.CommandsByDeviceName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceNameCommandNameRoute, cmd.IssueGetCommandByName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceNameCommandNameRoute, cmd.IssueSetCommandByName).Methods(http.MethodPut)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))
 }

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -476,8 +476,7 @@ func loadRestRoutes(r *mux.Router, dic *di.Container) {
 		}).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(bootstrapContainer.LoggingClientFrom(dic.Get)))
 }
 
 /*

--- a/internal/core/data/v2/router.go
+++ b/internal/core/data/v2/router.go
@@ -1,50 +1,54 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package v2
 
 import (
 	"net/http"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/gorilla/mux"
+
 	dataController "github.com/edgexfoundry/edgex-go/internal/core/data/v2/controller/http"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	commonController "github.com/edgexfoundry/edgex-go/internal/pkg/v2/controller/http"
-
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	v2Constant "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
-
-	"github.com/gorilla/mux"
 )
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	// v2 API routes
 	// Common
 	cc := commonController.NewV2CommonController(dic)
-	r.HandleFunc(v2Constant.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
 
 	// Events
 	ec := dataController.NewEventController(dic)
-	r.HandleFunc(v2Constant.ApiEventProfileNameDeviceNameSourceNameRoute, ec.AddEvent).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.EventById).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiEventIdRoute, ec.DeleteEventById).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiEventCountRoute, ec.EventTotalCount).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiEventCountByDeviceNameRoute, ec.EventCountByDeviceName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiAllEventRoute, ec.AllEvents).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.EventsByDeviceName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiEventByDeviceNameRoute, ec.DeleteEventsByDeviceName).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiEventByTimeRangeRoute, ec.EventsByTimeRange).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiEventByAgeRoute, ec.DeleteEventsByAge).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiEventProfileNameDeviceNameSourceNameRoute, ec.AddEvent).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiEventIdRoute, ec.EventById).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiEventIdRoute, ec.DeleteEventById).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiEventCountRoute, ec.EventTotalCount).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiEventCountByDeviceNameRoute, ec.EventCountByDeviceName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiAllEventRoute, ec.AllEvents).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiEventByDeviceNameRoute, ec.EventsByDeviceName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiEventByDeviceNameRoute, ec.DeleteEventsByDeviceName).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiEventByTimeRangeRoute, ec.EventsByTimeRange).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiEventByAgeRoute, ec.DeleteEventsByAge).Methods(http.MethodDelete)
 
 	// Readings
 	rc := dataController.NewReadingController(dic)
-	r.HandleFunc(v2Constant.ApiReadingCountRoute, rc.ReadingTotalCount).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiAllReadingRoute, rc.AllReadings).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiReadingByDeviceNameRoute, rc.ReadingsByDeviceName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiReadingByTimeRangeRoute, rc.ReadingsByTimeRange).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiReadingByResourceNameRoute, rc.ReadingsByResourceName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiReadingCountByDeviceNameRoute, rc.ReadingCountByDeviceName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiReadingCountRoute, rc.ReadingTotalCount).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiAllReadingRoute, rc.AllReadings).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiReadingByDeviceNameRoute, rc.ReadingsByDeviceName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiReadingByTimeRangeRoute, rc.ReadingsByTimeRange).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiReadingByResourceNameRoute, rc.ReadingsByResourceName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiReadingCountByDeviceNameRoute, rc.ReadingCountByDeviceName).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))
 }

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -68,8 +68,7 @@ func loadRestRoutes(r *mux.Router, dic *di.Container) {
 	loadCommandRoutes(b, dic)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(bootstrapContainer.LoggingClientFrom(dic.Get)))
 }
 
 func loadDeviceRoutes(b *mux.Router, dic *di.Container) {

--- a/internal/core/metadata/v2/router.go
+++ b/internal/core/metadata/v2/router.go
@@ -8,72 +8,71 @@ package v2
 import (
 	"net/http"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/gorilla/mux"
+
 	metadataController "github.com/edgexfoundry/edgex-go/internal/core/metadata/v2/controller/http"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	commonController "github.com/edgexfoundry/edgex-go/internal/pkg/v2/controller/http"
-
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	v2Constant "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
-
-	"github.com/gorilla/mux"
 )
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	// v2 API routes
 	// Common
 	cc := commonController.NewV2CommonController(dic)
-	r.HandleFunc(v2Constant.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
 
 	// Device Profile
 	dc := metadataController.NewDeviceProfileController(dic)
-	r.HandleFunc(v2Constant.ApiDeviceProfileRoute, dc.AddDeviceProfile).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiDeviceProfileRoute, dc.UpdateDeviceProfile).Methods(http.MethodPut)
-	r.HandleFunc(v2Constant.ApiDeviceProfileUploadFileRoute, dc.AddDeviceProfileByYaml).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiDeviceProfileUploadFileRoute, dc.UpdateDeviceProfileByYaml).Methods(http.MethodPut)
-	r.HandleFunc(v2Constant.ApiDeviceProfileByNameRoute, dc.DeviceProfileByName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceProfileByNameRoute, dc.DeleteDeviceProfileByName).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiAllDeviceProfileRoute, dc.AllDeviceProfiles).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceProfileByModelRoute, dc.DeviceProfilesByModel).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceProfileByManufacturerRoute, dc.DeviceProfilesByManufacturer).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceProfileByManufacturerAndModelRoute, dc.DeviceProfilesByManufacturerAndModel).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceProfileRoute, dc.AddDeviceProfile).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiDeviceProfileRoute, dc.UpdateDeviceProfile).Methods(http.MethodPut)
+	r.HandleFunc(v2.ApiDeviceProfileUploadFileRoute, dc.AddDeviceProfileByYaml).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiDeviceProfileUploadFileRoute, dc.UpdateDeviceProfileByYaml).Methods(http.MethodPut)
+	r.HandleFunc(v2.ApiDeviceProfileByNameRoute, dc.DeviceProfileByName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceProfileByNameRoute, dc.DeleteDeviceProfileByName).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiAllDeviceProfileRoute, dc.AllDeviceProfiles).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceProfileByModelRoute, dc.DeviceProfilesByModel).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceProfileByManufacturerRoute, dc.DeviceProfilesByManufacturer).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceProfileByManufacturerAndModelRoute, dc.DeviceProfilesByManufacturerAndModel).Methods(http.MethodGet)
 
 	// Device Resource
 	dr := metadataController.NewDeviceResourceController(dic)
-	r.HandleFunc(v2Constant.ApiDeviceResourceByProfileAndResourceRoute, dr.DeviceResourceByProfileNameAndResourceName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceResourceByProfileAndResourceRoute, dr.DeviceResourceByProfileNameAndResourceName).Methods(http.MethodGet)
 
 	// Device Service
 	ds := metadataController.NewDeviceServiceController(dic)
-	r.HandleFunc(v2Constant.ApiDeviceServiceRoute, ds.AddDeviceService).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiDeviceServiceRoute, ds.PatchDeviceService).Methods(http.MethodPatch)
-	r.HandleFunc(v2Constant.ApiDeviceServiceByNameRoute, ds.DeviceServiceByName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceServiceByNameRoute, ds.DeleteDeviceServiceByName).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiAllDeviceServiceRoute, ds.AllDeviceServices).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceServiceRoute, ds.AddDeviceService).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiDeviceServiceRoute, ds.PatchDeviceService).Methods(http.MethodPatch)
+	r.HandleFunc(v2.ApiDeviceServiceByNameRoute, ds.DeviceServiceByName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceServiceByNameRoute, ds.DeleteDeviceServiceByName).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiAllDeviceServiceRoute, ds.AllDeviceServices).Methods(http.MethodGet)
 
 	// Device
 	d := metadataController.NewDeviceController(dic)
-	r.HandleFunc(v2Constant.ApiDeviceRoute, d.AddDevice).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiDeviceByNameRoute, d.DeleteDeviceByName).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiDeviceByServiceNameRoute, d.DevicesByServiceName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceNameExistsRoute, d.DeviceNameExists).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceRoute, d.PatchDevice).Methods(http.MethodPatch)
-	r.HandleFunc(v2Constant.ApiAllDeviceRoute, d.AllDevices).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceByNameRoute, d.DeviceByName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiDeviceByProfileNameRoute, d.DevicesByProfileName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceRoute, d.AddDevice).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiDeviceByNameRoute, d.DeleteDeviceByName).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiDeviceByServiceNameRoute, d.DevicesByServiceName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceNameExistsRoute, d.DeviceNameExists).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceRoute, d.PatchDevice).Methods(http.MethodPatch)
+	r.HandleFunc(v2.ApiAllDeviceRoute, d.AllDevices).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceByNameRoute, d.DeviceByName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiDeviceByProfileNameRoute, d.DevicesByProfileName).Methods(http.MethodGet)
 
 	// ProvisionWatcher
 	pwc := metadataController.NewProvisionWatcherController(dic)
-	r.HandleFunc(v2Constant.ApiProvisionWatcherRoute, pwc.AddProvisionWatcher).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiProvisionWatcherByNameRoute, pwc.ProvisionWatcherByName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiProvisionWatcherByServiceNameRoute, pwc.ProvisionWatchersByServiceName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiProvisionWatcherByProfileNameRoute, pwc.ProvisionWatchersByProfileName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiAllProvisionWatcherRoute, pwc.AllProvisionWatchers).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiProvisionWatcherByNameRoute, pwc.DeleteProvisionWatcherByName).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiProvisionWatcherRoute, pwc.PatchProvisionWatcher).Methods(http.MethodPatch)
+	r.HandleFunc(v2.ApiProvisionWatcherRoute, pwc.AddProvisionWatcher).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiProvisionWatcherByNameRoute, pwc.ProvisionWatcherByName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiProvisionWatcherByServiceNameRoute, pwc.ProvisionWatchersByServiceName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiProvisionWatcherByProfileNameRoute, pwc.ProvisionWatchersByProfileName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiAllProvisionWatcherRoute, pwc.AllProvisionWatchers).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiProvisionWatcherByNameRoute, pwc.DeleteProvisionWatcherByName).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiProvisionWatcherRoute, pwc.PatchProvisionWatcher).Methods(http.MethodPatch)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))
 }

--- a/internal/support/notifications/router.go
+++ b/internal/support/notifications/router.go
@@ -409,6 +409,5 @@ func loadRestRoutes(r *mux.Router, dic *di.Container) {
 		}).Methods(http.MethodDelete)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(bootstrapContainer.LoggingClientFrom(dic.Get)))
 }

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -7,54 +7,53 @@ package v2
 import (
 	"net/http"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/gorilla/mux"
+
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	commonController "github.com/edgexfoundry/edgex-go/internal/pkg/v2/controller/http"
 	notificationsController "github.com/edgexfoundry/edgex-go/internal/support/notifications/v2/controller/http"
-
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	v2Constant "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
-
-	"github.com/gorilla/mux"
 )
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	// v2 API routes
 	// Common
 	cc := commonController.NewV2CommonController(dic)
-	r.HandleFunc(v2Constant.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
 
 	// Subscription
 	sc := notificationsController.NewSubscriptionController(dic)
-	r.HandleFunc(v2Constant.ApiSubscriptionRoute, sc.AddSubscription).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiAllSubscriptionRoute, sc.AllSubscriptions).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiSubscriptionByNameRoute, sc.SubscriptionByName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiSubscriptionByCategoryRoute, sc.SubscriptionsByCategory).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiSubscriptionByLabelRoute, sc.SubscriptionsByLabel).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiSubscriptionByReceiverRoute, sc.SubscriptionsByReceiver).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiSubscriptionByNameRoute, sc.DeleteSubscriptionByName).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiSubscriptionRoute, sc.PatchSubscription).Methods(http.MethodPatch)
+	r.HandleFunc(v2.ApiSubscriptionRoute, sc.AddSubscription).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiAllSubscriptionRoute, sc.AllSubscriptions).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiSubscriptionByNameRoute, sc.SubscriptionByName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiSubscriptionByCategoryRoute, sc.SubscriptionsByCategory).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiSubscriptionByLabelRoute, sc.SubscriptionsByLabel).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiSubscriptionByReceiverRoute, sc.SubscriptionsByReceiver).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiSubscriptionByNameRoute, sc.DeleteSubscriptionByName).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiSubscriptionRoute, sc.PatchSubscription).Methods(http.MethodPatch)
 
 	// Notification
 	nc := notificationsController.NewNotificationController(dic)
-	r.HandleFunc(v2Constant.ApiNotificationRoute, nc.AddNotification).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiNotificationByIdRoute, nc.NotificationById).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiNotificationByIdRoute, nc.DeleteNotificationById).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiNotificationByCategoryRoute, nc.NotificationsByCategory).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiNotificationByLabelRoute, nc.NotificationsByLabel).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiNotificationByStatusRoute, nc.NotificationsByStatus).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiNotificationByTimeRangeRoute, nc.NotificationsByTimeRange).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiNotificationBySubscriptionNameRoute, nc.NotificationsBySubscriptionName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiNotificationCleanupByAgeRoute, nc.CleanupNotificationsByAge).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiNotificationCleanupRoute, nc.CleanupNotifications).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiNotificationRoute, nc.AddNotification).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiNotificationByIdRoute, nc.NotificationById).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiNotificationByIdRoute, nc.DeleteNotificationById).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiNotificationByCategoryRoute, nc.NotificationsByCategory).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiNotificationByLabelRoute, nc.NotificationsByLabel).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiNotificationByStatusRoute, nc.NotificationsByStatus).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiNotificationByTimeRangeRoute, nc.NotificationsByTimeRange).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiNotificationBySubscriptionNameRoute, nc.NotificationsBySubscriptionName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiNotificationCleanupByAgeRoute, nc.CleanupNotificationsByAge).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiNotificationCleanupRoute, nc.CleanupNotifications).Methods(http.MethodDelete)
 
 	// Transmission
 	trans := notificationsController.NewTransmissionController(dic)
-	r.HandleFunc(v2Constant.ApiTransmissionByIdRoute, trans.TransmissionById).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiTransmissionByIdRoute, trans.TransmissionById).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))
 }

--- a/internal/support/scheduler/router.go
+++ b/internal/support/scheduler/router.go
@@ -221,6 +221,5 @@ func loadRestRoutes(r *mux.Router, dic *di.Container) {
 		}).Methods(http.MethodDelete)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(bootstrapContainer.LoggingClientFrom(dic.Get)))
 }

--- a/internal/support/scheduler/v2/router.go
+++ b/internal/support/scheduler/v2/router.go
@@ -7,42 +7,41 @@ package v2
 import (
 	"net/http"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/gorilla/mux"
+
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	commonController "github.com/edgexfoundry/edgex-go/internal/pkg/v2/controller/http"
 	schedulerController "github.com/edgexfoundry/edgex-go/internal/support/scheduler/v2/controller/http"
-
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	v2Constant "github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
-
-	"github.com/gorilla/mux"
 )
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	// v2 API routes
 	// Common
 	cc := commonController.NewV2CommonController(dic)
-	r.HandleFunc(v2Constant.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiVersionRoute, cc.Version).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiConfigRoute, cc.Config).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiMetricsRoute, cc.Metrics).Methods(http.MethodGet)
 
 	// Interval
 	interval := schedulerController.NewIntervalController(dic)
-	r.HandleFunc(v2Constant.ApiIntervalRoute, interval.AddInterval).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiIntervalByNameRoute, interval.IntervalByName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiAllIntervalRoute, interval.AllIntervals).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiIntervalByNameRoute, interval.DeleteIntervalByName).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiIntervalRoute, interval.PatchInterval).Methods(http.MethodPatch)
+	r.HandleFunc(v2.ApiIntervalRoute, interval.AddInterval).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiIntervalByNameRoute, interval.IntervalByName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiAllIntervalRoute, interval.AllIntervals).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiIntervalByNameRoute, interval.DeleteIntervalByName).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiIntervalRoute, interval.PatchInterval).Methods(http.MethodPatch)
 
 	// IntervalAction
 	action := schedulerController.NewIntervalActionController(dic)
-	r.HandleFunc(v2Constant.ApiIntervalActionRoute, action.AddIntervalAction).Methods(http.MethodPost)
-	r.HandleFunc(v2Constant.ApiAllIntervalActionRoute, action.AllIntervalActions).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiIntervalActionByNameRoute, action.IntervalActionByName).Methods(http.MethodGet)
-	r.HandleFunc(v2Constant.ApiIntervalActionByNameRoute, action.DeleteIntervalActionByName).Methods(http.MethodDelete)
-	r.HandleFunc(v2Constant.ApiIntervalActionRoute, action.PatchIntervalAction).Methods(http.MethodPatch)
+	r.HandleFunc(v2.ApiIntervalActionRoute, action.AddIntervalAction).Methods(http.MethodPost)
+	r.HandleFunc(v2.ApiAllIntervalActionRoute, action.AllIntervalActions).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiIntervalActionByNameRoute, action.IntervalActionByName).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiIntervalActionByNameRoute, action.DeleteIntervalActionByName).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiIntervalActionRoute, action.PatchIntervalAction).Methods(http.MethodPatch)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))
 }

--- a/internal/system/agent/router.go
+++ b/internal/system/agent/router.go
@@ -74,8 +74,7 @@ func loadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(clients.ApiVersionRoute, pkg.VersionHandler).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(bootstrapContainer.LoggingClientFrom(dic.Get)))
 }
 
 // metricsHandler implements a controller to execute a metrics request.

--- a/internal/system/agent/v2/router.go
+++ b/internal/system/agent/v2/router.go
@@ -8,10 +8,10 @@ package v2
 import (
 	"net/http"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/gorilla/mux"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/gorilla/mux"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	commonController "github.com/edgexfoundry/edgex-go/internal/pkg/v2/controller/http"
@@ -31,6 +31,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2.ApiHealthRoute, ac.GetHealth).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
-	r.Use(correlation.OnResponseComplete)
-	r.Use(correlation.OnRequestBegin)
+	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))
 }


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The original LoggingMiddleware would never work because `LoggingClient` wasn't initialized.
https://github.com/edgexfoundry/edgex-go/blob/6b23ec567a86ee52455607061a4fabaca114589a/internal/pkg/correlation/middleware.go#L38-L40

## Issue Number: fix #3369 


## What is the new behavior?
`LoggingClient` is correctly passed into Middleware func as a parameter, now the trace log will correctly shown:
```
level=TRACE ts=2021-05-10T09:30:32.4995448Z app=edgex-core-metadata source=middleware.go:37 X-Correlation-ID=a635250c-d679-429f-a5af-22c41d1e9ad3 path=/api/v2/deviceservice/all msg="Begin request"
level=TRACE ts=2021-05-10T09:30:32.5007807Z app=edgex-core-metadata source=middleware.go:39 X-Correlation-ID=a635250c-d679-429f-a5af-22c41d1e9ad3 duration=1.2372ms msg="Response complete"

```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
Currently the log is duplicated as LoggingMiddleware is added for the same router in both v1 and v2 `loadRestRoutes` function, once v1 code is removed in the future it should be good.
