### PR TITLE
fix(snap): add kuiper message-bus config

### DIFF
--- a/internal/security/secretstore/secure-messagebus.go
+++ b/internal/security/secretstore/secure-messagebus.go
@@ -37,7 +37,7 @@ default:
     Password: {{.Password}}
   port: 6379
   protocol: redis
-  server: edgex-redis
+  server: localhost
   serviceServer: http://localhost:48080
   topic: rules-events
   type: redis
@@ -46,7 +46,7 @@ mqtt_conf:
     ClientId: client1
   port: 1883
   protocol: tcp
-  server: 127.0.0.1
+  server: localhost
   topic: events
   type: mqtt
 `

--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -35,7 +35,7 @@ const consulAddRegistryACLRolesCfg = "env.security-bootstrapper.add-registry-acl
 
 // device-rest and device-virtual are both on the /cmd/security-file-token-provider/res/token-config.json file,
 // so they should not need to be set here as well
-const secretStoreTokens = "app-http-export,app-mqtt-export,device-camera,device-mqtt,device-modbus,device-coap,device-snmp"
+const secretStoreTokens = "app-rules-engine,app-http-export,app-mqtt-export,device-camera,device-mqtt,device-modbus,device-coap,device-snmp"
 
 const secretStoreKnownSecrets = "" +
 	"redisdb[app-rules-engine]," +

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -204,6 +204,10 @@ apps:
       KONGADMIN_CONFIGFILEPATH: $SNAP_DATA/config/kong.yml
       KONGADMIN_CONFIGJWTPATH: $SNAP_DATA/secrets/security-proxy-setup/kong-admin-jwt
 
+      # enable secure message bus setup for kuiper
+      SECUREMESSAGEBUS_TYPE: "redis"
+      SECUREMESSAGEBUS_KUIPERCONFIGPATH: "$SNAP_DATA/kuiper/etc/sources/edgex.yaml"
+
     start-timeout: 15m
     plugs: [network]
   security-proxy-setup:


### PR DESCRIPTION
This change updates the snap to override the message bus
configuration options of security-secretstore-setup which
are responsible for modifying the kuiper configuration to
work with the secure message bus (redis).

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Kuiper is not correctly configured to use the secure message bus (redis) due to the lack of configuration overrides to properly enable.

## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information