### PR TITLE
fix: Don't regenerate DB passwords if already exists & tweaks for Kuiper config

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/kuiper_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/kuiper_wait_install.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2021 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  ----------------------------------------------------------------------------------
+
+# This is customized entrypoint script for other Edgex services.
+# In particular, it waits for the ReadyToRunPort raised to be ready to roll
+#
+# Note:
+#   Since the entrypoint script is overridden, user should also override the command
+#   so that the $@ is set appropriately on the run-time.
+#
+
+set -e
+
+# env settings are populated from env files of docker-compose
+
+echo "Script for waiting on security bootstrapping ready-to-run"
+
+# gating on the ready-to-run port
+echo "$(date) Executing waitFor with $@ waiting on tcp://${STAGEGATE_BOOTSTRAPPER_HOST}:${STAGEGATE_READY_TORUNPORT}"
+/edgex-init/security-bootstrapper --confdir=/edgex-init/res waitFor \
+  -uri tcp://"${STAGEGATE_BOOTSTRAPPER_HOST}":"${STAGEGATE_READY_TORUNPORT}" \
+  -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
+
+echo "$(date) Starting Kuiper ..."
+exec 	/usr/bin/docker-entrypoint.sh ./bin/kuiperd

--- a/internal/security/secretstore/certs.go
+++ b/internal/security/secretstore/certs.go
@@ -21,7 +21,6 @@ package secretstore
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -48,8 +47,6 @@ type Certs struct {
 	secretServiceBaseURL string
 	loggingClient        logger.LoggingClient
 }
-
-var errNotFound = errors.New("proxy cert pair not found in secret store")
 
 func NewCerts(
 	caller internal.HttpCaller,

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -60,6 +60,8 @@ const (
 	secretBasePath       = "/v1/secret/edgex"
 )
 
+var errNotFound = errors.New("credential NOT found")
+
 type Bootstrap struct {
 	insecureSkipVerify bool
 	vaultInterval      int

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -57,6 +57,7 @@ const (
 	serviceListBegin     = "["
 	serviceListEnd       = "]"
 	serviceListSeparator = ";"
+	secretBasePath       = "/v1/secret/edgex"
 )
 
 type Bootstrap struct {
@@ -360,14 +361,26 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	// Redis 5.x only supports a single shared password. When Redis 6 is released, this can be updated
 	// to a per service password.
 
-	redis5Password, err := cred.GeneratePassword(ctx)
+	redis5Pair, err := getDBCredential("security-bootstrapper-redis", cred, "redisdb")
 	if err != nil {
-		lc.Error("failed to generate redis5 password")
-		os.Exit(1)
-	}
-	redis5Pair := UserPasswordPair{
-		User:     "redis5",
-		Password: redis5Password,
+		if err != errNotFound {
+			lc.Error("failed to determine if Redis credentials already exist or not: %w", err)
+			os.Exit(1)
+		}
+
+		lc.Info("Generating new password for Redis DB")
+		redis5Password, err := cred.GeneratePassword(ctx)
+		if err != nil {
+			lc.Error("failed to generate redis5 password")
+			os.Exit(1)
+		}
+
+		redis5Pair = UserPasswordPair{
+			User:     "redis5",
+			Password: redis5Password,
+		}
+	} else {
+		lc.Info("Redis DB credentials exist, skipping generating new password")
 	}
 
 	// Add any additional services that need the known DB secret
@@ -402,6 +415,10 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	}
 
 	err = ConfigureSecureMessageBus(configuration.SecureMessageBus, redis5Pair, lc)
+	if err != nil {
+		lc.Error("failed to configure for Secure Message Bus: %w", err)
+		os.Exit(1)
+	}
 
 	// Concat all cert path secretStore values together to check for empty values
 	certPathCheck := secretStoreConfig.CertPath +
@@ -573,7 +590,7 @@ func (b *Bootstrap) getKnownSecretsToAdd() (map[string][]string, error) {
 // variadic functions
 
 func addServiceCredential(lc logger.LoggingClient, db string, cred Cred, service string, pair UserPasswordPair) error {
-	path := fmt.Sprintf("/v1/secret/edgex/%s/%s", service, db)
+	path := fmt.Sprintf("%s/%s/%s", secretBasePath, service, db)
 	existing, err := cred.AlreadyInStore(path)
 	if err != nil {
 		return err
@@ -591,8 +608,19 @@ func addServiceCredential(lc logger.LoggingClient, db string, cred Cred, service
 	return err
 }
 
+func getDBCredential(db string, cred Cred, service string) (UserPasswordPair, error) {
+	path := fmt.Sprintf("%s/%s/%s", secretBasePath, db, service)
+
+	pair, err := cred.getUserPasswordPair(path)
+	if err != nil {
+		return UserPasswordPair{}, err
+	}
+
+	return *pair, err
+
+}
 func addDBCredential(lc logger.LoggingClient, db string, cred Cred, service string, pair UserPasswordPair) error {
-	path := fmt.Sprintf("/v1/secret/edgex/%s/%s", db, service)
+	path := fmt.Sprintf("%s/%s/%s", secretBasePath, db, service)
 	existing, err := cred.AlreadyInStore(path)
 	if err != nil {
 		lc.Error(err.Error())

--- a/internal/security/secretstore/secure-messagebus.go
+++ b/internal/security/secretstore/secure-messagebus.go
@@ -86,7 +86,7 @@ func configureKuiperForSecureMessageBus(credentials UserPasswordPair, configPath
 		return fmt.Errorf("failed to parse Kuiper Edgex config template: %w", err)
 	}
 
-	file, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open/create Kuiper Edgex config file %s: %w", configPath, err)
 	}

--- a/internal/security/secretstore/secure-messagebus.go
+++ b/internal/security/secretstore/secure-messagebus.go
@@ -100,7 +100,7 @@ func configureKuiperForSecureMessageBus(credentials UserPasswordPair, configPath
 		return fmt.Errorf("failed to write Kuiper Edgex config file %s: %w", configPath, err)
 	}
 
-	lc.Info("Wrote kuiper config at %s with secure MessageBus credentials", configPath)
+	lc.Infof("Wrote Kuiper config at %s with secure MessageBus credentials", configPath)
 
 	return nil
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
When Secret Store Setup is run it regenerates the DB password and since it is already in Vault it isn't used by Redis.
The new password is used for any new services and written to the Kuiper configuration.

## Issue Number: #3540


## What is the new behavior?
password is not regenerated is it already exist in Vault.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information