### PR TITLE
docs: Add path field to support-scheduler intervalAction API example

### DIFF
--- a/openapi/v2/support-scheduler.yaml
+++ b/openapi/v2/support-scheduler.yaml
@@ -190,6 +190,7 @@ components:
             host: "192.168.0.102"
             port: 8080
             httpMethod: "GET"
+            path: "/api/v2/ping"
         content:
           description: "The actual content to be sent as the body"
           type: string
@@ -229,6 +230,7 @@ components:
             host: "192.168.0.102"
             port: 8080
             httpMethod: "GET"
+            path: "/api/v2/ping"
         content:
           description: "The actual content to be sent as the body"
           type: string
@@ -531,6 +533,7 @@ components:
               host: "192.168.0.102"
               port: 8080
               httpMethod: "GET"
+              path: "/api/v2/ping"
             adminState: "UNLOCKED"
           - created: 1634280525302
             modified: 1634280525302
@@ -542,6 +545,7 @@ components:
               host: "192.168.0.102"
               port: 8080
               httpMethod: "GET"
+              path: "/api/v2/test"
             adminState: "UNLOCKED"
 paths:
   /interval:


### PR DESCRIPTION
Update support-scheduler API document to add path field to intervalAction address examples.

fix #3828

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A, fix in API docs only
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) N/A, fix in API docs only
- [ ] I have opened a PR for the related docs change (if not, why?) N/A, fix in API docs only

## Testing Instructions
<!-- How can the reviewers test your change? -->
N/A
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
N/A