### PR TITLE
fix: Rework Secure MessageBus to remove ZMQ dependency for all services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,40 +52,40 @@ ARCH=$(shell uname -m)
 build: $(MICROSERVICES)
 
 cmd/core-metadata/core-metadata:
-	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd/core-metadata
+	$(GO) build $(GOFLAGS) -o $@ ./cmd/core-metadata
 
 cmd/core-data/core-data:
 	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd/core-data
 
 cmd/core-command/core-command:
-	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd/core-command
+	$(GO) build $(GOFLAGS) -o $@ ./cmd/core-command
 
 cmd/support-notifications/support-notifications:
-	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd/support-notifications
+	$(GO) build $(GOFLAGS) -o $@ ./cmd/support-notifications
 
 cmd/sys-mgmt-executor/sys-mgmt-executor:
-	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd/sys-mgmt-executor
+	$(GO) build $(GOFLAGS) -o $@ ./cmd/sys-mgmt-executor
 
 cmd/sys-mgmt-agent/sys-mgmt-agent:
-	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd/sys-mgmt-agent
+	$(GO) build $(GOFLAGS) -o $@ ./cmd/sys-mgmt-agent
 
 cmd/support-scheduler/support-scheduler:
-	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd/support-scheduler
+	$(GO) build $(GOFLAGS) -o $@ ./cmd/support-scheduler
 
 cmd/security-proxy-setup/security-proxy-setup:
-	$(GOCGO) build $(GOFLAGS) -o ./cmd/security-proxy-setup/security-proxy-setup ./cmd/security-proxy-setup
+	$(GO) build $(GOFLAGS) -o ./cmd/security-proxy-setup/security-proxy-setup ./cmd/security-proxy-setup
 
 cmd/security-secretstore-setup/security-secretstore-setup:
-	$(GOCGO) build $(GOFLAGS) -o ./cmd/security-secretstore-setup/security-secretstore-setup ./cmd/security-secretstore-setup
+	$(GO) build $(GOFLAGS) -o ./cmd/security-secretstore-setup/security-secretstore-setup ./cmd/security-secretstore-setup
 
 cmd/security-file-token-provider/security-file-token-provider:
-	$(GOCGO) build $(GOFLAGS) -o ./cmd/security-file-token-provider/security-file-token-provider ./cmd/security-file-token-provider
+	$(GO) build $(GOFLAGS) -o ./cmd/security-file-token-provider/security-file-token-provider ./cmd/security-file-token-provider
 
 cmd/secrets-config/secrets-config:
-	$(GOCGO) build $(GOFLAGS) -o ./cmd/secrets-config ./cmd/secrets-config
+	$(GO) build $(GOFLAGS) -o ./cmd/secrets-config ./cmd/secrets-config
 
 cmd/security-bootstrapper/security-bootstrapper:
-	$(GOCGO) build $(GOFLAGS) -o ./cmd/security-bootstrapper/security-bootstrapper ./cmd/security-bootstrapper
+	$(GO) build $(GOFLAGS) -o ./cmd/security-bootstrapper/security-bootstrapper ./cmd/security-bootstrapper
 
 clean:
 	rm -f $(MICROSERVICES)

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -34,6 +34,7 @@ RUN go mod download
 
 COPY . .
 
+RUN go mod tidy
 RUN make cmd/core-command/core-command
 
 FROM alpine:3.12

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -34,6 +34,8 @@ COPY go.mod .
 RUN go mod download
 
 COPY . .
+
+RUN go mod tidy
 RUN make cmd/core-data/core-data
 
 #Next image - Copy built Go binary into new workspace

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -33,6 +33,8 @@ COPY go.mod .
 RUN go mod download
 
 COPY . .
+
+RUN go mod tidy
 RUN make cmd/core-metadata/core-metadata
 
 #Next image - Copy built Go binary into new workspace

--- a/cmd/security-bootstrapper/Dockerfile
+++ b/cmd/security-bootstrapper/Dockerfile
@@ -32,6 +32,7 @@ RUN go mod download
 
 COPY . .
 
+RUN go mod tidy
 RUN make cmd/security-bootstrapper/security-bootstrapper
 
 FROM alpine:3.12

--- a/cmd/security-proxy-setup/Dockerfile
+++ b/cmd/security-proxy-setup/Dockerfile
@@ -31,6 +31,7 @@ RUN go mod download
 
 COPY . .
 
+RUN go mod tidy
 RUN make cmd/security-proxy-setup/security-proxy-setup cmd/secrets-config/secrets-config
 
 FROM alpine:3.12

--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -31,6 +31,7 @@ RUN go mod download
 
 COPY . .
 
+RUN go mod tidy
 RUN make cmd/security-file-token-provider/security-file-token-provider \
   cmd/security-secretstore-setup/security-secretstore-setup
 

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -32,6 +32,8 @@ COPY go.mod .
 RUN go mod download
 
 COPY . .
+
+RUN go mod tidy
 RUN make cmd/support-notifications/support-notifications
 
 FROM alpine:3.12

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -33,6 +33,8 @@ COPY go.mod .
 RUN go mod download
 
 COPY . .
+
+RUN go mod tidy
 RUN make cmd/support-scheduler/support-scheduler
 
 FROM alpine:3.12

--- a/cmd/sys-mgmt-agent/Dockerfile
+++ b/cmd/sys-mgmt-agent/Dockerfile
@@ -22,6 +22,8 @@ RUN go mod download
 
 COPY . .
 
+RUN go mod tidy
+
 # Build the SMA executable.
 RUN make cmd/sys-mgmt-agent/sys-mgmt-agent
 

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.46
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.52
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.8
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.81
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.83
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.13
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.20

--- a/internal/core/command/config/config.go
+++ b/internal/core/command/config/config.go
@@ -96,8 +96,3 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return c.Writable.InsecureSecrets
 }
-
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}

--- a/internal/core/data/config/config.go
+++ b/internal/core/data/config/config.go
@@ -102,8 +102,3 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return c.Writable.InsecureSecrets
 }
-
-// GetMessageBusInfo returns the service's MessageQueue configuration.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return c.MessageQueue
-}

--- a/internal/core/data/container/messaging.go
+++ b/internal/core/data/container/messaging.go
@@ -24,5 +24,10 @@ var MessagingClientName = di.TypeInstanceToName((*messaging.MessageClient)(nil))
 
 // MessagingClientFrom helper function queries the DIC and returns the messaging client.
 func MessagingClientFrom(get di.Get) messaging.MessageClient {
-	return get(MessagingClientName).(messaging.MessageClient)
+	client, ok := get(MessagingClientName).(messaging.MessageClient)
+	if !ok {
+		return nil
+	}
+
+	return client
 }

--- a/internal/core/data/main.go
+++ b/internal/core/data/main.go
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
+
 package data
 
 import (
@@ -22,11 +23,11 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
 	dataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/container"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/messaging"
 	v2DataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/v2/bootstrap/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers/database"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	v2Handlers "github.com/edgexfoundry/edgex-go/internal/pkg/v2/bootstrap/handlers"
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/flags"

--- a/internal/core/data/messaging/messaging.go
+++ b/internal/core/data/messaging/messaging.go
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package messaging
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/data/container"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	messaging2 "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-messaging/v2/messaging"
+	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
+)
+
+// BootstrapHandler fulfills the BootstrapHandler contract.  if enabled, tt creates and initializes the Messaging client
+// and adds it to the DIC
+func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
+
+	messageBusInfo.AuthMode = strings.ToLower(strings.TrimSpace(messageBusInfo.AuthMode))
+	if len(messageBusInfo.AuthMode) > 0 && messageBusInfo.AuthMode != messaging2.AuthModeNone {
+		if err := messaging2.SetOptionsAuthData(&messageBusInfo, lc, dic); err != nil {
+			lc.Error(err.Error())
+			return false
+		}
+	}
+
+	msgClient, err := messaging.NewMessageClient(
+		types.MessageBusConfig{
+			PublishHost: types.HostInfo{
+				Host:     messageBusInfo.Host,
+				Port:     messageBusInfo.Port,
+				Protocol: messageBusInfo.Protocol,
+			},
+			Type:     messageBusInfo.Type,
+			Optional: messageBusInfo.Optional,
+		})
+
+	if err != nil {
+		lc.Errorf("Failed to create MessageClient: %v", err)
+		return false
+	}
+
+	for startupTimer.HasNotElapsed() {
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+			err = msgClient.Connect()
+			if err != nil {
+				lc.Warnf("Unable to connect MessageBus: %w", err)
+				startupTimer.SleepForInterval()
+				continue
+			}
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				select {
+				case <-ctx.Done():
+					if msgClient != nil {
+						_ = msgClient.Disconnect()
+					}
+					lc.Infof("Disconnected from MessageBus")
+				}
+			}()
+
+			dic.Update(di.ServiceConstructorMap{
+				container.MessagingClientName: func(get di.Get) interface{} {
+					return msgClient
+				},
+			})
+
+			lc.Info(fmt.Sprintf(
+				"Connected to %s Message Bus @ %s://%s:%d publishing on '%s' prefix topic with AuthMode='%s'",
+				messageBusInfo.Type,
+				messageBusInfo.Protocol,
+				messageBusInfo.Host,
+				messageBusInfo.Port,
+				messageBusInfo.PublishTopicPrefix,
+				messageBusInfo.AuthMode))
+
+			return true
+		}
+	}
+
+	lc.Error("Connecting to MessageBus time out")
+	return false
+}

--- a/internal/core/data/messaging/messaging.go
+++ b/internal/core/data/messaging/messaging.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/container"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
-	messaging2 "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
+	bootstrapMessaging "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-messaging/v2/messaging"
@@ -36,8 +36,8 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
 
 	messageBusInfo.AuthMode = strings.ToLower(strings.TrimSpace(messageBusInfo.AuthMode))
-	if len(messageBusInfo.AuthMode) > 0 && messageBusInfo.AuthMode != messaging2.AuthModeNone {
-		if err := messaging2.SetOptionsAuthData(&messageBusInfo, lc, dic); err != nil {
+	if len(messageBusInfo.AuthMode) > 0 && messageBusInfo.AuthMode != bootstrapMessaging.AuthModeNone {
+		if err := bootstrapMessaging.SetOptionsAuthData(&messageBusInfo, lc, dic); err != nil {
 			lc.Error(err.Error())
 			return false
 		}

--- a/internal/core/data/messaging/messaging_test.go
+++ b/internal/core/data/messaging/messaging_test.go
@@ -1,0 +1,108 @@
+package messaging
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	config2 "github.com/edgexfoundry/edgex-go/internal/core/data/config"
+	"github.com/edgexfoundry/edgex-go/internal/core/data/container"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces/mocks"
+	messaging2 "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-messaging/v2/messaging"
+	"github.com/stretchr/testify/assert"
+)
+
+var lc logger.LoggingClient
+var dic *di.Container
+var usernameSecretData = map[string]string{
+	messaging2.SecretUsernameKey: "username",
+	messaging2.SecretPasswordKey: "password",
+}
+
+func TestMain(m *testing.M) {
+	lc = logger.NewMockClient()
+
+	dic = di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return lc
+		},
+	})
+
+	os.Exit(m.Run())
+}
+
+func TestBootstrapHandler(t *testing.T) {
+	validCreateClient := config2.ConfigurationStruct{
+		MessageQueue: config.MessageBusInfo{
+			Type:               messaging.ZeroMQ, // Use ZMQ so no issue connecting.
+			Protocol:           "http",
+			Host:               "*",
+			Port:               8765,
+			PublishTopicPrefix: "edgex/events/#",
+			AuthMode:           messaging2.AuthModeUsernamePassword,
+			SecretName:         "redisdb",
+		},
+	}
+
+	invalidSecrets := config2.ConfigurationStruct{
+		MessageQueue: config.MessageBusInfo{
+			AuthMode:   messaging2.AuthModeCert,
+			SecretName: "redisdb",
+		},
+	}
+
+	invalidNoConnect := config2.ConfigurationStruct{
+		MessageQueue: config.MessageBusInfo{
+			Type:       messaging.MQTT, // This will cause no connection since broker not available
+			Protocol:   "tcp",
+			Host:       "localhost",
+			Port:       8765,
+			AuthMode:   messaging2.AuthModeUsernamePassword,
+			SecretName: "redisdb",
+		},
+	}
+
+	tests := []struct {
+		Name           string
+		Config         config2.ConfigurationStruct
+		ExpectedResult bool
+		ExpectClient   bool
+	}{
+		{"Valid - creates client", validCreateClient, true, true},
+		{"Invalid - secrets error", invalidSecrets, false, false},
+		{"Invalid - can't connect", invalidNoConnect, false, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			provider := &mocks.SecretProvider{}
+			provider.On("GetSecret", test.Config.MessageQueue.SecretName).Return(usernameSecretData, nil)
+			dic.Update(di.ServiceConstructorMap{
+				bootstrapContainer.ConfigurationInterfaceName: func(get di.Get) interface{} {
+					return test.Config
+				},
+				bootstrapContainer.SecretProviderName: func(get di.Get) interface{} {
+					return provider
+				},
+				container.MessagingClientName: func(get di.Get) interface{} {
+					return nil
+				},
+			})
+
+			actual := BootstrapHandler(context.Background(), &sync.WaitGroup{}, startup.NewTimer(1, 1), dic)
+			assert.Equal(t, test.ExpectedResult, actual)
+			if test.ExpectClient {
+				assert.NotNil(t, container.MessagingClientFrom(dic.Get))
+			} else {
+				assert.Nil(t, container.MessagingClientFrom(dic.Get))
+			}
+		})
+	}
+}

--- a/internal/core/metadata/config/config.go
+++ b/internal/core/metadata/config/config.go
@@ -108,8 +108,3 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return c.Writable.InsecureSecrets
 }
-
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}

--- a/internal/security/bootstrapper/config/config.go
+++ b/internal/security/bootstrapper/config/config.go
@@ -74,11 +74,6 @@ func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecre
 	return nil
 }
 
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}
-
 // GetRoleNames gets the slice of the keys (i.e. the service keys) from map Roles as ACL role names
 func (acl ACLInfo) GetACLRoleNames() []string {
 	roleNames := make([]string, 0, len(acl.Roles))

--- a/internal/security/bootstrapper/redis/config/config.go
+++ b/internal/security/bootstrapper/redis/config/config.go
@@ -86,8 +86,3 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return nil
 }
-
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}

--- a/internal/security/fileprovider/config/config.go
+++ b/internal/security/fileprovider/config/config.go
@@ -83,8 +83,3 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return nil
 }
-
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}

--- a/internal/security/proxy/config/config.go
+++ b/internal/security/proxy/config/config.go
@@ -129,8 +129,3 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return nil
 }
-
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}

--- a/internal/security/secretstore/config/config.go
+++ b/internal/security/secretstore/config/config.go
@@ -115,8 +115,3 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return nil
 }
-
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}

--- a/internal/support/notifications/config/config.go
+++ b/internal/support/notifications/config/config.go
@@ -121,8 +121,3 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return c.Writable.InsecureSecrets
 }
-
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}

--- a/internal/support/scheduler/config/config.go
+++ b/internal/support/scheduler/config/config.go
@@ -146,8 +146,3 @@ func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Datab
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return c.Writable.InsecureSecrets
 }
-
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}

--- a/internal/system/agent/config/config.go
+++ b/internal/system/agent/config/config.go
@@ -95,8 +95,3 @@ func (c *ConfigurationStruct) GetRegistryInfo() bootstrapConfig.RegistryInfo {
 func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return nil
 }
-
-// GetMessageBusInfo returns empty bootstrapConfig.MessageBusInfo since this is not used.
-func (c *ConfigurationStruct) GetMessageBusInfo() bootstrapConfig.MessageBusInfo {
-	return bootstrapConfig.MessageBusInfo{}
-}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Secure MessageBus common messaging handler create ZMQ dependency for all service

## Issue Number: #3446


## What is the new behavior?
Core Data has own messaging handler which avoids ZMQ dependecy for all services


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information