### PR TITLE
fix(notifications): Query with invalid offset range should return 416

### DIFF
--- a/internal/pkg/v2/infrastructure/redis/queries.go
+++ b/internal/pkg/v2/infrastructure/redis/queries.go
@@ -225,10 +225,12 @@ func objectsByKeys(conn redis.Conn, setMethod string, offset int, limit int, red
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindDatabaseError, "failed to query storeKeys", err)
 	}
-	if len(storeKeys) == 0 {
+	count := len(storeKeys)
+	if count == 0 || count == offset {
 		return nil, nil
-	}
-	if end >= len(storeKeys) || end == -1 {
+	} else if count > 0 && offset > count { // return RangeNotSatisfiable error when offset is out of range
+		return nil, errors.NewCommonEdgeX(errors.KindRangeNotSatisfiable, fmt.Sprintf("query objects bounds out of range. length:%v", count), nil)
+	} else if end >= count || end == -1 {
 		storeKeys = storeKeys[offset:]
 	} else { // as end index in golang re-slice is exclusive, increment the end index to ensure the end could be inclusive
 		storeKeys = storeKeys[offset : end+1]


### PR DESCRIPTION
Close #3545

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3545


## What is the new behavior?
- Query with invalid offset range should return 416
- Offset is equal to notification count, it should return 200 and empty list for notifications

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information