### PR TITLE
fix: security-proxy-setup will not terminate on success

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/proxy_setup_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/proxy_setup_wait_install.sh
@@ -54,4 +54,4 @@ done
 echo "$(date) ${API_GATEWAY_HOST} is ready"
 
 echo "$(date) Starting ${PROXY_SETUP_HOST} ..."
-exec /edgex/security-proxy-setup --init=true
+exec /usr/local/bin/entrypoint.sh "$*"

--- a/cmd/security-proxy-setup/Dockerfile
+++ b/cmd/security-proxy-setup/Dockerfile
@@ -33,7 +33,7 @@ RUN make cmd/security-proxy-setup/security-proxy-setup cmd/secrets-config/secret
 
 FROM alpine:3.14
 
-RUN apk add --update --no-cache curl
+RUN apk add --update --no-cache curl dumb-init
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Dell Technologies, Inc.'
@@ -46,5 +46,9 @@ COPY --from=builder /edgex-go/cmd/security-proxy-setup/security-proxy-setup .
 # as we are splitting security-proxy-setup into two different utilities for ease-of-use.
 COPY --from=builder /edgex-go/cmd/secrets-config/secrets-config .
 
-ENTRYPOINT ["/edgex/security-proxy-setup"]
-CMD ["--init=true"]
+# Setup the entry point script and assign perms
+COPY --from=builder /edgex-go/cmd/security-proxy-setup/entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/entrypoint.sh \
+    && ln -s /usr/local/bin/entrypoint.sh /
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/cmd/security-proxy-setup/entrypoint.sh
+++ b/cmd/security-proxy-setup/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/dumb-init /bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2022 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  ----------------------------------------------------------------------------------
+
+set -e
+
+/edgex/security-proxy-setup --init=true && exec tail -f /dev/null


### PR DESCRIPTION
The current behavior of security-proxy-setup terminating
on success causes issues for running EdgeX in Kubernetes,
as it is not possible to specify per-container restart policy.
This fix allows users who want to run EdgeX in a Kubernetes pod
to remove awkward workarounds to the current behavior.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)  Non-functional change of behavior
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  Not needed.

## Testing Instructions
To test, `make docker` and then `make run dev` from edgex-compose.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->