### PR TITLE
feat(security): Feature to enable CORS headers for API gateway

### DIFF
--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -38,6 +38,14 @@ Resource = "coredata"
 OutputPath = "accessToken.json"
 JWTFile = "/tmp/edgex/secrets/security-proxy-setup/kong-admin-jwt"
 
+[CORSConfiguration]
+EnableCORS = false
+CORSAllowCredentials = false
+CORSAllowedOrigins = "https://localhost"
+CORSAllowedMethods = "GET, POST, PUT, DELETE"
+CORSAllowedHeaders = "Content-Type"
+CORSPreflightMaxAge = 3600
+
 [SecretStore]
 Type = "vault"
 Protocol = "http"

--- a/internal/security/proxy/config/config.go
+++ b/internal/security/proxy/config/config.go
@@ -27,14 +27,15 @@ import (
 )
 
 type ConfigurationStruct struct {
-	LogLevel        string
-	RequestTimeout  int
-	SNIS            []string
-	AccessTokenFile string
-	KongURL         KongUrlInfo
-	KongAuth        KongAuthInfo
-	SecretStore     bootstrapConfig.SecretStoreInfo
-	Routes          map[string]models.KongService
+	LogLevel          string
+	RequestTimeout    int
+	SNIS              []string
+	AccessTokenFile   string
+	KongURL           KongUrlInfo
+	KongAuth          KongAuthInfo
+	CORSConfiguration CORSConfigurationInfo
+	SecretStore       bootstrapConfig.SecretStoreInfo
+	Routes            map[string]models.KongService
 }
 
 type KongUrlInfo struct {
@@ -44,6 +45,15 @@ type KongUrlInfo struct {
 	ApplicationPort    int
 	ApplicationPortSSL int
 	StatusPort         int
+}
+
+type CORSConfigurationInfo struct {
+	EnableCORS           bool
+	CORSAllowCredentials bool
+	CORSAllowedOrigins   string
+	CORSAllowedMethods   string
+	CORSAllowedHeaders   string
+	CORSPreflightMaxAge  int
 }
 
 func (k KongUrlInfo) GetProxyBaseURL() string {

--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -175,6 +175,13 @@ func (s *Service) Init() error {
 		if err != nil {
 			return err
 		}
+
+		if s.configuration.CORSConfiguration.EnableCORS {
+			err = s.initCORSRoutes(&s.configuration.CORSConfiguration, strings.ToLower(route.Name))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	s.loggingClient.Info("finishing initialization for reverse proxy")
@@ -396,6 +403,53 @@ func (s *Service) initKongRoutes(r *models.KongRoute, name string) error {
 		s.loggingClient.Info(fmt.Sprintf("successful to set up route for `%s` at `%v`", name, r.Paths))
 	default:
 		e := fmt.Sprintf("failed to set up route for %s with error %s", name, resp.Status)
+		s.loggingClient.Error(e)
+		return errors.New(e)
+	}
+	return nil
+}
+
+func (s *Service) initCORSRoutes(corsConfig *config.CORSConfigurationInfo, name string) error {
+	formVals := url.Values{
+		"name":               {"cors"},
+		"config.origins":     {corsConfig.CORSAllowedOrigins},
+		"config.credentials": {strconv.FormatBool(corsConfig.CORSAllowCredentials)},
+		"config.max_age":     {strconv.Itoa(corsConfig.CORSPreflightMaxAge)},
+	}
+
+	// Break out CORSAllowedMethods and CORSAllowedHeaders
+	for _, method := range strings.Split(corsConfig.CORSAllowedMethods, ",") {
+		formVals.Add("config.methods", strings.TrimSpace(method))
+	}
+	for _, header := range strings.Split(corsConfig.CORSAllowedHeaders, ",") {
+		formVals.Add("config.headers", strings.TrimSpace(header))
+	}
+
+	tokens := []string{s.configuration.KongURL.GetProxyBaseURL(), RoutesPath, name, "plugins"}
+
+	// Create routes associated to a specific service
+	req, err := http.NewRequest(http.MethodPost, strings.Join(tokens, "/"), strings.NewReader(formVals.Encode()))
+	if err != nil {
+		e := fmt.Sprintf("failed to set up routes for %s with error %s", name, err.Error())
+		s.loggingClient.Error(e)
+		return err
+	}
+	req.Header.Add(internal.AuthHeaderTitle, internal.BearerLabel+s.bearerToken)
+	req.Header.Add(common.ContentType, URLEncodedForm)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		e := fmt.Sprintf("failed to set up CORS for %s with error %s", name, err.Error())
+		s.loggingClient.Error(e)
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusConflict:
+		s.loggingClient.Info(fmt.Sprintf("successful to set up CORS at `%s`", name))
+	default:
+		e := fmt.Sprintf("failed to set up CORS for %s with error %s", name, resp.Status)
 		s.loggingClient.Error(e)
 		return errors.New(e)
 	}


### PR DESCRIPTION
Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Current Kong proxy does not return CORS headers to clients.

## Issue Number:
Closes #1913

## What is the new behavior?
New configuration has been added to allow settings of a limited number of CORS headers for the EdgeX routes.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X] No

## Specific Instructions
To test, modify `cmd/security-proxy-setup/res/configuration.toml` and set `EnableCORS` to `true`.  Customize other headers as needed.  Rebuild security-proxy-setup docker container (make docker_security_proxy_setup).  Restart framework.

Test with a command like
```
curl -ki -X OPTIONS -H "Origin: http://localhost" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: Content-Type" https://localhost:8443/core-data/api/v2/ping
```

Expected response:
```
HTTP/2 200 
date: Fri, 20 Aug 2021 02:18:02 GMT
vary: Origin
access-control-allow-origin: https://localhost
access-control-allow-headers: Content-Type
access-control-allow-methods: GET,POST,PUT,DELETE
access-control-max-age: 3600
content-length: 0
x-kong-response-latency: 1
server: kong/2.5.0
```


## Other information