### PR TITLE
fix(notifications): fix using the wrong key to update Subscription

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/subscription.go
+++ b/internal/pkg/v2/infrastructure/redis/subscription.go
@@ -213,7 +213,7 @@ func updateSubscription(conn redis.Conn, subscription models.Subscription) error
 		return errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
 	subscription.Modified = common.MakeTimestamp()
-	storedKey := intervalActionStoredKey(subscription.Id)
+	storedKey := subscriptionStoredKey(subscription.Id)
 
 	_ = conn.Send(MULTI)
 	sendDeleteSubscriptionCmd(conn, storedKey, oldSubscription)


### PR DESCRIPTION
Fix: #3344
Signed-off-by: weichou <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3344 


## What is the new behavior?
fix using the wrong key to update Subscription

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information