### PR TITLE
feat(security): Enable modern cipher suite / TLSv1.3 only

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,6 +140,7 @@ apps:
       KONG_ADMIN_ERROR_LOG: $SNAP_COMMON/logs/kong-admin-error.log
       KONG_ADMIN_LISTEN: "localhost:8001, localhost:8444 ssl"
       KONG_STATUS_LISTEN: "localhost:8100"
+      KONG_SSL_CIPHER_SUITE: "modern"
       # The DNS order was modified because of an issue with a Windows based host DNS issue.
       # Keeping the default order would cause the first API request to Kong's admin API much longer time to connect for
       # taking something minimum of 20 seconds to complete, and then others would complete as expected.


### PR DESCRIPTION
Closes #3680

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features) https://github.com/edgexfoundry/edgex-docs/pull/560

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
API gateway supports "intermediate" level of cipher suites.

## Issue Number:
- #3680

## What is the new behavior?
API gateway supports "modern" cipher suite and TLSv1.3 only.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes, but can by changed by configuration alone.
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information