### PR TITLE
refactor: Use service key for route names and add missing sys-mgmt-agent

### DIFF
--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -56,43 +56,49 @@ RetryWaitPeriod = "1s"
 
 [Routes]
   [Routes.core-data]
-  Name = "coredata"
+  Name = "core-data"
   Protocol = "http"
   Host = "localhost"
   Port = 59880
 	
   [Routes.core-metadata]
-  Name = "metadata"
+  Name = "core-metadata"
   Protocol = "http"
   Host = "localhost"
   Port = 59881
 	
   [Routes.core-command]
-  Name = "command"
+  Name = "core-command"
   Protocol = "http"
   Host = "localhost"
   Port = 59882
 	
   [Routes.support-notifications]
-  Name = "notifications"
+  Name = "support-notifications"
   Protocol = "http"
   Host = "localhost"
   Port = 59860
 
   [Routes.support-scheduler]
-  Name = "scheduler"
+  Name = "support-scheduler"
   Protocol = "http"
   Host = "localhost"
   Port = 59861
 
+  [Routes.sys-mgmt-agent]
+  Name = "sys-mgmt-agent"
+  Protocol = "http"
+  Host = "localhost"
+  Port = 58890
+
   [Routes.rules-engine]
-  Name = "rulesengine"
+  Name = "rules-engine"
   Protocol = "http"
   Host = "localhost"
   Port = 59720
 	
   [Routes.device-virtual]
-  Name = "virtualdevice"
+  Name = "device-virtual"
   Protocol = "http"
   Host = "localhost"
   Port = 59900


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Route names **not** using service key names
Route for sys-mgmt-agent missing

## Issue Number: #3512


## What is the new behavior?
Route names **now** using service key names
Route for sys-mgmt-agent added

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: API Gateway route names have changed.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information