### PR TITLE
fix(security): Mismatched types int and int32

### DIFF
--- a/internal/security/kdf/methods.go
+++ b/internal/security/kdf/methods.go
@@ -28,7 +28,7 @@ import (
 // in the event that the KDF inputKeyMaterial is less than random.
 const (
 	saltFile   string = "kdf-salt.dat"
-	saltLength        = 32
+	saltLength int    = 32
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Automatic type selection of saltLength constant causes type checking error in numerical comparison.


## Issue Number:
Closes #3654 

## What is the new behavior?
Ensure that the constant is of the same numeric type as Reader.Read() method.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information