### PR TITLE
feat(notifications): Implement query transmission by time range V2 API

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/client.go
+++ b/internal/pkg/v2/infrastructure/redis/client.go
@@ -1085,3 +1085,16 @@ func (c *Client) TransmissionById(id string) (trans model.Transmission, edgexErr
 	}
 	return
 }
+
+// TransmissionsByTimeRange query transmissions by time range, offset, and limit
+func (c *Client) TransmissionsByTimeRange(start int, end int, offset int, limit int) (transmissions []model.Transmission, err errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	transmissions, err = transmissionsByTimeRange(conn, start, end, offset, limit)
+	if err != nil {
+		return transmissions, errors.NewCommonEdgeX(errors.Kind(err),
+			fmt.Sprintf("fail to query transmissions by time range %v ~ %v, offset %d, and limit %d", start, end, offset, limit), err)
+	}
+	return transmissions, nil
+}

--- a/internal/pkg/v2/utils/http.go
+++ b/internal/pkg/v2/utils/http.go
@@ -139,6 +139,10 @@ func ParseTimeRangeOffsetLimit(r *http.Request, minOffset int, maxOffset int, mi
 	if edgexErr != nil {
 		return start, end, offset, limit, edgexErr
 	}
+	// Use maxLimit to specify the supported maximum size.
+	if limit == -1 {
+		limit = maxLimit
+	}
 
 	return start, end, offset, limit, nil
 }

--- a/internal/support/notifications/v2/application/transmission.go
+++ b/internal/support/notifications/v2/application/transmission.go
@@ -32,3 +32,17 @@ func TransmissionById(id string, dic *di.Container) (trans dtos.Transmission, ed
 	trans = dtos.FromTransmissionModelToDTO(transModel)
 	return trans, nil
 }
+
+// TransmissionsByTimeRange query transmissions with offset, limit and time range
+func TransmissionsByTimeRange(start int, end int, offset int, limit int, dic *di.Container) (transmissions []dtos.Transmission, err errors.EdgeX) {
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+	models, err := dbClient.TransmissionsByTimeRange(start, end, offset, limit)
+	if err != nil {
+		return transmissions, errors.NewCommonEdgeXWrapper(err)
+	}
+	transmissions = make([]dtos.Transmission, len(models))
+	for i, trans := range models {
+		transmissions[i] = dtos.FromTransmissionModelToDTO(trans)
+	}
+	return transmissions, nil
+}

--- a/internal/support/notifications/v2/controller/http/transmission_test.go
+++ b/internal/support/notifications/v2/controller/http/transmission_test.go
@@ -99,3 +99,72 @@ func TestTransmissionById(t *testing.T) {
 		})
 	}
 }
+
+func TestTransmissionsByTimeRange(t *testing.T) {
+	dic := mockDic()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("TransmissionsByTimeRange", 0, 100, 0, 10).Return([]models.Transmission{}, nil)
+	dic.Update(di.ServiceConstructorMap{
+		v2NotificationsContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	tc := NewTransmissionController(dic)
+	assert.NotNil(t, tc)
+
+	tests := []struct {
+		name               string
+		start              string
+		end                string
+		offset             string
+		limit              string
+		errorExpected      bool
+		expectedCount      int
+		expectedStatusCode int
+	}{
+		{"Valid - with proper start/end/offset/limit", "0", "100", "0", "10", false, 0, http.StatusOK},
+		{"Invalid - invalid start format", "aaa", "100", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - invalid end format", "0", "bbb", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - empty start", "", "100", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - empty end", "0", "", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - end before start", "10", "0", "0", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - invalid offset format", "0", "100", "aaa", "10", true, 0, http.StatusBadRequest},
+		{"Invalid - invalid limit format", "0", "100", "0", "aaa", true, 0, http.StatusBadRequest},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, v2.ApiTransmissionByTimeRangeRoute, http.NoBody)
+			query := req.URL.Query()
+			query.Add(v2.Offset, testCase.offset)
+			query.Add(v2.Limit, testCase.limit)
+			req.URL.RawQuery = query.Encode()
+			req = mux.SetURLVars(req, map[string]string{v2.Start: testCase.start, v2.End: testCase.end})
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(tc.TransmissionsByTimeRange)
+			handler.ServeHTTP(recorder, req)
+
+			// Assert
+			if testCase.errorExpected {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res responseDTO.MultiTransmissionsResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.Equal(t, testCase.expectedCount, len(res.Transmissions), "Transmission count not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -38,4 +38,5 @@ type DBClient interface {
 	AddTransmission(trans models.Transmission) (models.Transmission, errors.EdgeX)
 	UpdateTransmission(trans models.Transmission) errors.EdgeX
 	TransmissionById(id string) (models.Transmission, errors.EdgeX)
+	TransmissionsByTimeRange(start int, end int, offset int, limit int) ([]models.Transmission, errors.EdgeX)
 }

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -479,6 +479,31 @@ func (_m *DBClient) TransmissionById(id string) (models.Transmission, errors.Edg
 	return r0, r1
 }
 
+// TransmissionsByTimeRange provides a mock function with given fields: start, end, offset, limit
+func (_m *DBClient) TransmissionsByTimeRange(start int, end int, offset int, limit int) ([]models.Transmission, errors.EdgeX) {
+	ret := _m.Called(start, end, offset, limit)
+
+	var r0 []models.Transmission
+	if rf, ok := ret.Get(0).(func(int, int, int, int) []models.Transmission); ok {
+		r0 = rf(start, end, offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Transmission)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(int, int, int, int) errors.EdgeX); ok {
+		r1 = rf(start, end, offset, limit)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // UpdateNotification provides a mock function with given fields: s
 func (_m *DBClient) UpdateNotification(s models.Notification) errors.EdgeX {
 	ret := _m.Called(s)

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -53,6 +53,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	// Transmission
 	trans := notificationsController.NewTransmissionController(dic)
 	r.HandleFunc(v2.ApiTransmissionByIdRoute, trans.TransmissionById).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiTransmissionByTimeRangeRoute, trans.TransmissionsByTimeRange).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))


### PR DESCRIPTION
Close: #3466

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3466 


## What is the new behavior?
Implement GET /transmission/start/{start}/end/{end} V2 API according to the doc https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/get_transmission_start__start__end__end_

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information