### PR TITLE
feat: Configure Kuiper for secure message bus

### DIFF
--- a/cmd/security-secretstore-setup/res/configuration.toml
+++ b/cmd/security-secretstore-setup/res/configuration.toml
@@ -76,8 +76,13 @@ ConsulSecretsAdminTokenPath = "/tmp/edgex/secrets/edgex-consul/admin/token.json"
   [Databases.scheduler]
   Service = "support-scheduler"
   Username = "support-scheduler"
+
 [KongAdmin]
 ConfigTemplatePath = "/res/kong-admin-config.template.yml"
 ConfigFilePath = "/tmp/kong/kong.yml"
 ConfigJWTPath = "/tmp/edgex/secrets/security-proxy-setup/kong-admin-jwt"
 ConfigJWTDuration = "1h"
+
+[SecureMessageBus]
+Type = "redis" # blank or none if MessageBus not secured, 'redis' if secured. 'mqtt' is TBD
+KuiperConfigPath = "/tmp/kuiper/edgex.yaml"

--- a/cmd/security-secretstore-setup/res/configuration.toml
+++ b/cmd/security-secretstore-setup/res/configuration.toml
@@ -84,5 +84,5 @@ ConfigJWTPath = "/tmp/edgex/secrets/security-proxy-setup/kong-admin-jwt"
 ConfigJWTDuration = "1h"
 
 [SecureMessageBus]
-Type = "redis" # blank or none if MessageBus not secured, 'redis' if secured. 'mqtt' is TBD
+Type = "none" # blank or none if MessageBus not secured, 'redis' if secured. 'mqtt' is TBD
 KuiperConfigPath = "/tmp/kuiper/edgex.yaml"

--- a/internal/security/secretstore/config/config.go
+++ b/internal/security/secretstore/config/config.go
@@ -22,15 +22,21 @@ import (
 )
 
 type ConfigurationStruct struct {
-	LogLevel    string
-	SecretStore SecretStoreInfo
-	Databases   map[string]Database
-	KongAdmin   KongAdminInfo
+	LogLevel         string
+	SecretStore      SecretStoreInfo
+	Databases        map[string]Database
+	KongAdmin        KongAdminInfo
+	SecureMessageBus SecureMessageBusInfo
 }
 
 type Database struct {
 	Username string
 	Service  string
+}
+
+type SecureMessageBusInfo struct {
+	Type             string
+	KuiperConfigPath string
 }
 
 type SecretStoreInfo struct {

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -401,6 +401,8 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 		os.Exit(1)
 	}
 
+	err = ConfigureSecureMessageBus(configuration.SecureMessageBus, redis5Pair, lc)
+
 	// Concat all cert path secretStore values together to check for empty values
 	certPathCheck := secretStoreConfig.CertPath +
 		secretStoreConfig.CertFilePath +

--- a/internal/security/secretstore/secure-messagebus.go
+++ b/internal/security/secretstore/secure-messagebus.go
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package secretstore
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+)
+
+const (
+	usernamePlaceholder  = "<USERNAME_PLACEHOLDER>"
+	passwordPlaceholder  = "<PASSWORD_PLACEHOLDER>"
+	kuiperConfigTemplate = `
+application_conf:
+  port: 5571
+  protocol: tcp
+  server: localhost
+  topic: application
+default:
+  optional:
+    Username: ` + usernamePlaceholder + `
+    Password: ` + passwordPlaceholder + `
+  port: 6379
+  protocol: redis
+  server: edgex-redis
+  serviceServer: http://localhost:48080
+  topic: rules-events
+  type: redis
+mqtt_conf:
+  optional:
+    ClientId: client1
+  port: 1883
+  protocol: tcp
+  server: 127.0.0.1
+  topic: events
+  type: mqtt
+`
+	// Can't use constants from go-mod-messaging since that will create ZMQ dependency, which we do not want!
+	redisSecureMessageBusType = "redis"
+	mqttSecureMessageBusType  = "mqtt"
+	noneSecureMessageBusType  = "none"
+	blankSecureMessageBusType = ""
+)
+
+func ConfigureSecureMessageBus(secureMessageBus config.SecureMessageBusInfo, redis5Pair UserPasswordPair, lc logger.LoggingClient) error {
+	switch secureMessageBus.Type {
+	// Currently only support Secure MessageBus when using the Redis implementation
+	case redisSecureMessageBusType:
+		err := configureKuiperForSecureMessageBus(redis5Pair, secureMessageBus.KuiperConfigPath, lc)
+		if err != nil {
+			return err
+		}
+
+	// TODO: Add support for secure MQTT MessageBus
+	case mqttSecureMessageBusType:
+		return fmt.Errorf("Secure MQTT MessageBus not yet supported")
+
+	case noneSecureMessageBusType, blankSecureMessageBusType:
+		return nil
+
+	default:
+		return fmt.Errorf("Invalid Secure MessageBus Type of '%s'", secureMessageBus.Type)
+	}
+
+	return nil
+}
+
+func configureKuiperForSecureMessageBus(credentials UserPasswordPair, configPath string, lc logger.LoggingClient) error {
+	kuiperEdgexConfig := kuiperConfigTemplate
+	kuiperEdgexConfig = strings.Replace(kuiperEdgexConfig, usernamePlaceholder, credentials.User, -1)
+	kuiperEdgexConfig = strings.Replace(kuiperEdgexConfig, passwordPlaceholder, credentials.Password, -1)
+
+	err := ioutil.WriteFile(configPath, []byte(kuiperEdgexConfig), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write Kuiper Edgex config file %s: %w", configPath, err)
+	}
+
+	lc.Info("Wrote kuiper config at %s with secure MessageBus credentials", configPath)
+
+	return nil
+}

--- a/internal/security/secretstore/secure-messagebus_test.go
+++ b/internal/security/secretstore/secure-messagebus_test.go
@@ -77,6 +77,9 @@ func TestConfigureSecureMessageBus(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, strings.Contains(string(contents), test.Expected.User))
 			assert.True(t, strings.Contains(string(contents), test.Expected.Password))
+			err = os.Remove(secureMessageBus.KuiperConfigPath)
+			require.NoError(t, err)
+
 		})
 	}
 }

--- a/internal/security/secretstore/secure-messagebus_test.go
+++ b/internal/security/secretstore/secure-messagebus_test.go
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package secretstore
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureSecureMessageBus(t *testing.T) {
+	secureMessageBus := config.SecureMessageBusInfo{
+		KuiperConfigPath: "./testdata/edgex.yaml",
+	}
+
+	validExpected := UserPasswordPair{
+		User:     "testUser",
+		Password: "testPassword",
+	}
+
+	tests := []struct {
+		Name        string
+		Type        string
+		Credentials UserPasswordPair
+		Expected    *UserPasswordPair
+		ExpectError bool
+	}{
+		{"valid redis", redisSecureMessageBusType, validExpected, &validExpected, false},
+		{"valid blank", blankSecureMessageBusType, validExpected, nil, false},
+		{"valid none", noneSecureMessageBusType, validExpected, nil, false},
+		{"invalid type", "bogus", validExpected, nil, true},
+		{"invalid mqtt", mqttSecureMessageBusType, validExpected, nil, true},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			_ = os.Remove(secureMessageBus.KuiperConfigPath)
+			defer func() {
+				_ = os.Remove(secureMessageBus.KuiperConfigPath)
+			}()
+
+			secureMessageBus.Type = test.Type
+			err := ConfigureSecureMessageBus(secureMessageBus, test.Credentials, logger.NewMockClient())
+			if test.ExpectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if test.Expected == nil {
+				// Config file should not have been written
+				_, err = os.Stat(secureMessageBus.KuiperConfigPath)
+				require.True(t, os.IsNotExist(err))
+				return
+			}
+
+			// Config file should have been written
+			contents, err := os.ReadFile(secureMessageBus.KuiperConfigPath)
+			require.NoError(t, err)
+			assert.True(t, strings.Contains(string(contents), test.Expected.User))
+			assert.True(t, strings.Contains(string(contents), test.Expected.Password))
+		})
+	}
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Kuiper doesn't have secure message bus credentials for Redis MessageBus

## Issue Number: #3520


## What is the new behavior?
When in secure mode and message bus is `redis`, write Kuiper config file with Redis credentials.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information