### PR TITLE
fix(security): Move JWT auth method to individual routes

### DIFF
--- a/cmd/security-secretstore-setup/res/kong-admin-config.template.yml
+++ b/cmd/security-secretstore-setup/res/kong-admin-config.template.yml
@@ -58,10 +58,13 @@ services:
 # (placeholder)
 # -----------------------------------------------------------------------------
 routes:
-- paths:
-  - /admin
-  name: admin-route
+- name: admin-route
   service: admin-service
+  paths:
+  - /admin
+  plugins:
+  - name: jwt
+    enabled: true
 
 # -----------------------------------------------------------------------------
 # Activate JWT and ACL Plugins
@@ -69,13 +72,6 @@ routes:
 # (placeholder)
 # -----------------------------------------------------------------------------
 plugins:
-- enabled: true
-  name: jwt
-- enabled: true
-  name: acl
-  config:
-    allow:
-    - gateway-group
 - enabled: true
   name: acl
   route: admin-route

--- a/internal/security/proxy/models/kongParameters.go
+++ b/internal/security/proxy/models/kongParameters.go
@@ -43,15 +43,6 @@ type KongRoute struct {
 	Name  string   `json:"name,omitempty"`
 }
 
-type KongOAuth2Plugin struct {
-	Name                    string `url:"name"`
-	Scope                   string `url:"config.scopes"`
-	MandatoryScope          string `url:"config.mandatory_scope"`
-	EnableClientCredentials string `url:"config.enable_client_credentials"`
-	EnableGlobalCredentials string `url:"config.global_credentials"`
-	TokenTTL                int    `url:"config.refresh_token_ttl"`
-}
-
 type KongACLPlugin struct {
 	Name      string `url:"name"`
 	WhiteList string `url:"config.whitelist"`

--- a/internal/security/proxy/service_test.go
+++ b/internal/security/proxy/service_test.go
@@ -536,60 +536,6 @@ func TestGetSvcIDs(t *testing.T) {
 	}
 }
 
-func TestInitJWTAuth(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-		if r.Method != http.MethodPost {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return
-		}
-
-		if !strings.Contains(r.URL.EscapedPath(), PluginsPath) {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	host, port, err := parseHostAndPort(ts, t)
-	if err != nil {
-		t.Error(err.Error())
-		return
-	}
-
-	cfgOK := config.ConfigurationStruct{}
-	cfgOK.KongURL = config.KongUrlInfo{
-		Server:          host,
-		ApplicationPort: port,
-	}
-
-	cfgWrongPort := cfgOK
-	cfgWrongPort.KongURL.ApplicationPort = 123
-
-	tests := []struct {
-		name        string
-		config      config.ConfigurationStruct
-		expectError bool
-	}{
-		{"jwtOK", cfgOK, false},
-		{"InvalidPort", cfgWrongPort, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			svc := NewService(&http.Client{}, logger.MockLogger{}, &tt.config)
-			err := svc.initJWTAuth()
-			if err != nil && !tt.expectError {
-				t.Error(err)
-			}
-
-			if err == nil && tt.expectError {
-				t.Error("error was expected, none occurred")
-			}
-		})
-	}
-}
-
 func parseHostAndPort(server *httptest.Server, t *testing.T) (host string, port int, err error) {
 	parsed, err := url.Parse(server.URL)
 	if err != nil {

--- a/internal/security/proxy/testdata/configuration.toml
+++ b/internal/security/proxy/testdata/configuration.toml
@@ -27,7 +27,7 @@ ApplicationPort = 8000
 ApplicationPortSSL = 8443
 
 [KongAuth]
-Name = "oauth2"
+Name = "jwt"
 TokenTTL = 0
 Resource = "coredata"
 OutputPath = "accessToken.json"


### PR DESCRIPTION
This change moves the JWT auth method from a global setting
to a per-route setting.  This change allows EdgeX end-users
to add custom routes using the Kong admin API that use
alternative auth methods that are not JWT.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
Closes #3638

## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information