### PR TITLE
feat: Add Middleware to handler HTTP request timeout

### DIFF
--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
+	pkgCommon "github.com/edgexfoundry/edgex-go/internal/pkg/common"
+
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
@@ -47,6 +49,13 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 	LoadRestRoutes(b.router, dic)
 
 	configuration := container.ConfigurationFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+
+	err := pkgCommon.LoadRequestTimeoutHandler(b.router, configuration.Service.RequestTimeout)
+	if err != nil {
+		lc.Errorf("Fail to load the request timout handler, %v", err)
+		return false
+	}
 
 	// initialize clients required by the service
 	dic.Update(di.ServiceConstructorMap{

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -18,11 +18,10 @@ package data
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data/application"
 	dataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/container"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/common"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
@@ -50,12 +49,11 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 	configuration := dataContainer.ConfigurationFrom(dic.Get)
 	lc := container.LoggingClientFrom(dic.Get)
 
-	timeout, err := time.ParseDuration(configuration.Service.RequestTimeout)
+	err := common.LoadRequestTimeoutHandler(b.router, configuration.Service.RequestTimeout)
 	if err != nil {
-		lc.Errorf("unable to parse RequestTimeout value of %s to a duration: %w", configuration.Service.RequestTimeout, err)
+		lc.Errorf("Fail to load the request timout handler, %v", err)
 		return false
 	}
-	b.router.Use(correlation.ManageTimeout(timeout))
 
 	if configuration.MessageQueue.SubscribeEnabled {
 		err := application.SubscribeEvents(ctx, dic)

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -16,11 +16,14 @@ package metadata
 
 import (
 	"context"
-
 	"sync"
 
+	"github.com/edgexfoundry/edgex-go/internal/pkg/common"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+
 	"github.com/gorilla/mux"
 )
 
@@ -39,6 +42,15 @@ func NewBootstrap(router *mux.Router) *Bootstrap {
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the metadata service.
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
 	LoadRestRoutes(b.router, dic)
+
+	configuration := container.ConfigurationFrom(dic.Get)
+	lc := container.LoggingClientFrom(dic.Get)
+
+	err := common.LoadRequestTimeoutHandler(b.router, configuration.GetBootstrap().Service.RequestTimeout)
+	if err != nil {
+		lc.Errorf("Fail to load the request timout handler, %v", err)
+		return false
+	}
 
 	return true
 }

--- a/internal/pkg/common/util.go
+++ b/internal/pkg/common/util.go
@@ -6,7 +6,13 @@
 package common
 
 import (
+	"fmt"
 	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+
+	"github.com/gorilla/mux"
 )
 
 func MakeTimestamp() int64 {
@@ -46,4 +52,13 @@ func ConvertStringsToInterfaces(stringArray []string) []interface{} {
 		result[i] = s
 	}
 	return result
+}
+
+func LoadRequestTimeoutHandler(r *mux.Router, timeout string) errors.EdgeX {
+	td, err := time.ParseDuration(timeout)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("unable to parse RequestTimeout value of %s to a duration", timeout), err)
+	}
+	r.Use(correlation.ManageTimeout(td))
+	return nil
 }

--- a/internal/pkg/correlation/middleware.go
+++ b/internal/pkg/correlation/middleware.go
@@ -8,6 +8,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+
 	"github.com/google/uuid"
 )
 
@@ -41,5 +42,11 @@ func LoggingMiddleware(lc logger.LoggingClient) func(http.Handler) http.Handler 
 				next.ServeHTTP(w, r)
 			}
 		})
+	}
+}
+
+func ManageTimeout(timeout time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.TimeoutHandler(next, timeout, "HTTP request timeout")
 	}
 }

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/edgexfoundry/edgex-go/internal/pkg/common"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/application"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/application/scheduler"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
@@ -49,6 +50,12 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 
+	err := common.LoadRequestTimeoutHandler(b.router, configuration.Service.RequestTimeout)
+	if err != nil {
+		lc.Errorf("Fail to load the request timout handler, %v", err)
+		return false
+	}
+
 	// V2 Scheduler
 	schedulerManager := scheduler.NewManager(lc, configuration)
 	dic.Update(di.ServiceConstructorMap{
@@ -57,7 +64,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 		},
 	})
 
-	err := application.LoadIntervalToSchedulerManager(dic)
+	err = application.LoadIntervalToSchedulerManager(dic)
 	if err != nil {
 		lc.Errorf("Failed to load interval to scheduler, %v", err)
 		return false

--- a/internal/system/agent/init.go
+++ b/internal/system/agent/init.go
@@ -21,12 +21,14 @@ import (
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/gorilla/mux"
 
+	"github.com/edgexfoundry/edgex-go/internal/pkg/common"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/application"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/application/direct"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/application/executor"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/container"
+
+	"github.com/gorilla/mux"
 )
 
 // Bootstrap contains references to dependencies required by the BootstrapHandler.
@@ -46,6 +48,13 @@ func (b *Bootstrap) BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ sta
 	LoadRestRoutes(b.router, dic)
 
 	configuration := container.ConfigurationFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+
+	err := common.LoadRequestTimeoutHandler(b.router, configuration.Service.RequestTimeout)
+	if err != nil {
+		lc.Errorf("Fail to load the request timout handler, %v", err)
+		return false
+	}
 
 	// validate metrics implementation
 	switch configuration.MetricsMechanism {


### PR DESCRIPTION
Close: #2462

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #2462


## What is the new behavior?
Add a middleware to gracefully handle the HTTP request timeout. If a call runs for longer than its time limit, the handler responds with a 503 Service Unavailable error and the given message in its body.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information