### PR TITLE
feat(command): Support object value type in Set Command

### DIFF
--- a/internal/core/command/application/command.go
+++ b/internal/core/command/application/command.go
@@ -228,7 +228,7 @@ func IssueGetCommandByName(deviceName string, commandName string, queryParams st
 
 // IssueSetCommandByName issues the specified set(write) command referenced by the command name to the device/sensor, also
 // referenced by name.
-func IssueSetCommandByName(deviceName string, commandName string, queryParams string, settings map[string]string, dic *di.Container) (response commonDTO.BaseResponse, err errors.EdgeX) {
+func IssueSetCommandByName(deviceName string, commandName string, queryParams string, settings map[string]interface{}, dic *di.Container) (response commonDTO.BaseResponse, err errors.EdgeX) {
 	if deviceName == "" {
 		return response, errors.NewCommonEdgeX(errors.KindContractInvalid, "device name cannot be empty", nil)
 	}
@@ -262,5 +262,5 @@ func IssueSetCommandByName(deviceName string, commandName string, queryParams st
 	if dscc == nil {
 		return response, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceServiceCommandClient returned", nil)
 	}
-	return dscc.SetCommand(context.Background(), deviceServiceResponse.Service.BaseAddress, deviceName, commandName, queryParams, settings)
+	return dscc.SetCommandWithObject(context.Background(), deviceServiceResponse.Service.BaseAddress, deviceName, commandName, queryParams, settings)
 }

--- a/internal/core/command/controller/http/command_test.go
+++ b/internal/core/command/controller/http/command_test.go
@@ -67,10 +67,14 @@ func NewMockDIC() *di.Container {
 	})
 }
 
-func buildTestSettings() map[string]string {
-	var settings = make(map[string]string)
+func buildTestSettings() map[string]interface{} {
+	var settings = make(map[string]interface{})
 	settings["AHU-TargetTemperature"] = "28.5"
 	settings["AHU-TargetBand"] = "4.0"
+	settings["AHU-TargetHumidity"] = map[string]interface{}{
+		"Accuracy": "0.2-0.3% RH",
+		"Value":    float64(59),
+	}
 	return settings
 }
 
@@ -426,10 +430,10 @@ func TestIssueSetCommand(t *testing.T) {
 	testSettings := buildTestSettings()
 	testSettingsJsonStr, _ := json.Marshal(testSettings)
 	dsccMock := &mocks.DeviceServiceCommandClient{}
-	dsccMock.On("SetCommand", context.Background(), testBaseAddress, testDeviceName, testCommandName, testQueryStrings, testSettings).Return(expectedBaseResponse, nil)
-	dsccMock.On("SetCommand", context.Background(), testBaseAddress, testDeviceName, testCommandName, "", testSettings).Return(expectedBaseResponse, nil)
-	dsccMock.On("SetCommand", context.Background(), testBaseAddress, testDeviceName, testCommandName, testQueryStrings, "").Return(commonDTO.BaseResponse{}, errors.NewCommonEdgeX(errors.KindServerError, "no request body provided for PUT command", nil))
-	dsccMock.On("SetCommand", context.Background(), testBaseAddress, testDeviceName, nonExistName, testQueryStrings, testSettings).Return(commonDTO.BaseResponse{}, errors.NewCommonEdgeX(errors.KindContractInvalid, "no corresponding PUT command", nil))
+	dsccMock.On("SetCommandWithObject", context.Background(), testBaseAddress, testDeviceName, testCommandName, testQueryStrings, testSettings).Return(expectedBaseResponse, nil)
+	dsccMock.On("SetCommandWithObject", context.Background(), testBaseAddress, testDeviceName, testCommandName, "", testSettings).Return(expectedBaseResponse, nil)
+	dsccMock.On("SetCommandWithObject", context.Background(), testBaseAddress, testDeviceName, testCommandName, testQueryStrings, "").Return(commonDTO.BaseResponse{}, errors.NewCommonEdgeX(errors.KindServerError, "no request body provided for PUT command", nil))
+	dsccMock.On("SetCommandWithObject", context.Background(), testBaseAddress, testDeviceName, nonExistName, testQueryStrings, testSettings).Return(commonDTO.BaseResponse{}, errors.NewCommonEdgeX(errors.KindContractInvalid, "no corresponding PUT command", nil))
 
 	dic := NewMockDIC()
 	dic.Update(di.ServiceConstructorMap{

--- a/internal/pkg/utils/http.go
+++ b/internal/pkg/utils/http.go
@@ -170,15 +170,15 @@ func ParsePathParamToInt(r *http.Request, pathKey string) (int, errors.EdgeX) {
 	return result, nil
 }
 
-// Parse the body of http request to a map[string]string.  EdgeX error will be returned if any parsing error occurs.
-func ParseBodyToMap(r *http.Request) (map[string]string, errors.EdgeX) {
+// ParseBodyToMap parses the body of http request to a map[string]interfaces{}.  EdgeX error will be returned if any parsing error occurs.
+func ParseBodyToMap(r *http.Request) (map[string]interface{}, errors.EdgeX) {
 	defer r.Body.Close()
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to read request body", err)
 	}
 
-	var result map[string]string
+	var result map[string]interface{}
 	if err = json.Unmarshal(body, &result); err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to parse request body", err)
 	}

--- a/openapi/v2/core-command.yaml
+++ b/openapi/v2/core-command.yaml
@@ -98,6 +98,7 @@ components:
             - Int64Array
             - Float32Array
             - Float64Array
+            - Object
     CoreCommand:
       type: object
       properties:
@@ -144,7 +145,12 @@ components:
         type: string
       title: Setting
       type: object
-      example: { "AHU-TargetTemperature": "28.5", "AHU-TargetBand": "4.0" }
+      example:
+        AHU-TargetTemperature: "28.5"
+        AHU-TargetBand: "4.0"
+        AHU-TargetHumidity:
+          Accuracy: "0.2-0.3% RH"
+          Value: 59
     BaseReading:
       description: "A base reading type containing common properties from which more specific reading types inherit. This definition should not be implemented but is used elsewhere to indicate support for a mixed list of simple/binary readings in a single event."
       type: object
@@ -200,6 +206,7 @@ components:
             - Int64Array
             - Float32Array
             - Float64Array
+            - Object
       required:
         - apiVersion
         - deviceName


### PR DESCRIPTION
Make the Set Command payload to allow object value type parameters.

Closes #3753

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Update the unit test to reflect the change**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **Update the Swagger API in this PR**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Clone the repo or pull the branch from:
   - edgex-go https://github.com/edgexfoundry/edgex-go/pull/3762
   - sdk-go https://github.com/edgexfoundry/device-sdk-go/pull/1038
   - core-contracts https://github.com/edgexfoundry/go-mod-core-contracts/pull/676 
2. Run core-service and simple-device with specified core-contracts branch
3. Execute Set command
4. Execute Read command to inspect the result
5. Query event API to inspect the reading result

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->