### PR TITLE
fix: Use new ports for device-virtual and rules engine proxy routes

### DIFF
--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -89,13 +89,13 @@ RetryWaitPeriod = "1s"
   Name = "rulesengine"
   Protocol = "http"
   Host = "localhost"
-  Port = 48075
+  Port = 59720
 	
   [Routes.device-virtual]
   Name = "virtualdevice"
   Protocol = "http"
   Host = "localhost"
-  Port = 49990
+  Port = 59900
 
   [Routes.core-consul]
   Name = "consul"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Ports for Device Virtual and Rules Engine in `Proxy Setup` are the old port assignments


## Issue Number: #3495


## What is the new behavior?
Ports for Device Virtual and Rules Engine in `Proxy Setup` are the correct new port assignments


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information