### PR TITLE
fix(notifications): Remove warning from 32-bit build.

### DIFF
--- a/internal/support/notifications/controller/http/subscription.go
+++ b/internal/support/notifications/controller/http/subscription.go
@@ -82,7 +82,7 @@ func (sc *SubscriptionController) AllSubscriptions(w http.ResponseWriter, r *htt
 	config := notificationContainer.ConfigurationFrom(sc.dic.Get)
 
 	// parse URL query string for offset and limit
-	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxUint32, -1, config.Service.MaxResultCount)
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
 	if err != nil {
 		utils.WriteErrorResponse(w, ctx, lc, err, "")
 		return

--- a/internal/support/notifications/controller/http/transmission.go
+++ b/internal/support/notifications/controller/http/transmission.go
@@ -85,7 +85,7 @@ func (tc *TransmissionController) AllTransmissions(w http.ResponseWriter, r *htt
 	config := notificationContainer.ConfigurationFrom(tc.dic.Get)
 
 	// parse URL query string for offset and limit
-	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxUint32, -1, config.Service.MaxResultCount)
+	offset, limit, _, err := utils.ParseGetAllObjectsRequestQueryString(r, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
 	if err != nil {
 		utils.WriteErrorResponse(w, ctx, lc, err, "")
 		return


### PR DESCRIPTION
Building the core services on 32-bit ARM, I got a warning "Constant
4294967295 is bigger than 'int'", which stopped the build (my environment
may be too pedantic). This resolves it.

Signed-off-by: Corey Mutter <corey@friendlyandhelpful.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Did not open an issue for this, found it locally.


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ X ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ X ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?
I don't know if this is the best fix - maybe it would be better to change the function's prototype to take unsigned int?
New to both EdgeX and Golang.
Don't know how one would update tests or docs for this.

## Other information