### PR TITLE
fix: correct jwt error message when reading private key

### DIFF
--- a/internal/security/config/command/proxy/jwt/command.go
+++ b/internal/security/config/command/proxy/jwt/command.go
@@ -87,7 +87,7 @@ func (c *cmd) Execute() (int, error) {
 
 	bytes, err := os.ReadFile(c.privateKeyPath)
 	if err != nil {
-		return interfaces.StatusCodeExitWithError, fmt.Errorf("Could read private key from file %s: %w", c.privateKeyPath, err)
+		return interfaces.StatusCodeExitWithError, fmt.Errorf("Could not read private key from file %s: %w", c.privateKeyPath, err)
 	}
 
 	var signingMethod jwt.SigningMethod


### PR DESCRIPTION
This is a minor fix in the jwt package related to the error message returned when failing to read the private key. The correction makes the error message negative, see the diff.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->