### PR TITLE
build(snap): fix CI snap-minimal-build issue

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -471,12 +471,18 @@ apps:
 parts:
   version:
     plugin: nil
+    # we need to include git, in case we are building the minimal-snap-build
+    build-packages:
+      - git
     # as with static-packages part, the source dir is unrelated to this part and is used
     # since it changes rarely and therefore will not trigger a new pull
     source: snap/local/build-helpers
     override-pull: |
       cd $SNAPCRAFT_PROJECT_DIR
       GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      if [ -z "$GIT_VERSION" ]; then
+        GIT_VERSION="0.0.0"
+      fi
       snapcraftctl set-version ${GIT_VERSION}
   static-packages:
     plugin: nil


### PR DESCRIPTION
1) The Jenkins CI build uses the snap-minimal-build.sh script to create
a minimal version of snapcraft.yaml. As the snap version is now based
directly on the git tag, snapcraft needs to be able to run git. The
minimal snap build doesn't install git as a build package, so the build
fails. This commit fixes that.

To test, run

```
./snap/local/build-helpers/bin/minimal-snap-build.sh
snapcraft prime --use-lxd
```

2) Also, if there are no git tags present, then the version is now set to
0.0.0, instead of the build failing.

To test, run

```
git clone git@github.com:siggiskulason/edgex-go.git --no-tags
cd edgex-go
git checkout fix-snap-minimal-build
snapcraft --use-lxd
```

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information