### PR TITLE
fix: Revert port changes to V1 Swagger files

### DIFF
--- a/openapi/v1/core-command.yaml
+++ b/openapi/v1/core-command.yaml
@@ -3,7 +3,7 @@ info:
   title: core-command
   version: 1.2.1
 servers:
-- url: http://localhost:59882/api
+- url: http://localhost:48082/api
 paths:
   /v1/config:
     get:

--- a/openapi/v1/core-data.yaml
+++ b/openapi/v1/core-data.yaml
@@ -3,7 +3,7 @@ info:
   title: core-data
   version: 1.2.1
 servers:
-- url: http://localhost:59880/api
+- url: http://localhost:48080/api
 paths:
   /v1/config:
     get:

--- a/openapi/v1/core-metadata.yaml
+++ b/openapi/v1/core-metadata.yaml
@@ -3,7 +3,7 @@ info:
   title: core-metadata
   version: 1.2.1
 servers:
-- url: http://localhost:59881/api
+- url: http://localhost:48081/api
 paths:
   /v1/addressable:
     get:

--- a/openapi/v1/support-notifications.yaml
+++ b/openapi/v1/support-notifications.yaml
@@ -3,7 +3,7 @@ info:
   title: support-notifications
   version: 1.2.1
 servers:
-- url: http://localhost:59860/api
+- url: http://localhost:48060/api
 paths:
   /v1/config:
     get:

--- a/openapi/v1/support-scheduler.yaml
+++ b/openapi/v1/support-scheduler.yaml
@@ -3,7 +3,7 @@ info:
   title: support-scheduler
   version: 1.2.1
 servers:
-- url: http://localhost:59861/api
+- url: http://localhost:48085/api
 paths:
   /v1/config:
     get:

--- a/openapi/v1/system-agent.yaml
+++ b/openapi/v1/system-agent.yaml
@@ -3,7 +3,7 @@ info:
   title: system-agent
   version: 1.2.1
 servers:
-- url: http://localhost:58890/api
+- url: http://localhost:48090/api
 paths:
   /v1/config/{services}:
     get:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
New port assignments incorrectly applied to V1 Swagger, which got published.

## Issue Number: #3498


## What is the new behavior?
Old port assignments re-applied to V1 Swagger.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information