### PR TITLE
feat(notifications): Implement notification cleanup V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/notification.go
+++ b/internal/pkg/v2/infrastructure/redis/notification.go
@@ -235,7 +235,7 @@ func notificationAndTransmissionStoreKeys(conn redis.Conn, age int64) ([]string,
 	return ncStoreKeys, transStoreKeys, nil
 }
 
-// asyncDeleteReadingsByIds deletes all notifications with given storeKeys. This function is implemented to be run as a
+// asyncDeleteNotificationByStoreKeys deletes all notifications with given storeKeys. This function is implemented to be run as a
 // separate goroutine in the background to achieve better performance, so this function return nothing.  When
 // encountering any errors during deletion, this function will simply log the error.
 func (c *Client) asyncDeleteNotificationByStoreKeys(storeKeys []string) {

--- a/internal/pkg/v2/infrastructure/redis/notification.go
+++ b/internal/pkg/v2/infrastructure/redis/notification.go
@@ -40,7 +40,7 @@ func sendAddNotificationCmd(conn redis.Conn, storedKey string, n models.Notifica
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "unable to JSON marshal notification for Redis persistence", err)
 	}
 	_ = conn.Send(SET, storedKey, m)
-	_ = conn.Send(ZADD, NotificationCollection, 0, storedKey)
+	_ = conn.Send(ZADD, NotificationCollection, n.Modified, storedKey)
 	_ = conn.Send(ZADD, NotificationCollectionCreated, n.Created, storedKey)
 	if len(n.Category) > 0 {
 		_ = conn.Send(ZADD, CreateKey(NotificationCollectionCategory, n.Category), n.Modified, storedKey)
@@ -212,4 +212,143 @@ func notificationsByCategoriesAndLabels(conn redis.Conn, offset int, limit int, 
 		return notifications, errors.NewCommonEdgeXWrapper(err)
 	}
 	return convertObjectsToNotifications(objects)
+}
+
+// notificationAndTransmissionStoreKeys return the store keys of the notification and transmission that are older than age.
+func notificationAndTransmissionStoreKeys(conn redis.Conn, age int64) ([]string, []string, errors.EdgeX) {
+	expireTimestamp := common.MakeTimestamp() - age
+
+	ncStoreKeys, err := redis.Strings(conn.Do(ZRANGEBYSCORE, NotificationCollection, 0, expireTimestamp))
+	if err != nil {
+		return nil, nil, errors.NewCommonEdgeX(errors.KindDatabaseError, fmt.Sprintf("retrieve nitification storeKeys by %s failed", NotificationCollection), err)
+	}
+
+	var transStoreKeys []string
+	for _, ncStoreKey := range ncStoreKeys {
+		keys, err := redis.Strings(conn.Do(ZRANGE, CreateKey(TransmissionCollectionNotificationId, idFromStoredKey(ncStoreKey)), 0, -1))
+		if err != nil {
+			return nil, nil, errors.NewCommonEdgeX(errors.KindDatabaseError, "fail to retrieve transmission storeKeys", err)
+		}
+		transStoreKeys = append(transStoreKeys, keys...)
+	}
+
+	return ncStoreKeys, transStoreKeys, nil
+}
+
+// asyncDeleteReadingsByIds deletes all notifications with given storeKeys. This function is implemented to be run as a
+// separate goroutine in the background to achieve better performance, so this function return nothing.  When
+// encountering any errors during deletion, this function will simply log the error.
+func (c *Client) asyncDeleteNotificationByStoreKeys(storeKeys []string) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, edgeXerr := getObjectsByIds(conn, common.ConvertStringsToInterfaces(storeKeys))
+	if edgeXerr != nil {
+		c.loggingClient.Errorf("Deleted notifications failed while retrieving objects by storeKeys, %v", edgeXerr)
+		return
+	}
+
+	// cmdSize is used to count the notification deletion command
+	cmdSize := 0
+	// start the transaction before iteration
+	_ = conn.Send(MULTI)
+	// iterate each notifications for deletion in batch
+	for i, o := range objects {
+		nc := models.Notification{}
+		err := json.Unmarshal(o, &nc)
+		if err != nil {
+			c.loggingClient.Errorf("unable to marshal notification.  Err: %s", err.Error())
+			continue
+		}
+		sendDeleteNotificationCmd(conn, notificationStoredKey(nc.Id), nc)
+		cmdSize++
+
+		if cmdSize >= c.BatchSize {
+			_, err = conn.Do(EXEC)
+			if err != nil {
+				c.loggingClient.Errorf("unable to execute batch notification deletion, %v", err)
+				continue
+			}
+			// reset cmdSize to zero if EXEC is successfully executed without error
+			cmdSize = 0
+			// rerun another transaction when iteration is not finished
+			if i < len(objects)-1 {
+				_ = conn.Send(MULTI)
+			}
+		}
+	}
+
+	// Iteration is finished but there are commands need to execute
+	if cmdSize > 0 {
+		_, err := conn.Do(EXEC)
+		if err != nil {
+			c.loggingClient.Errorf("unable to execute batch notification deletion, %v", err)
+		}
+	}
+}
+
+// asyncDeleteTransmissionByStoreKeys deletes all transmissions with given storeKeys. This function is implemented to be run as a
+// separate goroutine in the background to achieve better performance, so this function return nothing.  When
+// encountering any errors during deletion, this function will simply log the error.
+func (c *Client) asyncDeleteTransmissionByStoreKeys(storeKeys []string) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	objects, edgeXerr := getObjectsByIds(conn, common.ConvertStringsToInterfaces(storeKeys))
+	if edgeXerr != nil {
+		c.loggingClient.Errorf("Deleted transmissions failed while retrieving objects by storeKeys, %v", edgeXerr)
+		return
+	}
+
+	// cmdSize is used to count the transmission deletion command
+	cmdSize := 0
+	// start the transaction before iteration
+	_ = conn.Send(MULTI)
+	// iterate each notifications for deletion in batch
+	for i, o := range objects {
+		trans := models.Transmission{}
+		err := json.Unmarshal(o, &trans)
+		if err != nil {
+			c.loggingClient.Errorf("unable to marshal transmission.  Err: %s", err.Error())
+			continue
+		}
+		sendDeleteTransmissionCmd(conn, transmissionStoredKey(trans.Id), trans)
+		cmdSize++
+
+		if cmdSize >= c.BatchSize {
+			_, err = conn.Do(EXEC)
+			if err != nil {
+				c.loggingClient.Errorf("unable to execute batch transmission deletion, %v", err)
+				continue
+			}
+			// reset cmdSize to zero if EXEC is successfully executed without error
+			cmdSize = 0
+			// rerun another transaction when iteration is not finished
+			if i < len(objects)-1 {
+				_ = conn.Send(MULTI)
+			}
+		}
+	}
+
+	// Iteration is finished but there are commands need to execute
+	if cmdSize > 0 {
+		_, err := conn.Do(EXEC)
+		if err != nil {
+			c.loggingClient.Errorf("unable to execute batch transmission deletion, %v", err)
+		}
+	}
+}
+
+// CleanupNotificationsByAge deletes notifications and their corresponding transmissions that are older than age.
+// This function is implemented to starts up two goroutines to delete transmissions and notifications in the background to achieve better performance.
+func (c *Client) CleanupNotificationsByAge(age int64) (err errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+	ncStoreKeys, transStoreKeys, err := notificationAndTransmissionStoreKeys(conn, age)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	go c.asyncDeleteNotificationByStoreKeys(ncStoreKeys)
+	go c.asyncDeleteTransmissionByStoreKeys(transStoreKeys)
+	return nil
 }

--- a/internal/pkg/v2/infrastructure/redis/queries.go
+++ b/internal/pkg/v2/infrastructure/redis/queries.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
@@ -238,4 +239,10 @@ func objectsByKeys(conn redis.Conn, setMethod string, offset int, limit int, red
 	}
 
 	return objects, nil
+}
+
+// idFromStoredKey extracts Id from the store key
+func idFromStoredKey(storeKey string) string {
+	substrings := strings.Split(storeKey, DBKeySeparator)
+	return substrings[len(substrings)-1]
 }

--- a/internal/support/notifications/v2/application/notification.go
+++ b/internal/support/notifications/v2/application/notification.go
@@ -156,3 +156,15 @@ func NotificationsBySubscriptionName(offset, limit int, subscriptionName string,
 	}
 	return notifications, nil
 }
+
+// CleanupNotificationsByAge invokes the infrastructure layer function to remove notifications that are older than age. And the corresponding transmissions will also be deleted
+// Age is supposed in milliseconds since created timestamp.
+func CleanupNotificationsByAge(age int64, dic *di.Container) errors.EdgeX {
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+
+	err := dbClient.CleanupNotificationsByAge(age)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}

--- a/internal/support/notifications/v2/controller/http/notification_test.go
+++ b/internal/support/notifications/v2/controller/http/notification_test.go
@@ -612,3 +612,110 @@ func TestNotificationsBySubscriptionName(t *testing.T) {
 		})
 	}
 }
+
+func TestCleanupNotificationByAge(t *testing.T) {
+	dic := mockDic()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("CleanupNotificationsByAge", int64(0)).Return(nil)
+	dic.Update(di.ServiceConstructorMap{
+		v2NotificationsContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	nc := NewNotificationController(dic)
+	assert.NotNil(t, nc)
+
+	tests := []struct {
+		name               string
+		age                string
+		errorExpected      bool
+		expectedCount      int
+		expectedStatusCode int
+	}{
+		{"Valid - age with proper format", "0", false, 0, http.StatusAccepted},
+		{"Invalid - age with unparsable format", "aaa", true, 0, http.StatusBadRequest},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, v2.ApiNotificationCleanupByAgeRoute, http.NoBody)
+			req = mux.SetURLVars(req, map[string]string{v2.Age: testCase.age})
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(nc.CleanupNotificationsByAge)
+			handler.ServeHTTP(recorder, req)
+
+			// Assert
+			if testCase.errorExpected {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}
+
+func TestCleanupNotification(t *testing.T) {
+	dic := mockDic()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("CleanupNotificationsByAge", int64(0)).Return(nil)
+	dic.Update(di.ServiceConstructorMap{
+		v2NotificationsContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	nc := NewNotificationController(dic)
+	assert.NotNil(t, nc)
+
+	tests := []struct {
+		name               string
+		age                string
+		errorExpected      bool
+		expectedStatusCode int
+	}{
+		{"Valid", "0", false, http.StatusAccepted},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, v2.ApiNotificationCleanupRoute, http.NoBody)
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(nc.CleanupNotifications)
+			handler.ServeHTTP(recorder, req)
+
+			// Assert
+			if testCase.errorExpected {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -33,6 +33,7 @@ type DBClient interface {
 	DeleteNotificationById(id string) errors.EdgeX
 	NotificationsByCategoriesAndLabels(offset, limit int, categories []string, labels []string) ([]models.Notification, errors.EdgeX)
 	UpdateNotification(s models.Notification) errors.EdgeX
+	CleanupNotificationsByAge(age int64) errors.EdgeX
 
 	AddTransmission(trans models.Transmission) (models.Transmission, errors.EdgeX)
 	UpdateTransmission(trans models.Transmission) errors.EdgeX

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -109,6 +109,22 @@ func (_m *DBClient) AllSubscriptions(offset int, limit int) ([]models.Subscripti
 	return r0, r1
 }
 
+// CleanupNotificationsByAge provides a mock function with given fields: age
+func (_m *DBClient) CleanupNotificationsByAge(age int64) errors.EdgeX {
+	ret := _m.Called(age)
+
+	var r0 errors.EdgeX
+	if rf, ok := ret.Get(0).(func(int64) errors.EdgeX); ok {
+		r0 = rf(age)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(errors.EdgeX)
+		}
+	}
+
+	return r0
+}
+
 // CloseSession provides a mock function with given fields:
 func (_m *DBClient) CloseSession() {
 	_m.Called()

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -47,6 +47,8 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2Constant.ApiNotificationByStatusRoute, nc.NotificationsByStatus).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiNotificationByTimeRangeRoute, nc.NotificationsByTimeRange).Methods(http.MethodGet)
 	r.HandleFunc(v2Constant.ApiNotificationBySubscriptionNameRoute, nc.NotificationsBySubscriptionName).Methods(http.MethodGet)
+	r.HandleFunc(v2Constant.ApiNotificationCleanupByAgeRoute, nc.CleanupNotificationsByAge).Methods(http.MethodDelete)
+	r.HandleFunc(v2Constant.ApiNotificationCleanupRoute, nc.CleanupNotifications).Methods(http.MethodDelete)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)


### PR DESCRIPTION
Close: #3455

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3455 


## What is the new behavior?
Implement notification cleanup API
- DELETE /cleanup/age/{age}: https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/delete_cleanup_age__age_
- DELETE /cleanup: https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/delete_cleanup

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information