### PR TITLE
fix(snap): Fix and extend secretStore component lists

### DIFF
--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -40,12 +40,18 @@ var secretStoreTokens = []string{
 	"app-rules-engine",
 	"app-http-export",
 	"app-mqtt-export",
+	"app-rfid-llrp-inventory",
 	"application-service",
 	"device-camera",
 	"device-mqtt",
 	"device-modbus",
 	"device-coap",
 	"device-snmp",
+	"device-gpio",
+	"device-bacnet",
+	"device-grove",
+	"device-uart",
+	"device-rfid-llrp",
 }
 
 var secretStoreKnownSecrets = []string{
@@ -53,6 +59,7 @@ var secretStoreKnownSecrets = []string{
 	"redisdb[app-rules-engine]",
 	"redisdb[app-http-export]",
 	"redisdb[app-mqtt-export]",
+	"redisdb[app-rfid-llrp-inventory]",
 	"redisdb[application-service]",
 	"redisdb[device-rest]",
 	"redisdb[device-virtual]",
@@ -61,6 +68,11 @@ var secretStoreKnownSecrets = []string{
 	"redisdb[device-modbus]",
 	"redisdb[device-coap]",
 	"redisdb[device-snmp]",
+	"redisdb[device-gpio]",
+	"redisdb[device-bacnet]",
+	"redisdb[device-grove]",
+	"redisdb[device-uart]",
+	"redisdb[device-rfid-llrp]",
 }
 
 var services = []string{

--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -35,22 +35,33 @@ const consulAddRegistryACLRolesCfg = "env.security-bootstrapper.add-registry-acl
 
 // device-rest and device-virtual are both on the /cmd/security-file-token-provider/res/token-config.json file,
 // so they should not need to be set here as well
-const secretStoreTokens = "app-functional-tests,app-rules-engine,app-http-export,app-mqtt-export,application-service" +
-	"device-camera,device-mqtt,device-modbus,device-coap,device-snmp"
+var secretStoreTokens = []string{
+	"app-functional-tests",
+	"app-rules-engine",
+	"app-http-export",
+	"app-mqtt-export",
+	"application-service",
+	"device-camera",
+	"device-mqtt",
+	"device-modbus",
+	"device-coap",
+	"device-snmp",
+}
 
-const secretStoreKnownSecrets = "" +
-	"redisdb[app-functional-tests]," +
-	"redisdb[app-rules-engine]," +
-	"redisdb[app-http-export]," +
-	"redisdb[app-mqtt-export]," +
-	"redisdb[application-service]," +
-	"redisdb[device-rest]," +
-	"redisdb[device-virtual]," +
-	"redisdb[device-camera]," +
-	"redisdb[device-mqtt]," +
-	"redisdb[device-modbus]," +
-	"redisdb[device-coap]," +
-	"redisdb[device-snmp]"
+var secretStoreKnownSecrets = []string{
+	"redisdb[app-functional-tests]",
+	"redisdb[app-rules-engine]",
+	"redisdb[app-http-export]",
+	"redisdb[app-mqtt-export]",
+	"redisdb[application-service]",
+	"redisdb[device-rest]",
+	"redisdb[device-virtual]",
+	"redisdb[device-camera]",
+	"redisdb[device-mqtt]",
+	"redisdb[device-modbus]",
+	"redisdb[device-coap]",
+	"redisdb[device-snmp]",
+}
 
 var services = []string{
 	"security-bootstrapper",
@@ -181,11 +192,11 @@ func installSecretStore() error {
 	//	ADD_REGISTRY_ACL_ROLES
 	// We do not have access to the snap configuration in the install hook,
 	// so this just sets the values to the default list of services
-	if err = cli.SetConfig(secretStoreAddTokensCfg, secretStoreTokens); err != nil {
+	if err = cli.SetConfig(secretStoreAddTokensCfg, strings.Join(secretStoreTokens, ",")); err != nil {
 		return err
 	}
 
-	if err = cli.SetConfig(secretStoreAddKnownSecretsCfg, secretStoreKnownSecrets); err != nil {
+	if err = cli.SetConfig(secretStoreAddKnownSecretsCfg, strings.Join(secretStoreKnownSecrets, ",")); err != nil {
 		return err
 	}
 
@@ -231,7 +242,7 @@ func installConsul() error {
 	// using the same list of services as used in ADD_KNOWN_SECRETS
 	// We do not have access to the snap configuration in the install hook,
 	// so this just sets the values to the default list of services
-	if err = cli.SetConfig(consulAddRegistryACLRolesCfg, secretStoreTokens); err != nil {
+	if err = cli.SetConfig(consulAddRegistryACLRolesCfg, strings.Join(secretStoreTokens, ",")); err != nil {
 		return err
 	}
 

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,0 +1,12 @@
+github.com/canonical/edgex-snap-hooks/v2 v2.0.5 h1:saDgLCXycrYZXfTbXQQVI3eQcadRKfSFl0od+MvTD+I=
+github.com/canonical/edgex-snap-hooks/v2 v2.0.5/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR:
- fixes #3756
- converts the lists to slices for better maintainability
- adds missing service snaps to secret store tokens and known secrets for the following:
   - app-rfid-llrp-inventory
   - device-gpio
   - device-bacnet
   - device-grove
   - device-uart
   - device-rfid-llrp

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
I have tested by building the snap, performing a fresh install, and checking the following to make sure the 5 new services are added:

Tokens:
```
$ sudo tree /var/snap/edgexfoundry/current/secrets/ 
/var/snap/edgexfoundry/current/secrets/
├── app-functional-tests
│   └── secrets-token.json
├── app-http-export
│   └── secrets-token.json
├── application-service
│   └── secrets-token.json
├── app-mqtt-export
│   └── secrets-token.json
├── app-rfid-llrp-inventory
│   └── secrets-token.json
├── app-rules-engine
│   └── secrets-token.json
├── consul-acl-token
│   └── bootstrap_token.json
├── core-command
│   └── secrets-token.json
├── core-data
│   └── secrets-token.json
├── core-metadata
│   └── secrets-token.json
├── device-bacnet
│   └── secrets-token.json
├── device-camera
│   └── secrets-token.json
├── device-coap
│   └── secrets-token.json
├── device-gpio
│   └── secrets-token.json
├── device-grove
│   └── secrets-token.json
├── device-modbus
│   └── secrets-token.json
├── device-mqtt
│   └── secrets-token.json
├── device-rest
│   └── secrets-token.json
├── device-rfid-llrp
│   └── secrets-token.json
├── device-snmp
│   └── secrets-token.json
├── device-uart
│   └── secrets-token.json
├── device-virtual
│   └── secrets-token.json
├── edgex-consul
│   └── admin
│       └── token.json
├── security-bootstrapper-redis
│   └── secrets-token.json
├── security-file-token-provider
│   └── secrets-token.json
├── security-proxy-setup
│   ├── kong-admin-jwt
│   └── secrets-token.json
├── security-secretstore-setup
│   └── secrets-token.json
├── support-notifications
│   └── secrets-token.json
├── support-scheduler
│   └── secrets-token.json
├── sys-mgmt-agent
│   └── secrets-token.json
└── tokenprovider
    └── secrets-token.json

32 directories, 32 files
```

Known secrets:
```
$ sudo snap get edgexfoundry env.security-secret-store.add-known-secrets
redisdb[app-functional-tests],redisdb[app-rules-engine],redisdb[app-http-export],redisdb[app-mqtt-export],redisdb[app-rfid-llrp-inventory],redisdb[application-service],redisdb[device-rest],redisdb[device-virtual],redisdb[device-camera],redisdb[device-mqtt],redisdb[device-modbus],redisdb[device-coap],redisdb[device-snmp],redisdb[device-gpio],redisdb[device-bacnet],redisdb[device-grove],redisdb[device-uart],redisdb[device-rfid-llrp]
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->