### PR TITLE
feat(snap): use updated environment variable injection

### DIFF
--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -605,7 +605,7 @@ func configure() {
 
 func configureApps() {
 	hooks.Info("edgexfoundry:configure Processing apps.* and config.* configuration")
-	err := snaphookoptions.ProcessOptions(
+	err := snaphookoptions.ProcessAppConfig(
 		"core-data",
 		"core-metadata",
 		"core-command",

--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
+	snaphookoptions "github.com/canonical/edgex-snap-hooks/v2/options"
 )
 
 const ( // iota is reset to 0
@@ -600,4 +601,27 @@ func configure() {
 			os.Exit(1)
 		}
 	}
+}
+
+func configureApps() {
+	hooks.Info("edgexfoundry:configure Processing apps.* and config.* configuration")
+	err := snaphookoptions.ProcessOptions(
+		"core-data",
+		"core-metadata",
+		"core-command",
+		"support-notifications",
+		"support-scheduler",
+		"app-service-configurable",
+		"device-virtual",
+		"security-secret-store",
+		"security-secretstore-setup",
+		"security-proxy-setup",
+		"security-bootstrapper",
+		"sys-mgmgt-agent")
+
+	if err != nil {
+		hooks.Error(fmt.Sprintf("edgexfoundry:configure could not process options: %v", err))
+		os.Exit(1)
+	}
+
 }

--- a/snap/local/hooks/cmd/configure/main.go
+++ b/snap/local/hooks/cmd/configure/main.go
@@ -29,6 +29,7 @@ func main() {
 	if len(os.Args) == 1 {
 		// configure everything
 		configure()
+		configureApps()
 		return
 	}
 

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.1.3
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2
 
 go 1.17

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta h1:FblUp4/cn7Qk1PJzXR6NfN8eFAHLilVHv7eFCp6Jvv0=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2 h1:HMh7QgZaJmlu3kAEGEgr1PJTr8nbfsQSWLmYuWeuPhI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.1.3 h1:mcV/atn6k6sN6Uik+lSQGEZi4Q6r96epgBW+u6AGZ3Y=
-github.com/canonical/edgex-snap-hooks/v2 v2.1.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta h1:FblUp4/cn7Qk1PJzXR6NfN8eFAHLilVHv7eFCp6Jvv0=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

This PR updates edgex-go to use the new environment variable injection. 

```
apps.<app>.config.<my.env.var> -> setting env var MY_ENV_VAR for an app (e.g. apps.core-data.config.service.port=1000)
config.<my.env.var> -> setting env variable for all apps (e.g. config.service.host=localhost)
```
 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A - they are in the imported module
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

Do
```
sudo snap set edgexfoundry env.core-data.service.host=localhost
sudo snap set edgexfoundry apps.core-data.config.service.port=8080
sudo snap set edgexfoundry config.debug=true
```

1) Confirm that all .env files have DEBUG=true
2) Confirm that the core-data .env file also has both the SERVICE_HOST and SERVICE_PORT settings

```
$ more /var/snap/edgexfoundry/current/config/core-data/res/core-data.env 
export SERVICE_HOST=localhost
export DEBUG=true
export SERVICE_PORT=8080
$ more /var/snap/edgexfoundry/current/config/core-command/res/core-command.env 
export DEBUG=true


```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->