### PR TITLE
fix(snap): defer service startup till after configure hook runs

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -206,6 +206,9 @@ Thus the following command will disable both:
 $ sudo snap set edgexfoundry security-secret-store=off
 ```
 
+*NOTE* - disabling security after the snap is installed is a convenience for developers. The snap will not allow the Secret Store to be
+re-enabled. The only way to re-enabled the Secret Store is to re-install the snap.
+
 #### API Gateway
 Kong is used for access control to the EdgeX services from external systems and is referred to as the API Gateway. 
 

--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -28,22 +28,30 @@ import (
 var cli *hooks.CtlCli = hooks.NewSnapCtl()
 
 const ( // iota is reset to 0
-	devVirtService = iota
-	kuiperService
+	kuiperService = iota
 	secProxyService
 	secStoreService
 	otherService
 )
 
 const (
-	ON  = "on"
-	OFF = "off"
+	INSTALL = "install"
+	ON      = "on"
+	OFF     = "off"
 )
+
+func getKuiperServices() []string {
+	return []string{hooks.ServiceAppCfg, hooks.ServiceKuiper}
+}
+
+func getProxyServices() []string {
+	return []string{"postgres", "kong-daemon", "security-proxy-setup"}
+}
 
 // handleSingleService starts or stops a service based on
 // the given state (ON|OFF). It also ensures that the top
 // level service configuration option is set accordingly.
-func handleSingleService(name, state string) error {
+func handleSingleService(name, state string, reset bool) error {
 
 	switch state {
 	case OFF:
@@ -64,6 +72,11 @@ func handleSingleService(name, state string) error {
 		}
 	case "":
 		hooks.Debug("edgexfoundry:configure: state: ''")
+		if reset {
+			if err := cli.UnsetConfig(name); err != nil {
+				return err
+			}
+		}
 	default:
 		return fmt.Errorf("edgexfoundry:configure: invalid state %s for service: %s", state, name)
 	}
@@ -71,10 +84,17 @@ func handleSingleService(name, state string) error {
 	return nil
 }
 
+func handleServices(serviceList []string, state string, reset bool) error {
+	for _, s := range serviceList {
+		if err := handleSingleService(s, state, reset); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func serviceType(name string) int {
 	switch name {
-	case hooks.ServiceDevVirt:
-		return devVirtService
 	case hooks.ServiceKuiper:
 		return kuiperService
 	case hooks.ServiceProxy:
@@ -86,22 +106,36 @@ func serviceType(name string) int {
 	}
 }
 
+func buildStartCmd(startServices []string, newServices []string) []string {
+	for _, s := range newServices {
+		s = hooks.SnapName + "." + s
+		startServices = append(startServices, s)
+	}
+	return startServices
+}
+
 // handleAllServices iterates through all of the services in the
 // edgexfoundry snap and:
 //
-// - queries the config option associated with the service state (on|off)
+// - queries the config option associated with the service state (on|off|install|'')
 // - queries the environment configuration for the service (env.<service-name>)
 //   - if env configuration for the service exists, use it to write a
 //     service-specific .env file to the service config dir in $SNAP_DATA
-// - start/stop any tightly couple services (e.g. if the secret-store
-//   is disabled, the proxy also has to come down) if required
-// - start/stop the service itself if required
+// - if install is true, just build a list of services to start, don't
+//   actually start/stop any services
+// - otherwise:
+//   - start/stop any tightly coupled services (e.g. if the secret-store
+//     is disabled, the proxy also has to come down) if required
+//   - start/stop the service itself if required
 //
 // NOTE - at this time, this function does *not* restart a service based
 // on env configuration changes. If changes are made after a service has
 // been started, the service must be restarted manually.
 //
-func handleAllServices() error {
+func handleAllServices(install bool) (error, []string) {
+	var startServices []string
+	var serviceList []string
+	secretStoreActive := true
 
 	// grab and log the current service configuration
 	for _, s := range hooks.Services {
@@ -109,131 +143,198 @@ func handleAllServices() error {
 
 		status, err := cli.Config(s)
 		if err != nil {
-			return err
+			return err, nil
 		}
 
-		hooks.Debug(fmt.Sprintf("edgexfoundry:configure: service: %s status: %s", s, status))
+		hooks.Info(fmt.Sprintf("edgexfoundry:configure: service: %s status: %s", s, status))
 
 		serviceCfg := hooks.EnvConfig + "." + s
 		envJSON, err = cli.Config(serviceCfg)
 		if err != nil {
-			return fmt.Errorf("edgexfoundry:configure failed to read service %s configuration - %v", s, err)
+			err = fmt.Errorf("edgexfoundry:configure failed to read service %s configuration - %v", s, err)
+			return err, nil
 		}
 
 		if envJSON != "" {
 			hooks.Debug(fmt.Sprintf("edgexfoundry:configure: service: %s envJSON: %s", s, envJSON))
 			if err := hooks.HandleEdgeXConfig(s, envJSON, nil); err != nil {
-				return err
+				return err, nil
 			}
+		}
+
+		// SecBootstrapper is a valid service for configuration
+		// purposes, however it isn't individually controlable
+		// using on|off, so once configuration has been handled
+		// skip to the next service.
+		if s == hooks.ServiceSecBootstrapper {
+			continue
 		}
 
 		sType := serviceType(s)
 
 		switch sType {
-		case devVirtService:
-			hooks.Debug("edgexfoundry:configure: device-virtual")
-			// device-virtual is built with device-sdk-go which waits
-			// for core-data and core-metadata to come online, so if we are
-			// enabling a device service, we should also enable those services
-			if status == ON {
-				if err = handleSingleService("core-data", ON); err != nil {
-					return err
-				}
-				if err = handleSingleService("core-metadata", ON); err != nil {
-					return err
-				}
-			}
-
-			// handle the service too
-			if err = handleSingleService(s, status); err != nil {
-				return nil
-			}
 		case kuiperService:
 			hooks.Debug("edgexfoundry:configure: kuiper")
 
-			// if we are turning kuiper on, make sure
-			// app-service-configurable is on too
-			if err = handleSingleService("app-service-configurable", status); err != nil {
-				return err
+			switch status {
+			case INSTALL:
+				if err := cli.UnsetConfig("kuiper"); err != nil {
+					return err, nil
+				}
+				fallthrough
+			case ON:
+				serviceList = getKuiperServices()
+				if install {
+					startServices = append(startServices, serviceList...)
+					hooks.Info(fmt.Sprintf("edgexfoundry:configure startServices: %v", startServices))
+					continue
+				}
+			case OFF:
+				if install {
+					continue
+				}
+
+				serviceList = getKuiperServices()
+			default:
+				// Note - this is the default status of all services if no
+				// configuration has been specified; no-op
+				continue
 			}
-			if err = handleSingleService("kuiper", status); err != nil {
-				return err
-			}
+
 		case secProxyService:
-			hooks.Debug("edgexfoundry:configure: proxy")
-			// FIXME - this logic always overrwrites the existing value. This
-			// should be fixed.
+			hooks.Info("edgexfoundry:configure: proxy")
 
-			// the security-proxy consists of the following base services
-			// - kong
-			// - postgres (because kong requires it)
-			if err = handleSingleService("postgres", status); err != nil {
-				return err
-			}
-			if err = handleSingleService("kong-daemon", status); err != nil {
-				return err
-			}
-			if err = handleSingleService("security-proxy-setup", status); err != nil {
-				return err
+			switch status {
+			case INSTALL:
+				if err := cli.UnsetConfig("security-proxy"); err != nil {
+					return err, nil
+				}
+				fallthrough
+			case ON:
+				// NOTE: the original bash based implementation would
+				// additionally handle the secret-store dependency.
+				// Due to the added complexity, this initial implementation
+				// does not automatically handle enabling the secret-store
+				// if/when the proxy is dynamically enabled.
+				if !secretStoreActive {
+					err = fmt.Errorf("edgexfoundry:configure security-proxy=on not allowed;" +
+						"secret-store=off")
+					return err, nil
+				}
+
+				serviceList = getProxyServices()
+				if install {
+					startServices = append(startServices, serviceList...)
+					hooks.Info(fmt.Sprintf("edgexfoundry:configure startServices: %v", startServices))
+					continue
+				}
+			case OFF:
+				if install {
+					continue
+				}
+
+				serviceList = getProxyServices()
+			default:
+				// Note - this is the default status of all services if no
+				// configuration has been specified; no-op
+				continue
 			}
 
-			// additionally, the security-proxy needs to use the following
-			// services:
-			// - vault (because security-proxy-setup will access/store secrets in vault)
-			// - security-secretstore-setup
-			// so if we are turning the security-api-gateway on, then turn
-			// those services on too
-			if status == ON {
-				if err = handleSingleService("vault", ON); err != nil {
-					return err
-				}
-				if err = handleSingleService("security-secretstore-setup", ON); err != nil {
-					return err
-				}
-			}
 		case secStoreService:
-			hooks.Debug("edgexfoundry:configure: secretstore")
-			// the security-api-gateway consists of the following services:
-			// - vault
-			// - security-secretstore-setup
-			// and since the security-api-gateway needs to be able to use
-			// security-secret-store, we also need to turn off those services
-			// if this one is disabled
-			if status == OFF {
-				if err = handleSingleService("postgres", OFF); err != nil {
-					return err
+			hooks.Info("edgexfoundry:configure: secretstore")
+
+			switch status {
+			case INSTALL:
+				if err := cli.UnsetConfig("security-secret-store"); err != nil {
+					return err, nil
 				}
-				if err = handleSingleService("kong-daemon", OFF); err != nil {
-					return err
+				fallthrough
+			case ON:
+				serviceList = []string{"vault", "security-secretstore-setup",
+					"security-consul-bootstrapper", "security-bootstrapper-redis"}
+				hooks.Info(fmt.Sprintf("edgexfoundry:configure serviceList: %v", serviceList))
+				if install {
+					startServices = append(startServices, serviceList...)
+					hooks.Info(fmt.Sprintf("edgexfoundry:configure startServices: %v", startServices))
+					continue
 				}
-				if err = handleSingleService("security-proxy-setup", OFF); err != nil {
-					return err
+			case OFF:
+				secretStoreActive = false
+
+				if install {
+					continue
 				}
 
+				serviceList = []string{"postgres", "kong-daemon", "security-proxy-setup",
+					"vault", "security-secretstore-setup", "security-consul-bootstrapper",
+					"security-bootstrapper-redis"}
+
+				// TODO: the original Hanoi implementation did NOT handle restarting the
+				// rest of the framework, nor does this implementation.
+				//
+				// If/when we can properly disable secret-store usage *after* install, we
+				// need to handle the following:
+				//
+				// - stop all services that use the secret store
+				// - stop consul & redis
+				// - clear redis password (rm $SNAP_DATA/conf/redis.conf)
+				//   touch same file
+				// - rm the consul ACL conf file (and maybe other consul files)
+				// - start all the services just disabled
+			default:
+				// Note - this is the default status of all services if no
+				// configuration has been specified; no-op
+				continue
 			}
-			if err = handleSingleService("vault", status); err != nil {
-				return err
-			}
-			if err = handleSingleService("security-secretstore-setup", status); err != nil {
-				return err
-			}
+
 		default:
-			hooks.Debug("edgexfoundry:configure: other service")
-			// default case for all other services just enable/disable the service using
-			// snapd/systemd
-			// if the service is meant to be off, then disable it
-			if err = handleSingleService(s, status); err != nil {
-				return nil
+			hooks.Info("edgexfoundry:configure: other service")
+			// default case for all other services
+
+			switch status {
+			case INSTALL:
+				// FIXME: make this cli.UnsetConfig
+				if err := cli.UnsetConfig(s); err != nil {
+					return err, nil
+				}
+				fallthrough
+			case ON:
+				serviceList = []string{s}
+
+				if install {
+					startServices = append(startServices, s)
+					hooks.Info(fmt.Sprintf("edgexfoundry:configure startServices: %v", startServices))
+					continue
+				}
+			case OFF:
+				if install {
+					continue
+				}
+
+				serviceList = append(serviceList, s)
+			default:
+				// Note - this is the default status of all services if no
+				// configuration has been specified; no-op
+				continue
 			}
 		}
+
+		hooks.Info(fmt.Sprintf("edgexfoundry:configure calling handleServices: %v", serviceList))
+		if err = handleServices(serviceList, status, false); err != nil {
+			return err, nil
+		}
+		// clear serviceList
+		serviceList = nil
 	}
 
-	return nil
+	return nil, startServices
 }
 
 func main() {
 	var debug = false
 	var err error
+	var installMode = false
+	var startServices []string
 
 	status, err := cli.Config("debug")
 	if err != nil {
@@ -250,8 +351,36 @@ func main() {
 
 	}
 
-	if err = handleAllServices(); err != nil {
+	install, err := cli.Config("install")
+	if err != nil {
+		fmt.Println(fmt.Sprintf("edgexfoundry:configure: reading 'install': %v", err))
+		os.Exit(1)
+	}
+
+	if install == "true" {
+		installMode = true
+	}
+
+	// if installMode is true, then this function just returns a list of services
+	// to start, otherwise it actually will start/stop services based on current
+	// configuration status of each service
+	if err, startServices = handleAllServices(installMode); err != nil {
 		hooks.Error(fmt.Sprintf("edgexfoundry:configure: error handling services: %v", err))
 		os.Exit(1)
+	}
+
+	// start all the services and clear install flag
+	if install == "true" {
+		hooks.Info(fmt.Sprintf("edgexfoundry:configure install=true; starting disabled services"))
+
+		if err = cli.StartMultiple(true, startServices...); err != nil {
+			hooks.Error(fmt.Sprintf("edgexfoundry:configure failure starting/enabling services: %v", err))
+			os.Exit(1)
+		}
+
+		if err = cli.SetConfig("install", "false"); err != nil {
+			hooks.Error(fmt.Sprintf("edgexfoundry:install setting 'install=false'; %v", err))
+			os.Exit(1)
+		}
 	}
 }

--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -388,23 +388,4 @@ func main() {
 		hooks.Error(fmt.Sprintf("edgexfoundry:install %v", err))
 		os.Exit(1)
 	}
-
-	// just like the configure hook, this code needs to iterate over every service
-	// and setup .env files for each if required...
-	for _, v := range hooks.Services {
-		serviceCfg := hooks.EnvConfig + "." + v
-		envJSON, err := cli.Config(serviceCfg)
-		if err != nil {
-			hooks.Error(fmt.Sprintf("edgexfoundry:install failed to read service %s configuration - %v", v, err))
-			os.Exit(1)
-		}
-
-		if envJSON != "" {
-			hooks.Debug(fmt.Sprintf("edgexfoundry:install: service envJSON: %s", envJSON))
-			if err := hooks.HandleEdgeXConfig(v, envJSON, nil); err != nil {
-				hooks.Error(fmt.Sprintf("edgexfoundry:install failed to process service %s configuration - %v", v, err))
-				os.Exit(1)
-			}
-		}
-	}
 }

--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -20,8 +20,10 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
@@ -347,11 +349,22 @@ func installProxy() error {
 	return nil
 }
 
+// This function creates the redis config dir under $SNAP_DATA,
+// and creates an empty redis.conf file. This allows the command
+// line for the service to always specify the config file, and
+// allows for redis when the config option security-secret-store
+// is "on" or "off".
 func installRedis() error {
-	if err := os.MkdirAll(hooks.SnapData+"/redis", 0755); err != nil {
-		return err
+	fileName := filepath.Join(hooks.SnapData,"/redis/conf/redis.conf")
+	if _, err := os.Stat(filepath.Join(hooks.SnapData,"redis")); err != nil {
+		// dir doesn't exist
+		if err := os.MkdirAll(filepath.Dir(fileName),0755); err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(fileName, nil, 0644); err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.0.5
+require github.com/canonical/edgex-snap-hooks/v2 v2.1.1
 
 go 1.16

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.0.5 h1:saDgLCXycrYZXfTbXQQVI3eQcadRKfSFl0od+MvTD+I=
-github.com/canonical/edgex-snap-hooks/v2 v2.0.5/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.1.1 h1:qmDJ2RYd19I/NYwIdjqC/kWGVJWLcrT+h9NevB+Gz/A=
+github.com/canonical/edgex-snap-hooks/v2 v2.1.1/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/runtime-helpers/bin/start-consul.sh
+++ b/snap/local/runtime-helpers/bin/start-consul.sh
@@ -15,16 +15,21 @@ cat > "$SNAP_DATA/consul/config/consul_default.json" <<EOF
 }
 EOF
 
-echo "$(date) deploying additional ACL configuration for Consul"
-cat > "$SNAP_DATA/consul/config/consul_acl.json" <<EOF
+acls=${EDGEX_SECURITY_SECRET_STORE:-true}
+logger "start-consul.sh: acls=$acls"
+
+if [ "$acls" == "true" ]; then
+    echo "$(date) deploying additional ACL configuration for Consul"
+    cat > "$SNAP_DATA/consul/config/consul_acl.json" <<EOF
 {
-    "acl": {
+      "acl": {
       "enabled": true,
       "default_policy": "deny",
       "enable_token_persistence": true
     }
 }
 EOF
+fi
 
 # start consul in the background
 "$SNAP/bin/consul" agent \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,8 @@ apps:
   consul:
     adapter: full
     command: bin/start-consul.sh
+    command-chain:
+      - bin/security-secret-store-env-var.sh
     daemon: forking
     plugs: [network, network-bind]
   redis:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -376,6 +376,7 @@ apps:
       - core-metadata
     command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual/res -cp -r
     command-chain:
+      - bin/security-secret-store-env-var.sh
       - bin/service-config-overrides.sh
     daemon: simple
     passthrough:
@@ -395,6 +396,7 @@ apps:
       -confdir $SNAP_DATA/config/app-service-configurable/res
       -profile rules-engine
     command-chain:
+      - bin/security-secret-store-env-var.sh
       - bin/service-config-overrides.sh
     daemon: simple
     passthrough:


### PR DESCRIPTION
This PR modifies the way the snap install and configure hooks when the snap in installed in order to ensure that snap configuration provided at install time is processed before services are started. This is working around an issue with snapd where snap configuration at install time is not made available to the snap until the configure hook is called, which is after the services have already been started.

So, this PR disables all of the services in the install hook, and then in the configure hook, the services are started after configuration has been processed.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [*] I have added unit tests for the new feature or bug fix (if not, why?)
  - units tests to be added before this is taken out of draft status 
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [NA] I have opened a PR for the related docs change (if not, why?)
  - This fix relates to the install behavior of the snap, and as such should be transparent to the installer. 

## Testing Instructions
 - Install the snap built from this PR and verify that all of the expected services start
 - Confirm that device-virtual can be enabled (`$ sudo snap set edgexfoundry device-virtual=on`)
 - Confirm that kuiper can be enabled (`$ sudo snap set edgexfoundry kuiper=on`); ensure that both kuiper and app-service-configurable are started
 - Confirm that support-notifications and support-scheduler can be started (e.g. `snap set... support-scheduler=on`)
 - Confirm that security-proxy can be disabled (`$sudo snap set security-proxy=off`)

Additional test instructions will be added to this PR as it progresses. The more advanced cases require a custom gadget snap which provides default configuration. This is currently the only way to disable secret-store usage. If possible, this PR will be extended to support dynamically disabling secret store usage, but this is currently blocked on issue #3712.

Also note, this has been tested using [our in-progress checkbox provider for Jakarta](https://code.launchpad.net/~mengyiw/checkbox-provider-edgex/+git/checkbox-provider-edgex/+merge/409927) and all of the tests pass.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->