### PR TITLE
build(snap): create the required kuiper connections directory

### DIFF
--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -239,6 +239,12 @@ func installSecretStore() error {
 		return err
 	}
 
+	// Create the kuiper connections directory for security-secretstore-setup's secure message bug credentials.
+	// This will no longer be required for eKuiper 1.4.0
+	if err = os.MkdirAll(hooks.SnapData+"/kuiper/etc/connections", 0755); err != nil {
+		return err
+	}
+
 	if err = os.Chmod(destPath, 0644); err != nil {
 		return err
 	}


### PR DESCRIPTION
Create the kuiper connections directory required by the secretstore, added by #3778.

This was causing a runtime fatal error for the `security-secretstore-setup`, effectively preventing the installation of `edgexfoundry` snap.

For the record, IMO, the directory creation should be part of the application logic and not the packaging.

See: https://github.com/edgexfoundry/edgex-go/pull/3778#issuecomment-952741429
Closes: #3786

We may wanna remove this when moving to eKuiper 1.4.0 because the directory already exists there.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```
$ snapcraft
$ sudo snap install ./edgexfoundry_2.0.1-dev.69_amd64.snap --dangerous
edgexfoundry 2.0.1-dev.69 installed
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->