### PR TITLE
feat(notifications): Implement GET /transmission/id/{id} V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -1073,3 +1073,15 @@ func (c *Client) UpdateTransmission(trans model.Transmission) errors.EdgeX {
 	defer conn.Close()
 	return updateTransmission(conn, trans)
 }
+
+// TransmissionById gets a transmission by id
+func (c *Client) TransmissionById(id string) (trans model.Transmission, edgexErr errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	trans, edgexErr = transmissionById(conn, id)
+	if edgexErr != nil {
+		return trans, errors.NewCommonEdgeX(errors.Kind(edgexErr), fmt.Sprintf("failed to query transmission by id %s", id), edgexErr)
+	}
+	return
+}

--- a/internal/support/notifications/v2/application/transmission.go
+++ b/internal/support/notifications/v2/application/transmission.go
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+import (
+	v2NotificationsContainer "github.com/edgexfoundry/edgex-go/internal/support/notifications/v2/bootstrap/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
+
+	"github.com/google/uuid"
+)
+
+// TransmissionById invokes the infrastructure layer function to query transmission by ID
+func TransmissionById(id string, dic *di.Container) (trans dtos.Transmission, edgeXerr errors.EdgeX) {
+	if id == "" {
+		return trans, errors.NewCommonEdgeX(errors.KindContractInvalid, "ID is empty", nil)
+	}
+	if _, err := uuid.Parse(id); err != nil {
+		return trans, errors.NewCommonEdgeX(errors.KindContractInvalid, "ID is not a valid UUID", err)
+	}
+
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+	transModel, edgeXerr := dbClient.TransmissionById(id)
+	if edgeXerr != nil {
+		return trans, errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+	trans = dtos.FromTransmissionModelToDTO(transModel)
+	return trans, nil
+}

--- a/internal/support/notifications/v2/controller/http/transmission.go
+++ b/internal/support/notifications/v2/controller/http/transmission.go
@@ -1,0 +1,52 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/v2/utils"
+	"github.com/edgexfoundry/edgex-go/internal/support/notifications/v2/application"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	responseDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
+
+	"github.com/gorilla/mux"
+)
+
+type TransmissionController struct {
+	dic *di.Container
+}
+
+// NewTransmissionController creates and initializes an TransmissionController
+func NewTransmissionController(dic *di.Container) *TransmissionController {
+	return &TransmissionController{
+		dic: dic,
+	}
+}
+
+// TransmissionById queries transmission by ID
+func (nc *TransmissionController) TransmissionById(w http.ResponseWriter, r *http.Request) {
+	lc := container.LoggingClientFrom(nc.dic.Get)
+	ctx := r.Context()
+
+	// URL parameters
+	vars := mux.Vars(r)
+	id := vars[v2.Id]
+
+	trans, err := application.TransmissionById(id, nc.dic)
+	if err != nil {
+		utils.WriteErrorResponse(w, ctx, lc, err, "")
+		return
+	}
+
+	response := responseDTO.NewTransmissionResponse("", "", http.StatusOK, trans)
+	utils.WriteHttpHeader(w, ctx, http.StatusOK)
+	pkg.Encode(response, w, lc)
+}

--- a/internal/support/notifications/v2/controller/http/transmission_test.go
+++ b/internal/support/notifications/v2/controller/http/transmission_test.go
@@ -1,0 +1,101 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v2NotificationsContainer "github.com/edgexfoundry/edgex-go/internal/support/notifications/v2/bootstrap/container"
+	dbMock "github.com/edgexfoundry/edgex-go/internal/support/notifications/v2/infrastructure/interfaces/mocks"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	responseDTO "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransmissionById(t *testing.T) {
+	transmissionId := "1208bbca-8521-434a-a923-66255a68ba11"
+	notificationId := "1208bbca-8521-434a-a923-66255a68ba22"
+	trans := models.Transmission{
+		Id:               transmissionId,
+		SubscriptionName: testSubscriptionName,
+		Channel:          models.RESTAddress{},
+		NotificationId:   notificationId,
+	}
+	emptyId := ""
+	notFoundId := "1208bbca-8521-434a-a923-000000000000"
+	invalidId := "invalidId"
+
+	dic := mockDic()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("TransmissionById", trans.Id).Return(trans, nil)
+	dbClientMock.On("TransmissionById", notFoundId).Return(models.Transmission{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "transmission doesn't exist in the database", nil))
+	dic.Update(di.ServiceConstructorMap{
+		v2NotificationsContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+
+	controller := NewTransmissionController(dic)
+	assert.NotNil(t, controller)
+
+	tests := []struct {
+		name               string
+		transmissionId     string
+		errorExpected      bool
+		expectedStatusCode int
+	}{
+		{"Valid - find transmission by ID", trans.Id, false, http.StatusOK},
+		{"Invalid - ID parameter is empty", emptyId, true, http.StatusBadRequest},
+		{"Invalid - ID parameter is not a valid UUID", invalidId, true, http.StatusBadRequest},
+		{"Invalid - transmission not found by ID", notFoundId, true, http.StatusNotFound},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			reqPath := fmt.Sprintf("%s/%s", v2.ApiTransmissionByIdRoute, testCase.transmissionId)
+			req, err := http.NewRequest(http.MethodGet, reqPath, http.NoBody)
+			req = mux.SetURLVars(req, map[string]string{v2.Id: testCase.transmissionId})
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(controller.TransmissionById)
+			handler.ServeHTTP(recorder, req)
+
+			// Assert
+			if testCase.errorExpected {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res responseDTO.TransmissionResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.Equal(t, testCase.transmissionId, res.Transmission.Id, "ID is not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -36,4 +36,5 @@ type DBClient interface {
 
 	AddTransmission(trans models.Transmission) (models.Transmission, errors.EdgeX)
 	UpdateTransmission(trans models.Transmission) errors.EdgeX
+	TransmissionById(id string) (models.Transmission, errors.EdgeX)
 }

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -440,6 +440,29 @@ func (_m *DBClient) SubscriptionsByReceiver(offset int, limit int, receiver stri
 	return r0, r1
 }
 
+// TransmissionById provides a mock function with given fields: id
+func (_m *DBClient) TransmissionById(id string) (models.Transmission, errors.EdgeX) {
+	ret := _m.Called(id)
+
+	var r0 models.Transmission
+	if rf, ok := ret.Get(0).(func(string) models.Transmission); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(models.Transmission)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(string) errors.EdgeX); ok {
+		r1 = rf(id)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // UpdateNotification provides a mock function with given fields: s
 func (_m *DBClient) UpdateNotification(s models.Notification) errors.EdgeX {
 	ret := _m.Called(s)

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -48,6 +48,10 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiNotificationByTimeRangeRoute, nc.NotificationsByTimeRange).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiNotificationBySubscriptionNameRoute, nc.NotificationsBySubscriptionName).Methods(http.MethodGet)
 
+	// Transmission
+	trans := notificationsController.NewTransmissionController(dic)
+	r.HandleFunc(v2Constant.ApiTransmissionByIdRoute, trans.TransmissionById).Methods(http.MethodGet)
+
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)
 	r.Use(correlation.OnRequestBegin)


### PR DESCRIPTION
Close: #3452
Signed-off-by: weichou <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3452 


## What is the new behavior?
Implement GET /transmission/id/{id} V2 API according to the doc https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/get_transmission_id__id_

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information