### PR TITLE
build(all): Remove 'openapi/v1' from swaggerApiFolders in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,6 @@ edgeXBuildGoParallel(
     testScript: 'make test',
     buildScript: 'make build',
     publishSwaggerDocs: true,
-    swaggerApiFolders: ['openapi/v1', 'openapi/v2'],
+    swaggerApiFolders: ['openapi/v2'],
     buildSnap: true
 )


### PR DESCRIPTION
Signed-off-by: Cherry Wang <cherry@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
Fix #3517 

## What is the new behavior?
Remove 'openapi/v1' from swaggerApiFolders on Jenkinsfile

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
No.

## Other information