### PR TITLE
feat: Send notification after updating device entity

### DIFF
--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -45,9 +45,9 @@ Type = 'consul'
 
 [Notifications]
 PostDeviceChanges = true
-Content = 'Device notice: '
+Content = 'Meatadata notice: '
 Sender = 'core-metadata'
-Description = 'Metadata device notice'
+Description = 'Metadata change notice'
 Label = 'metadata'
 
 [SecretStore]

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -45,8 +45,7 @@ Type = 'consul'
 
 [Notifications]
 PostDeviceChanges = true
-Slug = 'device-change-'
-Content = 'Device update: '
+Content = 'Device notice: '
 Sender = 'core-metadata'
 Description = 'Metadata device notice'
 Label = 'metadata'


### PR DESCRIPTION
Close: #3601

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #3601


## What is the new behavior?
The core-metadata V2 API should send a notification to support-notification after adding or updating the device entity.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information