### PR TITLE
refactor(sma): refactor sys-mgmt-executor

### DIFF
--- a/cmd/sys-mgmt-executor/main.go
+++ b/cmd/sys-mgmt-executor/main.go
@@ -23,13 +23,19 @@ import (
 )
 
 func main() {
-	result, err := json.Marshal(executor.Execute(os.Args, func(arg ...string) ([]byte, error) {
-		return exec.Command("docker", arg...).CombinedOutput()
-	}))
-	switch {
-	case err != nil:
-		fmt.Printf("json.Marshal error: %s", err.Error())
-	default:
-		fmt.Print(string(result))
+	output, err := executor.Execute(os.Args, func(args ...string) ([]byte, error) {
+		return exec.Command("docker", args...).CombinedOutput()
+	})
+	if err != nil {
+		fmt.Print(err.Error())
+		os.Exit(1)
 	}
+
+	result, err := json.Marshal(output)
+	if err != nil {
+		fmt.Printf("json.Marshal error: %s", err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Print(string(result))
 }

--- a/internal/system/agent/v2/application/executor/metrics.go
+++ b/internal/system/agent/v2/application/executor/metrics.go
@@ -46,11 +46,11 @@ func (m *metrics) Get(_ context.Context, services []string) ([]interface{}, erro
 		go func(serviceName string) {
 			defer wg.Done()
 
-			raw, err := m.executor(m.executorPath, serviceName, system.Metrics)
+			res, err := m.executor(m.executorPath, serviceName, system.Metrics)
 			if err != nil {
 				mu.Lock()
 				responses = append(responses, common.BaseWithMetricsResponse{
-					BaseResponse: common.NewBaseResponse("", err.Error(), http.StatusInternalServerError),
+					BaseResponse: common.NewBaseResponse("", res, http.StatusInternalServerError),
 					ServiceName:  serviceName,
 					Metrics:      nil,
 				})
@@ -58,7 +58,7 @@ func (m *metrics) Get(_ context.Context, services []string) ([]interface{}, erro
 				return
 			}
 
-			r := response.Process(raw, m.lc)
+			r := response.Process(res, m.lc)
 			mu.Lock()
 			responses = append(responses, common.BaseWithMetricsResponse{
 				BaseResponse: common.NewBaseResponse("", "", http.StatusOK),

--- a/internal/system/agent/v2/application/executor/operation.go
+++ b/internal/system/agent/v2/application/executor/operation.go
@@ -46,11 +46,11 @@ func (o *operation) Do(_ context.Context, operations []requests.OperationRequest
 			defer wg.Done()
 
 			o.lc.Debugf("Executing '%s' action on %s", operation.Action, operation.ServiceName)
-			_, err := o.executor(o.executorPath, operation.ServiceName, operation.Action)
+			res, err := o.executor(o.executorPath, operation.ServiceName, operation.Action)
 			if err != nil {
 				mu.Lock()
 				responses = append(responses, common.BaseWithServiceNameResponse{
-					BaseResponse: common.NewBaseResponse(operation.RequestId, err.Error(), http.StatusInternalServerError),
+					BaseResponse: common.NewBaseResponse(operation.RequestId, res, http.StatusInternalServerError),
 					ServiceName:  operation.ServiceName,
 				})
 				mu.Unlock()

--- a/internal/system/executor/docker.go
+++ b/internal/system/executor/docker.go
@@ -15,16 +15,15 @@
 package executor
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/edgexfoundry/edgex-go/internal/system"
 )
 
 const (
 	Start   = "start"
 	Stop    = "stop"
 	Restart = "restart"
-	Metrics = system.Metrics
+	Metrics = "metrics"
 
 	executorType        = "docker"
 	failedStartPrefix   = "Error starting service"
@@ -48,7 +47,7 @@ func messageMissingArguments() string {
 }
 
 // Execute is called from main (which supplies an executor) to process a request.
-func Execute(args []string, executor CommandExecutor) (result system.Result) {
+func Execute(args []string, executor CommandExecutor) (res interface{}, err error) {
 	switch {
 	case len(args) > 2:
 		service := args[1]
@@ -56,18 +55,17 @@ func Execute(args []string, executor CommandExecutor) (result system.Result) {
 
 		switch operation {
 		case Start:
-			result = executeACommand(operation, service, executor, failedStartPrefix, true)
+			return executeACommand(operation, service, executor, failedStartPrefix, true)
 		case Restart:
-			result = executeACommand(operation, service, executor, failedRestartPrefix, true)
+			return executeACommand(operation, service, executor, failedRestartPrefix, true)
 		case Stop:
-			result = executeACommand(operation, service, executor, failedStopPrefix, false)
+			return executeACommand(operation, service, executor, failedStopPrefix, false)
 		case Metrics:
-			result = gatherMetrics(service, executor)
+			return gatherMetrics(service, executor)
 		default:
-			result = system.Failure(service, operation, executorType, messageExecutorOperationNotSupported())
+			return res, errors.New(messageExecutorOperationNotSupported())
 		}
 	default:
-		result = system.Failure("", "", executorType, messageMissingArguments())
+		return res, errors.New(messageMissingArguments())
 	}
-	return
 }

--- a/internal/system/executor/docker_test.go
+++ b/internal/system/executor/docker_test.go
@@ -18,15 +18,14 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/edgexfoundry/edgex-go/internal/system"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
 	serviceName                   = "serviceName"
 	executableName                = "executableName"
 	errorMessage                  = "errorMessage"
-	invalidOperation              = "invalidOperation"
 	metricsSuccessRawResult       = "metricsSuccessRawResult"
 	jsonDecodeFailureErrorMessage = "EOF"
 )
@@ -100,53 +99,53 @@ func executeArguments(serviceName string, operation string) []string {
 
 func TestExecute(t *testing.T) {
 	tests := []struct {
-		name           string
-		operation      string
-		expectedResult system.Result
-		executorCalls  []executorStubCall
+		name          string
+		operation     string
+		expectedErr   bool
+		executorCalls []executorStubCall
 	}{
 		// start command test cases
 
 		{
 			"Start: first executor call fails",
 			Start,
-			system.Failure(serviceName, Start, executorType, messageExecutorCommandFailed(failedStartPrefix, string([]byte(nil)), errorMessage)),
+			true,
 			firstCommandCallFails(serviceName, Start),
 		},
 		{
 			"Start: second executor call fails",
 			Start,
-			system.Failure(serviceName, Start, executorType, messageExecutorInspectFailed(failedStartPrefix, errorMessage)),
+			true,
 			secondCommandCallFails(serviceName, Start),
 		},
 		{
 			"Start: container not found in inspect result",
 			Start,
-			system.Failure(serviceName, Start, executorType, messageExecutorInspectFailed(failedStartPrefix, messageContainerNotFound(serviceName))),
+			true,
 			secondCommandCallSucceeds(serviceName, Start, "[]"),
 		},
 		{
 			"Start: more than one container instance found in inspect result",
 			Start,
-			system.Failure(serviceName, Start, executorType, messageExecutorInspectFailed(failedStartPrefix, messageMoreThanOneContainerFound(serviceName))),
+			true,
 			secondCommandCallSucceeds(serviceName, Start, "[{\"State\": {\"Running\": false}}, {\"State\": {\"Running\": false}}]"),
 		},
 		{
 			"Start: inspect result says service is not running as expected",
 			Start,
-			system.Failure(serviceName, Start, executorType, messageServiceIsNotRunningButShouldBe(failedStartPrefix)),
+			true,
 			secondCommandCallSucceeds(serviceName, Start, "[{\"State\": {\"Running\": false}}]"),
 		},
 		{
 			"Start: isContainerRunning json.Decode Failure",
 			Start,
-			system.Failure(serviceName, Start, executorType, messageExecutorInspectFailed(failedStartPrefix, jsonDecodeFailureErrorMessage)),
+			true,
 			secondCommandCallSucceeds(serviceName, Start, ""),
 		},
 		{
 			"Start: Success",
 			Start,
-			system.Success(serviceName, Start, executorType),
+			false,
 			secondCommandCallSucceeds(serviceName, Start, "[{\"State\": {\"Running\": true}}]"),
 		},
 
@@ -155,43 +154,43 @@ func TestExecute(t *testing.T) {
 		{
 			"Restart: first executor call fails",
 			Restart,
-			system.Failure(serviceName, Restart, executorType, messageExecutorCommandFailed(failedRestartPrefix, string([]byte(nil)), errorMessage)),
+			true,
 			firstCommandCallFails(serviceName, Restart),
 		},
 		{
 			"Restart: second executor call fails",
 			Restart,
-			system.Failure(serviceName, Restart, executorType, messageExecutorInspectFailed(failedRestartPrefix, errorMessage)),
+			true,
 			secondCommandCallFails(serviceName, Restart),
 		},
 		{
 			"Restart: container not found in inspect result",
 			Restart,
-			system.Failure(serviceName, Restart, executorType, messageExecutorInspectFailed(failedRestartPrefix, messageContainerNotFound(serviceName))),
+			true,
 			secondCommandCallSucceeds(serviceName, Restart, "[]"),
 		},
 		{
 			"Restart: more than one container instance found in inspect result",
 			Restart,
-			system.Failure(serviceName, Restart, executorType, messageExecutorInspectFailed(failedRestartPrefix, messageMoreThanOneContainerFound(serviceName))),
+			true,
 			secondCommandCallSucceeds(serviceName, Restart, "[{\"State\": {\"Running\": false}}, {\"State\": {\"Running\": false}}]"),
 		},
 		{
 			"Restart: inspect result says service is not running as expected",
 			Restart,
-			system.Failure(serviceName, Restart, executorType, messageServiceIsNotRunningButShouldBe(failedRestartPrefix)),
+			true,
 			secondCommandCallSucceeds(serviceName, Restart, "[{\"State\": {\"Running\": false}}]"),
 		},
 		{
 			"Restart: isContainerRunning json.Decode Failure",
 			Restart,
-			system.Failure(serviceName, Restart, executorType, messageExecutorInspectFailed(failedRestartPrefix, jsonDecodeFailureErrorMessage)),
+			true,
 			secondCommandCallSucceeds(serviceName, Restart, ""),
 		},
 		{
 			"Restart: Success",
 			Restart,
-			system.Success(serviceName, Restart, executorType),
+			false,
 			secondCommandCallSucceeds(serviceName, Restart, "[{\"State\": {\"Running\": true}}]"),
 		},
 
@@ -200,43 +199,43 @@ func TestExecute(t *testing.T) {
 		{
 			"Stop: first executor call fails",
 			Stop,
-			system.Failure(serviceName, Stop, executorType, messageExecutorCommandFailed(failedStopPrefix, string([]byte(nil)), errorMessage)),
+			true,
 			firstCommandCallFails(serviceName, Stop),
 		},
 		{
 			"Stop: second executor call fails",
 			Stop,
-			system.Failure(serviceName, Stop, executorType, messageExecutorInspectFailed(failedStopPrefix, errorMessage)),
+			true,
 			secondCommandCallFails(serviceName, Stop),
 		},
 		{
 			"Stop: container not found in inspect result",
 			Stop,
-			system.Failure(serviceName, Stop, executorType, messageExecutorInspectFailed(failedStopPrefix, messageContainerNotFound(serviceName))),
+			true,
 			secondCommandCallSucceeds(serviceName, Stop, "[]"),
 		},
 		{
 			"Stop: more than one container instance found in inspect result",
 			Stop,
-			system.Failure(serviceName, Stop, executorType, messageExecutorInspectFailed(failedStopPrefix, messageMoreThanOneContainerFound(serviceName))),
+			true,
 			secondCommandCallSucceeds(serviceName, Stop, "[{\"State\": {\"Running\": true}}, {\"State\": {\"Running\": true}}]"),
 		},
 		{
 			"Stop: inspect result says service is not running as expected",
 			Stop,
-			system.Failure(serviceName, Stop, executorType, messageServiceIsRunningButShouldNotBe(failedStopPrefix)),
+			true,
 			secondCommandCallSucceeds(serviceName, Stop, "[{\"State\": {\"Running\": true}}]"),
 		},
 		{
 			"Stop: isContainerRunning json.Decode Failure",
 			Stop,
-			system.Failure(serviceName, Stop, executorType, messageExecutorInspectFailed(failedStopPrefix, jsonDecodeFailureErrorMessage)),
+			true,
 			secondCommandCallSucceeds(serviceName, Stop, ""),
 		},
 		{
 			"Stop: Success",
 			Stop,
-			system.Success(serviceName, Stop, executorType),
+			false,
 			secondCommandCallSucceeds(serviceName, Stop, "[{\"State\": {\"Running\": false}}]"),
 		},
 
@@ -245,47 +244,38 @@ func TestExecute(t *testing.T) {
 		{
 			"MetricsViaExecutor: Failure",
 			Metrics,
-			system.Failure(serviceName, Metrics, executorType, errorMessage),
+			true,
 			firstMetricsCallFails(serviceName),
 		},
 		{
 			"MetricsViaExecutor: Success (missing memory scale)",
 			Metrics,
-			system.MetricsSuccess(serviceName, executorType, 1.49, -1, []byte(metricsSuccessRawResult)),
+			false,
 			firstMetricsCallSucceeds(serviceName, "1.49%"+separator+"1234 / 7.786GiB"+separator+metricsSuccessRawResult),
 		},
 		{
 			"MetricsViaExecutor: Success (kb)",
 			Metrics,
-			system.MetricsSuccess(serviceName, executorType, 1.49, 1264, []byte(metricsSuccessRawResult)),
+			false,
 			firstMetricsCallSucceeds(serviceName, "1.49%"+separator+"1.234KiB / 7.786GiB"+separator+metricsSuccessRawResult),
 		},
 		{
 			"MetricsViaExecutor: Success (mb)",
 			Metrics,
-			system.MetricsSuccess(serviceName, executorType, 1.49, 1293943, []byte(metricsSuccessRawResult)),
+			false,
 			firstMetricsCallSucceeds(serviceName, "1.49%"+separator+"1.234MiB / 7.786GiB"+separator+metricsSuccessRawResult),
 		},
 		{
 			"MetricsViaExecutor: Success (gb)",
 			Metrics,
-			system.MetricsSuccess(serviceName, executorType, 1.49, 1324997411, []byte(metricsSuccessRawResult)),
+			false,
 			firstMetricsCallSucceeds(serviceName, "1.49%"+separator+"1.234GiB / 7.786GiB"+separator+metricsSuccessRawResult),
 		},
 		{
 			"MetricsViaExecutor: Success (missing cpu float value)",
 			Metrics,
-			system.MetricsSuccess(serviceName, executorType, -1.0, 1264, []byte(metricsSuccessRawResult)),
+			false,
 			firstMetricsCallSucceeds(serviceName, "badValue"+separator+"1.234KiB / 7.786GiB"+separator+metricsSuccessRawResult),
-		},
-
-		// invalid operation test case
-
-		{
-			"operation not supported by executor",
-			invalidOperation,
-			system.Failure(serviceName, invalidOperation, executorType, messageExecutorOperationNotSupported()),
-			[]executorStubCall{},
 		},
 	}
 
@@ -293,14 +283,16 @@ func TestExecute(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			executor := newExecutor(test.executorCalls)
 
-			result := Execute(executeArguments(serviceName, test.operation), executor.commandExecutor)
+			_, err := Execute(executeArguments(serviceName, test.operation), executor.commandExecutor)
+			if test.expectedErr {
+				require.Error(t, err)
+			}
 
 			if assert.Equal(t, len(test.executorCalls), executor.Called) {
 				for key, executorCall := range test.executorCalls {
 					assertArgsAreEqual(t, executorCall.expectedArgs, executor.capturedArgs[key])
 				}
 			}
-			assert.Equal(t, test.expectedResult, result)
 		})
 	}
 }
@@ -309,8 +301,8 @@ func TestMissingArguments(t *testing.T) {
 	missingArguments := []string{executableName}
 	executor := newExecutor([]executorStubCall{})
 
-	result := Execute(missingArguments, executor.commandExecutor)
+	_, err := Execute(missingArguments, executor.commandExecutor)
 
 	assert.Equal(t, 0, executor.Called)
-	assert.Equal(t, system.Failure("", "", executorType, messageMissingArguments()), result)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Current implementation of sys-mgmt-executor does not properly return error when the docker execution failed. It returns a `system.Result` interface with the success status and errorMessage embedded in. This makes SMA always return 200 even if the execution failed.

```
curl http://localhost:58890/api/v2/system/metrics?services=edgex-core-data,invalid
207
[
    {
        "apiVersion": "v2",
        "statusCode": 200,
        "serviceName": "invalid",
        "metrics": {
            "Success": false,
            "errorMessage": "exit status 1",
            "executor": "docker",
            "operation": "metrics",
            "service": "invalid"
        }
    },
    {
        "apiVersion": "v2",
        "statusCode": 200,
        "serviceName": "edgex-core-data",
        "metrics": {
            "Success": true,
            "executor": "docker",
            "operation": "metrics",
            "result": {
                "cpuUsedPercent": 0.04,
                "memoryUsed": 6639583,
                "raw": {
                    "block_io": "0B / 0B",
                    "cpu_perc": "0.04%",
                    "mem_perc": "0.32%",
                    "mem_usage": "6.332MiB / 1.94GiB",
                    "net_io": "33.7kB / 31.1kB",
                    "pids": "11"
                }
            },
            "service": "edgex-core-data"
        }
    }
]


POSTing /api/v2/system/operation with following payload:
[
    {
        "apiVersion": "v2",
        "serviceName": "invalid",
        "action": "restart"
    }
]

Result:
207
[
    {
        "apiVersion": "v2",
        "statusCode": 200,
        "serviceName": "invalid"
    }
]
```

## Issue Number: fix #3533


## What is the new behavior?

Not using `system.Result`, returns output and error of docker execution directly.

```
curl http://localhost:58890/api/v2/system/metrics?services=edgex-core-data,invalid
207
[
    {
        "apiVersion": "v2",
        "message": "exit status 1: Error response from daemon: No such container: invalid\n",
        "statusCode": 500,
        "serviceName": "invalid",
        "metrics": null
    },
    {
        "apiVersion": "v2",
        "statusCode": 200,
        "serviceName": "edgex-core-data",
        "metrics": {
            "cpuUsedPercent": 0.03,
            "memoryUsed": 11219763,
            "raw": {
                "block_io": "4.36MB / 0B",
                "cpu_perc": "0.03%",
                "mem_perc": "0.54%",
                "mem_usage": "10.7MiB / 1.94GiB",
                "net_io": "169kB / 169kB",
                "pids": "13"
            }
        }
    }
]


POSTing /api/v2/system/operation with following payload:
[
    {
        "apiVersion": "v2",
        "serviceName": "invalid",
        "action": "restart"
    }
]

Result:
207
[
    {
        "apiVersion": "v2",
        "message": "exit status 1: Error response from daemon: No such container: invalid\n",
        "statusCode": 500,
        "serviceName": "invalid"
    }
]
```

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information