### PR TITLE
fix(meta): device yaml marshal to Json  error

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -149,9 +149,6 @@ https://github.com/x448/float16/blob/master/LICENSE
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE
 
-gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
-https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
-
 gopkg.in/yaml.v3 (MIT) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v3/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	gopkg.in/eapache/queue.v1 v1.1.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	gopkg.in/eapache/queue.v1 v1.1.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 go 1.16

--- a/internal/core/metadata/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/controller/http/deviceprofile_test.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"

--- a/internal/io/reader.go
+++ b/internal/io/reader.go
@@ -15,7 +15,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 
 	"github.com/fxamacker/cbor/v2"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type DtoReader interface {


### PR DESCRIPTION
when add some complex vaules to the attributes of deviceResources in the device profile, error happens. use gopkg.in/yaml.v3 instead of gopkg.in/yaml.v2

Fixes: #3682

Signed-off-by: wangshihui <wangshihui_1985@163.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [x] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information