### PR TITLE
fix(metadata): add labels as part of query criteria when finding totalCount

### DIFF
--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -181,7 +181,7 @@ func AllDevices(offset int, limit int, labels []string, dic *di.Container) (devi
 	dbClient := container.DBClientFrom(dic.Get)
 	deviceModels, err := dbClient.AllDevices(offset, limit, labels)
 	if err == nil {
-		totalCount, err = dbClient.DeviceTotalCount()
+		totalCount, err = dbClient.DeviceCountByLabels(labels)
 	}
 	if err != nil {
 		return devices, totalCount, errors.NewCommonEdgeXWrapper(err)

--- a/internal/core/metadata/application/deviceprofile.go
+++ b/internal/core/metadata/application/deviceprofile.go
@@ -108,7 +108,7 @@ func AllDeviceProfiles(offset int, limit int, labels []string, dic *di.Container
 	dbClient := container.DBClientFrom(dic.Get)
 	dps, err := dbClient.AllDeviceProfiles(offset, limit, labels)
 	if err == nil {
-		totalCount, err = dbClient.DeviceProfileTotalCount()
+		totalCount, err = dbClient.DeviceProfileCountByLabels(labels)
 	}
 	if err != nil {
 		return deviceProfiles, totalCount, errors.NewCommonEdgeXWrapper(err)

--- a/internal/core/metadata/application/deviceservice.go
+++ b/internal/core/metadata/application/deviceservice.go
@@ -135,7 +135,7 @@ func AllDeviceServices(offset int, limit int, labels []string, ctx context.Conte
 	dbClient := container.DBClientFrom(dic.Get)
 	services, err := dbClient.AllDeviceServices(offset, limit, labels)
 	if err == nil {
-		totalCount, err = dbClient.DeviceServiceTotalCount()
+		totalCount, err = dbClient.DeviceServiceCountByLabels(labels)
 	}
 	if err != nil {
 		return deviceServices, totalCount, errors.NewCommonEdgeXWrapper(err)

--- a/internal/core/metadata/application/provisionwatcher.go
+++ b/internal/core/metadata/application/provisionwatcher.go
@@ -104,7 +104,7 @@ func AllProvisionWatchers(offset int, limit int, labels []string, dic *di.Contai
 	dbClient := container.DBClientFrom(dic.Get)
 	pwModels, err := dbClient.AllProvisionWatchers(offset, limit, labels)
 	if err == nil {
-		totalCount, err = dbClient.ProvisionWatcherTotalCount()
+		totalCount, err = dbClient.ProvisionWatcherCountByLabels(labels)
 	}
 	if err != nil {
 		return provisionWatchers, totalCount, errors.NewCommonEdgeXWrapper(err)

--- a/internal/core/metadata/controller/http/device_test.go
+++ b/internal/core/metadata/controller/http/device_test.go
@@ -570,7 +570,8 @@ func TestAllDevices(t *testing.T) {
 
 	dic := mockDic()
 	dbClientMock := &dbMock.DBClient{}
-	dbClientMock.On("DeviceTotalCount").Return(expectedDeviceTotalCount, nil)
+	dbClientMock.On("DeviceCountByLabels", []string(nil)).Return(expectedDeviceTotalCount, nil)
+	dbClientMock.On("DeviceCountByLabels", testDeviceLabels).Return(expectedDeviceTotalCount, nil)
 	dbClientMock.On("AllDevices", 0, 10, []string(nil)).Return(devices, nil)
 	dbClientMock.On("AllDevices", 0, 5, testDeviceLabels).Return([]models.Device{devices[0], devices[1]}, nil)
 	dbClientMock.On("AllDevices", 1, 2, []string(nil)).Return([]models.Device{devices[1], devices[2]}, nil)

--- a/internal/core/metadata/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/controller/http/deviceprofile_test.go
@@ -845,7 +845,8 @@ func TestAllDeviceProfiles(t *testing.T) {
 
 	dic := mockDic()
 	dbClientMock := &dbMock.DBClient{}
-	dbClientMock.On("DeviceProfileTotalCount").Return(expectedTotalProfileCount, nil)
+	dbClientMock.On("DeviceProfileCountByLabels", []string(nil)).Return(expectedTotalProfileCount, nil)
+	dbClientMock.On("DeviceProfileCountByLabels", testDeviceProfileLabels).Return(expectedTotalProfileCount, nil)
 	dbClientMock.On("AllDeviceProfiles", 0, 10, []string(nil)).Return(deviceProfiles, nil)
 	dbClientMock.On("AllDeviceProfiles", 0, 5, testDeviceProfileLabels).Return([]models.DeviceProfile{deviceProfiles[0], deviceProfiles[1]}, nil)
 	dbClientMock.On("AllDeviceProfiles", 1, 2, []string(nil)).Return([]models.DeviceProfile{deviceProfiles[1], deviceProfiles[2]}, nil)

--- a/internal/core/metadata/controller/http/deviceservice_test.go
+++ b/internal/core/metadata/controller/http/deviceservice_test.go
@@ -400,7 +400,8 @@ func TestAllDeviceServices(t *testing.T) {
 
 	dic := mockDic()
 	dbClientMock := &dbMock.DBClient{}
-	dbClientMock.On("DeviceServiceTotalCount").Return(expectedTotalDeviceServiceCount, nil)
+	dbClientMock.On("DeviceServiceCountByLabels", []string(nil)).Return(expectedTotalDeviceServiceCount, nil)
+	dbClientMock.On("DeviceServiceCountByLabels", testDeviceServiceLabels).Return(expectedTotalDeviceServiceCount, nil)
 	dbClientMock.On("AllDeviceServices", 0, 10, []string(nil)).Return(deviceServices, nil)
 	dbClientMock.On("AllDeviceServices", 0, 5, testDeviceServiceLabels).Return([]models.DeviceService{deviceServices[0], deviceServices[1]}, nil)
 	dbClientMock.On("AllDeviceServices", 1, 2, []string(nil)).Return([]models.DeviceService{deviceServices[1], deviceServices[2]}, nil)

--- a/internal/core/metadata/controller/http/provisionwatcher_test.go
+++ b/internal/core/metadata/controller/http/provisionwatcher_test.go
@@ -485,7 +485,8 @@ func TestProvisionWatcherController_AllProvisionWatchers(t *testing.T) {
 
 	dic := mockDic()
 	dbClientMock := &mocks.DBClient{}
-	dbClientMock.On("ProvisionWatcherTotalCount").Return(expectedTotalPWCount, nil)
+	dbClientMock.On("ProvisionWatcherCountByLabels", []string(nil)).Return(expectedTotalPWCount, nil)
+	dbClientMock.On("ProvisionWatcherCountByLabels", testProvisionWatcherLabels).Return(expectedTotalPWCount, nil)
 	dbClientMock.On("AllProvisionWatchers", 0, 10, []string(nil)).Return(provisionWatchers, nil)
 	dbClientMock.On("AllProvisionWatchers", 0, 5, testProvisionWatcherLabels).Return([]models.ProvisionWatcher{provisionWatchers[0], provisionWatchers[1]}, nil)
 	dbClientMock.On("AllProvisionWatchers", 1, 2, []string(nil)).Return([]models.ProvisionWatcher{provisionWatchers[1], provisionWatchers[2]}, nil)

--- a/internal/core/metadata/infrastructure/interfaces/db.go
+++ b/internal/core/metadata/infrastructure/interfaces/db.go
@@ -23,7 +23,7 @@ type DBClient interface {
 	DeviceProfilesByModel(offset int, limit int, model string) ([]model.DeviceProfile, errors.EdgeX)
 	DeviceProfilesByManufacturer(offset int, limit int, manufacturer string) ([]model.DeviceProfile, errors.EdgeX)
 	DeviceProfilesByManufacturerAndModel(offset int, limit int, manufacturer string, model string) ([]model.DeviceProfile, uint32, errors.EdgeX)
-	DeviceProfileTotalCount() (uint32, errors.EdgeX)
+	DeviceProfileCountByLabels(labels []string) (uint32, errors.EdgeX)
 	DeviceProfileCountByManufacturer(manufacturer string) (uint32, errors.EdgeX)
 	DeviceProfileCountByModel(model string) (uint32, errors.EdgeX)
 
@@ -35,7 +35,7 @@ type DBClient interface {
 	DeviceServiceNameExists(name string) (bool, errors.EdgeX)
 	AllDeviceServices(offset int, limit int, labels []string) ([]model.DeviceService, errors.EdgeX)
 	UpdateDeviceService(ds model.DeviceService) errors.EdgeX
-	DeviceServiceTotalCount() (uint32, errors.EdgeX)
+	DeviceServiceCountByLabels(labels []string) (uint32, errors.EdgeX)
 
 	AddDevice(d model.Device) (model.Device, errors.EdgeX)
 	DeleteDeviceById(id string) errors.EdgeX
@@ -48,7 +48,7 @@ type DBClient interface {
 	AllDevices(offset int, limit int, labels []string) ([]model.Device, errors.EdgeX)
 	DevicesByProfileName(offset int, limit int, profileName string) ([]model.Device, errors.EdgeX)
 	UpdateDevice(d model.Device) errors.EdgeX
-	DeviceTotalCount() (uint32, errors.EdgeX)
+	DeviceCountByLabels(labels []string) (uint32, errors.EdgeX)
 	DeviceCountByProfileName(profileName string) (uint32, errors.EdgeX)
 	DeviceCountByServiceName(serviceName string) (uint32, errors.EdgeX)
 
@@ -60,7 +60,7 @@ type DBClient interface {
 	AllProvisionWatchers(offset int, limit int, labels []string) ([]model.ProvisionWatcher, errors.EdgeX)
 	DeleteProvisionWatcherByName(name string) errors.EdgeX
 	UpdateProvisionWatcher(pw model.ProvisionWatcher) errors.EdgeX
-	ProvisionWatcherTotalCount() (uint32, errors.EdgeX)
+	ProvisionWatcherCountByLabels(labels []string) (uint32, errors.EdgeX)
 	ProvisionWatcherCountByServiceName(name string) (uint32, errors.EdgeX)
 	ProvisionWatcherCountByProfileName(name string) (uint32, errors.EdgeX)
 }

--- a/internal/core/metadata/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/core/metadata/infrastructure/interfaces/mocks/DBClient.go
@@ -370,6 +370,29 @@ func (_m *DBClient) DeviceByName(name string) (models.Device, errors.EdgeX) {
 	return r0, r1
 }
 
+// DeviceCountByLabels provides a mock function with given fields: labels
+func (_m *DBClient) DeviceCountByLabels(labels []string) (uint32, errors.EdgeX) {
+	ret := _m.Called(labels)
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func([]string) uint32); ok {
+		r0 = rf(labels)
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func([]string) errors.EdgeX); ok {
+		r1 = rf(labels)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // DeviceCountByProfileName provides a mock function with given fields: profileName
 func (_m *DBClient) DeviceCountByProfileName(profileName string) (uint32, errors.EdgeX) {
 	ret := _m.Called(profileName)
@@ -485,6 +508,29 @@ func (_m *DBClient) DeviceProfileByName(name string) (models.DeviceProfile, erro
 	return r0, r1
 }
 
+// DeviceProfileCountByLabels provides a mock function with given fields: labels
+func (_m *DBClient) DeviceProfileCountByLabels(labels []string) (uint32, errors.EdgeX) {
+	ret := _m.Called(labels)
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func([]string) uint32); ok {
+		r0 = rf(labels)
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func([]string) errors.EdgeX); ok {
+		r1 = rf(labels)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // DeviceProfileCountByManufacturer provides a mock function with given fields: manufacturer
 func (_m *DBClient) DeviceProfileCountByManufacturer(manufacturer string) (uint32, errors.EdgeX) {
 	ret := _m.Called(manufacturer)
@@ -545,29 +591,6 @@ func (_m *DBClient) DeviceProfileNameExists(name string) (bool, errors.EdgeX) {
 	var r1 errors.EdgeX
 	if rf, ok := ret.Get(1).(func(string) errors.EdgeX); ok {
 		r1 = rf(name)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(errors.EdgeX)
-		}
-	}
-
-	return r0, r1
-}
-
-// DeviceProfileTotalCount provides a mock function with given fields:
-func (_m *DBClient) DeviceProfileTotalCount() (uint32, errors.EdgeX) {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	var r1 errors.EdgeX
-	if rf, ok := ret.Get(1).(func() errors.EdgeX); ok {
-		r1 = rf()
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)
@@ -705,6 +728,29 @@ func (_m *DBClient) DeviceServiceByName(name string) (models.DeviceService, erro
 	return r0, r1
 }
 
+// DeviceServiceCountByLabels provides a mock function with given fields: labels
+func (_m *DBClient) DeviceServiceCountByLabels(labels []string) (uint32, errors.EdgeX) {
+	ret := _m.Called(labels)
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func([]string) uint32); ok {
+		r0 = rf(labels)
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func([]string) errors.EdgeX); ok {
+		r1 = rf(labels)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // DeviceServiceNameExists provides a mock function with given fields: name
 func (_m *DBClient) DeviceServiceNameExists(name string) (bool, errors.EdgeX) {
 	ret := _m.Called(name)
@@ -719,52 +765,6 @@ func (_m *DBClient) DeviceServiceNameExists(name string) (bool, errors.EdgeX) {
 	var r1 errors.EdgeX
 	if rf, ok := ret.Get(1).(func(string) errors.EdgeX); ok {
 		r1 = rf(name)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(errors.EdgeX)
-		}
-	}
-
-	return r0, r1
-}
-
-// DeviceServiceTotalCount provides a mock function with given fields:
-func (_m *DBClient) DeviceServiceTotalCount() (uint32, errors.EdgeX) {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	var r1 errors.EdgeX
-	if rf, ok := ret.Get(1).(func() errors.EdgeX); ok {
-		r1 = rf()
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(errors.EdgeX)
-		}
-	}
-
-	return r0, r1
-}
-
-// DeviceTotalCount provides a mock function with given fields:
-func (_m *DBClient) DeviceTotalCount() (uint32, errors.EdgeX) {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	var r1 errors.EdgeX
-	if rf, ok := ret.Get(1).(func() errors.EdgeX); ok {
-		r1 = rf()
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)
@@ -870,6 +870,29 @@ func (_m *DBClient) ProvisionWatcherByName(name string) (models.ProvisionWatcher
 	return r0, r1
 }
 
+// ProvisionWatcherCountByLabels provides a mock function with given fields: labels
+func (_m *DBClient) ProvisionWatcherCountByLabels(labels []string) (uint32, errors.EdgeX) {
+	ret := _m.Called(labels)
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func([]string) uint32); ok {
+		r0 = rf(labels)
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	var r1 errors.EdgeX
+	if rf, ok := ret.Get(1).(func([]string) errors.EdgeX); ok {
+		r1 = rf(labels)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.EdgeX)
+		}
+	}
+
+	return r0, r1
+}
+
 // ProvisionWatcherCountByProfileName provides a mock function with given fields: name
 func (_m *DBClient) ProvisionWatcherCountByProfileName(name string) (uint32, errors.EdgeX) {
 	ret := _m.Called(name)
@@ -907,29 +930,6 @@ func (_m *DBClient) ProvisionWatcherCountByServiceName(name string) (uint32, err
 	var r1 errors.EdgeX
 	if rf, ok := ret.Get(1).(func(string) errors.EdgeX); ok {
 		r1 = rf(name)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(errors.EdgeX)
-		}
-	}
-
-	return r0, r1
-}
-
-// ProvisionWatcherTotalCount provides a mock function with given fields:
-func (_m *DBClient) ProvisionWatcherTotalCount() (uint32, errors.EdgeX) {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	var r1 errors.EdgeX
-	if rf, ok := ret.Get(1).(func() errors.EdgeX); ok {
-		r1 = rf()
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)

--- a/internal/pkg/infrastructure/redis/client.go
+++ b/internal/pkg/infrastructure/redis/client.go
@@ -816,12 +816,12 @@ func (c *Client) UpdateProvisionWatcher(pw model.ProvisionWatcher) errors.EdgeX 
 	return updateProvisionWatcher(conn, pw)
 }
 
-// DeviceProfileTotalCount returns the total count of Device Profiles stored in the database
-func (c *Client) DeviceProfileTotalCount() (uint32, errors.EdgeX) {
+// DeviceProfileCountByLabels returns the total count of Device Profiles with labels specified.  If no label is specified, the total count of all device profiles will be returned.
+func (c *Client) DeviceProfileCountByLabels(labels []string) (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	count, edgeXerr := getMemberNumber(conn, ZCARD, DeviceProfileCollection)
+	count, edgeXerr := getMemberCountByLabels(conn, ZREVRANGE, DeviceProfileCollection, labels)
 	if edgeXerr != nil {
 		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -855,12 +855,12 @@ func (c *Client) DeviceProfileCountByModel(model string) (uint32, errors.EdgeX) 
 	return count, nil
 }
 
-// DeviceServiceTotalCount returns the total count of Device Services stored in the database
-func (c *Client) DeviceServiceTotalCount() (uint32, errors.EdgeX) {
+// DeviceServiceCountByLabels returns the total count of Device Services with labels specified.  If no label is specified, the total count of all device services will be returned.
+func (c *Client) DeviceServiceCountByLabels(labels []string) (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	count, edgeXerr := getMemberNumber(conn, ZCARD, DeviceServiceCollection)
+	count, edgeXerr := getMemberCountByLabels(conn, ZREVRANGE, DeviceServiceCollection, labels)
 	if edgeXerr != nil {
 		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -868,12 +868,12 @@ func (c *Client) DeviceServiceTotalCount() (uint32, errors.EdgeX) {
 	return count, nil
 }
 
-// DeviceTotalCount returns the total count of Devices stored in the database
-func (c *Client) DeviceTotalCount() (uint32, errors.EdgeX) {
+// DeviceCountByLabels returns the total count of Devices with labels specified.  If no label is specified, the total count of all devices will be returned.
+func (c *Client) DeviceCountByLabels(labels []string) (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	count, edgeXerr := getMemberNumber(conn, ZCARD, DeviceCollection)
+	count, edgeXerr := getMemberCountByLabels(conn, ZREVRANGE, DeviceCollection, labels)
 	if edgeXerr != nil {
 		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
@@ -907,12 +907,12 @@ func (c *Client) DeviceCountByServiceName(serviceName string) (uint32, errors.Ed
 	return count, nil
 }
 
-// ProvisionWatcherTotalCount returns the total count of Provision Watcher stored in the database
-func (c *Client) ProvisionWatcherTotalCount() (uint32, errors.EdgeX) {
+// ProvisionWatcherCountByLabels returns the total count of Provision Watchers with labels specified.  If no label is specified, the total count of all provision watchers will be returned.
+func (c *Client) ProvisionWatcherCountByLabels(labels []string) (uint32, errors.EdgeX) {
 	conn := c.Pool.Get()
 	defer conn.Close()
 
-	count, edgeXerr := getMemberNumber(conn, ZCARD, ProvisionWatcherCollection)
+	count, edgeXerr := getMemberCountByLabels(conn, ZREVRANGE, ProvisionWatcherCollection, labels)
 	if edgeXerr != nil {
 		return 0, errors.NewCommonEdgeXWrapper(edgeXerr)
 	}


### PR DESCRIPTION
Metadata service allows user to specify labels as part of query criteria for following v2 APIs:
`GET /device/all`
`GET /deviceprofile/all`
`GET /deviceservice/all`
`GET /provisionwatcher/all`

The original implementation for these APIs fails to consider labels, thus generating incorrect totalCount.
This PR fix the bug by adding labels as query criteria while finding totalCount.

Closes #3776 

Signed-off-by: Jude Hung <jude@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)  This is bug fix, and there is no need to update docs.
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Follow the reproduction steps as described in #3776, the totalCount should be correct.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->