### PR TITLE
feat: Location of client service obtained from the registry

### DIFF
--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -31,11 +31,7 @@ Host = "localhost"
 Port = 8500
 Type = "consul"
 
-[Clients]
-  [Clients.core-metadata]
-  Protocol = "http"
-  Host = "localhost"
-  Port = 59881
+[Clients] # Core data no longer dependent on "Client" services
 
 [Databases]
   [Databases.Primary]

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -36,11 +36,6 @@ Type = "consul"
   Host = "localhost"
   Port = 59860
 
-  [Clients.core-data]
-  Protocol = "http"
-  Host = "localhost"
-  Port = 59880
-
 [Databases]
   [Databases.Primary]
   Host = "localhost"

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/edgex-go
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.1.0
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.1-dev.28
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.9
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.8
 	github.com/edgexfoundry/go-mod-registry/v2 v2.1.0
@@ -39,7 +39,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-hclog v0.12.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/hashicorp/serf v0.9.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.1.0 h1:SKhMq8BLUQExVZwZ7slTzxbTsaNfJcWsxNYvZPAguLQ=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.1.0/go.mod h1:+ZXclfGAK0PAyJ4RygGB7R2R6IyoRN0qzsQpOsfClvA=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.1-dev.28 h1:OmQM+of8gO1cANcAqDOLwo58M9QOZtsMlajkgWcEesk=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.1-dev.28/go.mod h1:12Szn7YDPPoQLkO2FDaBJkH4/W7Q28CmTv3GRxRfwxo=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.1.0 h1:wiLtHYo1QxImARJZt7TYj88cUhq1ANh8se4TBvFsYvw=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.1.0/go.mod h1:MvHit0MxBXN4bC8LL0NZRsw72ByRE1XwtVLQP9C+2vg=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.1.0/go.mod h1:I6UhBPCREubcU0ouIGBdZlNG5Xx4NijUVN5rvEtD03k=
@@ -169,8 +169,9 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3 h1:zKjpN5BK/P5lMYrLmBHdBULWbJ0XpYR+7NGzqkZzoD4=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=

--- a/internal/core/command/application/command.go
+++ b/internal/core/command/application/command.go
@@ -24,9 +24,9 @@ import (
 // AllCommands query commands by offset, and limit
 func AllCommands(offset int, limit int, dic *di.Container) (deviceCoreCommands []dtos.DeviceCoreCommand, totalCount uint32, err errors.EdgeX) {
 	// retrieve device information through Metadata DeviceClient
-	dc := bootstrapContainer.MetadataDeviceClientFrom(dic.Get)
+	dc := bootstrapContainer.DeviceClientFrom(dic.Get)
 	if dc == nil {
-		return deviceCoreCommands, totalCount, errors.NewCommonEdgeX(errors.KindServerError, "nil MetadataDeviceClient returned", nil)
+		return deviceCoreCommands, totalCount, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceClient returned", nil)
 	}
 	multiDevicesResponse, err := dc.AllDevices(context.Background(), nil, offset, limit)
 	if err != nil {
@@ -34,9 +34,9 @@ func AllCommands(offset int, limit int, dic *di.Container) (deviceCoreCommands [
 	}
 
 	// retrieve device profile information through Metadata DeviceProfileClient
-	dpc := bootstrapContainer.MetadataDeviceProfileClientFrom(dic.Get)
+	dpc := bootstrapContainer.DeviceProfileClientFrom(dic.Get)
 	if dpc == nil {
-		return deviceCoreCommands, totalCount, errors.NewCommonEdgeX(errors.KindServerError, "nil MetadataDeviceProfileClient returned", nil)
+		return deviceCoreCommands, totalCount, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceProfileClient returned", nil)
 	}
 
 	// Prepare the url for command
@@ -69,9 +69,9 @@ func CommandsByDeviceName(name string, dic *di.Container) (deviceCoreCommand dto
 	}
 
 	// retrieve device information through Metadata DeviceClient
-	dc := bootstrapContainer.MetadataDeviceClientFrom(dic.Get)
+	dc := bootstrapContainer.DeviceClientFrom(dic.Get)
 	if dc == nil {
-		return deviceCoreCommand, errors.NewCommonEdgeX(errors.KindServerError, "nil MetadataDeviceClient returned", nil)
+		return deviceCoreCommand, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceClient returned", nil)
 	}
 	deviceResponse, err := dc.DeviceByName(context.Background(), name)
 	if err != nil {
@@ -79,9 +79,9 @@ func CommandsByDeviceName(name string, dic *di.Container) (deviceCoreCommand dto
 	}
 
 	// retrieve device profile information through Metadata DeviceProfileClient
-	dpc := bootstrapContainer.MetadataDeviceProfileClientFrom(dic.Get)
+	dpc := bootstrapContainer.DeviceProfileClientFrom(dic.Get)
 	if dpc == nil {
-		return deviceCoreCommand, errors.NewCommonEdgeX(errors.KindServerError, "nil MetadataDeviceProfileClient returned", nil)
+		return deviceCoreCommand, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceProfileClient returned", nil)
 	}
 	deviceProfileResponse, err := dpc.DeviceProfileByName(context.Background(), deviceResponse.Device.ProfileName)
 	if err != nil {
@@ -194,9 +194,9 @@ func IssueGetCommandByName(deviceName string, commandName string, queryParams st
 	}
 
 	// retrieve device information through Metadata DeviceClient
-	dc := bootstrapContainer.MetadataDeviceClientFrom(dic.Get)
+	dc := bootstrapContainer.DeviceClientFrom(dic.Get)
 	if dc == nil {
-		return res, errors.NewCommonEdgeX(errors.KindServerError, "nil MetadataDeviceClient returned", nil)
+		return res, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceClient returned", nil)
 	}
 	deviceResponse, err := dc.DeviceByName(context.Background(), deviceName)
 	if err != nil {
@@ -204,9 +204,9 @@ func IssueGetCommandByName(deviceName string, commandName string, queryParams st
 	}
 
 	// retrieve device service information through Metadata DeviceClient
-	dsc := bootstrapContainer.MetadataDeviceServiceClientFrom(dic.Get)
+	dsc := bootstrapContainer.DeviceServiceClientFrom(dic.Get)
 	if dsc == nil {
-		return res, errors.NewCommonEdgeX(errors.KindServerError, "nil MetadataDeviceServiceClient returned", nil)
+		return res, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceServiceClient returned", nil)
 	}
 	deviceServiceResponse, err := dsc.DeviceServiceByName(context.Background(), deviceResponse.Device.ServiceName)
 	if err != nil {
@@ -238,9 +238,9 @@ func IssueSetCommandByName(deviceName string, commandName string, queryParams st
 	}
 
 	// retrieve device information through Metadata DeviceClient
-	dc := bootstrapContainer.MetadataDeviceClientFrom(dic.Get)
+	dc := bootstrapContainer.DeviceClientFrom(dic.Get)
 	if dc == nil {
-		return response, errors.NewCommonEdgeX(errors.KindServerError, "nil MetadataDeviceClient returned", nil)
+		return response, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceClient returned", nil)
 	}
 	deviceResponse, err := dc.DeviceByName(context.Background(), deviceName)
 	if err != nil {
@@ -248,9 +248,9 @@ func IssueSetCommandByName(deviceName string, commandName string, queryParams st
 	}
 
 	// retrieve device service information through Metadata DeviceClient
-	dsc := bootstrapContainer.MetadataDeviceServiceClientFrom(dic.Get)
+	dsc := bootstrapContainer.DeviceServiceClientFrom(dic.Get)
 	if dsc == nil {
-		return response, errors.NewCommonEdgeX(errors.KindServerError, "nil MetadataDeviceServiceClient returned", nil)
+		return response, errors.NewCommonEdgeX(errors.KindServerError, "nil DeviceServiceClient returned", nil)
 	}
 	deviceServiceResponse, err := dsc.DeviceServiceByName(context.Background(), deviceResponse.Device.ServiceName)
 	if err != nil {

--- a/internal/core/command/controller/http/command_test.go
+++ b/internal/core/command/controller/http/command_test.go
@@ -87,10 +87,10 @@ func buildDeviceCoreCommands(t *testing.T, device dtos.Device, deviceProfile dto
 		Return(responseDTO.NewDeviceProfileResponse("", "", http.StatusOK, deviceProfile), nil)
 	dic := NewMockDIC()
 	dic.Update(di.ServiceConstructorMap{
-		bootstrapContainer.MetadataDeviceClientName: func(get di.Get) interface{} {
+		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
 			return dcMock
 		},
-		bootstrapContainer.MetadataDeviceProfileClientName: func(get di.Get) interface{} {
+		bootstrapContainer.DeviceProfileClientName: func(get di.Get) interface{} {
 			return dpcMock
 		},
 	})
@@ -190,10 +190,10 @@ func TestAllCommands(t *testing.T) {
 
 	dic := NewMockDIC()
 	dic.Update(di.ServiceConstructorMap{
-		bootstrapContainer.MetadataDeviceClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceClient
+		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
 			return dcMock
 		},
-		bootstrapContainer.MetadataDeviceProfileClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceProfileClient
+		bootstrapContainer.DeviceProfileClientName: func(get di.Get) interface{} {
 			return dpcMock
 		},
 	})
@@ -273,10 +273,10 @@ func TestCommandsByDeviceName(t *testing.T) {
 
 	dic := NewMockDIC()
 	dic.Update(di.ServiceConstructorMap{
-		bootstrapContainer.MetadataDeviceClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceClient
+		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
 			return dcMock
 		},
-		bootstrapContainer.MetadataDeviceProfileClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceProfileClient
+		bootstrapContainer.DeviceProfileClientName: func(get di.Get) interface{} {
 			return dpcMock
 		},
 	})
@@ -349,13 +349,13 @@ func TestIssueGetCommand(t *testing.T) {
 
 	dic := NewMockDIC()
 	dic.Update(di.ServiceConstructorMap{
-		bootstrapContainer.MetadataDeviceClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceClient
+		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
 			return dcMock
 		},
-		bootstrapContainer.MetadataDeviceServiceClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceProfileClient
+		bootstrapContainer.DeviceServiceClientName: func(get di.Get) interface{} {
 			return dscMock
 		},
-		bootstrapContainer.DeviceServiceCommandClientName: func(get di.Get) interface{} { // add v2 API DeviceServiceCommandClient
+		bootstrapContainer.DeviceServiceCommandClientName: func(get di.Get) interface{} {
 			return dsccMock
 		},
 	})
@@ -437,13 +437,13 @@ func TestIssueSetCommand(t *testing.T) {
 
 	dic := NewMockDIC()
 	dic.Update(di.ServiceConstructorMap{
-		bootstrapContainer.MetadataDeviceClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceClient
+		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
 			return dcMock
 		},
-		bootstrapContainer.MetadataDeviceServiceClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceProfileClient
+		bootstrapContainer.DeviceServiceClientName: func(get di.Get) interface{} {
 			return dscMock
 		},
-		bootstrapContainer.DeviceServiceCommandClientName: func(get di.Get) interface{} { // add v2 API DeviceServiceCommandClient
+		bootstrapContainer.DeviceServiceCommandClientName: func(get di.Get) interface{} {
 			return dsccMock
 		},
 	})

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -20,13 +20,8 @@ import (
 	"context"
 	"sync"
 
-	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
-	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	clients "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
-
 	"github.com/gorilla/mux"
 )
 
@@ -48,22 +43,5 @@ func NewBootstrap(router *mux.Router, serviceName string) *Bootstrap {
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
 	LoadRestRoutes(b.router, dic, b.serviceName)
 
-	configuration := container.ConfigurationFrom(dic.Get)
-
-	// initialize clients required by the service
-	dic.Update(di.ServiceConstructorMap{
-		bootstrapContainer.MetadataDeviceClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceClient
-			return clients.NewDeviceClient(configuration.Clients[common.CoreMetaDataServiceKey].Url() + common.ApiDeviceRoute)
-		},
-		bootstrapContainer.MetadataDeviceProfileClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceProfileClient
-			return clients.NewDeviceProfileClient(configuration.Clients[common.CoreMetaDataServiceKey].Url() + common.ApiDeviceProfileRoute)
-		},
-		bootstrapContainer.MetadataDeviceServiceClientName: func(get di.Get) interface{} { // add v2 API MetadataDeviceServiceClient
-			return clients.NewDeviceServiceClient(configuration.Clients[common.CoreMetaDataServiceKey].Url() + common.ApiDeviceServiceRoute)
-		},
-		bootstrapContainer.DeviceServiceCommandClientName: func(get di.Get) interface{} { // add v2 API DeviceServiceCommandClient
-			return clients.NewDeviceServiceCommandClient()
-		},
-	})
 	return true
 }

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -69,6 +69,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		dic,
 		true,
 		[]interfaces.BootstrapHandler{
+			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, common.CoreCommandServiceKey).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,

--- a/internal/core/data/main.go
+++ b/internal/core/data/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
-
 	"github.com/gorilla/mux"
 )
 

--- a/internal/core/metadata/application/notify.go
+++ b/internal/core/metadata/application/notify.go
@@ -222,7 +222,7 @@ func sendNotification(ctx context.Context, dic *di.Container, name string, actio
 		return
 	}
 	lc := container.LoggingClientFrom(dic.Get)
-	client := clients.NewNotificationClient(config.Clients[common.SupportNotificationsServiceKey].Url())
+	client := container.NotificationClientFrom(dic.Get)
 
 	dto := dtos.Notification{
 		Content:     fmt.Sprintf("%s %s %s", config.Notifications.Content, name, action),

--- a/internal/support/notifications/main.go
+++ b/internal/support/notifications/main.go
@@ -39,7 +39,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
-
 	"github.com/gorilla/mux"
 )
 
@@ -77,6 +76,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		true,
 		[]interfaces.BootstrapHandler{
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
+			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, common.SupportNotificationsServiceKey).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,

--- a/internal/support/scheduler/main.go
+++ b/internal/support/scheduler/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
-
 	"github.com/gorilla/mux"
 )
 
@@ -71,6 +70,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		true,
 		[]interfaces.BootstrapHandler{
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
+			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, common.SupportSchedulerServiceKey).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,


### PR DESCRIPTION
All core and support services now use new common handler from go-mod-bootstrap which uses registry (if enabled) to obtain the base URL.
This handler only creates the specific Clients for those configured in the [Clients] section.
For services that don't currently uses Clients and don't have any Clients in configuiration, no Clients are created.

closes #3874

This PR is dependent on https://github.com/edgexfoundry/go-mod-bootstrap/pull/305 and is in draft mode until it is merged.

Signed-off-by: lenny <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Build and run Core Command locally with rest of EdgeX non-secure stack running in Docker (docker core command stopped)
Use curl or Postman to send GET to `localhost:59882/api/v2/device/all`
Verify response received with available commands for Device Virtual

## New Dependency Instructions (If applicable)
**N/A**