### PR TITLE
refactor: Remove the io/ioutil usage

### DIFF
--- a/internal/core/data/v2/io/event.go
+++ b/internal/core/data/v2/io/event.go
@@ -8,7 +8,6 @@ package io
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
@@ -78,7 +77,7 @@ func (jsonEventReader) ReadAddEventRequest(bytes []byte) (dto.AddEventRequest, e
 
 func ReadDataInBytes(reader io.Reader) ([]byte, errors.EdgeX) {
 	// use LimitReader with defaultMaxEventSize to avoid unexpected memory exhaustion
-	bytes, err := ioutil.ReadAll(io.LimitReader(reader, defaultMaxEventSize))
+	bytes, err := io.ReadAll(io.LimitReader(reader, defaultMaxEventSize))
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindIOError, "AddEventRequest I/O reading failed", err)
 	}

--- a/internal/core/metadata/v2/io/deviceprofile.go
+++ b/internal/core/metadata/v2/io/deviceprofile.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"gopkg.in/yaml.v2"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 
@@ -55,7 +54,7 @@ func (jsonDeviceProfileReader) ReadDeviceProfileYaml(r *http.Request) (dtos.Devi
 		return dtos.DeviceProfile{}, errors.NewCommonEdgeX(errors.KindContractInvalid, "missing yaml file", err)
 	}
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return dtos.DeviceProfile{}, errors.NewCommonEdgeX(errors.KindServerError, "failed to read yaml file", err)
 	}

--- a/internal/pkg/v2/utils/http.go
+++ b/internal/pkg/v2/utils/http.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -165,7 +165,7 @@ func ParsePathParamToInt(r *http.Request, pathKey string) (int, errors.EdgeX) {
 // Parse the body of http request to a map[string]string.  EdgeX error will be returned if any parsing error occurs.
 func ParseBodyToMap(r *http.Request) (map[string]string, errors.EdgeX) {
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to read request body", err)
 	}

--- a/internal/pkg/v2/utils/restaddress.go
+++ b/internal/pkg/v2/utils/restaddress.go
@@ -8,7 +8,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -95,7 +95,7 @@ func sendRequestAndGetResponse(client *http.Client, req *http.Request) (res stri
 	defer resp.Body.Close()
 	resp.Close = true
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.NewCommonEdgeX(errors.KindIOError, "fail to read the response body", err)
 	}

--- a/internal/security/bootstrapper/command/setupacl/aclbootstrap.go
+++ b/internal/security/bootstrapper/command/setupacl/aclbootstrap.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -59,7 +59,7 @@ func (c *cmd) generateBootStrapACLToken() (*BootStrapACLTokenInfo, error) {
 		_ = resp.Body.Close()
 	}()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read response body of bootstrap ACL: %w", err)
 	}

--- a/internal/security/bootstrapper/command/setupacl/aclpolicies.go
+++ b/internal/security/bootstrapper/command/setupacl/aclpolicies.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -126,7 +126,7 @@ func (c *cmd) getOrCreateRegistryPolicy(tokenID, policyName, policyRules string)
 		_ = resp.Body.Close()
 	}()
 
-	createPolicyResp, err := ioutil.ReadAll(resp.Body)
+	createPolicyResp, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read create a new policy response body: %w", err)
 	}
@@ -170,7 +170,7 @@ func (c *cmd) getPolicyByName(tokenID, policyName string) (*Policy, error) {
 		_ = resp.Body.Close()
 	}()
 
-	readPolicyResp, err := ioutil.ReadAll(resp.Body)
+	readPolicyResp, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read readPolicyByName response body: %w", err)
 	}

--- a/internal/security/bootstrapper/command/setupacl/aclroles.go
+++ b/internal/security/bootstrapper/command/setupacl/aclroles.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -129,7 +129,7 @@ func (c *cmd) createRole(secretStoreToken string, registryRole RegistryRole) err
 		c.loggingClient.Infof("successfully created a role [%s] for secretstore", registryRole.RoleName)
 		return nil
 	default:
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			c.loggingClient.Errorf("cannot read resp.Body: %v", err)
 		}

--- a/internal/security/bootstrapper/command/setupacl/acltokens.go
+++ b/internal/security/bootstrapper/command/setupacl/acltokens.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -104,7 +104,7 @@ func (c *cmd) isACLTokenPersistent(bootstrapACLToken string) (bool, error) {
 		_ = resp.Body.Close()
 	}()
 
-	checkAgentResp, err := ioutil.ReadAll(resp.Body)
+	checkAgentResp, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, fmt.Errorf("Failed to read checkAgent response body: %w", err)
 	}
@@ -206,7 +206,7 @@ func (c *cmd) getEdgeXAgentToken(bootstrapACLToken BootStrapACLTokenInfo) (strin
 		_ = resp.Body.Close()
 	}()
 
-	listTokensResp, err := ioutil.ReadAll(resp.Body)
+	listTokensResp, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return share.EmptyToken, fmt.Errorf("Failed to read getEdgeXAgentToken response body: %w", err)
 	}
@@ -274,7 +274,7 @@ func (c *cmd) readTokenIDBy(bootstrapACLToken BootStrapACLTokenInfo, accessorID 
 		_ = resp.Body.Close()
 	}()
 
-	readTokenResp, err := ioutil.ReadAll(resp.Body)
+	readTokenResp, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return share.EmptyToken, fmt.Errorf("Failed to read readTokenID response body: %w", err)
 	}
@@ -378,7 +378,7 @@ func (c *cmd) setAgentToken(bootstrapACLToken BootStrapACLTokenInfo, agentTokenI
 		// no response body returned in this case
 		c.loggingClient.Infof("agent token is set with type [%s]", tokenType)
 	default:
-		setAgentTokenResp, err := ioutil.ReadAll(resp.Body)
+		setAgentTokenResp, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("Failed to read SetAgentToken response body with status code=%d: %w", resp.StatusCode, err)
 		}
@@ -424,7 +424,7 @@ func (c *cmd) createNewToken(bootstrapACLTokenID string, createToken CreateRegis
 		_ = resp.Body.Close()
 	}()
 
-	createTokenResp, err := ioutil.ReadAll(resp.Body)
+	createTokenResp, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return share.EmptyToken, fmt.Errorf("Failed to read create a new token response body: %w", err)
 	}

--- a/internal/security/bootstrapper/command/setupacl/command.go
+++ b/internal/security/bootstrapper/command/setupacl/command.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -511,7 +511,7 @@ func (c *cmd) getNonEmptyConsulLeader() error {
 		_ = resp.Body.Close()
 	}()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("Failed to read response body to get leader: %w", err)
 	}
@@ -626,7 +626,7 @@ func (c *cmd) configureConsulAccess(secretStoreToken string, bootstrapACLToken s
 		c.loggingClient.Info("successfully configure Consul access for secretstore")
 		return nil
 	default:
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			c.loggingClient.Errorf("cannot read resp.Body: %v", err)
 		}

--- a/internal/security/bootstrapper/command/setupacl/command_test.go
+++ b/internal/security/bootstrapper/command/setupacl/command_test.go
@@ -18,7 +18,6 @@ package setupacl
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -153,7 +152,7 @@ func TestExecute(t *testing.T) {
 			if test.adminDir != "" {
 				err = helper.CreateDirectoryIfNotExists(test.adminDir)
 				require.NoError(t, err)
-				err = ioutil.WriteFile(conf.StageGate.Registry.ACL.SecretsAdminTokenPath,
+				err = os.WriteFile(conf.StageGate.Registry.ACL.SecretsAdminTokenPath,
 					[]byte(secretstoreTokenJsonStub), 0600)
 				require.NoError(t, err)
 			}
@@ -244,7 +243,7 @@ func TestMultipleExecuteCalls(t *testing.T) {
 			if test.adminDir != "" {
 				err = helper.CreateDirectoryIfNotExists(test.adminDir)
 				require.NoError(t, err)
-				err = ioutil.WriteFile(conf.StageGate.Registry.ACL.SecretsAdminTokenPath,
+				err = os.WriteFile(conf.StageGate.Registry.ACL.SecretsAdminTokenPath,
 					[]byte(secretstoreTokenJsonStub), 0600)
 				require.NoError(t, err)
 			}

--- a/internal/security/bootstrapper/command/setupacl/stubregistryserver_test.go
+++ b/internal/security/bootstrapper/command/setupacl/stubregistryserver_test.go
@@ -18,7 +18,7 @@ package setupacl
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -278,7 +278,7 @@ func (registry *registryTestServer) getRegistryServerConf(t *testing.T) *config.
 			require.Equal(t, http.MethodPut, r.Method)
 			if registry.serverOptions.createNewPolicyOk {
 				w.WriteHeader(http.StatusOK)
-				reqBody, err := ioutil.ReadAll(r.Body)
+				reqBody, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				var policyMap map[string]interface{}
 				err = json.Unmarshal(reqBody, &policyMap)

--- a/internal/security/bootstrapper/helper/helper.go
+++ b/internal/security/bootstrapper/helper/helper.go
@@ -16,7 +16,6 @@
 package helper
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -60,7 +59,7 @@ func CheckIfFileExists(fileName string) bool {
 
 func writeFile(aFileName string) error {
 	timestamp := []byte(strconv.FormatInt(time.Now().Unix(), 10))
-	return ioutil.WriteFile(aFileName, timestamp, 0400)
+	return os.WriteFile(aFileName, timestamp, 0400)
 }
 
 // GenerateRandomString will return a randomized string of characters at the

--- a/internal/security/config/command/proxy/adduser/command.go
+++ b/internal/security/config/command/proxy/adduser/command.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -150,7 +150,7 @@ func (c *cmd) createConsumer() error {
 		return fmt.Errorf("Failed to send new consumer request %s: %w", c.username, err)
 	}
 	defer resp.Body.Close()
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (c *cmd) addUserToGroup() error {
 		return fmt.Errorf("Failed to submit request to associate consumer %s to group %s: %w", c.username, c.group, err)
 	}
 	defer resp.Body.Close()
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -213,7 +213,7 @@ func (c *cmd) addUserToGroup() error {
 // ExecuteAddJwt will add a user to the Kong gateway, assign the user to the
 // group specified, and then create a JWT entry for the user.
 func (c *cmd) ExecuteAddJwt() (int, error) {
-	publicKey, err := ioutil.ReadFile(c.publicKeyPath)
+	publicKey, err := os.ReadFile(c.publicKeyPath)
 	if err != nil {
 		return interfaces.StatusCodeExitWithError, fmt.Errorf("failed to read public key from file %s: %w", c.publicKeyPath, err)
 	}
@@ -258,7 +258,7 @@ func (c *cmd) ExecuteAddJwt() (int, error) {
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return interfaces.StatusCodeExitWithError, err
 	}
@@ -328,7 +328,7 @@ func (c *cmd) ExecuteAddOAuth2() (statusCode int, err error) {
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return interfaces.StatusCodeExitWithError, err
 	}

--- a/internal/security/config/command/proxy/deluser/command.go
+++ b/internal/security/config/command/proxy/deluser/command.go
@@ -9,7 +9,7 @@ package deluser
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -90,7 +90,7 @@ func (c *cmd) Execute() (int, error) {
 	case http.StatusNoContent:
 		c.loggingClient.Info(fmt.Sprintf("deleted consumer (user) '%s'", c.username))
 	default:
-		responseBody, _ := ioutil.ReadAll(resp.Body)
+		responseBody, _ := io.ReadAll(resp.Body)
 		c.loggingClient.Error(fmt.Sprintf("Error response: %s", responseBody))
 		return interfaces.StatusCodeExitWithError, fmt.Errorf("Delete consumer request failed with code: %d", resp.StatusCode)
 	}

--- a/internal/security/config/command/proxy/jwt/command.go
+++ b/internal/security/config/command/proxy/jwt/command.go
@@ -9,7 +9,6 @@ package jwt
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -86,7 +85,7 @@ func (c *cmd) Execute() (int, error) {
 		claims.ExpiresAt = now + int64(duration.Seconds())
 	}
 
-	bytes, err := ioutil.ReadFile(c.privateKeyPath)
+	bytes, err := os.ReadFile(c.privateKeyPath)
 	if err != nil {
 		return interfaces.StatusCodeExitWithError, fmt.Errorf("Could read private key from file %s: %w", c.privateKeyPath, err)
 	}

--- a/internal/security/config/command/proxy/oauth2/command.go
+++ b/internal/security/config/command/proxy/oauth2/command.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -113,7 +113,7 @@ func (c *cmd) Execute() (statusCode int, err error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	// Get the response
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return interfaces.StatusCodeExitWithError, err
 	}

--- a/internal/security/config/command/proxy/tls/command.go
+++ b/internal/security/config/command/proxy/tls/command.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -94,11 +94,11 @@ func (c *cmd) Execute() (statusCode int, err error) {
 }
 
 func (c *cmd) readCertKeyPairFromFiles() (*bootstrapConfig.CertKeyPair, error) {
-	certPem, err := ioutil.ReadFile(c.certificatePath)
+	certPem, err := os.ReadFile(c.certificatePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read TLS certificate from file %s: %w", c.certificatePath, err)
 	}
-	prvKey, err := ioutil.ReadFile(c.privateKeyPath)
+	prvKey, err := os.ReadFile(c.privateKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read private key from file %s: %w", c.privateKeyPath, err)
 	}
@@ -174,7 +174,7 @@ func (c *cmd) listKongTLSCertificates() (certificateIDs, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body to list Kong snis tls certs: %w", err)
 	}
@@ -262,7 +262,7 @@ func (c *cmd) postKongTLSCertificate(certKeyPair *bootstrapConfig.CertKeyPair) e
 		return fmt.Errorf("failed to send request to post Kong tls cert: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %v", err)
 	}

--- a/internal/security/proxy/requestor.go
+++ b/internal/security/proxy/requestor.go
@@ -18,8 +18,8 @@ package proxy
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal"
@@ -39,7 +39,7 @@ func NewRequestor(
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 	} else {
-		caCert, err := ioutil.ReadFile(caCertPath)
+		caCert, err := os.ReadFile(caCertPath)
 		if err != nil {
 			lc.Error("failed to load rootCA certificate.")
 			return nil

--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -130,7 +130,7 @@ func (s *Service) ResetProxy() error {
 func (s *Service) Init() error {
 
 	// Read in JWT
-	jwtBytes, err := ioutil.ReadFile(s.configuration.KongAuth.JWTFile)
+	jwtBytes, err := os.ReadFile(s.configuration.KongAuth.JWTFile)
 	if err != nil {
 		return fmt.Errorf("failed to read config template: %w", err)
 	}
@@ -310,7 +310,7 @@ func (s *Service) postCert(cp bootstrapConfig.CertKeyPair) *CertError {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
 		s.loggingClient.Info("successfully added certificate to the reverse proxy")
 	default:
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return &CertError{err.Error(), InternalError}
 		}

--- a/internal/security/proxy/service_test.go
+++ b/internal/security/proxy/service_test.go
@@ -16,7 +16,7 @@
 package proxy
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -40,7 +40,7 @@ import (
 
 func TestPostCertExists(t *testing.T) {
 	fileName := "./testdata/configuration.toml"
-	contents, err := ioutil.ReadFile(fileName)
+	contents, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Errorf("could not load configuration file (%s): %s", fileName, err.Error())
 		return
@@ -88,7 +88,7 @@ func TestPostCertExists(t *testing.T) {
 
 func TestInit(t *testing.T) {
 	fileName := "./testdata/configuration.toml"
-	contents, err := ioutil.ReadFile(fileName)
+	contents, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Errorf("could not load configuration file (%s): %s", fileName, err.Error())
 		return
@@ -114,7 +114,7 @@ func TestInit(t *testing.T) {
 			return
 		}
 
-		_, err := ioutil.ReadAll(r.Body)
+		_, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -279,7 +279,7 @@ func TestInitKongService(t *testing.T) {
 			return
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/internal/security/proxy/serviceplugin.go
+++ b/internal/security/proxy/serviceplugin.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -88,7 +88,7 @@ func (s *Service) getServicePluginIDBy(serviceName, pluginName string) (string, 
 
 	defer func() { _ = resp.Body.Close() }()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body to get plugins: %w", err)
 	}
@@ -149,7 +149,7 @@ func (s *Service) deleteServicePlugin(serviceName, pluginID string) error {
 
 		return nil
 	default:
-		responseBody, err := ioutil.ReadAll(resp.Body)
+		responseBody, err := io.ReadAll(resp.Body)
 		var errMsg string
 		if err != nil {
 			errMsg = fmt.Sprintf("failed to read response body for delete service plugin: %v", err)
@@ -223,7 +223,7 @@ func (s *Service) createConsulTokenHeaderForServicePlugin(serviceName, pluginNam
 
 		return nil
 	default:
-		responseBody, err := ioutil.ReadAll(resp.Body)
+		responseBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read response body for creating Consul token header: %w", err)
 		}

--- a/internal/security/proxy/serviceplugin_test.go
+++ b/internal/security/proxy/serviceplugin_test.go
@@ -17,7 +17,6 @@ package proxy
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -79,7 +78,7 @@ func TestAddConsulHeaderTo(t *testing.T) {
 			// prepare test
 			if test.accessTokenFileCreate {
 				// use test name as the config name so that it is unique
-				err := ioutil.WriteFile(test.name, []byte(tokenData), 0600)
+				err := os.WriteFile(test.name, []byte(tokenData), 0600)
 				require.NoError(t, err)
 			}
 

--- a/internal/security/secretstore/certs.go
+++ b/internal/security/secretstore/certs.go
@@ -22,9 +22,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal"
 
@@ -148,13 +149,13 @@ func (cs *Certs) getCertPair() (*CertPair, error) {
 }
 
 func (cs *Certs) ReadFrom(certPath string, keyPath string) (*CertPair, error) {
-	certPEMBlock, err := ioutil.ReadFile(certPath)
+	certPEMBlock, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
 	cert := string(certPEMBlock)
 
-	keyPEMBlock, err := ioutil.ReadFile(keyPath)
+	keyPEMBlock, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +196,7 @@ func (cs *Certs) UploadToStore(cp *CertPair) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/internal/security/secretstore/kongadminapi.go
+++ b/internal/security/secretstore/kongadminapi.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -116,7 +115,7 @@ func (k *KongAdminAPI) Setup() error {
 	defer k.clearSecrets()
 
 	// Read in the configuration template
-	configTemplateBytes, err := ioutil.ReadFile(k.paths.template)
+	configTemplateBytes, err := os.ReadFile(k.paths.template)
 	if err != nil {
 		return fmt.Errorf("%s Failed to read config template from file %s: %w", k.prefixes.errText, k.paths.template, err)
 	}
@@ -134,7 +133,7 @@ func (k *KongAdminAPI) Setup() error {
 		"<<INSERT-ADMIN-JWT-ISSUER-KEY>>", k.secrets.jwt.issuer, -1)
 
 	// Write the config file to the configured save path
-	err = ioutil.WriteFile(k.paths.config, []byte(configTemplateText), 0644)
+	err = os.WriteFile(k.paths.config, []byte(configTemplateText), 0644)
 	if err != nil {
 		return fmt.Errorf("%s Failed to write config template to file %s: %w", k.prefixes.errText, k.paths.config, err)
 	}
@@ -146,7 +145,7 @@ func (k *KongAdminAPI) Setup() error {
 	}
 
 	// Write JWT to secret file (used solely by "admin" group in Kong)
-	err = ioutil.WriteFile(k.paths.jwt, []byte(k.secrets.jwt.signed), 0400)
+	err = os.WriteFile(k.paths.jwt, []byte(k.secrets.jwt.signed), 0400)
 	if err != nil {
 		return fmt.Errorf("%s Failed to write JWT to file %s: %w", k.prefixes.errText, k.paths.jwt, err)
 	}

--- a/internal/security/secretstore/password.go
+++ b/internal/security/secretstore/password.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -206,7 +206,7 @@ func (cr *Cred) UploadToStore(pair *UserPasswordPair, path string) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Close: #3334

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3334 


## What is the new behavior?
Since the io/ioutil package has been deprecated in Go 1.16, so we should remove the dependency of this package.
https://golang.org/doc/go1.16#ioutil

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information