### PR TITLE
feat(security): Revert CORS changes for API Gateway

### DIFF
--- a/cmd/security-proxy-setup/res/configuration.toml
+++ b/cmd/security-proxy-setup/res/configuration.toml
@@ -38,14 +38,6 @@ Resource = "coredata"
 OutputPath = "accessToken.json"
 JWTFile = "/tmp/edgex/secrets/security-proxy-setup/kong-admin-jwt"
 
-[CORSConfiguration]
-EnableCORS = false
-CORSAllowCredentials = false
-CORSAllowedOrigins = "https://localhost"
-CORSAllowedMethods = "GET, POST, PUT, DELETE"
-CORSAllowedHeaders = "Content-Type"
-CORSPreflightMaxAge = 3600
-
 [SecretStore]
 Type = "vault"
 Protocol = "http"

--- a/internal/security/proxy/config/config.go
+++ b/internal/security/proxy/config/config.go
@@ -27,15 +27,14 @@ import (
 )
 
 type ConfigurationStruct struct {
-	LogLevel          string
-	RequestTimeout    int
-	SNIS              []string
-	AccessTokenFile   string
-	KongURL           KongUrlInfo
-	KongAuth          KongAuthInfo
-	CORSConfiguration CORSConfigurationInfo
-	SecretStore       bootstrapConfig.SecretStoreInfo
-	Routes            map[string]models.KongService
+	LogLevel        string
+	RequestTimeout  int
+	SNIS            []string
+	AccessTokenFile string
+	KongURL         KongUrlInfo
+	KongAuth        KongAuthInfo
+	SecretStore     bootstrapConfig.SecretStoreInfo
+	Routes          map[string]models.KongService
 }
 
 type KongUrlInfo struct {
@@ -45,15 +44,6 @@ type KongUrlInfo struct {
 	ApplicationPort    int
 	ApplicationPortSSL int
 	StatusPort         int
-}
-
-type CORSConfigurationInfo struct {
-	EnableCORS           bool
-	CORSAllowCredentials bool
-	CORSAllowedOrigins   string
-	CORSAllowedMethods   string
-	CORSAllowedHeaders   string
-	CORSPreflightMaxAge  int
 }
 
 func (k KongUrlInfo) GetProxyBaseURL() string {


### PR DESCRIPTION
Reverts #3678 due to strategy change.  See #1913.

It was decided to move CORS functionality to the
microservice level so that it can be applied both
in the security-enabled as well as security-disabled
states.

This functionality was never implemented in Ireland,
thus implementing and reverting it in Jakarta is
not a breaking change.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

@magallardo
