### PR TITLE
refactor(all): Use formatted alternative log function instead of fmt.Sprintf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.9
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.20
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.21
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.9
 	github.com/edgexfoundry/go-mod-registry/v2 v2.1.0
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.2.0-dev.5

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.9 h1:q3IbjfovzgBvnPF3Ma9y
 github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.9/go.mod h1:arWuBlvgtE3nCZ0BKHG3zxEXRVVt/Gpcr20m8ely7hc=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.1.0 h1:wiLtHYo1QxImARJZt7TYj88cUhq1ANh8se4TBvFsYvw=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.1.0/go.mod h1:MvHit0MxBXN4bC8LL0NZRsw72ByRE1XwtVLQP9C+2vg=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.20 h1:qsKWnEun+xHhN3FpaXHz6CUPFHca3KQmHLyTvRSzMbg=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.20/go.mod h1:jyfVSx7mI3u/o/oo10COxBRBvJ8O/9I3z2xAwPmNt/Q=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.21 h1:TaMLM2060NuezEmK9uhVItnguoH80NXLK+SPJ6Z/5sY=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.21/go.mod h1:jyfVSx7mI3u/o/oo10COxBRBvJ8O/9I3z2xAwPmNt/Q=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.9 h1:AESiDfBaY+8ch7fQU0xxOQfhEjfaPoOCT051SqKXzT4=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.9/go.mod h1:+X6C0h8ZTJe+lLU2AGJfiAzCJK3zL+yM6cej9VC+79E=
 github.com/edgexfoundry/go-mod-registry/v2 v2.1.0 h1:ks0ejtLLUYKuoKrUBbWxygCU7q2mBFJlHE/+dEzV2Gw=

--- a/internal/core/data/application/event.go
+++ b/internal/core/data/application/event.go
@@ -58,11 +58,11 @@ func AddEvent(e models.Event, ctx context.Context, dic *di.Container) (err error
 		}
 		e = addedEvent
 
-		lc.Debug(fmt.Sprintf(
+		lc.Debugf(
 			"Event created on DB successfully. Event-id: %s, Correlation-id: %s ",
 			e.Id,
 			correlationId,
-		))
+		)
 	}
 
 	return nil
@@ -76,16 +76,15 @@ func PublishEvent(data []byte, profileName string, deviceName string, sourceName
 	correlationId := correlation.FromContext(ctx)
 
 	publishTopic := fmt.Sprintf("%s/%s/%s/%s", configuration.MessageQueue.PublishTopicPrefix, profileName, deviceName, sourceName)
-	lc.Debug(fmt.Sprintf("Publishing V2 AddEventRequest to message queue. Topic: %s", publishTopic), common.CorrelationHeader, correlationId)
+	lc.Debugf("Publishing V2 AddEventRequest to message queue. Topic: %s; %s: %s", publishTopic, common.CorrelationHeader, correlationId)
 
 	msgEnvelope := msgTypes.NewMessageEnvelope(data, ctx)
 	err := msgClient.Publish(msgEnvelope, publishTopic)
 	if err != nil {
-		lc.Error(fmt.Sprintf("Unable to send message for V2 API event. Correlation-id: %s, Profile Name: %s, "+
-			"Device Name: %s, Source Name: %s, Error: %v", correlationId, profileName, deviceName, sourceName, err))
+		lc.Errorf("Unable to send message for V2 API event. Correlation-id: %s, Profile Name: %s, "+
+			"Device Name: %s, Source Name: %s, Error: %v", correlationId, profileName, deviceName, sourceName, err)
 	} else {
-		lc.Debug(fmt.Sprintf(
-			"V2 API Event Published on message queue. Topic: %s, Correlation-id: %s ", publishTopic, correlationId))
+		lc.Debugf("V2 API Event Published on message queue. Topic: %s, Correlation-id: %s ", publishTopic, correlationId)
 	}
 }
 

--- a/internal/core/data/messaging/messaging.go
+++ b/internal/core/data/messaging/messaging.go
@@ -16,7 +16,6 @@ package messaging
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 
@@ -92,14 +91,14 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 				},
 			})
 
-			lc.Info(fmt.Sprintf(
+			lc.Infof(
 				"Connected to %s Message Bus @ %s://%s:%d publishing on '%s' prefix topic with AuthMode='%s'",
 				messageBusInfo.Type,
 				messageBusInfo.Protocol,
 				messageBusInfo.Host,
 				messageBusInfo.Port,
 				messageBusInfo.PublishTopicPrefix,
-				messageBusInfo.AuthMode))
+				messageBusInfo.AuthMode)
 
 			return true
 		}

--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -51,11 +51,11 @@ func AddDevice(d models.Device, ctx context.Context, dic *di.Container) (id stri
 		return "", errors.NewCommonEdgeXWrapper(err)
 	}
 
-	lc.Debug(fmt.Sprintf(
+	lc.Debugf(
 		"Device created on DB successfully. Device ID: %s, Correlation-ID: %s ",
 		addedDevice.Id,
 		correlation.FromContext(ctx),
-	))
+	)
 	go addDeviceCallback(ctx, dic, dtos.FromDeviceModelToDTO(d))
 	return addedDevice.Id, nil
 }
@@ -156,10 +156,10 @@ func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container) 
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 
-	lc.Debug(fmt.Sprintf(
+	lc.Debugf(
 		"Device patched on DB successfully. Correlation-ID: %s ",
 		correlation.FromContext(ctx),
-	))
+	)
 
 	if oldServiceName != "" {
 		go updateDeviceCallback(ctx, dic, oldServiceName, device)

--- a/internal/core/metadata/application/deviceprofile.go
+++ b/internal/core/metadata/application/deviceprofile.go
@@ -34,11 +34,11 @@ func AddDeviceProfile(d models.DeviceProfile, ctx context.Context, dic *di.Conta
 		return "", errors.NewCommonEdgeXWrapper(err)
 	}
 
-	lc.Debug(fmt.Sprintf(
+	lc.Debugf(
 		"DeviceProfile created on DB successfully. DeviceProfile-id: %s, Correlation-id: %s ",
 		addedDeviceProfile.Id,
 		correlationId,
-	))
+	)
 
 	return addedDeviceProfile.Id, nil
 }
@@ -54,10 +54,10 @@ func UpdateDeviceProfile(d models.DeviceProfile, ctx context.Context, dic *di.Co
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 
-	lc.Debug(fmt.Sprintf(
+	lc.Debugf(
 		"DeviceProfile updated on DB successfully. Correlation-id: %s ",
 		correlation.FromContext(ctx),
-	))
+	)
 	go updateDeviceProfileCallback(ctx, dic, dtos.FromDeviceProfileModelToDTO(d))
 	return nil
 }

--- a/internal/pkg/bootstrap/handlers/database.go
+++ b/internal/pkg/bootstrap/handlers/database.go
@@ -7,7 +7,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -90,7 +89,7 @@ func (d Database) BootstrapHandler(
 			break
 		}
 
-		lc.Warn(fmt.Sprintf("couldn't retrieve database credentials: %v", err.Error()))
+		lc.Warnf("couldn't retrieve database credentials: %v", err.Error())
 		startupTimer.SleepForInterval()
 	}
 
@@ -104,7 +103,7 @@ func (d Database) BootstrapHandler(
 			break
 		}
 		dbClient = nil
-		lc.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
+		lc.Warnf("couldn't create database client: %v", err.Error())
 		startupTimer.SleepForInterval()
 	}
 

--- a/internal/pkg/infrastructure/redis/event.go
+++ b/internal/pkg/infrastructure/redis/event.go
@@ -35,7 +35,7 @@ func (c *Client) asyncDeleteEventsByIds(eventIds []string) {
 	//start a transaction to get all events
 	events, edgeXerr := getObjectsByIds(conn, pkgCommon.ConvertStringsToInterfaces(eventIds))
 	if edgeXerr != nil {
-		c.loggingClient.Error(fmt.Sprintf("Deleted events failed while retrieving objects by Ids.  Err: %s", edgeXerr.DebugMessages()))
+		c.loggingClient.Errorf("Deleted events failed while retrieving objects by Ids.  Err: %s", edgeXerr.DebugMessages())
 		return
 	}
 
@@ -46,7 +46,7 @@ func (c *Client) asyncDeleteEventsByIds(eventIds []string) {
 	for i, event := range events {
 		err := json.Unmarshal(event, &e)
 		if err != nil {
-			c.loggingClient.Error(fmt.Sprintf("unable to marshal event.  Err: %s", err.Error()))
+			c.loggingClient.Errorf("unable to marshal event.  Err: %s", err.Error())
 			continue
 		}
 		storedKey := eventStoredKey(e.Id)
@@ -60,7 +60,7 @@ func (c *Client) asyncDeleteEventsByIds(eventIds []string) {
 		if queriesInQueue >= c.BatchSize {
 			_, err = conn.Do(EXEC)
 			if err != nil {
-				c.loggingClient.Error(fmt.Sprintf("unable to execute batch event deletion.  Err: %s", err.Error()))
+				c.loggingClient.Errorf("unable to execute batch event deletion.  Err: %s", err.Error())
 				continue
 			}
 			// reset queriesInQueue to zero if EXEC is successfully executed without error
@@ -75,7 +75,7 @@ func (c *Client) asyncDeleteEventsByIds(eventIds []string) {
 	if queriesInQueue > 0 {
 		_, err := conn.Do(EXEC)
 		if err != nil {
-			c.loggingClient.Error(fmt.Sprintf("unable to execute batch event deletion.  Err: %s", err.Error()))
+			c.loggingClient.Errorf("unable to execute batch event deletion.  Err: %s", err.Error())
 		}
 	}
 }
@@ -90,9 +90,9 @@ func (c *Client) DeleteEventsByDeviceName(deviceName string) (edgeXerr errors.Ed
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
-	c.loggingClient.Debug(fmt.Sprintf("Prepare to delete %v readings", len(readingIds)))
+	c.loggingClient.Debugf("Prepare to delete %v readings", len(readingIds))
 	go c.asyncDeleteReadingsByIds(readingIds)
-	c.loggingClient.Debug(fmt.Sprintf("Prepare to delete %v events", len(eventIds)))
+	c.loggingClient.Debugf("Prepare to delete %v events", len(eventIds))
 	go c.asyncDeleteEventsByIds(eventIds)
 
 	return nil
@@ -110,9 +110,9 @@ func (c *Client) DeleteEventsByAge(age int64) (edgeXerr errors.EdgeX) {
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
-	c.loggingClient.Debug(fmt.Sprintf("Prepare to delete %v readings", len(readingIds)))
+	c.loggingClient.Debugf("Prepare to delete %v readings", len(readingIds))
 	go c.asyncDeleteReadingsByIds(readingIds)
-	c.loggingClient.Debug(fmt.Sprintf("Prepare to delete %v events", len(eventIds)))
+	c.loggingClient.Debugf("Prepare to delete %v events", len(eventIds))
 	go c.asyncDeleteEventsByIds(eventIds)
 
 	return nil

--- a/internal/security/config/command/proxy/adduser/command.go
+++ b/internal/security/config/command/proxy/adduser/command.go
@@ -142,7 +142,7 @@ func (c *cmd) createConsumer() error {
 		"username": []string{c.username},
 	}
 	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers"}, "/")
-	c.loggingClient.Info(fmt.Sprintf("creating consumer (user) on the endpoint of %s", kongURL))
+	c.loggingClient.Infof("creating consumer (user) on the endpoint of %s", kongURL)
 
 	formVal := form.Encode()
 	req, err := http.NewRequest(http.MethodPost, kongURL, strings.NewReader(formVal))
@@ -164,9 +164,9 @@ func (c *cmd) createConsumer() error {
 	switch resp.StatusCode {
 	case http.StatusOK:
 	case http.StatusCreated:
-		c.loggingClient.Info(fmt.Sprintf("created consumer (user) '%s'", c.username))
+		c.loggingClient.Infof("created consumer (user) '%s'", c.username)
 	case http.StatusConflict:
-		c.loggingClient.Info(fmt.Sprintf("consumer '%s' already created", c.username))
+		c.loggingClient.Infof("consumer '%s' already created", c.username)
 	default:
 		c.loggingClient.Error(string(responseBody))
 		return fmt.Errorf("Create consumer request failed with code: %d", resp.StatusCode)
@@ -183,7 +183,7 @@ func (c *cmd) addUserToGroup() error {
 		"group": []string{c.group},
 	}
 	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers", c.username, "acls"}, "/")
-	c.loggingClient.Info(fmt.Sprintf("Associating consumer to acl using endpoint %s", kongURL))
+	c.loggingClient.Infof("Associating consumer to acl using endpoint %s", kongURL)
 
 	formVal := form.Encode()
 	req, err := http.NewRequest(http.MethodPost, kongURL, strings.NewReader(formVal))
@@ -205,9 +205,9 @@ func (c *cmd) addUserToGroup() error {
 	switch resp.StatusCode {
 	case http.StatusOK:
 	case http.StatusCreated:
-		c.loggingClient.Info(fmt.Sprintf("associated consumer %s to group %s", c.username, c.group))
+		c.loggingClient.Infof("associated consumer %s to group %s", c.username, c.group)
 	case http.StatusConflict:
-		c.loggingClient.Info(fmt.Sprintf("consumer %s already associated to group %s", c.username, c.group))
+		c.loggingClient.Infof("consumer %s already associated to group %s", c.username, c.group)
 	default:
 		c.loggingClient.Error(string(responseBody))
 		return fmt.Errorf("failed to associate consumer to group with status: %d", resp.StatusCode)
@@ -249,7 +249,7 @@ func (c *cmd) ExecuteAddJwt() (int, error) {
 	}
 
 	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers", c.username, "jwt"}, "/")
-	c.loggingClient.Info(fmt.Sprintf("associating JWT on the endpoint of %s", kongURL))
+	c.loggingClient.Infof("associating JWT on the endpoint of %s", kongURL)
 
 	formVal := form.Encode()
 	req, err := http.NewRequest(http.MethodPost, kongURL, strings.NewReader(formVal))
@@ -319,7 +319,7 @@ func (c *cmd) ExecuteAddOAuth2() (statusCode int, err error) {
 	}
 
 	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers", c.username, "oauth2"}, "/")
-	c.loggingClient.Info(fmt.Sprintf("creating oauth application at %s", kongURL))
+	c.loggingClient.Infof("creating oauth application at %s", kongURL)
 
 	formVal := form.Encode()
 	req, err := http.NewRequest(http.MethodPost, kongURL, strings.NewReader(formVal))

--- a/internal/security/config/command/proxy/deluser/command.go
+++ b/internal/security/config/command/proxy/deluser/command.go
@@ -71,7 +71,7 @@ func (c *cmd) Execute() (int, error) {
 	// https://docs.konghq.com/2.1.x/admin-api/#delete-consumer
 
 	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "consumers", c.username}, "/")
-	c.loggingClient.Info(fmt.Sprintf("deleting consumer (user) on the endpoint of %s", kongURL))
+	c.loggingClient.Infof("deleting consumer (user) on the endpoint of %s", kongURL)
 
 	// Setup request
 	req, err := http.NewRequest(http.MethodDelete, kongURL, nil)
@@ -88,7 +88,7 @@ func (c *cmd) Execute() (int, error) {
 
 	switch resp.StatusCode {
 	case http.StatusNoContent:
-		c.loggingClient.Info(fmt.Sprintf("deleted consumer (user) '%s'", c.username))
+		c.loggingClient.Infof("deleted consumer (user) '%s'", c.username)
 	default:
 		responseBody, _ := io.ReadAll(resp.Body)
 		c.loggingClient.Error(fmt.Sprintf("Error response: %s", responseBody))

--- a/internal/security/config/command/proxy/oauth2/command.go
+++ b/internal/security/config/command/proxy/oauth2/command.go
@@ -82,7 +82,7 @@ func (c *cmd) Execute() (statusCode int, err error) {
 
 	// Setup the URL to send a request to
 	kongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), c.configuration.KongAuth.Resource, "oauth2/token"}, "/")
-	c.loggingClient.Info(fmt.Sprintf("creating token on the endpoint of %s", kongURL))
+	c.loggingClient.Infof("creating token on the endpoint of %s", kongURL)
 
 	// Setup the request
 	req, err := http.NewRequest(

--- a/internal/security/config/command/proxy/tls/command.go
+++ b/internal/security/config/command/proxy/tls/command.go
@@ -120,7 +120,7 @@ func (c *cmd) uploadProxyTlsCert() error {
 		return err
 	}
 
-	c.loggingClient.Debug(fmt.Sprintf("number of existing Kong tls certs = %d", len(existingCertIDs)))
+	c.loggingClient.Debugf("number of existing Kong tls certs = %d", len(existingCertIDs))
 
 	if len(existingCertIDs) > 0 {
 		// delete the existing certs first
@@ -160,7 +160,7 @@ func (c *cmd) listKongTLSCertificates() (certificateIDs, error) {
 
 	// list snis certificates association to see if any already exists
 	certKongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(), "snis"}, "/")
-	c.loggingClient.Info(fmt.Sprintf("list snis tls certificates on the endpoint of %s", certKongURL))
+	c.loggingClient.Infof("list snis tls certificates on the endpoint of %s", certKongURL)
 
 	req, err := http.NewRequest(http.MethodGet, certKongURL, http.NoBody)
 	if err != nil {
@@ -211,7 +211,7 @@ func (c *cmd) deleteKongTLSCertificateById(certId string) error {
 	// Delete the Kong TLS certificate
 	delCertKongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(),
 		"certificates", certId}, "/")
-	c.loggingClient.Info(fmt.Sprintf("deleting tls certificate on the endpoint of %s", delCertKongURL))
+	c.loggingClient.Infof("deleting tls certificate on the endpoint of %s", delCertKongURL)
 
 	req, err := http.NewRequest(http.MethodDelete, delCertKongURL, http.NoBody)
 	if err != nil {
@@ -230,7 +230,7 @@ func (c *cmd) deleteKongTLSCertificateById(certId string) error {
 		c.loggingClient.Info("Successfully deleted Kong tls cert")
 	case http.StatusNotFound:
 		// not able to find this certId but should be ok to proceed and post a new certificate
-		c.loggingClient.Warn(fmt.Sprintf("Unable to delete Kong tls cert because the certificate Id %s not found", certId))
+		c.loggingClient.Warnf("Unable to delete Kong tls cert because the certificate Id %s not found", certId)
 	default:
 		return fmt.Errorf("delete Kong tls certificate request failed with code: %d", resp.StatusCode)
 	}
@@ -240,7 +240,7 @@ func (c *cmd) deleteKongTLSCertificateById(certId string) error {
 func (c *cmd) postKongTLSCertificate(certKeyPair *bootstrapConfig.CertKeyPair) error {
 	postCertKongURL := strings.Join([]string{c.configuration.KongURL.GetSecureURL(),
 		"certificates"}, "/")
-	c.loggingClient.Info(fmt.Sprintf("posting tls certificate on the endpoint of %s", postCertKongURL))
+	c.loggingClient.Infof("posting tls certificate on the endpoint of %s", postCertKongURL)
 
 	form := url.Values{
 		"cert": []string{certKeyPair.Cert},

--- a/internal/security/proxy/resource.go
+++ b/internal/security/proxy/resource.go
@@ -64,7 +64,7 @@ func (r *Resource) Remove(path string) error {
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
-		r.loggingClient.Info(fmt.Sprintf("successful to delete %s at %s", r.name, path))
+		r.loggingClient.Infof("successful to delete %s at %s", r.name, path)
 	default:
 		e := fmt.Sprintf("failed to delete %s at %s with errocode %d.", r.name, path, resp.StatusCode)
 		r.loggingClient.Error(e)

--- a/internal/security/proxy/service.go
+++ b/internal/security/proxy/service.go
@@ -100,7 +100,7 @@ func (s *Service) checkServiceStatus(path string) error {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		s.loggingClient.Info(fmt.Sprintf("the service on %s is up successfully", path))
+		s.loggingClient.Infof("the service on %s is up successfully", path)
 	default:
 		err = fmt.Errorf("unexpected http status %v %s", resp.StatusCode, path)
 		s.loggingClient.Error(err.Error())
@@ -194,7 +194,7 @@ func (s *Service) Init() error {
 			return fmt.Errorf("unsupported authetication method: %s", s.configuration.KongAuth.Name)
 		}
 
-		s.loggingClient.Info(fmt.Sprintf("selected auth method %s", s.configuration.KongAuth.Name))
+		s.loggingClient.Infof("selected auth method %s", s.configuration.KongAuth.Name)
 
 		if err := s.initRouteAuthentication(strings.ToLower(route.Name), formVals.Encode()); err != nil {
 			return err
@@ -294,9 +294,9 @@ func (s *Service) mergeRoutesWith(additional map[string]models.KongService) map[
 	for serviceName, route := range additional {
 		_, exists := merged[serviceName]
 		if exists {
-			s.loggingClient.Warn(fmt.Sprintf(
+			s.loggingClient.Warnf(
 				"attempting to add additional service name %s that already exists in the config. "+
-					"Ignoring additional", serviceName))
+					"Ignoring additional", serviceName)
 			continue
 		}
 		merged[serviceName] = route
@@ -321,12 +321,12 @@ func (s *Service) postCert(cp bootstrapConfig.CertKeyPair) *CertError {
 	req, err := http.NewRequest(http.MethodPost, strings.Join(tokens, "/"), strings.NewReader(string(data)))
 	req.Header.Add(common.ContentType, common.ContentTypeJSON)
 	if err != nil {
-		s.loggingClient.Error("failed to create upload cert request -- %s", err.Error())
+		s.loggingClient.Errorf("failed to create upload cert request -- %s", err.Error())
 		return &CertError{err.Error(), InternalError}
 	}
 	resp, err := s.client.Do(req)
 	if err != nil {
-		s.loggingClient.Error("failed to upload cert to proxy server with error %s", err.Error())
+		s.loggingClient.Errorf("failed to upload cert to proxy server with error %s", err.Error())
 		return &CertError{err.Error(), InternalError}
 	}
 	defer resp.Body.Close()
@@ -377,9 +377,9 @@ func (s *Service) initKongService(service *models.KongService) error {
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated:
-		s.loggingClient.Info(fmt.Sprintf("successful to set up proxy service for `%s` at `%s:%d`", service.Name, service.Host, service.Port))
+		s.loggingClient.Infof("successful to set up proxy service for `%s` at `%s:%d`", service.Name, service.Host, service.Port)
 	case http.StatusConflict:
-		s.loggingClient.Info(fmt.Sprintf("proxy service for %s has been set up", service.Name))
+		s.loggingClient.Infof("proxy service for %s has been set up", service.Name)
 	default:
 		err = fmt.Errorf("proxy service for %s returned status %d", service.Name, resp.StatusCode)
 		s.loggingClient.Error(err.Error())
@@ -417,7 +417,7 @@ func (s *Service) initKongRoutes(r *models.KongRoute, name string) error {
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
 		s.routes[name] = r
-		s.loggingClient.Info(fmt.Sprintf("successful to set up route for `%s` at `%v`", name, r.Paths))
+		s.loggingClient.Infof("successful to set up route for `%s` at `%v`", name, r.Paths)
 	default:
 		e := fmt.Sprintf("failed to set up route for %s with error %s", name, resp.Status)
 		s.loggingClient.Error(e)
@@ -467,7 +467,7 @@ func (s *Service) initCORSRoutes(corsConfig *bootstrapConfig.CORSConfigurationIn
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
-		s.loggingClient.Info(fmt.Sprintf("successful to set up CORS at `%s`", name))
+		s.loggingClient.Infof("successful to set up CORS at `%s`", name)
 	default:
 		e := fmt.Sprintf("failed to set up CORS for %s with error %s", name, resp.Status)
 		s.loggingClient.Error(e)
@@ -500,7 +500,7 @@ func (s *Service) initRouteAuthentication(routeName string, formVals string) err
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusConflict:
-		s.loggingClient.Info(fmt.Sprintf("successful to set up route authentication for `%s`", routeName))
+		s.loggingClient.Infof("successful to set up route authentication for `%s`", routeName)
 	default:
 		body, _ := io.ReadAll(resp.Body)
 		e := fmt.Sprintf("failed to set up route authentication for %s with error %s, %s", routeName, resp.Status, string(body))

--- a/internal/security/secretstore/certs.go
+++ b/internal/security/secretstore/certs.go
@@ -109,7 +109,7 @@ func (cs *Certs) retrieve() (*CertPair, error) {
 	cc := CertCollect{}
 
 	if resp.StatusCode == http.StatusNotFound {
-		cs.loggingClient.Info(fmt.Sprintf("proxy cert pair NOT found in secret store @/%s, status: %s", cs.certPath, resp.Status))
+		cs.loggingClient.Infof("proxy cert pair NOT found in secret store @/%s, status: %s", cs.certPath, resp.Status)
 		return nil, errNotFound
 	} else if resp.StatusCode != http.StatusOK {
 		e := fmt.Errorf("failed to retrieve the proxy cert pair on path %s with error code %d", cs.certPath, resp.StatusCode)

--- a/internal/security/secretstore/password.go
+++ b/internal/security/secretstore/password.go
@@ -45,7 +45,7 @@ func NewPasswordGenerator(lc logger.LoggingClient, passwordProvider string, pass
 		pp := NewPasswordProvider(lc, NewDefaultExecRunner())
 		err := pp.SetConfiguration(passwordProvider, passwordProviderArgs)
 		if err != nil {
-			lc.Warn(fmt.Sprintf("Could not configure password generator %s: error: %s", passwordProvider, err.Error()))
+			lc.Warnf("Could not configure password generator %s: error: %s", passwordProvider, err.Error())
 			return gk // fall-back to builtin
 		}
 		gk.generatorImplementation = pp
@@ -138,7 +138,7 @@ func (cr *Cred) retrieve(path string) (*UserPasswordPair, error) {
 	cred := CredCollect{}
 
 	if resp.StatusCode == http.StatusNotFound {
-		cr.loggingClient.Info(fmt.Sprintf("credential pair NOT found in secret store @/%s, status: %s", path, resp.Status))
+		cr.loggingClient.Infof("credential pair NOT found in secret store @/%s, status: %s", path, resp.Status)
 		return nil, errNotFound
 	} else if resp.StatusCode != http.StatusOK {
 		e := fmt.Errorf("failed to retrieve the credential pair on path %s with error code %d", path, resp.StatusCode)

--- a/internal/security/secretstore/passwordprovider.go
+++ b/internal/security/secretstore/passwordprovider.go
@@ -60,7 +60,7 @@ func (p *PasswordProvider) Generate(ctx context.Context) (string, error) {
 
 	p.execRunner.SetStdout(&outputBuffer)
 
-	p.loggingClient.Info(fmt.Sprintf("Launching password provider %s with arguments %s", p.resolvedPath, strings.Join(p.passwordProviderArgs, " ")))
+	p.loggingClient.Infof("Launching password provider %s with arguments %s", p.resolvedPath, strings.Join(p.passwordProviderArgs, " "))
 	cmd := p.execRunner.CommandContext(ctx, p.resolvedPath, p.passwordProviderArgs...)
 	if err := cmd.Start(); err != nil {
 		// For example, this might occur if a shared library was missing

--- a/internal/security/secretstore/tokenmaintenance.go
+++ b/internal/security/secretstore/tokenmaintenance.go
@@ -34,8 +34,6 @@ For Fuji.DOT/Geneva, all root tokens will be revoked.
 */
 
 import (
-	"fmt"
-
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokencreatable"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
@@ -77,7 +75,7 @@ func (tm *TokenMaintenance) CreateTokenIssuingToken(rootToken string) (map[strin
 	createTokenParameters["ttl"] = "1h"
 	createTokenResponse, err := tm.secretClient.CreateToken(rootToken, createTokenParameters)
 	if err != nil {
-		tm.logging.Error(fmt.Sprintf("failed creation of token-issuing-token: %s", err.Error()))
+		tm.logging.Errorf("failed creation of token-issuing-token: %s", err.Error())
 		return nil, nil, err
 	}
 
@@ -85,7 +83,7 @@ func (tm *TokenMaintenance) CreateTokenIssuingToken(rootToken string) (map[strin
 	revokeFunc := func() {
 		tm.logging.Info("revoking token-issuing-token")
 		if err2 := tm.secretClient.RevokeToken(newToken); err2 != nil {
-			tm.logging.Warn("failed revocation of token-issuing-token: %s", err2.Error())
+			tm.logging.Warnf("failed revocation of token-issuing-token: %s", err2.Error())
 		}
 	}
 	return createTokenResponse, revokeFunc, nil

--- a/internal/security/spiffetokenprovider/maketoken.go
+++ b/internal/security/spiffetokenprovider/maketoken.go
@@ -73,8 +73,8 @@ func makeToken(serviceName string,
 	secretStoreClient secrets.SecretStoreClient,
 	lc logger.LoggingClient) (interface{}, error) {
 
-	lc.Info(fmt.Sprintf("generating policy/token defaults for service %s", serviceName))
-	lc.Info(fmt.Sprintf("using policy/token defaults for service %s", serviceName))
+	lc.Infof("generating policy/token defaults for service %s", serviceName)
+	lc.Infof("using policy/token defaults for service %s", serviceName)
 	servicePolicy := makeDefaultTokenPolicy(serviceName)
 	defaultPolicyPaths := servicePolicy["path"].(map[string]interface{})
 	for pathKey, policy := range defaultPolicyPaths {


### PR DESCRIPTION

close #3932

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)NA, replace log functions
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)NA, replace log functions
- [ ] I have opened a PR for the related docs change (if not, why?)NA, replace log functions
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->