### PR TITLE
feat(data): new API to search Readings by multiple resource names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.1-dev.23
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.1-dev.25
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.1
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0/go.mod h1:E5KLeFEwTuIbjrKMCIn
 github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0 h1:S1rUyJPJWSvlkNHLbHLFWBvqzH+ShO1xPp4HH7Pvn9I=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0/go.mod h1:NZnjQtCdQtPH/eoOuTKA+8+FsoUU3WSlZ5JpXWuiYQQ=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0/go.mod h1:pfXURRetgIto0GR0sCjDrfa71hqJ1wxmQWi/mOzWfWU=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.1-dev.23 h1:kVg8RVx2MaOOctd3I6XLy0N3exOZ3muyK4IHRyD9Dzs=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.1-dev.23/go.mod h1:I6UhBPCREubcU0ouIGBdZlNG5Xx4NijUVN5rvEtD03k=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.1-dev.25 h1:AFQD5sbxpAfwESF/SXApyq7piSDgoioWLL5D3GY8qvw=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.1-dev.25/go.mod h1:I6UhBPCREubcU0ouIGBdZlNG5Xx4NijUVN5rvEtD03k=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.0.1 h1:8nT3CiPLIft5RmR+vbmXBW9Kbz7TqPZ6C8QuQ6TTn6w=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.0.1/go.mod h1:bLKWB9yeOHLZoQtHLZlGwz8MjsMJIvHDFce7CcUb4fE=
 github.com/edgexfoundry/go-mod-registry/v2 v2.0.0 h1:FCodcfCo3EqgINbGa9Rn6LqbiwkdT2FPKgCnk81GbFs=

--- a/internal/core/data/application/reading.go
+++ b/internal/core/data/application/reading.go
@@ -97,9 +97,8 @@ func ReadingsByTimeRange(start int, end int, offset int, limit int, dic *di.Cont
 
 	if err != nil {
 		return readings, totalCount, errors.NewCommonEdgeXWrapper(err)
-	} else {
-		return readings, totalCount, nil
 	}
+	return readings, totalCount, nil
 }
 
 func convertReadingModelsToDTOs(readingModels []models.Reading) (readings []dtos.BaseReading, err errors.EdgeX) {
@@ -140,9 +139,8 @@ func ReadingsByResourceNameAndTimeRange(resourceName string, start int, end int,
 
 	if err != nil {
 		return readings, totalCount, errors.NewCommonEdgeXWrapper(err)
-	} else {
-		return readings, totalCount, nil
 	}
+	return readings, totalCount, nil
 }
 
 // ReadingsByDeviceNameAndResourceName query readings with offset, limit, device name and its associated resource name
@@ -165,9 +163,8 @@ func ReadingsByDeviceNameAndResourceName(deviceName string, resourceName string,
 
 	if err != nil {
 		return readings, totalCount, errors.NewCommonEdgeXWrapper(err)
-	} else {
-		return readings, totalCount, nil
 	}
+	return readings, totalCount, nil
 }
 
 // ReadingsByDeviceNameAndResourceNameAndTimeRange query readings with offset, limit, device name, its associated resource name and specified time range
@@ -190,7 +187,32 @@ func ReadingsByDeviceNameAndResourceNameAndTimeRange(deviceName string, resource
 
 	if err != nil {
 		return readings, totalCount, errors.NewCommonEdgeXWrapper(err)
-	} else {
-		return readings, totalCount, nil
 	}
+	return readings, totalCount, nil
+}
+
+// ReadingsByDeviceNameAndResourceNamesAndTimeRange query readings with offset, limit, device name, its associated resource name and specified time range
+func ReadingsByDeviceNameAndResourceNamesAndTimeRange(deviceName string, resourceNames []string, start, end, offset, limit int, dic *di.Container) (readings []dtos.BaseReading, totalCount uint32, err errors.EdgeX) {
+	if deviceName == "" {
+		return readings, totalCount, errors.NewCommonEdgeX(errors.KindContractInvalid, "device name is empty", nil)
+	}
+
+	dbClient := container.DBClientFrom(dic.Get)
+	var readingModels []models.Reading
+	if len(resourceNames) > 0 {
+		readingModels, totalCount, err = dbClient.ReadingsByDeviceNameAndResourceNamesAndTimeRange(deviceName, resourceNames, start, end, offset, limit)
+	} else {
+		readingModels, err = dbClient.ReadingsByDeviceNameAndTimeRange(deviceName, start, end, offset, limit)
+		if err == nil {
+			totalCount, err = dbClient.ReadingCountByDeviceNameAndTimeRange(deviceName, start, end)
+		}
+	}
+
+	if err == nil {
+		readings, err = convertReadingModelsToDTOs(readingModels)
+	}
+	if err != nil {
+		return readings, totalCount, errors.NewCommonEdgeXWrapper(err)
+	}
+	return readings, totalCount, nil
 }

--- a/internal/core/data/infrastructure/interfaces/db.go
+++ b/internal/core/data/infrastructure/interfaces/db.go
@@ -38,4 +38,7 @@ type DBClient interface {
 	ReadingCountByDeviceNameAndResourceNameAndTimeRange(deviceName string, resourceName string, start int, end int) (uint32, errors.EdgeX)
 	ReadingCountByTimeRange(start int, end int) (uint32, errors.EdgeX)
 	ReadingsByResourceNameAndTimeRange(resourceName string, start int, end int, offset int, limit int) ([]model.Reading, errors.EdgeX)
+	ReadingsByDeviceNameAndResourceNamesAndTimeRange(deviceName string, resourceNames []string, start, end, offset, limit int) ([]model.Reading, uint32, errors.EdgeX)
+	ReadingsByDeviceNameAndTimeRange(deviceName string, start int, end int, offset int, limit int) ([]model.Reading, errors.EdgeX)
+	ReadingCountByDeviceNameAndTimeRange(deviceName string, start int, end int) (uint32, errors.EdgeX)
 }

--- a/internal/core/data/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/data/infrastructure/interfaces/mocks/DBClient.go
@@ -352,6 +352,29 @@ func (_m *DBClient) ReadingCountByDeviceNameAndResourceNameAndTimeRange(deviceNa
 	return r0, r1
 }
 
+// ReadingCountByDeviceNameAndTimeRange provides a mock function with given fields: deviceName, start, end
+func (_m *DBClient) ReadingCountByDeviceNameAndTimeRange(deviceName string, start int, end int) (uint32, errors.EdgeX) {
+	ret := _m.Called(deviceName, start, end)
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func(string, int, int) uint32); ok {
+		r0 = rf(deviceName, start, end)
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(string, int, int) errors.EdgeX); ok {
+		r1 = rf(deviceName, start, end)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // ReadingCountByResourceName provides a mock function with given fields: resourceName
 func (_m *DBClient) ReadingCountByResourceName(resourceName string) (uint32, errors.EdgeX) {
 	ret := _m.Called(resourceName)
@@ -510,6 +533,63 @@ func (_m *DBClient) ReadingsByDeviceNameAndResourceNameAndTimeRange(deviceName s
 	var r1 errors.EdgeX
 	if rf, ok := ret.Get(1).(func(string, string, int, int, int, int) errors.EdgeX); ok {
 		r1 = rf(deviceName, resourceName, start, end, offset, limit)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
+// ReadingsByDeviceNameAndResourceNamesAndTimeRange provides a mock function with given fields: deviceName, resourceNames, start, end, offset, limit
+func (_m *DBClient) ReadingsByDeviceNameAndResourceNamesAndTimeRange(deviceName string, resourceNames []string, start int, end int, offset int, limit int) ([]models.Reading, uint32, errors.EdgeX) {
+	ret := _m.Called(deviceName, resourceNames, start, end, offset, limit)
+
+	var r0 []models.Reading
+	if rf, ok := ret.Get(0).(func(string, []string, int, int, int, int) []models.Reading); ok {
+		r0 = rf(deviceName, resourceNames, start, end, offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Reading)
+		}
+	}
+
+	var r1 uint32
+	if rf, ok := ret.Get(1).(func(string, []string, int, int, int, int) uint32); ok {
+		r1 = rf(deviceName, resourceNames, start, end, offset, limit)
+	} else {
+		r1 = ret.Get(1).(uint32)
+	}
+
+	var r2 errors.EdgeX
+	if rf, ok := ret.Get(2).(func(string, []string, int, int, int, int) errors.EdgeX); ok {
+		r2 = rf(deviceName, resourceNames, start, end, offset, limit)
+	} else {
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1, r2
+}
+
+// ReadingsByDeviceNameAndTimeRange provides a mock function with given fields: deviceName, start, end, offset, limit
+func (_m *DBClient) ReadingsByDeviceNameAndTimeRange(deviceName string, start int, end int, offset int, limit int) ([]models.Reading, errors.EdgeX) {
+	ret := _m.Called(deviceName, start, end, offset, limit)
+
+	var r0 []models.Reading
+	if rf, ok := ret.Get(0).(func(string, int, int, int, int) []models.Reading); ok {
+		r0 = rf(deviceName, start, end, offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Reading)
+		}
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func(string, int, int, int, int) errors.EdgeX); ok {
+		r1 = rf(deviceName, start, end, offset, limit)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -51,6 +51,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container) {
 	r.HandleFunc(common.ApiReadingByResourceNameAndTimeRangeRoute, rc.ReadingsByResourceNameAndTimeRange).Methods(http.MethodGet)
 	r.HandleFunc(common.ApiReadingByDeviceNameAndResourceNameRoute, rc.ReadingsByDeviceNameAndResourceName).Methods(http.MethodGet)
 	r.HandleFunc(common.ApiReadingByDeviceNameAndResourceNameAndTimeRangeRoute, rc.ReadingsByDeviceNameAndResourceNameAndTimeRange).Methods(http.MethodGet)
+	r.HandleFunc(common.ApiReadingByDeviceNameAndTimeRangeRoute, rc.ReadingsByDeviceNameAndResourceNamesAndTimeRange).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))

--- a/internal/pkg/infrastructure/redis/client.go
+++ b/internal/pkg/infrastructure/redis/client.go
@@ -678,6 +678,44 @@ func (c *Client) ReadingsByDeviceNameAndResourceNameAndTimeRange(deviceName stri
 	return readings, nil
 }
 
+func (c *Client) ReadingsByDeviceNameAndResourceNamesAndTimeRange(deviceName string, resourceNames []string, start, end, offset, limit int) (readings []model.Reading, totalCount uint32, err errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	readings, totalCount, err = readingsByDeviceNameAndResourceNamesAndTimeRange(conn, deviceName, resourceNames, start, end, offset, limit)
+	if err != nil {
+		return readings, totalCount, errors.NewCommonEdgeX(errors.Kind(err),
+			fmt.Sprintf("fail to query readings by deviceName %s, resourceNames %v and time range %v ~ %v", deviceName, resourceNames, start, end), err)
+	}
+
+	return readings, totalCount, nil
+}
+
+func (c *Client) ReadingsByDeviceNameAndTimeRange(deviceName string, start int, end int, offset int, limit int) (readings []model.Reading, err errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	readings, err = readingsByDeviceNameAndTimeRange(conn, deviceName, start, end, offset, limit)
+	if err != nil {
+		return readings, errors.NewCommonEdgeX(errors.Kind(err),
+			fmt.Sprintf("fail to query readings by deviceName %s, and time range %v ~ %v", deviceName, start, end), err)
+	}
+
+	return readings, nil
+}
+
+func (c *Client) ReadingCountByDeviceNameAndTimeRange(deviceName string, start int, end int) (uint32, errors.EdgeX) {
+	conn := c.Pool.Get()
+	defer conn.Close()
+
+	count, edgeXerr := getMemberCountByScoreRange(conn, CreateKey(ReadingsCollectionDeviceName, deviceName), start, end)
+	if edgeXerr != nil {
+		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+
+	return count, nil
+}
+
 // AddProvisionWatcher adds a new provision watcher
 func (c *Client) AddProvisionWatcher(pw model.ProvisionWatcher) (model.ProvisionWatcher, errors.EdgeX) {
 	conn := c.Pool.Get()

--- a/internal/pkg/infrastructure/redis/queries.go
+++ b/internal/pkg/infrastructure/redis/queries.go
@@ -258,6 +258,47 @@ func objectsByKeys(conn redis.Conn, setMethod string, offset int, limit int, red
 	return objects, nil
 }
 
+// unionObjectsByKeysAndScoreRange returns objects resulting from the union of all the given sets with specified score range, offset, and limit
+func unionObjectsByKeysAndScoreRange(conn redis.Conn, start, end, offset, limit int, redisKeys ...string) ([][]byte, uint32, errors.EdgeX) {
+	return objectsByKeysAndScoreRange(conn, ZUNIONSTORE, start, end, offset, limit, redisKeys...)
+}
+
+// objectsByKeysAndScoreRange returns objects resulting from the set method of all the given sets with specified score range, offset, and limit.  The data set method could be either ZINTERSTORE or ZUNIONSTORE
+func objectsByKeysAndScoreRange(conn redis.Conn, setMethod string, start, end, offset, limit int, redisKeys ...string) (objects [][]byte, totalCount uint32, edgeXerr errors.EdgeX) {
+	// build up the redis command arguments
+	args := redis.Args{}
+	cacheSet := uuid.New().String()
+	args = append(args, cacheSet)
+	args = append(args, strconv.Itoa(len(redisKeys)))
+	for _, key := range redisKeys {
+		args = args.Add(key)
+	}
+
+	// create a temporary sorted set, cacheSet, resulting from the specified setMethod
+	_, err := conn.Do(setMethod, args...)
+	if err != nil {
+		return nil, totalCount, errors.NewCommonEdgeX(errors.KindDatabaseError, fmt.Sprintf("failed to execute %s command with args %v", setMethod, args), err)
+	}
+
+	// get the total count of the temporary sorted set
+	if totalCount, edgeXerr = getMemberCountByScoreRange(conn, cacheSet, start, end); edgeXerr != nil {
+		return nil, totalCount, edgeXerr
+	}
+
+	// get objects from the temporary sorted set
+	if objects, edgeXerr = getObjectsByScoreRange(conn, cacheSet, start, end, offset, limit); edgeXerr != nil {
+		return nil, totalCount, edgeXerr
+	}
+
+	// clean up unused temporary sorted set
+	_, err = redis.Int(conn.Do(DEL, cacheSet))
+	if err != nil {
+		return nil, totalCount, errors.NewCommonEdgeX(errors.KindDatabaseError, "cache set deletion failed", err)
+	}
+
+	return objects, totalCount, nil
+}
+
 // idFromStoredKey extracts Id from the store key
 func idFromStoredKey(storeKey string) string {
 	substrings := strings.Split(storeKey, DBKeySeparator)

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -1706,6 +1706,94 @@ paths:
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'
+  /reading/device/name/{deviceName}/start/{start}/end/{end}:
+    parameters:
+      - $ref: '#/components/parameters/correlatedRequestHeader'
+      - name: deviceName
+        in: path
+        required: true
+        schema:
+          type: string
+        description: "The device name name of readings"
+      - name: start
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: "Unix timestamp (nanoseconds) indicating the start of a date/time range"
+      - name: end
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: "Unix timestamp (nanoseconds) indicating the end of a date/time range"
+      - $ref: '#/components/parameters/offsetParam'
+      - $ref: '#/components/parameters/limitParam'
+    get:
+      summary: "Return a paginated range of readings by deviceName and specified time range while also allowing multiple resource names specified in the request body as query criteria.  If resource names or request body is empty, return all the readings that meet deviceName and specified time range."
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddEventRequest'
+            example:
+              resourceNames:
+                - resource-001
+                - resource-002
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultiReadingsResponse'
+              examples:
+                MultiReadingsExample:
+                  $ref: '#/components/examples/ReadingsByResourceNameAndTimeRangeExample'
+        '400':
+          description: "Request is in an invalid state."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '416':
+          description: "Request range is not satisfiable"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                416Example:
+                  $ref: '#/components/examples/416Example'
+        '500':
+          description: "An unexpected error occurred on the server"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   /config:
     get:
       summary: "Returns the current configuration of the service."


### PR DESCRIPTION
Add a new Get API that will accept multiple resource names in the payload as the query criteria.
`GET /reading/device/name/{deviceName}/start/{start}/end/{end}`

the query payload would be:

{
  "resourceNames": ["r1", "r2", "r3"]
}

If the resourceNames or the payload is empty, return all the Readings meet the deviceName and in the start/end timestamp

Signed-off-by: Jude Hung <jude@iotechsys.com>

closes #3693 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) This PR updates openapi doc to describe the new API.
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Modify the edgex-go's go.mod to replace the core-contracts lib
2. Run core-data
3. Add several events and readings with various resource name under the same device name. Query readings through following API verify if expected readings are returned:
`GET reading/device/name/{deviceName}/start/{start}/end/{end}`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->