### PR TITLE
fix(data): add codes to remove db index of reading:deviceName:resourceName when deleting readings

### DIFF
--- a/internal/pkg/infrastructure/redis/reading.go
+++ b/internal/pkg/infrastructure/redis/reading.go
@@ -60,6 +60,7 @@ func (c *Client) asyncDeleteReadingsByIds(readingIds []string) {
 		_ = conn.Send(ZREM, ReadingsCollectionOrigin, storedKey)
 		_ = conn.Send(ZREM, CreateKey(ReadingsCollectionDeviceName, r.DeviceName), storedKey)
 		_ = conn.Send(ZREM, CreateKey(ReadingsCollectionResourceName, r.ResourceName), storedKey)
+		_ = conn.Send(ZREM, CreateKey(ReadingsCollectionDeviceNameResourceName, r.DeviceName, r.ResourceName), storedKey)
 		queriesInQueue++
 
 		if queriesInQueue >= c.BatchSize {


### PR DESCRIPTION
When adding readings, a redis sorted set will be created as db index for
the relation of reading:deviceName:resourceName, and this index will be
used to query readings by deviceName and resourceName.

However, the current implementation doesn't remove such index when an
associated event is deleted, thus generating incorrect query result for
readings.

This commit fixes this bug by adding codes to remove db index of
reading:deviceName:resourceName while deleting readings.

closes #3774

Signed-off-by: Jude Hung <jude@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) The verification will need to run up a redis instance, and our unit tests framework doesn't have such capability at this moment.
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) No doc changes needed as this is a bug fix.
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Follow the reproduction steps as described in https://github.com/edgexfoundry/edgex-go/issues/3774, the totalCount should be correct.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->