### PR TITLE
feat(command): Allow Get Command to pass parameters in the payload

### DIFF
--- a/internal/core/command/application/command.go
+++ b/internal/core/command/application/command.go
@@ -184,7 +184,7 @@ func buildCoreCommands(deviceName string, serviceUrl string, profile dtos.Device
 
 // IssueGetCommandByName issues the specified get(read) command referenced by the command name to the device/sensor, also
 // referenced by name.
-func IssueGetCommandByName(deviceName string, commandName string, queryParams string, dic *di.Container) (res *responses.EventResponse, err errors.EdgeX) {
+func IssueGetCommandByName(deviceName string, commandName string, queryParams string, parameters map[string]interface{}, dic *di.Container) (res *responses.EventResponse, err errors.EdgeX) {
 	if deviceName == "" {
 		return res, errors.NewCommonEdgeX(errors.KindContractInvalid, "device name cannot be empty", nil)
 	}
@@ -218,7 +218,7 @@ func IssueGetCommandByName(deviceName string, commandName string, queryParams st
 	if dscc == nil {
 		return res, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceServiceCommandClient returned", nil)
 	}
-	res, err = dscc.GetCommand(context.Background(), deviceServiceResponse.Service.BaseAddress, deviceName, commandName, queryParams)
+	res, err = dscc.GetCommandWithObject(context.Background(), deviceServiceResponse.Service.BaseAddress, deviceName, commandName, queryParams, parameters)
 	if err != nil {
 		return res, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/core/command/controller/http/command.go
+++ b/internal/core/command/controller/http/command.go
@@ -105,8 +105,14 @@ func (cc *CommandController) IssueGetCommandByName(w http.ResponseWriter, r *htt
 		utils.WriteErrorResponse(w, ctx, lc, err, "")
 		return
 	}
+	// Request body
+	parameters, err := utils.ParseBodyToMap(r)
+	if err != nil {
+		utils.WriteErrorResponse(w, ctx, lc, err, "")
+		return
+	}
 
-	response, err := application.IssueGetCommandByName(deviceName, commandName, queryParams, cc.dic)
+	response, err := application.IssueGetCommandByName(deviceName, commandName, queryParams, parameters, cc.dic)
 	if err != nil {
 		utils.WriteErrorResponse(w, ctx, lc, err, "")
 		return

--- a/internal/pkg/utils/http.go
+++ b/internal/pkg/utils/http.go
@@ -179,6 +179,10 @@ func ParseBodyToMap(r *http.Request) (map[string]interface{}, errors.EdgeX) {
 	}
 
 	var result map[string]interface{}
+	// The request body is optional for Get command
+	if r.Method == http.MethodGet && len(body) == 0 {
+		return result, nil
+	}
 	if err = json.Unmarshal(body, &result); err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to parse request body", err)
 	}

--- a/openapi/v2/core-command.yaml
+++ b/openapi/v2/core-command.yaml
@@ -526,6 +526,13 @@ paths:
         description: "A name uniquely identifying a command."
     get:
       summary: "Issue the specified read command referenced by the command name to the device/sensor that is also referenced by name."
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SettingRequest'
+        required: false
+        description: The user can put additional parameters in the request body because the parameters might be a more complex data structure for the specific device like the Onvif camera. Then the device service can retrieve the parameters from the request if needed.
       parameters:
         - $ref: '#/components/parameters/correlatedRequestHeader'
         - in: path


### PR DESCRIPTION
Allow Get Command to pass the parameters in the payload to Device Services

Closes #3754

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  **Update the swagger doc**

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core-service and device-simple
    - core-contracts branch: https://github.com/edgexfoundry/go-mod-core-contracts/pull/680
    - edgex-go branch:
    - device-sdk-go branch: https://github.com/edgexfoundry/device-sdk-go/pull/1043
2. Execute Get command API with payload
3. Debug the protocol driver should receive the payload which is the attributes of the commandRequest.

https://github.com/edgexfoundry/device-sdk-go/blob/1be87f15213c05ab1957194b5dea87ff4eff74a4/pkg/models/commandrequest.go#L15

For example, the Get Command request contains the payload:
```
curl --location --request GET 'http://0.0.0.0:59882/api/v2/device/name/Simple-Device01/Switch' \
--header 'Content-Type: application/json' \
--data-raw ' {
    "foo":"123",
    "bar":{
        "foobar":"456"
    }
}'
```
The commandRequest should be
```
{
	DeviceResourceName: "..."
	Attributes :  {
                "foo":"123",
                "bar":{
                   "foobar":"456"
                           }
               }
	Type : "..."
}
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->