### PR TITLE
feat(security): Give user instructions on how to install linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,9 @@ hadolint:
 	if which hadolint > /dev/null ; then hadolint --config .hadolint.yml `find * -type f -name 'Dockerfile*' -print` ; elif test "${ARCH}" = "x86_64" && which docker > /dev/null ; then docker run --rm -v `pwd`:/host:ro,z --entrypoint /bin/hadolint hadolint/hadolint:latest --config /host/.hadolint.yml `find * -type f -name 'Dockerfile*' | xargs -i echo '/host/{}'` ; fi
 	
 lint:
-	if [ "z${ARCH}" = "zx86_64" ] && which golangci-lint ; then golangci-lint run --config .golangci.yml ; fi
+	@which golangci-lint >/dev/null || echo "WARNING: go linter not installed. To install, run\n  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$$(go env GOPATH)/bin v1.42.1"
+	@if [ "z${ARCH}" = "zx86_64" ] && which golangci-lint >/dev/null ; then golangci-lint run --config .golangci.yml ; else echo "WARNING: Linting skipped (not on x86_64 or linter not installed)"; fi
+
 
 test: unittest hadolint lint
 	GO111MODULE=on go vet ./...


### PR DESCRIPTION
Adds the following warning message:

Addresses #3565

WARNING: go linter not installed. To install, run
  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1

WARNING: Linting skipped (not on x86_64 or linter not installed)

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
User is not warned if lint checks are skipped.

## Issue Number:
#3565

## What is the new behavior?
Users will be told how to install the linter.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information