### PR TITLE
build(snap): add script to generate version

### DIFF
--- a/snap/local/build-helpers/bin/set-version.sh
+++ b/snap/local/build-helpers/bin/set-version.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+if [ -z "$SNAPCRAFT_PROJECT_DIR" ]; then
+    echo "Error: SNAPCRAFT_PROJECT_DIR not set!"
+    exit 1
+fi
+
+pushd $SNAPCRAFT_PROJECT_DIR
+
+if git describe ; then
+    # get the short tag without commit count and hash when there are untagged commits
+    TAG=$(git describe --tags --abbrev=0) 
+    # drop the v prefix
+    VERSION=$(echo $TAG | sed 's/v//')
+    # count the number of commits after the tag
+    COMMITS_COUNT=$(git rev-list --count $TAG..HEAD)
+else
+    VERSION="0.0.0"
+fi
+
+# When there are commits after the tag, add the number of commits as semver
+# build metadata: https://semver.org/#spec-item-10
+if [ "$COMMITS_COUNT" != "0" ]; then  
+    VERSION="${VERSION}+${COMMITS_COUNT}"   
+fi
+
+echo "Version: $VERSION"
+
+# set snap version
+snapcraftctl set-version ${VERSION}
+
+# write to file for the build using Makefile
+echo $VERSION > ./VERSION
+
+popd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -501,13 +501,9 @@ parts:
     # as with static-packages part, the source dir is unrelated to this part and is used
     # since it changes rarely and therefore will not trigger a new pull
     source: snap/local/build-helpers
-    override-pull: |
-      cd $SNAPCRAFT_PROJECT_DIR
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      if [ -z "$GIT_VERSION" ]; then
-        GIT_VERSION="0.0.0"
-      fi
-      snapcraftctl set-version ${GIT_VERSION}
+    override-build: |
+      $SNAPCRAFT_PART_SRC/bin/set-version.sh
+
   static-packages:
     plugin: nil
     # the default source for a part that doesn't specify one is ".", which


### PR DESCRIPTION
This PR adds a script which is meant to replace version generation logic from this and other snaps. As before, the script generates the version from the short git tag, excluding the `v` prefix.

This script is meant to be used for versioning of this snap by calling it locally and all other snaps by downloading and executing at build-time.

In addition to the current versioning approach, the script appends some build metadata to the version whenever there are untagged commits. The metadata is chosen to be the number of commits after the tag. 

Semver build metadata is denoted by appending a `+` followed by the metadata: https://semver.org/#spec-item-10

For example, if the current version is `2.1.0` and the HEAD is 1 commit ahead of it, the version would extended to `2.1.0+1`.

Build metadata is useful for distinguishing nightly or manual builds from a branch that doesn't get tagged on every commit. This is based on the assumption that `jakarta` branch is not going to be tagged after every merged PR.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
#### Before making this commit
```
$ snapcraft
...
Building version 
+ /root/parts/version/src/bin/set-version.sh
~/project ~/parts/version/build
v2.2.0-dev.2
Version: 2.2.0-dev.2
~/parts/version/build
...
Snapped edgexfoundry_2.2.0-dev.2_amd64.snap
```

#### After making this commit
```
$ snapcraft
...
Updating build step for version ('pull' step changed)
+ /root/parts/version/src/bin/set-version.sh
~/project ~/parts/version/build
v2.2.0-dev.2-1-gd1e12c50
Version: 2.2.0-dev.2+1
~/parts/version/build
...
Snapped edgexfoundry_2.2.0-dev.2+1_amd64.snap
```
Since this commit is not tagged, there is a `+1` in the version.

#### Use from another snap
snapcraft snippet:
```
adopt-info: version
parts:
  version:
    plugin: nil
    build-packages: [curl]
    override-pull: |
      curl -s https://raw.githubusercontent.com/farshidtz/edgex-go/snap-version-script/snap/local/build-helpers/bin/set-version.sh | bash   
```
build:
```
$ snapcraft
...
Pulling version 
+ curl -s https://raw.githubusercontent.com/farshidtz/edgex-go/snap-version-script/snap/local/build-helpers/bin/set-version.sh
+ bash
~/project ~/parts/version/src
v2.0.2-dev.1-13-gee1913c
Version: 2.0.2-dev.1+13
~/parts/version/src
...
Snapped edgex-device-camera_2.0.2-dev.1+13_amd64.snap
```
This is in a branch from a branch which is 13 commits ahead of 2.0.2-dev.1.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->