### PR TITLE
feat(sma): add 'edgex-' prefix for executor-based API

### DIFF
--- a/internal/system/agent/application/executor/executor.go
+++ b/internal/system/agent/application/executor/executor.go
@@ -16,6 +16,8 @@ package executor
 
 import "os/exec"
 
+const edgexPrefix = "edgex-"
+
 // CommandExecutor provides the common callout to the configuration-defined executor.
 func CommandExecutor(executorPath, serviceName, operation string) (string, error) {
 	bytes, err := exec.Command(executorPath, serviceName, operation).CombinedOutput()

--- a/internal/system/agent/application/executor/metrics.go
+++ b/internal/system/agent/application/executor/metrics.go
@@ -45,7 +45,7 @@ func (m *metrics) Get(_ context.Context, services []string) ([]interface{}, erro
 		go func(serviceName string) {
 			defer wg.Done()
 
-			res, err := m.executor(m.executorPath, serviceName, "metrics")
+			res, err := m.executor(m.executorPath, edgexPrefix+serviceName, "metrics")
 			if err != nil {
 				mu.Lock()
 				responses = append(responses, common.BaseWithMetricsResponse{

--- a/internal/system/agent/application/executor/operation.go
+++ b/internal/system/agent/application/executor/operation.go
@@ -46,7 +46,7 @@ func (o *operation) Do(_ context.Context, operations []requests.OperationRequest
 			defer wg.Done()
 
 			o.lc.Debugf("Executing '%s' action on %s", operation.Action, operation.ServiceName)
-			res, err := o.executor(o.executorPath, operation.ServiceName, operation.Action)
+			res, err := o.executor(o.executorPath, edgexPrefix+operation.ServiceName, operation.Action)
 			if err != nil {
 				mu.Lock()
 				responses = append(responses, common.BaseWithServiceNameResponse{

--- a/openapi/v2/system-agent.yaml
+++ b/openapi/v2/system-agent.yaml
@@ -53,6 +53,7 @@ components:
         servieName:
           description: "A field indicates the original requested serviceName"
           type: string
+          example: "core-data"
     BaseWithMetricsResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -62,6 +63,7 @@ components:
         servieName:
           description: "A field indicates the original requested serviceName"
           type: string
+          example: "core-data"
         metrics:
           description: "A response from the /metrics endpoint providing memory and cpu utilization stats."
           type: object
@@ -74,6 +76,7 @@ components:
         servieName:
           description: "A field indicates the original requested serviceName"
           type: string
+          example: "core-data"
         config:
           description: "An object containing the service's configuration. Please refer the configuration documentation of each service for more details at [EdgeX Foundry Documentation](https://docs.edgexfoundry.org)."
           type: object
@@ -204,7 +207,6 @@ paths:
                 type: array
                 items:
                   anyOf:
-                    - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/BaseWithServiceNameResponse'
         '400':
           description: "Bad request"
@@ -246,7 +248,6 @@ paths:
                 type: array
                 items:
                   anyOf:
-                    - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/BaseWithMetricsResponse'
         '400':
           description: "Bad request"
@@ -288,7 +289,6 @@ paths:
                 type: array
                 items:
                   anyOf:
-                    - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/BaseWithConfigResponse'
         '400':
           description: "Bad request"
@@ -333,7 +333,6 @@ paths:
                 type: array
                 items:
                   anyOf:
-                    - $ref: '#/components/schemas/ErrorResponse'
                     - $ref: '#/components/schemas/BaseWithServiceNameResponse'
         '400':
           description: "Bad request"


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
For API that relies on executor, user needs to refer to the service by its container name:

```
curl http://localhost:58890/api/v2/system/metrics?services=edgex-core-data,edgex-core-metadata
207

...
```

## Issue Number: fix #3559 


## What is the new behavior?
`edgex-` prefix will be automatically added for default service (those defined in edgex-compose file)
So user can either refer to those services by their service name (e.g. core-data) or container name (e.g. edgex-core-data)


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information