### PR TITLE
fix(snap): Apply proxy's runtime config options after startup

### DIFF
--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -28,8 +28,6 @@ import (
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
 )
 
-var cli *hooks.CtlCli = hooks.NewSnapCtl()
-
 const ( // iota is reset to 0
 	kuiperService = iota
 	secProxyService
@@ -310,7 +308,6 @@ func handleAllServices(deferStartup bool) error {
 
 	// grab and log the current service configuration
 	for _, s := range hooks.Services {
-		var envJSON string
 		var serviceList []string
 
 		status, err := cli.Config(s)
@@ -320,23 +317,9 @@ func handleAllServices(deferStartup bool) error {
 
 		hooks.Debug(fmt.Sprintf("edgexfoundry:configure: service: %s status: %s", s, status))
 
-		if deferStartup && s == "security-proxy" {
-			hooks.Info("edgexfoundry:configure: defer-startup mode. Skip security-proxy config handling to after the startup")
-			continue
-		}
-
-		serviceCfg := hooks.EnvConfig + "." + s
-		envJSON, err = cli.Config(serviceCfg)
+		err = applyConfigOptions(s)
 		if err != nil {
-			err = fmt.Errorf("edgexfoundry:configure failed to read service %s configuration - %v", s, err)
-			return err
-		}
-
-		if envJSON != "" {
-			hooks.Debug(fmt.Sprintf("edgexfoundry:configure: service: %s envJSON: %s", s, envJSON))
-			if err := hooks.HandleEdgeXConfig(s, envJSON, nil); err != nil {
-				return err
-			}
+			return fmt.Errorf("failed to apply config options for %s: %v", s, err)
 		}
 
 		// if deferStartup is set, don't start/stop services
@@ -532,7 +515,7 @@ func checkSecurityConfig(services []string) ([]string, error) {
 	return services, nil
 }
 
-func main() {
+func configure() {
 	var debug = false
 	var err error
 	var startServices []string
@@ -549,8 +532,8 @@ func main() {
 	if err = hooks.Init(debug, "edgexfoundry"); err != nil {
 		fmt.Println(fmt.Sprintf("edgexfoundry:configure: initialization failure: %v", err))
 		os.Exit(1)
-
 	}
+	hooks.Info("edgexfoundry:configure: started")
 
 	val, err := cli.Config("install-mode")
 	if err != nil {
@@ -606,6 +589,7 @@ func main() {
 			os.Exit(1)
 		}
 
+		// NOTE - the services will be started after the configure hook finishes
 		if err = cli.StartMultiple(true, startServices...); err != nil {
 			hooks.Error(fmt.Sprintf("edgexfoundry:configure failure starting/enabling services: %v", err))
 			os.Exit(1)

--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -320,6 +320,11 @@ func handleAllServices(deferStartup bool) error {
 
 		hooks.Debug(fmt.Sprintf("edgexfoundry:configure: service: %s status: %s", s, status))
 
+		if deferStartup && s == "security-proxy" {
+			hooks.Info("edgexfoundry:configure: defer-startup mode. Skip security-proxy config handling to after the startup")
+			continue
+		}
+
 		serviceCfg := hooks.EnvConfig + "." + s
 		envJSON, err = cli.Config(serviceCfg)
 		if err != nil {

--- a/snap/local/hooks/cmd/configure/main.go
+++ b/snap/local/hooks/cmd/configure/main.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package main
+
+import (
+	"os"
+
+	hooks "github.com/canonical/edgex-snap-hooks/v2"
+)
+
+var cli *hooks.CtlCli = hooks.NewSnapCtl()
+
+func main() {
+	// no subcommand, as called by snapd
+	if len(os.Args) == 1 {
+		// configure everything
+		configure()
+		return
+	}
+
+	subCommand := os.Args[1]
+	switch subCommand {
+	case "options":
+		// configure options
+		options()
+	default:
+		panic("Unknown CLI sub-command: " + subCommand)
+	}
+}

--- a/snap/local/hooks/cmd/configure/options.go
+++ b/snap/local/hooks/cmd/configure/options.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	hooks "github.com/canonical/edgex-snap-hooks/v2"
+)
+
+func applyConfigOptions(service string) error {
+	envJSON, err := cli.Config(hooks.EnvConfig + "." + service)
+	if err != nil {
+		return fmt.Errorf("failed to read config options for %s: %v", service, err)
+	}
+
+	if envJSON != "" {
+		hooks.Debug(fmt.Sprintf("edgexfoundry:configure-options: service: %s envJSON: %s", service, envJSON))
+		if err := hooks.HandleEdgeXConfig(service, envJSON, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// options is called by the main function to configure options
+func options() {
+	flagset := flag.NewFlagSet("options", flag.ExitOnError)
+	service := flagset.String("service", "", "Handle config options of a single service only")
+	flagset.Parse(os.Args[2:])
+
+	fmt.Println("Configuring options for service: " + *service)
+
+	debug, err := cli.Config("debug")
+	if err != nil {
+		fmt.Println(fmt.Sprintf("edgexfoundry:configure-options: can't read value of 'debug': %v", err))
+		os.Exit(1)
+	}
+
+	if err = hooks.Init(debug == "true", "edgexfoundry"); err != nil {
+		fmt.Println(fmt.Sprintf("edgexfoundry:configure-options: initialization failure: %v", err))
+		os.Exit(1)
+	}
+
+	hooks.Info("edgexfoundry:configure-options: handling config options for a single service: " + *service)
+
+	if err := applyConfigOptions(*service); err != nil {
+		hooks.Error(fmt.Sprintf("edgexfoundry:configure-options: error handling config options for %s: %v", *service, err))
+		os.Exit(1)
+	}
+}

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,6 @@
 module github.com/canonical/edgex-go/hooks
 
+// should bump to include https://github.com/canonical/edgex-snap-hooks/pull/25
 require github.com/canonical/edgex-snap-hooks/v2 v2.1.1
 
 go 1.16

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,6 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-// should bump to include https://github.com/canonical/edgex-snap-hooks/pull/25
-require github.com/canonical/edgex-snap-hooks/v2 v2.1.1
+require github.com/canonical/edgex-snap-hooks/v2 v2.1.3
 
 go 1.16

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.1.1 h1:qmDJ2RYd19I/NYwIdjqC/kWGVJWLcrT+h9NevB+Gz/A=
-github.com/canonical/edgex-snap-hooks/v2 v2.1.1/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.1.3 h1:mcV/atn6k6sN6Uik+lSQGEZi4Q6r96epgBW+u6AGZ3Y=
+github.com/canonical/edgex-snap-hooks/v2 v2.1.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/runtime-helpers/bin/security-proxy-post-setup.sh
+++ b/snap/local/runtime-helpers/bin/security-proxy-post-setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+# This script is called as a post-stop-command when
+# security-proxy-setup oneshot service stops.
+#
+# Several config options depend on resources that only exist after proxy is 
+# setup. This scripts re-runs the configure hook after the deferred startup 
+# of security-proxy-setup to apply such configurations.
+
+logger "edgex-secretstore-proxy:post-setup: calling configure hook"
+
+# add bin directory to have e.g. secret-config in PATH
+export PATH="$SNAP/bin:$PATH"
+
+$SNAP/snap/hooks/configure

--- a/snap/local/runtime-helpers/bin/security-proxy-post-setup.sh
+++ b/snap/local/runtime-helpers/bin/security-proxy-post-setup.sh
@@ -2,14 +2,12 @@
 
 # This script is called as a post-stop-command when
 # security-proxy-setup oneshot service stops.
-#
-# Several config options depend on resources that only exist after proxy is 
-# setup. This scripts re-runs the configure hook after the deferred startup 
-# of security-proxy-setup to apply such configurations.
 
-logger "edgex-secretstore-proxy:post-setup: calling configure hook"
+logger "edgexfoundry:security-proxy-post-setup"
 
 # add bin directory to have e.g. secret-config in PATH
 export PATH="$SNAP/bin:$PATH"
 
-$SNAP/snap/hooks/configure
+# Several config options depend on resources that only exist after proxy 
+# setup. This re-applies the config options logic after deferred startup:
+$SNAP/snap/hooks/configure options --service=security-proxy

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -221,6 +221,7 @@ apps:
     command: bin/security-proxy-setup -confdir $SNAP_DATA/config/security-proxy-setup/res $INIT_ARG
     command-chain:
       - bin/service-config-overrides.sh
+    post-stop-command: bin/security-proxy-post-setup.sh
     environment:
       INIT_ARG: "--init=true"
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/security-proxy-setup/secrets-token.json


### PR DESCRIPTION
Fixes #3863, see the issue for details.

~This PR changes the configure hook to skip configuration options of security-proxy in defer-startup mode. To apply those options, the configure hook is called again after security-proxy-setup completes.~

This PR changes the configure hook to skip **runtime** configuration options of security-proxy in **defer-startup** mode. Those config options should be applied after security-proxy-setup completes.

To achieve that:
a) The config option handling function is changed to ignore runtime config options of security-proxy in defer-startup install mode: https://github.com/canonical/edgex-snap-hooks/pull/25
b) The `configure` executable is extended with an `options` subcommand which takes a service name as follows:
```
./configure options --service=security-proxy
```
The above command is called in a `post-stop` script after the security-proxy setup. 

Prior to this change, the `configure` executable was called only as the snap configure hook. Future work may focus on file re-structuring of various executables under `snap` directory to add better visiblity into various helper executables.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) - gadget testing is WIP
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR> - not required

## Testing Instructions
<!-- How can the reviewers test your change? -->
The [checkbox tests](https://github.com/canonical/edgex-checkbox-provider/blob/b7b12b1a471067e7bf7d59d9e1016b34f6910213/data/latest/test-security-services-proxy-certs.sh) have coverage for the affected config options. Those tests were passing even before this fix because the config sets in those tests are executed after service startup.

To test the seeding, we should pass defaults from a Gadget snap:
```
defaults: 
  # edgexfoundry
  AZGf0KNnh8aqdkbGATNuRuxnt1GNRKkV:
    # Services that should auto start
    device-virtual: "on"
    support-scheduler: "on" 
    support-notifications: "on"
    
    env.security-proxy:
        # set a default user
        user: "admin,1,ES256"
        public-key: |
          -----BEGIN PUBLIC KEY-----
          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETuwPTr5tL/NxiTkUWh2r93i6yaQf
          XiFV8kNjemjuTpOTc6yZu+zgNyt1pXpHmPmtIZ8X4eE0QGCIjlnfAz0dQA==
          -----END PUBLIC KEY-----
```
The OS must boot without error and the config options must be applied.

To seed this snap into an Ubuntu Core image to test the above, use the build from this branch under channel: `latest/edge/fix-snap-proxy-config`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->