### PR TITLE
feat(sma): implement v2 GET /metrics/{services} API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.57
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.8
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.91
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.15
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.21

--- a/internal/system/agent/v2/application/const.go
+++ b/internal/system/agent/v2/application/const.go
@@ -1,0 +1,11 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+const (
+	DirectMechanism   = "direct-service"
+	ExecutorMechanism = "executor"
+)

--- a/internal/system/agent/v2/application/direct/health.go
+++ b/internal/system/agent/v2/application/direct/health.go
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package application
+package direct
 
 import (
 	"fmt"

--- a/internal/system/agent/v2/application/direct/health_test.go
+++ b/internal/system/agent/v2/application/direct/health_test.go
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package application
+package direct
 
 import (
 	"errors"

--- a/internal/system/agent/v2/application/direct/metrics.go
+++ b/internal/system/agent/v2/application/direct/metrics.go
@@ -1,0 +1,88 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package direct
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
+	"github.com/edgexfoundry/go-mod-registry/v2/registry"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	clients "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/config"
+)
+
+type metrics struct {
+	lc     logger.LoggingClient
+	rc     registry.Client
+	config *config.ConfigurationStruct
+}
+
+func NewMetrics(lc logger.LoggingClient, rc registry.Client, config *config.ConfigurationStruct) *metrics {
+	return &metrics{
+		lc:     lc,
+		rc:     rc,
+		config: config,
+	}
+}
+
+func (m *metrics) Get(ctx context.Context, services []string) (res interface{}, err errors.EdgeX) {
+	metrics := make(map[string]interface{})
+
+	for _, service := range services {
+		var client interfaces.GeneralClient
+		if m.rc != nil {
+			ok, err := m.rc.IsServiceAvailable(service)
+			if err != nil {
+				errMsg := fmt.Sprintf("service %s not found in Registry", service)
+				return res, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, err)
+			}
+			if !ok {
+				errMsg := fmt.Sprintf("service %s unavailable", service)
+				return res, errors.NewCommonEdgeX(errors.KindServiceUnavailable, errMsg, nil)
+			}
+
+			m.lc.Infof("Registry responded with %s serviceName available", service)
+
+			// Since service is unknown to SMA, ask the Registry for a ServiceEndpoint
+			e, err := m.rc.GetServiceEndpoint(service)
+			if err != nil {
+				return res, errors.NewCommonEdgeXWrapper(err)
+			}
+
+			clientInfo := bootstrapConfig.ClientInfo{
+				Protocol: "http",
+				Host:     e.Host,
+				Port:     e.Port,
+			}
+			client = clients.NewGeneralClient(clientInfo.Url())
+		} else {
+			c, ok := m.config.Clients[service]
+			if ok {
+				client = clients.NewGeneralClient(c.Url())
+			} else {
+				errMsg := fmt.Sprintf("service %s not found in Configuration.Clients section", service)
+				return res, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, err)
+			}
+		}
+
+		m, err := client.FetchMetrics(ctx)
+		if err != nil {
+			return res, errors.NewCommonEdgeXWrapper(err)
+		}
+		metrics[service] = m
+	}
+
+	res = common.NewMultiMetricsResponse("", "", http.StatusOK, metrics)
+	return res, nil
+}

--- a/internal/system/agent/v2/application/executor/executor.go
+++ b/internal/system/agent/v2/application/executor/executor.go
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package executor
+
+import "os/exec"
+
+// CommandExecutor provides the common callout to the configuration-defined executor.
+func CommandExecutor(executorPath, serviceName, operation string) (string, error) {
+	bytes, err := exec.Command(executorPath, serviceName, operation).CombinedOutput()
+	return string(bytes), err
+}

--- a/internal/system/agent/v2/application/executor/metrics.go
+++ b/internal/system/agent/v2/application/executor/metrics.go
@@ -1,0 +1,69 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"github.com/edgexfoundry/edgex-go/internal/system"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/response"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+)
+
+// metrics contains references to dependencies required to handle the metrics via external executor use case.
+type metrics struct {
+	executor     interfaces.CommandExecutor
+	lc           logger.LoggingClient
+	executorPath string
+}
+
+// NewMetrics is a factory function that returns an initialized metrics receiver struct.
+func NewMetrics(executor interfaces.CommandExecutor, lc logger.LoggingClient, executorPath string) *metrics {
+	return &metrics{
+		executor:     executor,
+		lc:           lc,
+		executorPath: executorPath,
+	}
+}
+
+// Get implements the Metrics interface to obtain metrics via executor for one or more services concurrently.
+func (m *metrics) Get(_ context.Context, services []string) (interface{}, errors.EdgeX) {
+	metrics := make(map[string]interface{})
+
+	var wg sync.WaitGroup
+	var errCh = make(chan error, len(services))
+	for _, service := range services {
+		wg.Add(1)
+		go func(serviceName string) {
+			defer wg.Done()
+
+			raw, err := m.executor(m.executorPath, serviceName, system.Metrics)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			r := response.Process(raw, m.lc)
+			metrics[serviceName] = r
+		}(service)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	err := <-errCh
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindUnknown, "", err)
+	}
+
+	res := common.NewMultiMetricsResponse("", "", http.StatusOK, metrics)
+	return res, nil
+}

--- a/internal/system/agent/v2/container/metrics.go
+++ b/internal/system/agent/v2/container/metrics.go
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/v2/interfaces"
+)
+
+// V2MetricsInterfaceName contains the name of the interfaces.Metrics implementation in the DIC.
+var V2MetricsInterfaceName = di.TypeInstanceToName((*interfaces.Metrics)(nil))
+
+// V2MetricsFrom helper function queries the DIC and returns the interfaces.Metrics implementation.
+func V2MetricsFrom(get di.Get) interfaces.Metrics {
+	return get(V2MetricsInterfaceName).(interfaces.Metrics)
+}

--- a/internal/system/agent/v2/interfaces/metrics.go
+++ b/internal/system/agent/v2/interfaces/metrics.go
@@ -1,0 +1,17 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package interfaces
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+)
+
+// Metrics defines a metrics gathering abstraction.
+type Metrics interface {
+	Get(ctx context.Context, services []string) (interface{}, errors.EdgeX)
+}

--- a/internal/system/agent/v2/router.go
+++ b/internal/system/agent/v2/router.go
@@ -29,6 +29,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 
 	ac := smaController.NewAgentController(dic)
 	r.HandleFunc(v2.ApiHealthRoute, ac.GetHealth).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiMultiMetricsRoute, ac.GetMetrics).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))

--- a/openapi/v2/system-agent.yaml
+++ b/openapi/v2/system-agent.yaml
@@ -72,14 +72,6 @@ components:
                  "core-data" : {"Clients" : {"Logging" : {"Host" : "localhost", "Port" : "48061" , "Protocol":"http"}}}}
       required:
         - config
-    HealthRequest:
-      allOf:
-        - $ref: '#/components/schemas/BaseRequest'
-      properties:
-        service:
-          description: "The services from which to obtain health information."
-          type: string
-          example: "core-data"
     HealthResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -92,44 +84,16 @@ components:
             type: string
           example:
             core-data: healthy
-    MetricsRequest:
-      allOf:
-        - $ref: '#/components/schemas/BaseRequest'
-      properties:
-        service:
-          description: "The service from which to obtain metrics."
-          type: string
-          example: "core-data"
-    MetricsResponse:
+    MultiMetricsResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
       type: object
+      description: "Response containing the metrics information for the targeted services."
       properties:
-        executor:
-          description: "The type of executor used to process the retrieve the metrics"
-          type: string
-          example: "docker"
-        operation:
-          description: "The type of operation performed"
-          type: string
-          example: "metrics"
-        service:
-          description: "The service associated with the metrics"
-          type: string
-          example: "core-data"
-        result:
-          description: "The metric information retrieved from the targeted service"
+        metrics:
           type: object
-          properties:
-            cpuBusyAvg:
-              type: integer
-            cpuUsedPercent:
-              type: integer
-            memoryUsed:
-              type: integer
-            raw:
-              additionalProperties: true
-              type: object
+          additionalProperties:
+            $ref: '#/components/schemas/MetricsResponse'
     OperationRequest:
       allOf:
         - $ref: '#/components/schemas/BaseRequest'
@@ -160,17 +124,6 @@ components:
           description: "The type of executor which processed the operation"
           type: string
           example: "docker"
-    PingResponse:
-      type: object
-      properties:
-        apiVersion:
-          description: "A version number shows the API version in DTOs."
-          type: string
-          example: v2
-        timestamp:
-          description: "Outputs the current server timestamp in RFC1123 format"
-          example: "Mon, 02 Jan 2006 15:04:05 MST"
-          type: string
     RequestEnvelope:
       description: "A wrapper type for use when sending a request to the /batch endpoint. Each individual request type in the HTTP request should be wrapped in an envelope to facilitate instantiation of the correct routing handler. See property descriptions below for more details."
       type: object
@@ -260,6 +213,17 @@ components:
           example: "core-command"
       required:
         - service
+    PingResponse:
+      type: object
+      properties:
+        apiVersion:
+          description: "A version number shows the API version in DTOs."
+          type: string
+          example: v2
+        timestamp:
+          description: "Outputs the current server timestamp in RFC1123 format"
+          example: "Mon, 02 Jan 2006 15:04:05 MST"
+          type: string
     VersionResponse:
       description: "A response returned from the /version endpoint whose purpose is to report out the latest version supported by the service."
       type: object
@@ -281,6 +245,37 @@ components:
         config:
           description: "An object containing the service's configuration. Please refer the configuration documentation of each service for more details at [EdgeX Foundry Documentation](https://docs.edgexfoundry.org)."
           type: object
+    MetricsResponse:
+      description: "A response from the /metrics endpoint providing memory and cpu utilization stats."
+      type: object
+      properties:
+        apiVersion:
+          description: "A version number shows the API version in DTOs."
+          type: string
+        metrics:
+          type: object
+          properties:
+            memAlloc:
+              description: "Alloc is bytes of allocated heap objects."
+              type: integer
+            memFrees:
+              description: "Frees is the cumulative count of heap objects freed."
+              type: integer
+            memLiveObjects:
+              description: "The number of live objects is Mallocs - Frees."
+              type: integer
+            memMallocs:
+              description: "The cumulative count of heap objects allocated."
+              type: integer
+            memSys:
+              description: "The total bytes of memory obtained from the OS."
+              type: integer
+            memTotalAlloc:
+              description: "Cumulative bytes allocated for heap objects."
+              type: integer
+            cpuBusyAvg:
+              description: "Indicates the average level of CPU utilization"
+              type: number
   parameters:
     correlatedRequestHeader:
       in: header
@@ -371,6 +366,53 @@ paths:
                 $ref: '#/components/schemas/HealthResponse'
         '400':
           description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: "Internal Server Error"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /metrics/{services}:
+    get:
+      summary: "Obtain metrics information from the targeted service(s)."
+      parameters:
+        - name: services
+          in: path
+          description: A comma-separated list of EdgeX service names to query for metrics.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultiMetricsResponse'
+        '400':
+          description: "Bad request"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: "Not Found"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'


### PR DESCRIPTION
- support both `executor` and `direct-service` MetricsMechanism
- reuse Metrics interface with v2 model
- heavily leverage v1 executor code but simplify concurrent logic

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #3454


## What is the new behavior?
response if `MetricsMechanism` is `executor`:
```
{
  apiVersion: "v2",
  statusCode: 200,
  metrics: {
    edgex-core-data: {
      Success: true,
      executor: "docker",
      operation: "metrics",
      result: {
        cpuUsedPercent: 0.07,
        memoryUsed: 8642363,
        raw: {
          block_io: "135kB / 0B",
          cpu_perc: "0.07%",
          mem_perc: "0.41%",
          mem_usage: "8.242MiB / 1.94GiB",
          net_io: "2.89MB / 6.3MB",
          pids: "13"
        }
      },
      service: "edgex-core-data"
    }
  }
}
```

response if `MetricsMechanism` is `direct-service`:
```
{
  apiVersion: "v2",
  statusCode: 200,
  metrics: {
    edgex-core-data: {
      apiVersion: "v2",
      metrics: {
        memAlloc: 1924632,
        memFrees: 23593,
        memLiveObjects: 13231,
        memMallocs: 36824,
        memSys: 74466312,
        memTotalAlloc: 3583736,
        cpuBusyAvg: 0
      }
    }
  }
}
```


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions

## Other information

The API design is to return non-200 if any of the requested service failed (not found, unhealthy, ... etc)  
But currently the implementation of `sys-mgmt-executor` will not return error, so it is possible to get the following result when `MetricsMechanism` is set to `executor`:
```
$ curl http://localhost:48090/api/v2/metrics/edgex-core-metadata,invalid. 

{
  apiVersion: "v2",
  statusCode: 200,
  metrics: {
    edgex-core-metadata: {
      Success: true,
      executor: "docker",
      operation: "metrics",
      result: {
        cpuUsedPercent: 0.04,
        memoryUsed: 15906898,
        raw: {
          block_io: "8.22MB / 0B",
          cpu_perc: "0.04%",
          mem_perc: "0.76%",
          mem_usage: "15.17MiB / 1.94GiB",
          net_io: "85.8kB / 97.8kB",
          pids: "13"
        }
      },
      service: "edgex-core-metadata"
    },
    invalid: {
      Success: false,
      errorMessage: "exit status 1",
      executor: "docker",
      operation: "metrics",
      service: "invalid"
    }
  }
}
```
compared to `direct-service`:
```
$ curl http://localhost:48090/api/v2/metrics/edgex-core-metadata,invalid

{
  apiVersion: "v2",
  message: "service invalid not found in Registry",
  statusCode: 404
}
```

To fix this we need to refactor `sys-mgmt-executor` as well.


=====================================================

Another point worth mentioning is that v1 relies on a map struct to cache the GeneralClient of edgex micro services:
https://github.com/edgexfoundry/edgex-go/blob/b670e2469c07ac1f8846de0fecc826f49b7ede2c/internal/system/agent/clients/general.go#L27

v2 implementation will try to get the endpoint from either registry or configuration and create a new GeneralClient every time, let me know if we need to use cache instead.
