### PR TITLE
fix(all): add PING check after Dial to validate DB is ready

### DIFF
--- a/internal/pkg/db/redis/client.go
+++ b/internal/pkg/db/redis/client.go
@@ -74,10 +74,14 @@ func NewClient(config db.Configuration, lc logger.LoggingClient) (*Client, error
 			conn, err := redis.Dial(
 				"tcp", connectionString, opts...,
 			)
-			if err != nil {
-				return nil, fmt.Errorf("Could not dial Redis: %s", err)
+			if err == nil {
+				_, err = conn.Do("PING")
+				if err == nil {
+					return conn, nil
+				}
 			}
-			return conn, nil
+
+			return nil, fmt.Errorf("could not dial Redis: %s", err)
 		}
 		// Default the batch size to 1,000 if not set
 		batchSize := 1000


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
core service is ready even if DB is still loading, this results in the bootstrap failed in device service (notice the time Redis is ready):
```
$ docker logs edgex-redis
...
1:M 25 May 2021 06:05:43.544 * DB loaded from append only file: 26.494 seconds
1:M 25 May 2021 06:05:43.544 * Ready to accept connections


$ docker logs edgex-core-metadata
...
level=INFO ts=2021-05-25T06:05:26.8633534Z app=core-metadata source=database.go:145 msg="Database connected"
level=INFO ts=2021-05-25T06:05:26.8642979Z app=core-metadata source=database.go:121 msg="Database for V2 API connected"
level=INFO ts=2021-05-25T06:05:26.8668508Z app=core-metadata source=telemetry.go:86 msg="Telemetry starting"
level=ERROR ts=2021-05-25T06:05:26.8669092Z app=core-metadata source=httpserver.go:92 msg="unable to parse RequestTimeout value of 5s to a duration: %!w(<nil>)"
level=INFO ts=2021-05-25T06:05:26.8669397Z app=core-metadata source=httpserver.go:110 msg="Web server starting (edgex-core-metadata:59881)"
level=INFO ts=2021-05-25T06:05:26.8669584Z app=core-metadata source=message.go:50 msg="Service dependencies resolved..."
level=INFO ts=2021-05-25T06:05:26.8669773Z app=core-metadata source=message.go:51 msg="Starting core-metadata 2.0.0-dev.235 "
level=INFO ts=2021-05-25T06:05:26.8669903Z app=core-metadata source=message.go:55 msg="This is the EdgeX Core Metadata Microservice"
level=INFO ts=2021-05-25T06:05:26.8670155Z app=core-metadata source=message.go:58 msg="Service started in: 175.6688ms"
level=ERROR ts=2021-05-25T06:05:40.141714Z app=core-metadata source=http.go:39 X-Correlation-ID=ff9ce8ae-03bc-4fdc-ab70-1655bb820c9c msg="query device-rest from the database failed -> LOADING Redis is loading the dataset in memory"


$ docker logs edgex-device-rest
...
level=ERROR ts=2021-05-25T06:05:40.1422688Z app=device-rest source=service.go:210 msg="failed to find device service device-rest"
level=ERROR ts=2021-05-25T06:05:40.1423652Z app=device-rest source=init.go:64 msg="Failed to register service on Metadata: request failed, status code: 500, err: {\"apiVersion\":\"v2\",\"message\":\"query device-rest from the database failed\",\"statusCode\":500}\n"
level=INFO ts=2021-05-25T06:05:40.1425545Z app=device-rest source=httpserver.go:104 msg="Web server shutting down"
level=ERROR ts=2021-05-25T06:05:40.1428953Z app=device-rest source=httpserver.go:121 msg="Web server failed: http: Server closed"
level=INFO ts=2021-05-25T06:05:40.1447692Z app=device-rest source=httpserver.go:106 msg="Web server shut down"
level=INFO ts=2021-05-25T06:05:40.144809Z app=device-rest source=bootstrap.go:135 msg="Un-Registering service from the Registry"


```


## Issue Number: fix #2692 


## What is the new behavior?

add a `PING` command in the end of dialFunc to make sure dbClient is ready to use.

```
$ docker logs edgex-redis
...
1:M 25 May 2021 05:57:54.675 * DB loaded from append only file: 27.354 seconds
1:M 25 May 2021 05:57:54.675 * Ready to accept connections

$ docker logs edgex-core-metadata
...
level=WARN ts=2021-05-25T05:57:52.8751179Z app=core-metadata source=database.go:130 msg="couldn't create database client: could not dial Redis: LOADING Redis is loading the dataset in memory"
level=WARN ts=2021-05-25T05:57:53.8805743Z app=core-metadata source=database.go:130 msg="couldn't create database client: could not dial Redis: LOADING Redis is loading the dataset in memory"
level=INFO ts=2021-05-25T05:57:54.8499373Z app=core-metadata source=database.go:145 msg="Database connected"
level=INFO ts=2021-05-25T05:57:54.851781Z app=core-metadata source=database.go:121 msg="Database for V2 API connected"
level=INFO ts=2021-05-25T05:57:54.858687Z app=core-metadata source=telemetry.go:86 msg="Telemetry starting"
level=ERROR ts=2021-05-25T05:57:54.858828Z app=core-metadata source=httpserver.go:92 msg="unable to parse RequestTimeout value of 5s to a duration: %!w(<nil>)"
level=INFO ts=2021-05-25T05:57:54.8589Z app=core-metadata source=httpserver.go:110 msg="Web server starting (edgex-core-metadata:59881)"
level=INFO ts=2021-05-25T05:57:54.859053Z app=core-metadata source=message.go:50 msg="Service dependencies resolved..."
level=INFO ts=2021-05-25T05:57:54.8591497Z app=core-metadata source=message.go:51 msg="Starting core-metadata 0.0.0 "
level=INFO ts=2021-05-25T05:57:54.8591806Z app=core-metadata source=message.go:55 msg="This is the EdgeX Core Metadata Microservice"
level=INFO ts=2021-05-25T05:57:54.8592612Z app=core-metadata source=message.go:58 msg="Service started in: 17.3021144s"

```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information