### PR TITLE
feat(security): Remove ENABLE_REGISTRY_ACL feature flag

### DIFF
--- a/internal/security/secretstore/constants.go
+++ b/internal/security/secretstore/constants.go
@@ -32,9 +32,6 @@ const (
 	// and the the length of the name is upto 512 characters
 	ServiceNameValidationRegx = `^[\w. \~\^\-\|\<\>\{\}]{1,512}$`
 
-	// this is a feature key to indicate whether to enable Registry Consul's ACL or not
-	RegistryACLFeatureFlag = "ENABLE_REGISTRY_ACL"
-
 	VaultToken             = "X-Vault-Token"
 	TokenCreatorPolicyName = "privileged-token-creator"
 

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -444,24 +444,21 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 		lc.Info("proxy certificate pair upload was skipped because cert secretStore value(s) were blank")
 	}
 
-	// If Registry Consul ACL feature is enabled, then we need to create and save a Vault token to configure
+	// create and save a Vault token to configure
 	// Consul secret engine access, role operations, and managing Consul agent tokens.
-	registryACLEnabled := os.Getenv(RegistryACLFeatureFlag)
-	if registryACLEnabled == "true" {
-		// Enable Consul secret engine
-		if err := secretsengine.New(secretsengine.ConsulSecretEngineMountPoint, secretsengine.Consul).
-			Enable(&rootToken, lc, client); err != nil {
-			lc.Errorf("failed to enable Consul secrets engine: %s", err.Error())
-			os.Exit(1)
-		}
+	// Enable Consul secret engine
+	if err := secretsengine.New(secretsengine.ConsulSecretEngineMountPoint, secretsengine.Consul).
+		Enable(&rootToken, lc, client); err != nil {
+		lc.Errorf("failed to enable Consul secrets engine: %s", err.Error())
+		os.Exit(1)
+	}
 
-		// generate a management token for Consul secrets engine operations:
-		tokenFileWriter := tokenfilewriter.NewWriter(lc, client, fileOpener)
-		if _, err := tokenFileWriter.CreateAndWrite(rootToken, configuration.SecretStore.ConsulSecretsAdminTokenPath,
-			tokenFileWriter.CreateMgmtTokenForConsulSecretsEngine); err != nil {
-			lc.Errorf("failed to create and write the token for Consul secret management: %s", err.Error())
-			os.Exit(1)
-		}
+	// generate a management token for Consul secrets engine operations:
+	tokenFileWriter := tokenfilewriter.NewWriter(lc, client, fileOpener)
+	if _, err := tokenFileWriter.CreateAndWrite(rootToken, configuration.SecretStore.ConsulSecretsAdminTokenPath,
+		tokenFileWriter.CreateMgmtTokenForConsulSecretsEngine); err != nil {
+		lc.Errorf("failed to create and write the token for Consul secret management: %s", err.Error())
+		os.Exit(1)
 	}
 
 	// Configure Kong Admin API

--- a/snap/local/runtime-helpers/bin/setup-consul-acl.sh
+++ b/snap/local/runtime-helpers/bin/setup-consul-acl.sh
@@ -3,15 +3,9 @@
 # we don't want to exit out the whole Consul process when ACL bootstrapping failed, just that
 # Consul won't have ACL to be used
 
-echo "$(date) in setup-consul-acl.sh: ENABLE_REGISTRY_ACL = ${ENABLE_REGISTRY_ACL}"
-
-if [ "${ENABLE_REGISTRY_ACL}" == "true" ]; then
-    # setup Consul's ACL via security-bootstrapper's subcommand
-    "$SNAP"/bin/security-bootstrapper -confdir "$SNAP_DATA"/config/security-bootstrapper/res setupRegistryACL
-    setupACL_code=$?
-    if [ "${setupACL_code}" -ne 0 ]; then
-      echo "$(date) failed to set up Consul ACL"
-    fi
-else
-    echo "$(date) ACL not enabled, skip Consul's ACL setup"
+# setup Consul's ACL via security-bootstrapper's subcommand
+"$SNAP"/bin/security-bootstrapper -confdir "$SNAP_DATA"/config/security-bootstrapper/res setupRegistryACL
+setupACL_code=$?
+if [ "${setupACL_code}" -ne 0 ]; then
+  echo "$(date) failed to set up Consul ACL"
 fi

--- a/snap/local/runtime-helpers/bin/start-consul.sh
+++ b/snap/local/runtime-helpers/bin/start-consul.sh
@@ -15,13 +15,8 @@ cat > "$SNAP_DATA/consul/config/consul_default.json" <<EOF
 }
 EOF
 
-echo "$(date) ENABLE_REGISTRY_ACL = ${ENABLE_REGISTRY_ACL}"
-
-# if feature flag ENABLE_REGISTRY_ACL is true, then we need to add additional configuration settings to Consul's ACL system
-# according to the securing Consul ADR, we set the "default_policy" to "allow" in Phase 1
-if [ "${ENABLE_REGISTRY_ACL}" == "true" ]; then
-    echo "$(date) deploying additional ACL configuration for Consul"
-    cat > "$SNAP_DATA/consul/config/consul_acl.json" <<EOF
+echo "$(date) deploying additional ACL configuration for Consul"
+cat > "$SNAP_DATA/consul/config/consul_acl.json" <<EOF
 {
     "acl": {
       "enabled": true,
@@ -30,7 +25,6 @@ if [ "${ENABLE_REGISTRY_ACL}" == "true" ]; then
     }
 }
 EOF
-fi
 
 # start consul in the background
 "$SNAP/bin/consul" agent \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,8 +76,6 @@ apps:
   consul:
     adapter: full
     command: bin/start-consul.sh
-    environment:
-      ENABLE_REGISTRY_ACL: "true"
     daemon: forking
     plugs: [network, network-bind]
   redis:
@@ -162,7 +160,6 @@ apps:
       SECRETSTORE_TOKENPROVIDERARGS: "-confdir, $SNAP_DATA/config/security-file-token-provider/res"
       SECRETSTORE_TOKENPROVIDERADMINTOKENPATH: $SNAP_DATA/secrets/tokenprovider/secrets-token.json
       # registry consul ACL related environment variables:
-      ENABLE_REGISTRY_ACL: "true"
       SECRETSTORE_CONSULSECRETSADMINTOKENPATH: $SNAP_DATA/secrets/edgex-consul/admin/token.json
 
       # environment for security-file-token-provider, exec'd by secretstore-setup
@@ -211,7 +208,6 @@ apps:
       - security-secretstore-setup
     command: bin/setup-consul-acl.sh
     environment:
-      ENABLE_REGISTRY_ACL: "true"
       STAGEGATE_REGISTRY_HOST: localhost
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: $SNAP_DATA/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_SECRETSADMINTOKENPATH: $SNAP_DATA/secrets/edgex-consul/admin/token.json


### PR DESCRIPTION
- feature flag "ENABLE_REGISTRY_ACL" is removed from both edgex-go and snap package building
and so by default Consul will use ACL when it runs in secure mode.

Closes: #3458

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently there is feature flag `ENABLE_REGISTRY_ACL` in the code.

## Issue Number:  #3458 


## What is the new behavior?
feature flag removed and ACL is enabled by default when it is running in secure mode.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information