### PR TITLE
fix(security): secrets-config user connect using TLS

### DIFF
--- a/internal/security/config/command/proxy/adduser/command.go
+++ b/internal/security/config/command/proxy/adduser/command.go
@@ -141,7 +141,7 @@ func (c *cmd) createConsumer() error {
 	form := url.Values{
 		"username": []string{c.username},
 	}
-	kongURL := strings.Join([]string{c.configuration.KongURL.GetProxyBaseURL(), "consumers"}, "/")
+	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers"}, "/")
 	c.loggingClient.Info(fmt.Sprintf("creating consumer (user) on the endpoint of %s", kongURL))
 
 	formVal := form.Encode()
@@ -182,7 +182,7 @@ func (c *cmd) addUserToGroup() error {
 	form := url.Values{
 		"group": []string{c.group},
 	}
-	kongURL := strings.Join([]string{c.configuration.KongURL.GetProxyBaseURL(), "consumers", c.username, "acls"}, "/")
+	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers", c.username, "acls"}, "/")
 	c.loggingClient.Info(fmt.Sprintf("Associating consumer to acl using endpoint %s", kongURL))
 
 	formVal := form.Encode()
@@ -248,7 +248,7 @@ func (c *cmd) ExecuteAddJwt() (int, error) {
 		form.Set("key", c.jwtID)
 	}
 
-	kongURL := strings.Join([]string{c.configuration.KongURL.GetProxyBaseURL(), "consumers", c.username, "jwt"}, "/")
+	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers", c.username, "jwt"}, "/")
 	c.loggingClient.Info(fmt.Sprintf("associating JWT on the endpoint of %s", kongURL))
 
 	formVal := form.Encode()
@@ -318,7 +318,7 @@ func (c *cmd) ExecuteAddOAuth2() (statusCode int, err error) {
 		form.Set("client_secret", c.clientSecret)
 	}
 
-	kongURL := strings.Join([]string{c.configuration.KongURL.GetProxyBaseURL(), "consumers", c.username, "oauth2"}, "/")
+	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers", c.username, "oauth2"}, "/")
 	c.loggingClient.Info(fmt.Sprintf("creating oauth application at %s", kongURL))
 
 	formVal := form.Encode()

--- a/internal/security/config/command/proxy/adduser/command_test.go
+++ b/internal/security/config/command/proxy/adduser/command_test.go
@@ -66,7 +66,7 @@ func TestAddUserJWT(t *testing.T) {
 	publicKey := "testdata/rsa.pub"
 
 	// Create a mock server for handling the command requests
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		// Check to make sure the JWT authorization header exists
 		assert.NotNil(t, r.Header.Values(internal.AuthHeaderTitle))
@@ -103,7 +103,7 @@ func TestAddUserJWT(t *testing.T) {
 	require.NoError(t, err)
 
 	config.KongURL.Server = tsURL.Hostname()
-	config.KongURL.ApplicationPort, _ = strconv.Atoi(tsURL.Port())
+	config.KongURL.ApplicationPortSSL, _ = strconv.Atoi(tsURL.Port())
 
 	// Setup command "addUser w/JWT"
 	command, err := NewCommand(lc, config, []string{

--- a/internal/security/config/command/proxy/deluser/command.go
+++ b/internal/security/config/command/proxy/deluser/command.go
@@ -70,7 +70,7 @@ func (c *cmd) Execute() (int, error) {
 	// Delete Kong consumer
 	// https://docs.konghq.com/2.1.x/admin-api/#delete-consumer
 
-	kongURL := strings.Join([]string{c.configuration.KongURL.GetProxyBaseURL(), "consumers", c.username}, "/")
+	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers", c.username}, "/")
 	c.loggingClient.Info(fmt.Sprintf("deleting consumer (user) on the endpoint of %s", kongURL))
 
 	// Setup request

--- a/internal/security/config/command/proxy/deluser/command_test.go
+++ b/internal/security/config/command/proxy/deluser/command_test.go
@@ -48,7 +48,7 @@ func delUserWithArgs(t *testing.T, args []string) {
 	lc := logger.MockLogger{}
 	config := &config.ConfigurationStruct{}
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.EscapedPath() {
 		case "/admin/consumers/someuser":
 			require.Equal(t, "DELETE", r.Method)
@@ -63,7 +63,7 @@ func delUserWithArgs(t *testing.T, args []string) {
 	require.NoError(t, err)
 
 	config.KongURL.Server = tsURL.Hostname()
-	config.KongURL.ApplicationPort, _ = strconv.Atoi(tsURL.Port())
+	config.KongURL.ApplicationPortSSL, _ = strconv.Atoi(tsURL.Port())
 
 	// Act
 	command, err := NewCommand(lc, config, args)

--- a/internal/security/config/command/proxy/tls/command.go
+++ b/internal/security/config/command/proxy/tls/command.go
@@ -159,7 +159,7 @@ func (c *cmd) listKongTLSCertificates() (certificateIDs, error) {
 	}
 
 	// list snis certificates association to see if any already exists
-	certKongURL := strings.Join([]string{c.configuration.KongURL.GetProxyBaseURL(), "snis"}, "/")
+	certKongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "snis"}, "/")
 	c.loggingClient.Info(fmt.Sprintf("list snis tls certificates on the endpoint of %s", certKongURL))
 
 	req, err := http.NewRequest(http.MethodGet, certKongURL, http.NoBody)
@@ -209,7 +209,7 @@ func (c *cmd) listKongTLSCertificates() (certificateIDs, error) {
 func (c *cmd) deleteKongTLSCertificateById(certId string) error {
 
 	// Delete the Kong TLS certificate
-	delCertKongURL := strings.Join([]string{c.configuration.KongURL.GetProxyBaseURL(),
+	delCertKongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(),
 		"certificates", certId}, "/")
 	c.loggingClient.Info(fmt.Sprintf("deleting tls certificate on the endpoint of %s", delCertKongURL))
 
@@ -238,7 +238,7 @@ func (c *cmd) deleteKongTLSCertificateById(certId string) error {
 }
 
 func (c *cmd) postKongTLSCertificate(certKeyPair *bootstrapConfig.CertKeyPair) error {
-	postCertKongURL := strings.Join([]string{c.configuration.KongURL.GetProxyBaseURL(),
+	postCertKongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(),
 		"certificates"}, "/")
 	c.loggingClient.Info(fmt.Sprintf("posting tls certificate on the endpoint of %s", postCertKongURL))
 

--- a/internal/security/config/command/proxy/tls/command_test.go
+++ b/internal/security/config/command/proxy/tls/command_test.go
@@ -106,7 +106,7 @@ func TestTLSAddNewCertificate(t *testing.T) {
 			require.NoError(t, err)
 
 			config.KongURL.Server = tsURL.Hostname()
-			config.KongURL.ApplicationPort, _ = strconv.Atoi(tsURL.Port())
+			config.KongURL.ApplicationPortSSL, _ = strconv.Atoi(tsURL.Port())
 
 			args := []string{
 				"--incert", "testdata/testCert.pem",
@@ -160,7 +160,7 @@ func TestGetServerNameIndicators(t *testing.T) {
 func getTlsCertificateTestServer(listCertCase int, listCertOk bool, deleteCertOk bool, postCertOk bool,
 	t *testing.T) *httptest.Server {
 	builtinSnis := []string{"localhost", "kong"}
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		urlPath := r.URL.EscapedPath()
 		switch r.Method {
 		case http.MethodGet:


### PR DESCRIPTION
Closes #3694

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
Secrets config utility contacts Kong via insecure port.
Interferes with ability to configure Kong remotely.

## Issue Number:
#3694

## What is the new behavior?
Secrets config utility contacts Kong via secure port.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information