### PR TITLE
feat(snap): add vault ttl config support

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -438,7 +438,7 @@ Example: `snap set edgexfoundry env.device-virtual.service.port=7777`
 | --------------------- | ----------- |
 | add-secretstore-tokens | The add-secretstore-tokens setting is a csv list of service keys to be added to the list of Vault tokens that security-file-token-provider (launched by security-secretstore-setup) creates. It is set to a default list of additional services by the snap, so be sure to examine the default setting before providing a custom list of services. NOTE - this setting is not a configuration override, it's a top-level environment variable used by the security-secretstore-setup. |
 | add-known-secrets | The add-known-secrets setting is a csv list of secret paths and associated services. It's used to provision the specified secret for the given service in Vault. It is set to a default list of additional services by the snap, so be sure to examine the default setting before providing a custom list of services. NOTE - this setting is not a configuration override, it's a top-level environment variable used by the security-secretstore-setup.|
-
+| default-token-ttl | The default-token-ttl setting is a Go Duration string, a sequence of decimal numbers, each with optional fraction and a unit suffix (e.g. "ns", "us" (or "µs"), "ms", "s", "m", "h"). It's used to set the TTL of vault tokens generated for EdgeX services during bootstrap. This setting can be used to increase (or decrease) the default TTL (one hour). If the TTL of a token expires before a service is started, the service will not be able to access the Secret Store.|
 
 ### Security bootstrapper settings (prefix: env.security-bootstrapper.)
 

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.0.3
+require github.com/canonical/edgex-snap-hooks/v2 v2.0.4
 
 go 1.16


### PR DESCRIPTION
This commit adds configure hook support for the new security-file-token-provider `DefaultTokenTTL`
option, which can be used to increase or decrease the default TTL (one hour) assigned to new Vault tokens.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)**
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

** See #testing for details on how this can be tested.

## What is the current behavior?
It's not possible to override the security-file-token-provider's `DefaultTokenTTL` configuration option when using the edgexfoundry snap.

## Issue Number:
none

## What is the new behavior?
The snap configure hook now supports setting this new option.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

## Testing
Since in Ireland, it's not possible to restart security-secretstore-setup, this config option needs to be provide before any of the services start. Currently the only way to do this is by using the default snap configuration feature of the gadget snap.

I tested this by modifying the snap install hook to set initialize the config option to '15m':

```
$ git diff
diff --git a/snap/local/hooks/cmd/install/install.go b/snap/local/hooks/cmd/install/install.go
index 12228f20..c63b64c6 100644
--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -366,6 +366,12 @@ func main() {
                os.Exit(1)
        }
 
+       // **TEST CODE**
+       if err = cli.SetConfig("env.security-secret-store.default-token-ttl", "15m"); err != nil {
+               hooks.Error(fmt.Sprintf("edgexfoundry:install %v", err))
+               os.Exit(1)
+       }
+
        // just like the configure hook, this code needs to iterate over every service
        // and setup .env files for each if required...
        for _, v := range hooks.Services {
```

I built the snap with this extra modification and then just tested by:

- installing the snap and enabling kuiper (e.g. snap set edgexfoundry kuiper=on) before 15m had passed, then I just verified that app-service-configurable (profile=rules-engine) started OK
- re-installed and waited longer then '15m', and again activated kuiper; this time app-service-configurable fails to start because its token has expired