### PR TITLE
feat(snap): add secretstore token for edgex-ekuiper snap

### DIFF
--- a/snap/local/hooks/cmd/install/install.go
+++ b/snap/local/hooks/cmd/install/install.go
@@ -56,6 +56,7 @@ var secretStoreTokens = []string{
 	"device-grove",
 	"device-uart",
 	"device-rfid-llrp",
+	"edgex-ekuiper",
 }
 
 var secretStoreKnownSecrets = []string{
@@ -79,6 +80,7 @@ var secretStoreKnownSecrets = []string{
 	"redisdb[device-grove]",
 	"redisdb[device-uart]",
 	"redisdb[device-rfid-llrp]",
+	"redisdb[edgex-ekuiper]",
 }
 
 // services w/configuration that needs to be copied


### PR DESCRIPTION
This PR adds edgex-ekuiper as an [add-on service](https://docs.edgexfoundry.org/2.2/security/Ch-Configuring-Add-On-Services/) to `secretStoreTokens` and `secretStoreKnownSecrets` (for redisdb) lists.

The Vault token is required for the standalone deployment of eKuiper with snap, where a script queries the Redis credentials after authenticating with Vault. The snap receives the vault token using the `edgex-secretstore-token` content interface or via other means.

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->
<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->