### PR TITLE
feat(security): Enable lint hooked to make test + a few trivial fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+  disable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - ineffassign
+    - staticcheck
+    - unused
+    - varcheck

--- a/internal/core/metadata/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/controller/http/deviceprofile_test.go
@@ -115,7 +115,7 @@ func createDeviceProfileRequestWithFile(fileContents []byte) (*http.Request, err
 	boundary := writer.Boundary()
 
 	err = writer.Close()
-	if err != err {
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/db/redis/client.go
+++ b/internal/pkg/db/redis/client.go
@@ -38,7 +38,6 @@ type Client struct {
 
 type CoreDataClient struct {
 	*Client
-	logger logger.LoggingClient
 }
 
 // Return a pointer to the Redis client

--- a/internal/security/secretstore/tokenprovider_linux_test.go
+++ b/internal/security/secretstore/tokenprovider_linux_test.go
@@ -52,6 +52,6 @@ func TestCreatesFile(t *testing.T) {
 	defer cancel()
 
 	file, err := os.Open(testfile)
-	defer file.Close()
 	assert.NoError(t, err) // fails if file wasn't created
+	defer file.Close()
 }

--- a/internal/support/scheduler/application/scheduler/manager.go
+++ b/internal/support/scheduler/application/scheduler/manager.go
@@ -123,8 +123,6 @@ func (m *manager) execute(
 		m.lc.Debugf("requeue interval %s", executor.Interval.Name)
 		m.executorQueue.Add(executor)
 	}
-
-	return
 }
 
 func (m *manager) executeAction(action models.IntervalAction) errors.EdgeX {


### PR DESCRIPTION
Closes #3565

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
No linting performed as part of automated testing.

## Issue Number:
#3565

## What is the new behavior?
This command enables "make lint" and hooks lint into the "make test" target after unit tests.
The current .golangci.yaml disables many of the default linters so that they can be enabled one-by-one-with appropriate fixes.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

Requires that golangci-lint be installed in order to be effective.
If not installed, nothing happens.


## Other information