### PR TITLE
fix: Change publish and subscribe topics so Core doesn't receive its published Events

### DIFF
--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -49,9 +49,9 @@ Port = 6379
 Type = 'redis'
 AuthMode = 'usernamepassword'  # required for redis messagebus (secure or insecure).
 SecretName = 'redisdb'
-PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name> will be added to this Publish Topic prefix
+PublishTopicPrefix = 'edgex/events/core' # /<device-profile-name>/<device-name> will be added to this Publish Topic prefix
 SubscribeEnabled = true
-SubscribeTopic = "edgex/events/#"  # required for subscribing to Events from MessageBus
+SubscribeTopic = "edgex/events/device/#"  # required for subscribing to Events from MessageBus
   [MessageQueue.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
   # Client Identifiers


### PR DESCRIPTION
Signed-off-by: lenny <leonard.goodell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Core data publish and subscribe topics allows it to receive the events that it publishes

## Issue Number: #3497


## What is the new behavior?
Core data publish and subscribe topics not prevent it from receiving the events that it publishes

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information