### PR TITLE
build(snap): upgrade kuiper to 1.4.2

### DIFF
--- a/internal/security/secretstore/secure-messagebus.go
+++ b/internal/security/secretstore/secure-messagebus.go
@@ -40,7 +40,7 @@ default:
   port: 6379
   protocol: redis
   server: localhost
-  serviceServer: http://localhost:48080
+  connectionSelector: edgex.redisMsgBus
   topic: rules-events
   type: redis
 mqtt_conf:

--- a/snap/local/runtime-helpers/bin/install-setup-kuiper.sh
+++ b/snap/local/runtime-helpers/bin/install-setup-kuiper.sh
@@ -8,9 +8,11 @@ if [ ! -f "$SNAP_DATA/kuiper/data" ]; then
     mkdir -p "$SNAP_DATA/kuiper/etc/services"
     mkdir -p "$SNAP_DATA/kuiper/etc/sinks"
     mkdir -p "$SNAP_DATA/kuiper/etc/sources"
+    mkdir -p "$SNAP_DATA/kuiper/etc/connections"
     mkdir -p "$SNAP_DATA/kuiper/plugins/functions"
     mkdir -p "$SNAP_DATA/kuiper/plugins/sinks"
     mkdir -p "$SNAP_DATA/kuiper/plugins/sources"
+    mkdir -p "$SNAP_DATA/kuiper/plugins/portable"
 
     for cfg in client kuiper; do
         cp "$SNAP/etc/$cfg.yaml" "$SNAP_DATA/kuiper/etc"
@@ -26,14 +28,16 @@ if [ ! -f "$SNAP_DATA/kuiper/data" ]; then
 
     cp "$SNAP/etc/services/"*.proto "$SNAP_DATA/kuiper/etc/services"
 
-    for sink in file edgex influx log nop; do
+    for sink in file edgex influx log nop mqtt; do
         cp "$SNAP/etc/sinks/$sink.json" "$SNAP_DATA/kuiper/etc/sinks"
     done
 
-    for src in edgex random; do
+    for src in edgex; do
         cp "$SNAP/etc/sources/$src.json" "$SNAP_DATA/kuiper/etc/sources"
         cp "$SNAP/etc/sources/$src.yaml" "$SNAP_DATA/kuiper/etc/sources"
     done
+
+    cp "$SNAP/etc/connections/connection.yaml" "$SNAP_DATA/kuiper/etc/connections"
 
     cp "$SNAP/etc/multilingual/"*.ini "$SNAP_DATA/kuiper/etc/multilingual"
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -863,7 +863,7 @@ parts:
 
   kuiper:
     source: https://github.com/lf-edge/ekuiper.git
-    source-tag: 1.3.1
+    source-tag: 1.4.2
     source-depth: 1
     plugin: make
     after: [go-build-helper]
@@ -888,16 +888,15 @@ parts:
         -e 's@restPort\: 9081@restPort\: 59720@' \
         $SNAPCRAFT_PART_INSTALL/etc/kuiper.yaml
 
+      # override the default settings to specify the stream 
+      # to reuse the connection to EdgeX message bus
       # update the edgex source's port to 5566 to match
       # app-service-configurable's message bus publish port
-      sed -i -e 's@port\: 5563@port\: 5566@' \
+      sed -i -e '/type\: redis/a  \  connectionSelector: edgex.redisMsgBus' \
+        -e '/type\: redis/a  \  topic: rules-events' \
+        -e '/type\: redis/a  \  messageType: event' \
+        -e 's@port\: 5563@port\: 5566@' \
         $SNAPCRAFT_PART_INSTALL/etc/sources/edgex.yaml
-
-      # update the edgex sink's port to 5567 so that it
-      # doesn't collide with the default port used by
-      # app-service-configurable
-      sed -i -e 's@"default": 5563@"default": 5567@' \
-        $SNAPCRAFT_PART_INSTALL/etc/sinks/edgex.json
 
       install -DT "$SNAPCRAFT_PART_SRC/LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/kuiper/LICENSE"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -875,7 +875,7 @@ parts:
       make build_with_edgex
       make real_pkg
       cd $SNAPCRAFT_PART_INSTALL
-      # TODO: SIMPLIFY THIS!!!
+   
       tar -xvf kuiper*.tar.gz --strip-components=1
       rm *.gz
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -888,16 +888,6 @@ parts:
         -e 's@restPort\: 9081@restPort\: 59720@' \
         $SNAPCRAFT_PART_INSTALL/etc/kuiper.yaml
 
-      # override the default settings to specify the stream 
-      # to reuse the connection to EdgeX message bus
-      # update the edgex source's port to 5566 to match
-      # app-service-configurable's message bus publish port
-      sed -i -e '/type\: redis/a  \  connectionSelector: edgex.redisMsgBus' \
-        -e '/type\: redis/a  \  topic: rules-events' \
-        -e '/type\: redis/a  \  messageType: event' \
-        -e 's@port\: 5563@port\: 5566@' \
-        $SNAPCRAFT_PART_INSTALL/etc/sources/edgex.yaml
-
       install -DT "$SNAPCRAFT_PART_SRC/LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/kuiper/LICENSE"
     stage:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -877,7 +877,7 @@ parts:
       cd $SNAPCRAFT_PART_INSTALL
       # TODO: SIMPLIFY THIS!!!
       tar -xvf kuiper*.tar.gz --strip-components=1
-      rm *.zip *.gz
+      rm *.gz
 
       # configure logging & restrict to localhost
       # configure REST API service port to 59720


### PR DESCRIPTION
This PR is to upgrade kuiper to 1.4.2 
- add `connectionSelector` to re-use EdgeX message bus
- remove unused configure and install scripts 



<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?) https://github.com/canonical/edgex-checkbox-provider/pull/22
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Install
```
snapcraft
snap install edgexfoundry_2.0.1-dev.71_amd64.snap --dangerous
snap set edgexfoundry kuiper=on
snap set edgexfoundry device-virtual=on
```
2. Create stream and sink with `connectionSelector`
```
curl -X POST \
  http://localhost:59720/streams \
  -d '{
  "sql": "create stream edgexAll() WITH (FORMAT=\"JSON\", TYPE=\"edgex\", SHARED=\"true\")"
}'

curl -X POST \
  http://localhost:59720/rules \
  -d '{
  "id": "rule-demo",
   "sql": "SELECT * from edgexAll  WHERE meta(deviceName)=\"Random-Integer-Device\"",
   "actions": [
      {
         "edgex": {
            "connectionSelector": "edgex.redisMsgBus",
            "topicPrefix": "edgex/events/device", 
            "messageType": "request",
            "contentType": "application/json",
            "deviceName": "device-demo"
         }
      }
   ]
}'
```
3. Validate rule is working
```
curl -X GET http://localhost:59720/rules/rule-demo/status
```
Expect:
```
{
  "source_edgexAll_0_records_in_total": 137,
  "source_edgexAll_0_records_out_total": 137,
  "source_edgexAll_0_exceptions_total": 0,
  "source_edgexAll_0_process_latency_us": 1,
  "source_edgexAll_0_buffer_length": 0,
  "source_edgexAll_0_last_invocation": "2022-01-24T09:17:19.956633",
  "op_2_filter_0_records_in_total": 137,
  "op_2_filter_0_records_out_total": 40,
  "op_2_filter_0_exceptions_total": 0,
  "op_2_filter_0_process_latency_us": 5,
  "op_2_filter_0_buffer_length": 0,
  "op_2_filter_0_last_invocation": "2022-01-24T09:17:19.956639",
  "op_3_project_0_records_in_total": 40,
  "op_3_project_0_records_out_total": 40,
  "op_3_project_0_exceptions_total": 0,
  "op_3_project_0_process_latency_us": 5,
  "op_3_project_0_buffer_length": 0,
  "op_3_project_0_last_invocation": "2022-01-24T09:17:14.953311",
  "sink_edgex_0_0_records_in_total": 40,
  "sink_edgex_0_0_records_out_total": 40, <---------------------------------------sink is working
  "sink_edgex_0_0_exceptions_total": 0,
  "sink_edgex_0_0_process_latency_us": 39,
  "sink_edgex_0_0_buffer_length": 0,
  "sink_edgex_0_0_last_invocation": "2022-01-24T09:17:14.953321"
}

```
4. Validate rule is re-using EdgeX message bus
```
curl -X GET http://localhost:59880/api/v2/reading/device/name/device-demo?limit=3 | jq '.'
```
Expect:
```
{
  "apiVersion": "v2",
  "statusCode": 200,
  "totalCount": 16,
  "readings": [
    {
      "id": "54efdfa4-ac66-436d-b66a-438ed8f1b976",
      "origin": 1643012144946162000,
      "deviceName": "device-demo",
      "resourceName": "Int16",
      "profileName": "ekuiperProfile",
      "valueType": "Int64",
      "value": "11357"
    },
    {
      "id": "90e965ac-a73a-4668-b868-64b4e27030f2",
      "origin": 1643012144945702100,
      "deviceName": "device-demo",
      "resourceName": "Int8",
      "profileName": "ekuiperProfile",
      "valueType": "Int64",
      "value": "98"
    },
    {
      "id": "6dc38635-3b07-40c1-bcea-4faa80b0a284",
      "origin": 1643012144944587000,
      "deviceName": "device-demo",
      "resourceName": "Int64",
      "profileName": "ekuiperProfile",
      "valueType": "Int64",
      "value": "4729033642373210121"
    }
  ]
}
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->