### PR TITLE
fix(core-command): Restore creation of DeviceServiceCommandClient in handler

### DIFF
--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"sync"
 
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	clients "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http"
 	"github.com/gorilla/mux"
 )
 
@@ -42,6 +44,13 @@ func NewBootstrap(router *mux.Router, serviceName string) *Bootstrap {
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the command service.
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
 	LoadRestRoutes(b.router, dic, b.serviceName)
+
+	// DeviceServiceCommandClient is not part of the common clients handled by the NewClientsBootstrap handler
+	dic.Update(di.ServiceConstructorMap{
+		bootstrapContainer.DeviceServiceCommandClientName: func(get di.Get) interface{} { // add v2 API DeviceServiceCommandClient
+			return clients.NewDeviceServiceCommandClient()
+		},
+	})
 
 	return true
 }


### PR DESCRIPTION

fixes #3884

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
Start non-secure Edgex stack
Send `curl http://localhost:59882/api/v2/device/name/Random-Binary-Device/Binary`
Verify response is a 500 with `nil DeviceServiceCommandClient returned`
Stop Core Command container
Build and run core command from this branch with no parameters `./core-command`
Send `curl http://localhost:59882/api/v2/device/name/Random-Binary-Device/Binary`
Verify response is a 500 with `failed to send a http request`
This is a result of the hybrid deployment, but proves the previous error is fxed.


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->