### PR TITLE
feat(notifications): Implement DELETE /notifications/age/{age} V2 API

### DIFF
--- a/internal/support/notifications/v2/application/notification.go
+++ b/internal/support/notifications/v2/application/notification.go
@@ -158,11 +158,23 @@ func NotificationsBySubscriptionName(offset, limit int, subscriptionName string,
 }
 
 // CleanupNotificationsByAge invokes the infrastructure layer function to remove notifications that are older than age. And the corresponding transmissions will also be deleted
-// Age is supposed in milliseconds since created timestamp.
+// Age is supposed in milliseconds since modified timestamp.
 func CleanupNotificationsByAge(age int64, dic *di.Container) errors.EdgeX {
 	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
 
 	err := dbClient.CleanupNotificationsByAge(age)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	return nil
+}
+
+// DeleteProcessedNotificationsByAge invokes the infrastructure layer function to remove processed notifications that are older than age. And the corresponding transmissions will also be deleted
+// Age is supposed in milliseconds since modified timestamp.
+func DeleteProcessedNotificationsByAge(age int64, dic *di.Container) errors.EdgeX {
+	dbClient := v2NotificationsContainer.DBClientFrom(dic.Get)
+
+	err := dbClient.DeleteProcessedNotificationsByAge(age)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/support/notifications/v2/controller/http/notification_test.go
+++ b/internal/support/notifications/v2/controller/http/notification_test.go
@@ -637,7 +637,7 @@ func TestCleanupNotificationByAge(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, v2.ApiNotificationCleanupByAgeRoute, http.NoBody)
+			req, err := http.NewRequest(http.MethodDelete, v2.ApiNotificationCleanupByAgeRoute, http.NoBody)
 			req = mux.SetURLVars(req, map[string]string{v2.Age: testCase.age})
 			require.NoError(t, err)
 
@@ -690,12 +690,67 @@ func TestCleanupNotification(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, v2.ApiNotificationCleanupRoute, http.NoBody)
+			req, err := http.NewRequest(http.MethodDelete, v2.ApiNotificationCleanupRoute, http.NoBody)
 			require.NoError(t, err)
 
 			// Act
 			recorder := httptest.NewRecorder()
 			handler := http.HandlerFunc(nc.CleanupNotifications)
+			handler.ServeHTTP(recorder, req)
+
+			// Assert
+			if testCase.errorExpected {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res common.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, v2.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, res.StatusCode, "Response status code not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}
+
+func TestDeleteNotificationByAge(t *testing.T) {
+	dic := mockDic()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("DeleteProcessedNotificationsByAge", int64(0)).Return(nil)
+	dic.Update(di.ServiceConstructorMap{
+		v2NotificationsContainer.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+	nc := NewNotificationController(dic)
+	assert.NotNil(t, nc)
+
+	tests := []struct {
+		name               string
+		age                string
+		errorExpected      bool
+		expectedCount      int
+		expectedStatusCode int
+	}{
+		{"Valid - age with proper format", "0", false, 0, http.StatusAccepted},
+		{"Invalid - age with unparsable format", "aaa", true, 0, http.StatusBadRequest},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodDelete, v2.ApiNotificationByAgeRoute, http.NoBody)
+			req = mux.SetURLVars(req, map[string]string{v2.Age: testCase.age})
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(nc.DeleteProcessedNotificationsByAge)
 			handler.ServeHTTP(recorder, req)
 
 			// Assert

--- a/internal/support/notifications/v2/infrastructure/interfaces/db.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/db.go
@@ -34,6 +34,7 @@ type DBClient interface {
 	NotificationsByCategoriesAndLabels(offset, limit int, categories []string, labels []string) ([]models.Notification, errors.EdgeX)
 	UpdateNotification(s models.Notification) errors.EdgeX
 	CleanupNotificationsByAge(age int64) errors.EdgeX
+	DeleteProcessedNotificationsByAge(age int64) errors.EdgeX
 
 	AddTransmission(trans models.Transmission) (models.Transmission, errors.EdgeX)
 	UpdateTransmission(trans models.Transmission) errors.EdgeX

--- a/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/notifications/v2/infrastructure/interfaces/mocks/DBClient.go
@@ -146,6 +146,22 @@ func (_m *DBClient) DeleteNotificationById(id string) errors.EdgeX {
 	return r0
 }
 
+// DeleteProcessedNotificationsByAge provides a mock function with given fields: age
+func (_m *DBClient) DeleteProcessedNotificationsByAge(age int64) errors.EdgeX {
+	ret := _m.Called(age)
+
+	var r0 errors.EdgeX
+	if rf, ok := ret.Get(0).(func(int64) errors.EdgeX); ok {
+		r0 = rf(age)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(errors.EdgeX)
+		}
+	}
+
+	return r0
+}
+
 // DeleteSubscriptionByName provides a mock function with given fields: name
 func (_m *DBClient) DeleteSubscriptionByName(name string) errors.EdgeX {
 	ret := _m.Called(name)

--- a/internal/support/notifications/v2/router.go
+++ b/internal/support/notifications/v2/router.go
@@ -49,6 +49,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2.ApiNotificationBySubscriptionNameRoute, nc.NotificationsBySubscriptionName).Methods(http.MethodGet)
 	r.HandleFunc(v2.ApiNotificationCleanupByAgeRoute, nc.CleanupNotificationsByAge).Methods(http.MethodDelete)
 	r.HandleFunc(v2.ApiNotificationCleanupRoute, nc.CleanupNotifications).Methods(http.MethodDelete)
+	r.HandleFunc(v2.ApiNotificationByAgeRoute, nc.DeleteProcessedNotificationsByAge).Methods(http.MethodDelete)
 
 	// Transmission
 	trans := notificationsController.NewTransmissionController(dic)


### PR DESCRIPTION
Close: #3469

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3469 


## What is the new behavior?
Implement DELETE /notifications/age/{age} V2 API according to the doc https://app.swaggerhub.com/apis-docs/EdgeXFoundry1/support-notifications/2.x#/default/delete_notification_age__age_

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information