### PR TITLE
fix(snap): defer service startup till after configure hook runs

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -205,6 +205,9 @@ Thus the following command will disable both:
 $ sudo snap set edgexfoundry security-secret-store=off
 ```
 
+*NOTE* - disabling security after the snap is installed is a convenience for developers. The snap will not allow the Secret Store to be
+re-enabled. The only way to re-enable the Secret Store is to re-install the snap.
+
 #### API Gateway
 Kong is used for access control to the EdgeX services from external systems and is referred to as the API Gateway. 
 

--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -20,7 +20,10 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
 )
@@ -35,26 +38,73 @@ const ( // iota is reset to 0
 )
 
 const (
-	INSTALL = "install"
-	ON      = "on"
-	OFF     = "off"
-	UNSET   = ""
+	ON    = "on"
+	OFF   = "off"
+	UNSET = ""
 )
 
-func getDefaultServices() []string {
-	return []string{"consul", "redis", "core-data",
-		"core-metadata", "core-command",
-		"security-secretstore-setup", "security-proxy-setup",
-		"security-bootstrapper-redis", "security-consul-bootstrapper",
-		"kong-daemon", "postgres", "vault"}
-}
-
+// getKuiperServices returns the list of services used for
+// EdgeX rules-engine processing.
 func getKuiperServices() []string {
 	return []string{hooks.ServiceAppCfg, hooks.ServiceKuiper}
 }
 
+// getProxyServices returns the list of services which implement
+// the API Gateway. Note this list *excludes* Consul and the
+// Secret Store services.
 func getProxyServices() []string {
 	return []string{"postgres", "kong-daemon", "security-proxy-setup"}
+}
+
+// getSecretStoreServices returns the list of services which implement
+// the Secret Store and related dependencies (i.e. the services that
+// secure redis and consul which are tightly bound to the secret store
+// being enabled).
+func getSecretStoreServices() []string {
+	return []string{"security-secretstore-setup", "vault",
+		"security-consul-bootstrapper", "security-bootstrapper-redis"}
+}
+
+// getEdgeXRefServices returns the list of EdgeX reference services in the snap
+// (excludes all non-EdgeX runtime dependencies, and security-*-setup jobs).
+func getEdgeXRefServices() []string {
+	return []string{"core-data", "core-metadata", "core-command",
+		"device-virtual", "support-notifications",
+		"support-scheduler", "sys-mgmt-agent"}
+}
+
+// getRequiredServices returns the minimum list of required
+// snap services for a working EdgeX instance.
+func getRequiredServices() []string {
+	return []string{"consul", "redis", "core-metadata"}
+}
+
+// getCoreDefaultServices returns the list of core services
+// that are started by default (in addition to the required
+// services)
+func getCoreDefaultServices() []string {
+	return []string{"core-command", "core-data"}
+}
+
+// getOptServices returns the list of optional EdgeX services
+// (i.e. disabled by default).
+//
+// Note:
+// - sys-mgmt-agent isn't included because as of Ireland
+//   it's considered deprecated.
+// - kuiper isn't included because it's not yet possible
+//   to provide kuiper configuration via content interface
+func getOptServices() []string {
+	return []string{"support-notifications", "support-scheduler", "device-virtual"}
+}
+
+func isDisableAllowed(s string) error {
+	for _, v := range getRequiredServices() {
+		if s == v {
+			return fmt.Errorf("edgexfoundry:configure: can't disable required service: %s", s)
+		}
+	}
+	return nil
 }
 
 // handleSingleService starts or stops a service based on
@@ -116,35 +166,159 @@ func buildStartCmd(startServices []string, newServices []string) []string {
 	return startServices
 }
 
+// This function creates the redis config dir under $SNAP_DATA,
+// and creates an empty redis.conf file. This allows the command
+// line for the service to always specify the config file, and
+// allows for redis when the config option security-secret-store
+// is "on" or "off".
+func clearRedisConf() error {
+	path := filepath.Join(hooks.SnapData, "/redis/conf/redis.conf")
+	if err := ioutil.WriteFile(path, nil, 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func consulAclFileExists() bool {
+	path := filepath.Join(hooks.SnapData, "/consul/config/consul_acl.json")
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// This function deletes the Consul ACL configuration file. This
+// allows Consul to operate in insecure mode.
+func rmConsulAclFile() error {
+	path := filepath.Join(hooks.SnapData, "/consul/config/consul_acl.json")
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func disableSecretStoreAndRestart() error {
+	hooks.Info(fmt.Sprintf("edgexfoundry:configure: disabling secret store"))
+
+	// if consul_acls.json doesn't exist, then secret-store has already been
+	// disabled, so just return
+	if !consulAclFileExists() {
+		hooks.Info(fmt.Sprintf("edgexfoundry:configure: secret store is already disabled"))
+		return nil
+	}
+
+	// stop & disable proxy services
+	for _, s := range getProxyServices() {
+		if err := handleSingleService(s, OFF); err != nil {
+			return err
+		}
+	}
+
+	// stop & disable secret store services
+	for _, s := range getSecretStoreServices() {
+		if err := handleSingleService(s, OFF); err != nil {
+			return err
+		}
+	}
+
+	// stop EdgeX services
+	// TODO: can't use handleServices because that would result in the
+	// snap config option for each service to be needlessly set to "off"
+	// then back to "on"; re-factor handleServices/handleSingleService
+	for _, s := range getEdgeXRefServices() {
+		if err := cli.Stop(s, false); err != nil {
+			return err
+		}
+	}
+
+	// stop Kuiper-related services
+	// TODO - kuiper will be stopped, but not restarted because
+	// additional re-configuration may be needed.
+	for _, s := range getKuiperServices() {
+		if err := cli.Stop(s, false); err != nil {
+			return err
+		}
+	}
+
+	// stop redis
+	if err := cli.Stop("redis", false); err != nil {
+		return err
+	}
+
+	// stop consul
+	if err := cli.Stop("consul", false); err != nil {
+		return err
+	}
+
+	// - clear redis password
+	if err := clearRedisConf(); err != nil {
+		return err
+	}
+
+	// - clear consul ACLs
+	if err := rmConsulAclFile(); err != nil {
+		return err
+	}
+
+	// - start required services
+	for _, s := range getRequiredServices() {
+		if err := cli.Start(s, false); err != nil {
+			return err
+		}
+	}
+
+	// Now check config status of the optional EdgeX
+	// services and restart where necessary
+	for _, s := range getEdgeXRefServices() {
+		status, err := cli.Config(s)
+		if err != nil {
+			return err
+		}
+
+		// walk thru remaining edgex services
+		// if status is ON, start
+		// if status isn't set, if the service is
+		// part of the enabledServices (i.e. services
+		// always started), then also start it
+		if status == ON || (status == "" && strings.HasPrefix(s, "core-")) {
+			if err := cli.Start(s, false); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // handleAllServices iterates through all of the services in the
 // edgexfoundry snap and:
 //
-// - queries the config option associated with the service state (on|off|install|'')
+// - queries the config option associated with the service state (on|off|'')
 // - queries the environment configuration for the service (env.<service-name>)
 //   - if env configuration for the service exists, use it to write a
 //     service-specific .env file to the service config dir in $SNAP_DATA
+// - if deferStartup == true, continue to the next service
+// - otherwise handle runtime state changes
 //   - start/stop any tightly coupled services (e.g. if the secret-store
 //     is disabled, the proxy also has to come down) if required
 //   - start/stop the service itself if required
+//
 //
 // NOTE - at this time, this function does *not* restart a service based
 // on env configuration changes. If changes are made after a service has
 // been started, the service must be restarted manually.
 //
-func handleAllServices() error {
-	var serviceList []string
+func handleAllServices(deferStartup bool) error {
 	secretStoreActive := true
 
 	// grab and log the current service configuration
 	for _, s := range hooks.Services {
 		var envJSON string
+		var serviceList []string
 
 		status, err := cli.Config(s)
 		if err != nil {
 			return err
 		}
 
-		hooks.Info(fmt.Sprintf("edgexfoundry:configure: service: %s status: %s", s, status))
+		hooks.Debug(fmt.Sprintf("edgexfoundry:configure: service: %s status: %s", s, status))
 
 		serviceCfg := hooks.EnvConfig + "." + s
 		envJSON, err = cli.Config(serviceCfg)
@@ -158,6 +332,11 @@ func handleAllServices() error {
 			if err := hooks.HandleEdgeXConfig(s, envJSON, nil); err != nil {
 				return err
 			}
+		}
+
+		// if deferStartup is set, don't start/stop services
+		if deferStartup {
+			continue
 		}
 
 		// SecBootstrapper is a valid service for configuration
@@ -175,9 +354,7 @@ func handleAllServices() error {
 			hooks.Debug("edgexfoundry:configure: kuiper")
 
 			switch status {
-			case ON:
-				fallthrough
-			case OFF:
+			case ON, OFF:
 				serviceList = getKuiperServices()
 			case UNSET:
 				// this is the default status of all services if no
@@ -188,7 +365,7 @@ func handleAllServices() error {
 			}
 
 		case secProxyService:
-			hooks.Info("edgexfoundry:configure: proxy")
+			hooks.Debug("edgexfoundry:configure: proxy")
 
 			switch status {
 			case ON:
@@ -215,32 +392,23 @@ func handleAllServices() error {
 			}
 
 		case secStoreService:
-			hooks.Info("edgexfoundry:configure: secretstore")
+			hooks.Debug("edgexfoundry:configure: secretstore")
 
 			switch status {
 			case ON:
-				serviceList = []string{"vault", "security-secretstore-setup",
-					"security-consul-bootstrapper", "security-bootstrapper-redis"}
-				hooks.Info(fmt.Sprintf("edgexfoundry:configure serviceList: %v", serviceList))
+				return fmt.Errorf("edgexfoundry:configure security-secret-store=on not allowed")
 			case OFF:
+				// TODO - this var is used by the secProxyCase to ensure that the
+				// secret store is active when the proxy is being enabled at runtime.
+				// This relies on the fact that the secret store comes before the proxy
+				// in hooks.Services. To make this less fragile, the proxy case should
+				// check the status of the secret store directly.
 				secretStoreActive = false
 
-				serviceList = []string{"postgres", "kong-daemon", "security-proxy-setup",
-					"vault", "security-secretstore-setup", "security-consul-bootstrapper",
-					"security-bootstrapper-redis"}
-
-				// TODO: the original Hanoi implementation did NOT handle restarting the
-				// rest of the framework, nor does this implementation.
-				//
-				// If/when we can properly disable secret-store usage *after* install, we
-				// need to handle the following:
-				//
-				// - stop all services that use the secret store
-				// - stop consul & redis
-				// - clear redis password (rm $SNAP_DATA/conf/redis.conf)
-				//   touch same file
-				// - rm the consul ACL conf file (and maybe other consul files)
-				// - start all the services just disabled
+				if err = disableSecretStoreAndRestart(); err != nil {
+					return err
+				}
+				continue
 			case UNSET:
 				// this is the default status of all services if no
 				// configuration has been specified; no-op
@@ -250,14 +418,17 @@ func handleAllServices() error {
 			}
 
 		default:
-			hooks.Info("edgexfoundry:configure: other service")
+			hooks.Debug("edgexfoundry:configure: other service")
 			// default case for all other services
 
 			switch status {
 			case ON:
-				fallthrough
+				serviceList = []string{s}
 			case OFF:
-				serviceList = append(serviceList, s)
+				if err := isDisableAllowed(s); err != nil {
+					return err
+				}
+				serviceList = []string{s}
 			case UNSET:
 				// this is the default status of all services if no
 				// configuration has been specified; no-op
@@ -267,15 +438,93 @@ func handleAllServices() error {
 			}
 		}
 
-		hooks.Info(fmt.Sprintf("edgexfoundry:configure calling handleServices: %v", serviceList))
+		hooks.Debug(fmt.Sprintf("edgexfoundry:configure calling handleServices: %v", serviceList))
 		if err = handleServices(serviceList, status); err != nil {
 			return err
 		}
-		// clear serviceList
-		serviceList = nil
 	}
 
 	return nil
+}
+
+func checkCoreConfig(services []string) ([]string, error) {
+	// walk thru the list of default services
+	for _, s := range getCoreDefaultServices() {
+		status, err := cli.Config(s)
+		if err != nil {
+			return nil, err
+		}
+
+		switch status {
+		case OFF:
+			break
+		case ON, UNSET:
+			services = append(services, s)
+		default:
+			err = fmt.Errorf("edgexfoundry:configure: invalid value: %s for %s", status, s)
+			return nil, err
+		}
+	}
+	return services, nil
+}
+
+func checkOptConfig(services []string) ([]string, error) {
+	// walk thru the list of default services
+	for _, s := range getOptServices() {
+		status, err := cli.Config(s)
+		if err != nil {
+			return nil, err
+		}
+
+		switch status {
+		case OFF, UNSET:
+			break
+		case ON:
+			services = append(services, s)
+		default:
+			err = fmt.Errorf("edgexfoundry:configure: invalid value: %s for %s", status, s)
+			return nil, err
+		}
+	}
+	return services, nil
+}
+
+func checkSecurityConfig(services []string) ([]string, error) {
+
+	status, err := cli.Config("security-secret-store")
+	if err != nil {
+		return nil, err
+	}
+
+	switch status {
+	case OFF:
+		// if security-secret-store is off, no proxy either...
+		return services, nil
+	case UNSET:
+		// default behavior
+		services = append(services, getSecretStoreServices()...)
+	default:
+		err = fmt.Errorf("edgexfoundry:configure: invalid setting for security-secret-store: %s", status)
+		return nil, err
+	}
+
+	// check secret-proxy
+	status, err = cli.Config("security-proxy")
+	if err != nil {
+		return nil, err
+	}
+
+	switch status {
+	case OFF:
+		break
+	case UNSET:
+		// default behavior
+		services = append(services, getProxyServices()...)
+	default:
+		err = fmt.Errorf("edgexfoundry:configure: invalid setting for security-proxy: %s", status)
+		return nil, err
+	}
+	return services, nil
 }
 
 func main() {
@@ -298,27 +547,58 @@ func main() {
 
 	}
 
-	install, err := cli.Config("install")
+	val, err := cli.Config("install-mode")
 	if err != nil {
-		fmt.Println(fmt.Sprintf("edgexfoundry:configure: reading 'install': %v", err))
+		hooks.Error(fmt.Sprintf("edgexfoundry:configure: reading 'install-mode': %v", err))
 		os.Exit(1)
 	}
 
-	if install == "true" {
-		hooks.Info(fmt.Sprintf("edgexfoundry:configure install=true; starting disabled services"))
+	deferStartup := (val == "defer-startup")
+	hooks.Info(fmt.Sprintf("edgexfoundry:configure: deferStartup=%v", deferStartup))
 
-		for _, s := range getDefaultServices() {
-			status, err := cli.Config(s)
-			if err != nil {
-				fmt.Println(fmt.Sprintf("edgexfoundry:configure: reading %s status; %v", s, err))
-				os.Exit(1)
-			}
+	// handle per service configuration and enable/disable services
+	if err = handleAllServices(deferStartup); err != nil {
+		hooks.Error(fmt.Sprintf("edgexfoundry:configure: error handling services: %v", err))
+		os.Exit(1)
+	}
 
-			if status != OFF {
-				startServices = append(startServices, s)
-			}
+	// Handle deferred startup of services disabled in the install hook.
+	//
+	// NOTE - there's code duplication between this startup logic and
+	// the function handleAllServices(). While it might be possible to
+	// merge the two, since delayed startup is itself a workaround to
+	// an underlying snapd limitation (namely that services are started
+	// before the config hook runs), leaving the duplication means less
+	// re-factoring if/when snapd adds a new hook.
+	if deferStartup {
+		hooks.Info(fmt.Sprintf("edgexfoundry:configure install-mode=defer-startup; starting disabled services"))
 
-			// TODO: add code to handle optional services set to ON
+		// add required services
+		startServices = append(startServices, getRequiredServices()...)
+
+		// check security configuration
+		startServices, err = checkSecurityConfig(startServices)
+		if err != nil {
+			hooks.Error(fmt.Sprintf("edgexfoundry:configure: security config error; %v", err))
+			os.Exit(1)
+		}
+
+		// TODO: don't support kuiper until it's possible to share
+		// kuiper & app-services-configurable (rules-engine) config
+		// via content interface
+
+		// check core services
+		startServices, err = checkCoreConfig(startServices)
+		if err != nil {
+			hooks.Error(fmt.Sprintf("edgexfoundry:configure: core config error; %v", err))
+			os.Exit(1)
+		}
+
+		// check optional services
+		startServices, err = checkOptConfig(startServices)
+		if err != nil {
+			hooks.Error(fmt.Sprintf("edgexfoundry:configure: optional config error; %v", err))
+			os.Exit(1)
 		}
 
 		if err = cli.StartMultiple(true, startServices...); err != nil {
@@ -326,15 +606,8 @@ func main() {
 			os.Exit(1)
 		}
 
-		// TODO: use unset configuration
-		if err = cli.SetConfig("install", "false"); err != nil {
-			hooks.Error(fmt.Sprintf("edgexfoundry:install setting 'install=false'; %v", err))
-			os.Exit(1)
-		}
-	} else {
-		// handle runtime configuration
-		if err = handleAllServices(); err != nil {
-			hooks.Error(fmt.Sprintf("edgexfoundry:configure: error handling services: %v", err))
+		if err = cli.UnsetConfig("install-mode"); err != nil {
+			hooks.Error(fmt.Sprintf("edgexfoundry:install un-setting 'install'; %v", err))
 			os.Exit(1)
 		}
 	}

--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -81,7 +81,7 @@ var secretStoreKnownSecrets = []string{
 // to $SNAP_DATA
 func getServicesWithConfig() []string {
 	return []string{"security-bootstrapper", "security-bootstrap-redis",
-		"security-file-token-provider",	"security-proxy-setup",
+		"security-file-token-provider", "security-proxy-setup",
 		"security-secretstore-setup", "core-command", "core-data",
 		"core-metadata", "support-notifications", "support-scheduler",
 		"sys-mgmt-agent", "device-virtual", "app-service-configurable"}
@@ -91,8 +91,8 @@ func getServicesWithConfig() []string {
 func getAllServices() []string {
 	return []string{"consul", "redis", "postgres",
 		"kong-daemon", "vault", "security-secretstore-setup",
-		"security-proxy-setup",	"security-bootstrapper-redis",
-		"security-consul-bootstrapper",	"core-command",
+		"security-proxy-setup", "security-bootstrapper-redis",
+		"security-consul-bootstrapper", "core-command",
 		"core-data", "core-metadata", "support-notifications",
 		"support-scheduler", "sys-mgmt-agent", "device-virtual",
 		"kuiper", "app-service-configurable"}
@@ -338,10 +338,10 @@ func installProxy() error {
 // allows for redis when the config option security-secret-store
 // is "on" or "off".
 func installRedis() error {
-	fileName := filepath.Join(hooks.SnapData,"/redis/conf/redis.conf")
-	if _, err := os.Stat(filepath.Join(hooks.SnapData,"redis")); err != nil {
+	fileName := filepath.Join(hooks.SnapData, "/redis/conf/redis.conf")
+	if _, err := os.Stat(filepath.Join(hooks.SnapData, "redis")); err != nil {
 		// dir doesn't exist
-		if err := os.MkdirAll(filepath.Dir(fileName),0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fileName), 0755); err != nil {
 			return err
 		}
 		if err := ioutil.WriteFile(fileName, nil, 0644); err != nil {
@@ -412,7 +412,7 @@ func main() {
 
 	// Stop and disable all *enabled* services as they will be
 	// re-enabled in the configure hook if the config option
-	// 'install=true'.
+	// 'install-mode=defer-startup'.
 	for _, s := range getAllServices() {
 		hooks.Info(fmt.Sprintf("edgexfoundry:install disabling service: %s", s))
 		if err = cli.Stop(s, true); err != nil {
@@ -421,8 +421,8 @@ func main() {
 		}
 	}
 
-	if err = cli.SetConfig("install", "true"); err != nil {
-		hooks.Error(fmt.Sprintf("edgexfoundry:install setting 'install=true'; %v", err))
+	if err = cli.SetConfig("install-mode", "defer-startup"); err != nil {
+		hooks.Error(fmt.Sprintf("edgexfoundry:install setting 'install-mode'; %v", err))
 		os.Exit(1)
 	}
 }

--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -388,23 +388,4 @@ func main() {
 		hooks.Error(fmt.Sprintf("edgexfoundry:install %v", err))
 		os.Exit(1)
 	}
-
-	// just like the configure hook, this code needs to iterate over every service
-	// and setup .env files for each if required...
-	for _, v := range hooks.Services {
-		serviceCfg := hooks.EnvConfig + "." + v
-		envJSON, err := cli.Config(serviceCfg)
-		if err != nil {
-			hooks.Error(fmt.Sprintf("edgexfoundry:install failed to read service %s configuration - %v", v, err))
-			os.Exit(1)
-		}
-
-		if envJSON != "" {
-			hooks.Debug(fmt.Sprintf("edgexfoundry:install: service envJSON: %s", envJSON))
-			if err := hooks.HandleEdgeXConfig(v, envJSON, nil); err != nil {
-				hooks.Error(fmt.Sprintf("edgexfoundry:install failed to process service %s configuration - %v", v, err))
-				os.Exit(1)
-			}
-		}
-	}
 }

--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -20,8 +20,10 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
@@ -330,11 +332,22 @@ func installProxy() error {
 	return nil
 }
 
+// This function creates the redis config dir under $SNAP_DATA,
+// and creates an empty redis.conf file. This allows the command
+// line for the service to always specify the config file, and
+// allows for redis when the config option security-secret-store
+// is "on" or "off".
 func installRedis() error {
-	if err := os.MkdirAll(hooks.SnapData+"/redis", 0755); err != nil {
-		return err
+	fileName := filepath.Join(hooks.SnapData,"/redis/conf/redis.conf")
+	if _, err := os.Stat(filepath.Join(hooks.SnapData,"redis")); err != nil {
+		// dir doesn't exist
+		if err := os.MkdirAll(filepath.Dir(fileName),0755); err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(fileName, nil, 0644); err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 

--- a/snap/local/runtime-helpers/bin/service-config-overrides.sh
+++ b/snap/local/runtime-helpers/bin/service-config-overrides.sh
@@ -10,9 +10,13 @@ BINPATH="${ARGV[0]}"
 SERVICE=$(basename "$BINPATH")
 SERVICE_ENV="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
 
+logger "edgex checking for service env: $SERVICE_ENV"
+
 if [ -f "$SERVICE_ENV" ]; then
     logger "edgex service override: : sourcing $SERVICE_ENV"
     source "$SERVICE_ENV"
 fi
+
+logger "edgex starting: $SERVICE"
 
 exec "$@"

--- a/snap/local/runtime-helpers/bin/start-consul.sh
+++ b/snap/local/runtime-helpers/bin/start-consul.sh
@@ -15,16 +15,21 @@ cat > "$SNAP_DATA/consul/config/consul_default.json" <<EOF
 }
 EOF
 
-echo "$(date) deploying additional ACL configuration for Consul"
-cat > "$SNAP_DATA/consul/config/consul_acl.json" <<EOF
+acls=${EDGEX_SECURITY_SECRET_STORE:-true}
+logger "start-consul.sh: acls=$acls"
+
+if [ "$acls" == "true" ]; then
+    echo "$(date) deploying additional ACL configuration for Consul"
+    cat > "$SNAP_DATA/consul/config/consul_acl.json" <<EOF
 {
-    "acl": {
+      "acl": {
       "enabled": true,
       "default_policy": "deny",
       "enable_token_persistence": true
     }
 }
 EOF
+fi
 
 # start consul in the background
 "$SNAP/bin/consul" agent \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -370,6 +370,7 @@ apps:
       - core-metadata
     command: bin/device-virtual -confdir $SNAP_DATA/config/device-virtual/res -cp -r
     command-chain:
+      - bin/security-secret-store-env-var.sh
       - bin/service-config-overrides.sh
     daemon: simple
     environment:
@@ -387,6 +388,7 @@ apps:
       -confdir $SNAP_DATA/config/app-service-configurable/res
       -profile rules-engine
     command-chain:
+      - bin/security-secret-store-env-var.sh
       - bin/service-config-overrides.sh
     daemon: simple
     environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,8 @@ apps:
   consul:
     adapter: full
     command: bin/start-consul.sh
+    command-chain:
+      - bin/security-secret-store-env-var.sh
     daemon: forking
     plugs: [network, network-bind]
   redis:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -325,8 +325,6 @@ apps:
     environment:
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/support-notifications/secrets-token.json
     daemon: simple
-    passthrough:
-      install-mode: disable    
     plugs: [network, network-bind]
     stop-timeout: 10s
   support-scheduler:
@@ -343,8 +341,6 @@ apps:
     environment:
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/support-scheduler/secrets-token.json
     daemon: simple
-    passthrough:
-      install-mode: disable    
     plugs: [network, network-bind]
     stop-timeout: 10s
   sys-mgmt-agent:
@@ -362,8 +358,6 @@ apps:
       EXECUTORPATH: $SNAP/bin/sys-mgmt-agent-snap-executor.sh
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/sys-mgmt-agent/secrets-token.json
     daemon: simple
-    passthrough:
-      install-mode: disable    
     plugs: [network, network-bind]
   device-virtual:
     adapter: full
@@ -378,8 +372,6 @@ apps:
     command-chain:
       - bin/service-config-overrides.sh
     daemon: simple
-    passthrough:
-      install-mode: disable    
     environment:
       DEVICE_DEVICESDIR: $SNAP_DATA/config/device-virtual/res/devices
       DEVICE_PROFILESDIR: $SNAP_DATA/config/device-virtual/res/profiles
@@ -397,8 +389,6 @@ apps:
     command-chain:
       - bin/service-config-overrides.sh
     daemon: simple
-    passthrough:
-      install-mode: disable    
     environment:
       BINDING_PUBLISHTOPIC: events
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/app-rules-engine/secrets-token.json
@@ -488,8 +478,6 @@ apps:
     adapter: full
     command: bin/kuiperd
     daemon: simple
-    passthrough:
-      install-mode: disable    
     environment:
       KuiperBaseKey: $SNAP_DATA/kuiper
     plugs: [network, network-bind]


### PR DESCRIPTION
This PR modifies the way the snap install and configure hooks when the snap in installed in order to ensure that snap configuration provided at install time is processed before services are started. This is working around an issue with snapd where snap configuration at install time is not made available to the snap until the configure hook is called, which is after the services have already been started.

So, this PR disables all of the services in the install hook, and then in the configure hook, the services are started after configuration has been processed.

**Note** - this PR supersedes PR #3791.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [*] I have added unit tests for the new feature or bug fix (if not, why?)
  - units tests to be added before this is taken out of draft status 
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [NA] I have opened a PR for the related docs change (if not, why?)
  - This fix relates to the install behavior of the snap, and as such should be transparent to the installer. 

## Testing Instructions
 - Install the snap built from this PR and verify that all of the expected services start
 - Confirm that device-virtual can be enabled (`$ sudo snap set edgexfoundry device-virtual=on`)
 - Confirm that kuiper can be enabled (`$ sudo snap set edgexfoundry kuiper=on`); ensure that both kuiper and app-service-configurable are started
 - Confirm that support-notifications and support-scheduler can be started (e.g. `snap set... support-scheduler=on`)
 - Confirm that security-proxy can be disabled (`$sudo snap set security-proxy=off`)

Additional test instructions will be added to this PR as it progresses. The more advanced cases require a custom gadget snap which provides default configuration. This is currently the only way to disable secret-store usage. If possible, this PR will be extended to support dynamically disabling secret store usage, but this is currently blocked on issue #3712.

Also note, this has been tested using [our in-progress checkbox provider for Jakarta](https://code.launchpad.net/~mengyiw/checkbox-provider-edgex/+git/checkbox-provider-edgex/+merge/409927) and all of the tests pass.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->