### PR TITLE
fix(metadata): add 404 case for not-yet-upgraded device-service

### DIFF
--- a/internal/core/metadata/application/notify.go
+++ b/internal/core/metadata/application/notify.go
@@ -78,6 +78,8 @@ func validateDeviceCallback(ctx context.Context, dic *di.Container, device dtos.
 		// allow this case for the backward-compatability in v2
 		if err.Code() == http.StatusServiceUnavailable {
 			lc.Warnf("Skipping device validation for device %s (device service %s unavailable)", device.Name, device.ServiceName)
+		} else if err.Code() == http.StatusNotFound {
+			lc.Warnf("Skipping device validation for device %s (device service %s < v2.2)", device.Name, device.ServiceName)
 		} else {
 			return errors.NewCommonEdgeX(errors.KindServerError, "device validation failed", err)
 		}


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. run core-metadata from this branch
2. run device-service which is not yet upgraded sdk to v2.2.0-dev.16
3. verify there's no 404 error and device can be successfully added to metadata

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->