### PR TITLE
fix: Fix the issue of mismatch Consul service key in proxy-setup

### DIFF
--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -47,7 +47,7 @@ const (
 	// AddProxyRoutesEnv is the environment variable name for adding the additional Kong routes for app services
 	AddProxyRoutesEnv = "ADD_PROXY_ROUTE"
 
-	edgeXCoreConsulServiceKey = "edgex-core-consul"
+	edgeXCoreConsulServiceKey = "core-consul"
 )
 
 type CertError struct {


### PR DESCRIPTION
- servie key for Consul got changed from edgex-core-consul to core-consul and thus we need to change in the code, too

Fix: #3547
Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently the Consul kong route cannot be accessed (forbidden) due to mismatch service key condition.

## Issue Number: #3547 


## What is the new behavior?
Fixed the right service key for "core-consul"

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information