### PR TITLE
fix(security): remove unused curl executable from secretstore-setup Dockerfile

### DIFF
--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -37,7 +37,7 @@ RUN make cmd/security-file-token-provider/security-file-token-provider \
 
 FROM alpine:3.12
 
-RUN apk add --update --no-cache ca-certificates dumb-init curl su-exec
+RUN apk add --update --no-cache ca-certificates dumb-init su-exec
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Dell Technologies, Inc.'


### PR DESCRIPTION
- curl command executable is not used, so it is removed from the Docker file of security service `secretstore-setup`

Fixes: #3656

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Unused `curl` binary is included in the Docker image of `secretstore-setup`

## Issue Number: #3656 


## What is the new behavior?
`curl` binary is removed from Docker image of `secretstore-setup`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information