### PR TITLE
fix(security): update kong admin token file permissions

### DIFF
--- a/internal/security/secretstore/kongadminapi.go
+++ b/internal/security/secretstore/kongadminapi.go
@@ -146,7 +146,7 @@ func (k *KongAdminAPI) Setup() error {
 	}
 
 	// Write JWT to secret file (used solely by "admin" group in Kong)
-	err = os.WriteFile(k.paths.jwt, []byte(k.secrets.jwt.signed), 0400)
+	err = os.WriteFile(k.paths.jwt, []byte(k.secrets.jwt.signed), 0600)
 	if err != nil {
 		return fmt.Errorf("%s Failed to write JWT to file %s: %w", k.prefixes.errText, k.paths.jwt, err)
 	}

--- a/internal/security/secretstore/kongadminapi_test.go
+++ b/internal/security/secretstore/kongadminapi_test.go
@@ -29,6 +29,13 @@ func TestKongAdminAPI_Setup(t *testing.T) {
 	err := k.Setup()
 	assert.NoError(t, err)
 
+	// check file permission of jwt
+	info, err := os.Stat(k.paths.jwt)
+	assert.NoError(t, err)
+
+	fileMode := info.Mode().String()
+	assert.Equal(t, "-rw-------", fileMode, "The jwt should be read+write for owner")
+
 	// Clean up files created
 	os.Remove(k.paths.config)
 	os.Remove(k.paths.jwt)

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+#
+# Force remove kong-admin-jwt due to the fact that it's
+# written by security-secretstore-setup (2.0.0-*) with
+# read-only perm for the owner.
+#
+# See: https://github.com/edgexfoundry/edgex-go/issues/3818
+#
+# This is hook is called in the context of the new snap
+# revision, and prior to services being started.
+if [ -f "$SNAP_DATA/secrets/security-proxy-setup/kong-admin-jwt" ]; then
+    logger "edgexfoundry:post-refresh removing stale kong-admin-jwt"
+    rm -f "$SNAP_DATA/secrets/security-proxy-setup/kong-admin-jwt"
+fi


### PR DESCRIPTION
This PR contains two commits:
 - security-secretstore-setup now creates the kong-admin-jwt file with read+write (owner) permission
 - adds a snap post-refresh hook which deletes a stale kong-admin-jwt file with read-only (owner) permissions

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [NA] I have opened a PR for the related docs change (if not, why?)

## Testing Instructions

The easiest way to test this is to:
```

$ sudo snap remove edgexfoundry
$ sudo snap install edgexfoundry --channel=2.0
edgexfoundry (2.0/stable) 2.0.0-2 from Canonical✓ installed
$ sudo ls -l /var/snap/edgexfoundry/current/secrets/security-proxy-setup
-r-------- 1 root root 248 Nov 15 17:10 /var/snap/edgexfoundry/current/secrets/security-proxy-setup/kong-admin-jwt
```

Verify that the file permission now is `-r--------`.

Now build a local snap from this PR (see snap/README.md for instructions), and re-run the above scenario, the file permissions for the jwt file should now be `-rw-------`.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->