### PR TITLE
refactor(scheduler): Remove runOnce feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.61
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.8
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.96
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.99
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.15
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.23

--- a/internal/support/scheduler/v2/application/interval.go
+++ b/internal/support/scheduler/v2/application/interval.go
@@ -160,7 +160,6 @@ func LoadIntervalToSchedulerManager(dic *di.Container) errors.EdgeX {
 			Start:    configuration.Intervals[i].Start,
 			End:      configuration.Intervals[i].End,
 			Interval: configuration.Intervals[i].Interval,
-			RunOnce:  configuration.Intervals[i].RunOnce,
 		}
 		_, err := dbClient.IntervalByName(interval.Name)
 		if errors.Kind(err) == errors.KindEntityDoesNotExist {

--- a/internal/support/scheduler/v2/application/scheduler/executor.go
+++ b/internal/support/scheduler/v2/application/scheduler/executor.go
@@ -72,7 +72,8 @@ func (executor *Executor) Initialize(interval models.Interval, lc logger.Logging
 
 // IsComplete checks whether the Executor is complete
 func (executor *Executor) IsComplete() bool {
-	return executor.isComplete(time.Now())
+	expired := executor.NextTime.Unix() > executor.EndTime.Unix()
+	return expired
 }
 
 // UpdateNextTime increase the NextTime by frequency if the Executor not complete
@@ -80,9 +81,4 @@ func (executor *Executor) UpdateNextTime() {
 	if !executor.IsComplete() {
 		executor.NextTime = executor.NextTime.Add(executor.Frequency)
 	}
-}
-
-func (executor *Executor) isComplete(time time.Time) bool {
-	expired := executor.NextTime.Unix() > executor.EndTime.Unix()
-	return expired
 }

--- a/internal/support/scheduler/v2/application/scheduler/executor.go
+++ b/internal/support/scheduler/v2/application/scheduler/executor.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	TIMELAYOUT = "20060102T150405"
+	SchedulerTimeFormat = "20060102T150405"
 )
 
 type Executor struct {
@@ -25,8 +25,6 @@ type Executor struct {
 	EndTime            time.Time
 	NextTime           time.Time
 	Frequency          time.Duration
-	CurrentIterations  int64
-	MaxIterations      int64
 	MarkedDeleted      bool
 }
 
@@ -35,19 +33,11 @@ func (executor *Executor) Initialize(interval models.Interval, lc logger.Logging
 	executor.Interval = interval
 	currentTime := time.Now()
 
-	// run times, current and max iteration
-	if executor.Interval.RunOnce {
-		executor.MaxIterations = 1
-	} else {
-		executor.MaxIterations = 0
-	}
-	executor.CurrentIterations = 0
-
 	// start and end time
 	if executor.Interval.Start == "" {
 		executor.StartTime = currentTime
 	} else {
-		t, err := time.Parse(TIMELAYOUT, executor.Interval.Start)
+		t, err := time.Parse(SchedulerTimeFormat, executor.Interval.Start)
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("fail to parse the StartTime string %s", executor.Interval.End), err)
 		}
@@ -58,28 +48,24 @@ func (executor *Executor) Initialize(interval models.Interval, lc logger.Logging
 		// use max time
 		executor.EndTime = time.Unix(1<<63-62135596801, 999999999)
 	} else {
-		t, err := time.Parse(TIMELAYOUT, executor.Interval.End)
+		t, err := time.Parse(SchedulerTimeFormat, executor.Interval.End)
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("fail to parse the EndTime string %s", executor.Interval.End), err)
 		}
 		executor.EndTime = t
 	}
 
+	frequency, err := time.ParseDuration(executor.Interval.Interval)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "interval parse frequency error", err)
+	}
+	executor.Frequency = frequency
+
 	executor.NextTime = executor.StartTime
-
-	// Parse frequency when RunOnce is false because we can use frequency or runOnce but not both
-	if !executor.Interval.RunOnce {
-		frequency, err := time.ParseDuration(executor.Interval.Interval)
-		if err != nil {
-			return errors.NewCommonEdgeX(errors.KindContractInvalid, "interval parse frequency error", err)
-		}
-		executor.Frequency = frequency
-
-		// Increase the NextTime by interval frequency when NextTime small than the CurrentTime
-		nowBenchmark := currentTime.Unix()
-		for executor.NextTime.Unix() <= nowBenchmark {
-			executor.NextTime = executor.NextTime.Add(executor.Frequency)
-		}
+	// Increase the NextTime by interval frequency when NextTime small than the CurrentTime
+	nowBenchmark := currentTime.Unix()
+	for executor.NextTime.Unix() <= nowBenchmark {
+		executor.NextTime = executor.NextTime.Add(executor.Frequency)
 	}
 	return nil
 }
@@ -87,13 +73,6 @@ func (executor *Executor) Initialize(interval models.Interval, lc logger.Logging
 // IsComplete checks whether the Executor is complete
 func (executor *Executor) IsComplete() bool {
 	return executor.isComplete(time.Now())
-}
-
-// UpdateIterations increase the CurrentIterations times if the Executor not complete
-func (executor *Executor) UpdateIterations() {
-	if !executor.IsComplete() {
-		executor.CurrentIterations += 1
-	}
 }
 
 // UpdateNextTime increase the NextTime by frequency if the Executor not complete
@@ -104,8 +83,6 @@ func (executor *Executor) UpdateNextTime() {
 }
 
 func (executor *Executor) isComplete(time time.Time) bool {
-	ranOnce := executor.StartTime.Unix() < time.Unix() && executor.Interval.RunOnce
 	expired := executor.NextTime.Unix() > executor.EndTime.Unix()
-	iterationLimitReached := (executor.MaxIterations != 0) && (executor.CurrentIterations >= executor.MaxIterations)
-	return ranOnce || expired || iterationLimitReached
+	return expired
 }

--- a/internal/support/scheduler/v2/application/scheduler/executor_test.go
+++ b/internal/support/scheduler/v2/application/scheduler/executor_test.go
@@ -26,15 +26,13 @@ func TestInitialize(t *testing.T) {
 		startTime         string
 		endTime           string
 		interval          string
-		runOnce           bool
 		expectedErrorKind errors.ErrKind
 	}{
-		{"run once", "midnight", "20000101T000000", "", "24h", true, ""},
-		{"run with interval", "midnight", "20000101T000000", "22000101T000000", "24h", false, ""},
-		{"run without startTime ", "midnight", "", "22000101T000000", "24h", false, ""},
-		{"wrong startTime string format", "midnight", "20000101T", "", "24h", false, errors.KindContractInvalid},
-		{"wrong endTime string format", "midnight", "", "20000101T", "24h", false, errors.KindContractInvalid},
-		{"wrong frequency string format", "midnight", "", "", "24", false, errors.KindContractInvalid},
+		{"run with interval", "midnight", "20000101T000000", "22000101T000000", "24h", ""},
+		{"run without startTime ", "midnight", "", "22000101T000000", "24h", ""},
+		{"wrong startTime string format", "midnight", "20000101T", "", "24h", errors.KindContractInvalid},
+		{"wrong endTime string format", "midnight", "", "20000101T", "24h", errors.KindContractInvalid},
+		{"wrong frequency string format", "midnight", "", "", "24", errors.KindContractInvalid},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -42,7 +40,7 @@ func TestInitialize(t *testing.T) {
 			interval := models.Interval{
 				Name:  testCase.intervalName,
 				Start: testCase.startTime, End: testCase.endTime,
-				Interval: testCase.interval, RunOnce: testCase.runOnce,
+				Interval: testCase.interval,
 			}
 			executor := Executor{}
 
@@ -61,20 +59,9 @@ func TestInitialize(t *testing.T) {
 			if interval.End != "" {
 				assert.Equal(t, interval.End, executor.EndTime.Format("20060102T000000"))
 			}
-			if interval.RunOnce {
-				assert.LessOrEqual(t, executor.NextTime.Unix(), current.Unix())
-				assert.EqualValues(t, executor.MaxIterations, 1)
-				assert.EqualValues(t, executor.Frequency.Seconds(), 0)
-				if interval.Start == "" {
-					assert.Equal(t, executor.StartTime, executor.NextTime)
-					assert.LessOrEqual(t, executor.NextTime.Unix(), current.Unix())
-				}
-				assert.True(t, executor.IsComplete())
-			} else {
-				assert.GreaterOrEqual(t, executor.NextTime.Unix(), current.Unix())
-				assert.Greater(t, executor.Frequency.Seconds(), float64(0))
-				assert.False(t, executor.IsComplete())
-			}
+			assert.GreaterOrEqual(t, executor.NextTime.Unix(), current.Unix())
+			assert.Greater(t, executor.Frequency.Seconds(), float64(0))
+			assert.False(t, executor.IsComplete())
 		})
 	}
 }

--- a/internal/support/scheduler/v2/application/scheduler/manager.go
+++ b/internal/support/scheduler/v2/application/scheduler/manager.go
@@ -116,7 +116,6 @@ func (m *manager) execute(
 	}
 
 	executor.UpdateNextTime()
-	executor.UpdateIterations()
 
 	if executor.IsComplete() {
 		m.lc.Debugf("completed interval %s", executor.Interval.Name)

--- a/internal/support/scheduler/v2/application/scheduler/queue_test.go
+++ b/internal/support/scheduler/v2/application/scheduler/queue_test.go
@@ -48,7 +48,6 @@ func intervalData() models.Interval {
 		Start:    "",
 		End:      "",
 		Interval: "10s",
-		RunOnce:  false,
 	}
 }
 

--- a/internal/support/scheduler/v2/controller/http/const_test.go
+++ b/internal/support/scheduler/v2/controller/http/const_test.go
@@ -11,7 +11,6 @@ const (
 	TestIntervalStart     = "20190102T150405"
 	TestIntervalEnd       = "20190802T150405"
 	TestIntervalFrequency = "30ms"
-	TestIntervalRunOnce   = false
 
 	TestIntervalActionName = "TestIntervalAction"
 	TestHost               = "localhost"

--- a/internal/support/scheduler/v2/controller/http/interval_test.go
+++ b/internal/support/scheduler/v2/controller/http/interval_test.go
@@ -65,7 +65,6 @@ func addIntervalRequestData() requests.AddIntervalRequest {
 			Start:    TestIntervalStart,
 			End:      TestIntervalEnd,
 			Interval: TestIntervalFrequency,
-			RunOnce:  TestIntervalRunOnce,
 		},
 	}
 

--- a/openapi/v2/support-scheduler.yaml
+++ b/openapi/v2/support-scheduler.yaml
@@ -120,9 +120,6 @@ components:
         name:
           description: "Non-database identifier for an interval (*must be unique)"
           type: string
-        runOnce:
-          description: "Indicates that this interval runs one time - at the time indicated by the start"
-          type: boolean
         start:
           description: "Start time in ISO 8601 format YYYYMMDD'T'HHmmss 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = \"yyyymmdd'T'HHmmss\")"
           type: string
@@ -149,9 +146,6 @@ components:
         interval:
           description: Interval indicates how often the specific resource needs to be polled. It represents as a duration string. The format of this field is to be an unsigned integer followed by a unit which may be "ns", "us" (or "µs"), "ms", "s", "m", "h" representing nanoseconds, microseconds, milliseconds, seconds, minutes or hours. Eg, "100ms", "24h"
           type: string
-        runOnce:
-          description: "Indicates that this interval runs one time - at the time indicated by the start"
-          type: boolean
       required:
         - id
         - name


### PR DESCRIPTION
Close: #3532

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3532 


## What is the new behavior?
Remove runOnce feature from the scheduler service

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information