### PR TITLE
fix(core-data): Loosen Subscriber Topic Validation

### DIFF
--- a/internal/core/data/application/subscriber.go
+++ b/internal/core/data/application/subscriber.go
@@ -96,12 +96,17 @@ func unmarshalPayload(envelope types.MessageEnvelope, target interface{}) error 
 func validateEvent(messageTopic string, e dtos.Event) errors.EdgeX {
 	// Parse messageTopic by the pattern `edgex/events/<device-profile-name>/<device-name>/<source-name>`
 	fields := strings.Split(messageTopic, "/")
-	if len(fields) != 5 {
+
+	// assumes a non-empty base topic with /profileName/deviceName/sourceName appended by publisher
+	if len(fields) < 4 {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid message topic %s", messageTopic), nil)
 	}
-	profileName := fields[2]
-	deviceName := fields[3]
-	sourceName := fields[4]
+
+	len := len(fields)
+	profileName := fields[len-3]
+	deviceName := fields[len-2]
+	sourceName := fields[len-1]
+
 	// Check whether the event fields match the message topic
 	if e.ProfileName != profileName {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("event's profileName %s mismatches with the name %s received in topic", e.ProfileName, profileName), nil)


### PR DESCRIPTION
Look for a topic with >= 4 segments instead of a fixed length of 5 to
better accomodate configurable base topics for device service
publishing.

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
Fix #3580 

## What is the new behavior?
Only looks for topic containing >= 4 "segments" instead of 5 exactly

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information