### PR TITLE
fix(snap): update edgex-snap-hooks to v2.0.5

### DIFF
--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.0.4
+require github.com/canonical/edgex-snap-hooks/v2 v2.0.5
 
 go 1.16


### PR DESCRIPTION
Update the version of edgex-snap-hooks used in the snap hooks to v2.0.5.

This version of edgex-snap-hooks fixes an issue with calls made to the
secrets-config command. See https://github.com/canonical/edgex-snap-hooks/pull/8
for details.

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
This commit updates the version of a dependency in the snap install/configure hooks. That update has been tested as per https://github.com/canonical/edgex-snap-hooks/pull/8 

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->