### PR TITLE
fix(meta): Fix the typo of notification message

### DIFF
--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -53,7 +53,7 @@ Type = "consul"
 
 [Notifications]
 PostDeviceChanges = false
-Content = "Meatadata notice: "
+Content = "Metadata notice: "
 Sender = "core-metadata"
 Description = "Metadata change notice"
 Label = "metadata"


### PR DESCRIPTION
Fix the typo of notification message from the configuration.toml

Fix #3835

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **not impact the unit test**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?) **not impact the doc**
  <link to docs PR>

## Testing Instructions
1. Run metadata service with enabled Notifications.PostDeviceChanges
2. Run notification service
3. Run Modbus device service 
4. The metadata service will send a notification with the message 'Metadata notice:  Modbus-TCP-test-device Device creation'

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->