### PR TITLE
feat(sma): implement v2 POST /operation API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.58
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.8
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.93
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.94
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.15
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.21

--- a/internal/system/agent/v2/application/executor/operation.go
+++ b/internal/system/agent/v2/application/executor/operation.go
@@ -1,0 +1,60 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
+
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/interfaces"
+)
+
+// operation contains references to dependencies required to handle the operation via external executor use case.
+type operation struct {
+	executor     interfaces.CommandExecutor
+	executorPath string
+	lc           logger.LoggingClient
+}
+
+// NewOperation is a factory function that returns an initialized operation receiver struct.
+func NewOperation(executor interfaces.CommandExecutor, executorPath string, lc logger.LoggingClient) *operation {
+	return &operation{
+		executor:     executor,
+		executorPath: executorPath,
+		lc:           lc,
+	}
+}
+
+// Do concurrently delegates a start/stop/restart operation request to the configuration-defined executor.
+func (o *operation) Do(_ context.Context, operations []requests.OperationRequest) ([]interface{}, errors.EdgeX) {
+	var wg sync.WaitGroup
+	var responses []interface{}
+
+	for _, operation := range operations {
+		wg.Add(1)
+		go func(operation requests.OperationRequest) {
+			defer wg.Done()
+
+			o.lc.Debugf("Executing '%s' action on %s", operation.Action, operation.ServiceName)
+			_, err := o.executor(o.executorPath, operation.ServiceName, operation.Action)
+			if err != nil {
+				responses = append(responses, common.NewBaseResponse(operation.RequestId, err.Error(), http.StatusInternalServerError))
+				return
+			}
+
+			responses = append(responses, common.NewBaseResponse(operation.RequestId, "", http.StatusOK))
+		}(operation)
+	}
+
+	wg.Wait()
+	return responses, nil
+}

--- a/internal/system/agent/v2/controller/http/controller.go
+++ b/internal/system/agent/v2/controller/http/controller.go
@@ -6,20 +6,26 @@
 package http
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
 	"github.com/gorilla/mux"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/responses"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/v2/utils"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/container"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/v2/application/direct"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/v2/application/direct/config"
-	"github.com/edgexfoundry/edgex-go/internal/system/agent/v2/container"
+	"github.com/edgexfoundry/edgex-go/internal/system/agent/v2/application/executor"
+	v2Container "github.com/edgexfoundry/edgex-go/internal/system/agent/v2/container"
 )
 
 type AgentController struct {
@@ -47,7 +53,7 @@ func (c *AgentController) GetMetrics(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	services := strings.Split(vars[v2.Services], v2.CommaSeparator)
 
-	metricsImpl := container.V2MetricsFrom(c.dic.Get)
+	metricsImpl := v2Container.V2MetricsFrom(c.dic.Get)
 	res, err := metricsImpl.Get(ctx, services)
 	if err != nil {
 		utils.WriteErrorResponse(w, ctx, lc, err, "")
@@ -73,4 +79,32 @@ func (c *AgentController) GetConfigs(w http.ResponseWriter, r *http.Request) {
 
 	utils.WriteHttpHeader(w, ctx, http.StatusOK)
 	pkg.Encode(configs, w, lc)
+}
+
+func (c *AgentController) PostOperations(w http.ResponseWriter, r *http.Request) {
+	if r.Body != nil {
+		defer func() { _ = r.Body.Close() }()
+	}
+
+	lc := bootstrapContainer.LoggingClientFrom(c.dic.Get)
+	ctx := r.Context()
+
+	var operations []requests.OperationRequest
+	err := json.NewDecoder(r.Body).Decode(&operations)
+	if err != nil {
+		edgexErr := errors.NewCommonEdgeX(errors.KindContractInvalid, "OperationRequest json decoding failed", err)
+		utils.WriteErrorResponse(w, ctx, lc, edgexErr, "")
+		return
+	}
+
+	configuration := container.ConfigurationFrom(c.dic.Get)
+	operator := executor.NewOperation(executor.CommandExecutor, configuration.ExecutorPath, lc)
+	res, edgexErr := operator.Do(ctx, operations)
+	if edgexErr != nil {
+		utils.WriteErrorResponse(w, ctx, lc, edgexErr, "")
+		return
+	}
+
+	utils.WriteHttpHeader(w, ctx, http.StatusMultiStatus)
+	pkg.Encode(res, w, lc)
 }

--- a/internal/system/agent/v2/router.go
+++ b/internal/system/agent/v2/router.go
@@ -31,6 +31,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(v2.ApiHealthRoute, ac.GetHealth).Methods(http.MethodGet)
 	r.HandleFunc(v2.ApiMultiMetricsRoute, ac.GetMetrics).Methods(http.MethodGet)
 	r.HandleFunc(v2.ApiMultiConfigsRoute, ac.GetConfigs).Methods(http.MethodGet)
+	r.HandleFunc(v2.ApiOperationRoute, ac.PostOperations).Methods(http.MethodPost)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))

--- a/openapi/v2/system-agent.yaml
+++ b/openapi/v2/system-agent.yaml
@@ -49,29 +49,6 @@ components:
         - $ref: '#/components/schemas/BaseResponse'
       description: "A response type for returning a generic error to the caller."
       type: object
-    GetConfigRequest:
-      allOf:
-        - $ref: '#/components/schemas/BaseRequest'
-      description: "Retrieves the current configuration for the targeted service."
-      type: object
-      properties:
-        service:
-          type: string
-          example: core-data
-    GetConfigResponse:
-      allOf:
-        - $ref: '#/components/schemas/BaseResponse'
-      description: "Provides a response containing the configuration for the targeted service."
-      type: object
-      properties:
-        additionalProperties:
-          type: object
-          title: service
-          description: "Map of service(key) and configuration(value)"
-      example: { "apiVersion":"v2","statusCode": 200,
-                 "core-data" : {"Clients" : {"Logging" : {"Host" : "localhost", "Port" : "48061" , "Protocol":"http"}}}}
-      required:
-        - config
     HealthResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -113,116 +90,10 @@ components:
           description: "The operation to execute on the service."
           type: string
           enum: [start, stop, restart]
-        service:
+        serviceName:
           description: "The service to which to apply the action."
           type: string
           example: "core-data"
-    OperationResponse:
-      allOf:
-        - $ref: '#/components/schemas/BaseResponse'
-      additionalProperties: true
-      properties:
-        operation:
-          description: "The operation executed on the targeted service"
-          type: string
-          example: "start"
-        service:
-          description: "The name of the targeted service"
-          type: string
-          example: edgex-redis
-        executor:
-          description: "The type of executor which processed the operation"
-          type: string
-          example: "docker"
-    RequestEnvelope:
-      description: "A wrapper type for use when sending a request to the /batch endpoint. Each individual request type in the HTTP request should be wrapped in an envelope to facilitate instantiation of the correct routing handler. See property descriptions below for more details."
-      type: object
-      properties:
-        action:
-          type: string
-          description: "Indicates the type of operation applicable to the wrapped request. Valid values are 'create','read','update','delete', and 'command'"
-        content:
-          type: string
-          format: byte
-          description: "A byte array containing a marshalled request type instance. This is the specific, semantically identifiable request -- such as an AddDeviceRequest."
-        strategy:
-          type: string
-          description: "Indicates the expectation of whether a response should be produced synchronously or asynchronously. If asynchronously, desire for either a polling or push/callback should be provided. Valid values are 'sync','async-push','async-poll'"
-        type:
-          type: string
-          description: "The name of the type applicable to the request instance contained in the 'content' property."
-        version:
-          description: "Explicitly defines major-only version number of request DTO."
-          type: string
-          example: "2"
-      required:
-        - action
-        - content
-        - strategy
-        - type
-        - version
-    ResponseEnvelope:
-      description: "A wrapper type for use when receiving a response from the /batch endpoint. Each individual response type in the HTTP response should be wrapped in an envelope to facilitate unmarshaling by the client. See property descriptions below for more details."
-      type: object
-      properties:
-        action:
-          type: string
-          description: "Indicates the type of operation applicable to the wrapped response. This should be recapitulated from the originating request. Valid values are 'create','read','update','delete', and 'command'"
-        content:
-          type: string
-          format: byte
-          description: "A byte array containing a marshalled response type instance. This is the specific, semantically identifiable response -- such as an AddDeviceResponse."
-        strategy:
-          type: string
-          description: "Recapitulates the expectation with regard to the delivery of response that was specified on the originating request. Valid values are 'sync','async-push','async-poll'"
-        type:
-          type: string
-          description: "The name of the type applicable to the response instance contained in the 'content' property."
-        version:
-          description: "Explicitly defines major-only version number of response DTO."
-          type: string
-          example: "2"
-      required:
-        - action
-        - content
-        - strategy
-        - type
-        - version
-    SetConfigRequest:
-      description: "A request associated with the /config endpoint."
-      allOf:
-        - $ref: '#/components/schemas/BaseRequest'
-      type: object
-      properties:
-        service:
-          description: "Updates the target service's configuration"
-          type: string
-          example: "core-data"
-        configuration:
-          description: "Service's configuration"
-          type: array
-          items:
-            properties:
-              key:
-                description: "Path of the configuration to update"
-                type: string
-                example: "Writable.LogLevel"
-              value:
-                description: "New value to which the configuration should be updated"
-                type: string
-                example: "DEBUG"
-    SetConfigResponse:
-      allOf:
-        - $ref: '#/components/schemas/BaseResponse'
-      description: "Provides a response containing the configuration for the targeted service."
-      type: object
-      properties:
-        service:
-          description: "The service which the update was applied"
-          type: string
-          example: "core-command"
-      required:
-        - service
     PingResponse:
       type: object
       properties:
@@ -456,15 +327,6 @@ paths:
                   items:
                     $ref: '#/components/schemas/OperationRequest'
       responses:
-        '200':
-          description: "OK"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OperationResponse'
         '207':
           description: "Indicates a multi-part response supportive of accepting multiple requests at once. The 'statusCode' property of each response in the returned array will indicate success or failure."
           headers:
@@ -477,7 +339,7 @@ paths:
                 items:
                   anyOf:
                     - $ref: '#/components/schemas/ErrorResponse'
-                    - $ref: '#/components/schemas/OperationResponse'
+                    - $ref: '#/components/schemas/BaseResponse'
         '400':
           description: "Bad request"
           headers:


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #3496 


## What is the new behavior?
example request body POSTing `/api/v2/operation`:
```
[
    {
        "apiVersion": "v2",
        "requestId": "2f6fe5e2-dd93-478c-a2ba-21642e42a5f5",
        "serviceName": "edgex-core-data",
        "action": "start"
    },
    {
        "apiVersion": "v2",
        "requestId": "998d70a3-7245-4735-b308-ebb9f448fb38",
        "serviceName": "edgex-core-command",
        "action": "start"
    }
]
```

example response:
```
207 Multi-Status
[
    {
        "apiVersion": "v2",
        "requestId": "998d70a3-7245-4735-b308-ebb9f448fb38",
        "statusCode": 200
    },
    {
        "apiVersion": "v2",
        "requestId": "2f6fe5e2-dd93-478c-a2ba-21642e42a5f5",
        "statusCode": 200
    }
]
```


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
@lenny-intel are we planning to remove the `edgex-` prefix for container name as well ?
The behavior in SMA is inconsistent:
 - for API that relies on executor (e.g. `/operation`, `metrics/{services}`), you need to refer the service by its container name, which have `edgex-` prefix
 - for API which will trigger requested service's own API (e.g. `/configs/{services}`), you don't have to add `edgex-` prefix

For example:
```
$ curl http://localhost:58890/api/v2/configs/core-data,core-metadata

200
{...}

$ curl  http://localhost:58890/api/v2/metrics/core-data,core-metadata
200 (should be 400 or 404 but need to refactor sys-mgmt-executor ....)
{
    "apiVersion": "v2",
    "statusCode": 200,
    "metrics": {
        "core-data": {
            "Success": false,
            "errorMessage": "exit status 1",
            "executor": "docker",
            "operation": "metrics",
            "service": "core-data"
        },
        "core-metadata": {
            "Success": false,
            "errorMessage": "exit status 1",
            "executor": "docker",
            "operation": "metrics",
            "service": "core-metadata"
        }
    }
}

curl http://localhost:58890/api/v2/metrics/edgex-core-data,edgex-core-metadata
200
{
    "apiVersion": "v2",
    "statusCode": 200,
    "metrics": {
        "edgex-core-data": {
            "Success": true,
            "executor": "docker",
            "operation": "metrics",
            "result": {
                "cpuUsedPercent": 0.02,
                "memoryUsed": 7184843,
                "raw": {
                    "block_io": "0B / 0B",
                    "cpu_perc": "0.02%",
                    "mem_perc": "0.34%",
                    "mem_usage": "6.852MiB / 1.94GiB",
                    "net_io": "46.9kB / 46kB",
                    "pids": "12"
                }
            },
            "service": "edgex-core-data"
        },
        "edgex-core-metadata": {
            "Success": true,
            "executor": "docker",
            "operation": "metrics",
            "result": {
                "cpuUsedPercent": 0.06,
                "memoryUsed": 7679771,
                "raw": {
                    "block_io": "0B / 0B",
                    "cpu_perc": "0.06%",
                    "mem_perc": "0.37%",
                    "mem_usage": "7.324MiB / 1.94GiB",
                    "net_io": "42.1kB / 40.8kB",
                    "pids": "12"
                }
            },
            "service": "edgex-core-metadata"
        }
    }
}
```