### PR TITLE
build(snap): upgrade to device-virtual v2.2.0-dev.7 and app-service-configurable latest/beta

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -816,7 +816,7 @@ parts:
     source-depth: 1
     # Set source-branch to tag so that depth of 1 is relative to that tag.
     # This is equivalent to "git clone --depth 1 --branch <tag> <url>"
-    source-branch: v2.1.0
+    source-tag: v2.2.0-dev.7
     plugin: make
     after: [go-build-helper]
     override-build: |
@@ -848,7 +848,7 @@ parts:
   app-service-configurable:
     plugin: nil
     stage-snaps:
-      - edgex-app-service-configurable/2.1/stable
+      - edgex-app-service-configurable/latest/beta
     stage:
       # Exclude every profile other than the "rules-engine":
       - -res/external-mqtt-trigger/configuration.toml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -816,7 +816,7 @@ parts:
     source-depth: 1
     # Set source-branch to tag so that depth of 1 is relative to that tag.
     # This is equivalent to "git clone --depth 1 --branch <tag> <url>"
-    source-tag: v2.2.0-dev.7
+    source-branch: v2.2.0-dev.7
     plugin: make
     after: [go-build-helper]
     override-build: |


### PR DESCRIPTION
This upgrade resolves edgexfoundry/device-virtual-go#268
Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?) [checkbox test (device virtual)](https://github.com/canonical/edgex-checkbox-provider/blob/master/data/latest/test-device-virtual.sh) and [checkbox test (rules engine)](https://github.com/canonical/edgex-checkbox-provider/blob/master/data/latest/test-rules-engine.sh) passed
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Set up edgexfoundry
```
snap install edgexfoundry_2.2.0-dev.38_amd64.snap --devmode
snap set edgexfoundry device-virtual=on
```
2. Modify ASC
```
sudo nano /var/snap/edgexfoundry/current/config/app-service-configurable/res/rules-engine/configuration.toml
LogLevel = "DEBUG"

  [Writable.Pipeline]
  ExecutionOrder = "FilterByDeviceName, Transform, SetResponseData"

  [Writable.Pipeline.Functions]
    [Writable.Pipeline.Functions.FilterByDeviceName]
      [Writable.Pipeline.Functions.FilterByDeviceName.Parameters]
      DeviceNames = "Random-Boolean-Device"
      FilterOut = "true"
    [Writable.Pipeline.Functions.Transform]
      [Writable.Pipeline.Functions.Transform.Parameters]
      Type = "json"
```
3. Set up kuiper and app-service-configurable
```
snap set edgexfoundry kuiper=on
sudo edgexfoundry.kuiper-cli create stream edgexAll '()WITH(FORMAT="JSON",TYPE="edgex")'
sudo edgexfoundry.kuiper-cli create rule rule1 '
{
   "sql":"SELECT * from edgexAll",
   "actions":[
      {
         "mqtt":{
            "server":"tcp://127.0.0.1:1883",
            "topic":"sinkResult"
         }
      }
   ]
}'
```
4. Check ASC function:
```
mosquitto_sub -t sinkResult
```
Expect: Random-Boolean-Device's readings have been filtered out

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->