### PR TITLE
fix(security): Fix for spiffe-config crashloop

### DIFF
--- a/cmd/security-spire-config/seed_builtin_entries.sh
+++ b/cmd/security-spire-config/seed_builtin_entries.sh
@@ -33,3 +33,6 @@ for service in security-spiffe-token-provider \
     app-service-external-mqtt-trigger; do
     spire-server entry create -socketPath "${SPIFFE_SERVER_SOCKET}" -parentID "${local_agent_svid}" -dns "edgex-${service}" -spiffeID "${SPIFFE_EDGEX_SVID_BASE}/${service}" -selector "docker:label:com.docker.compose.service:${service}"
 done
+
+# Always exit successfully even if couldn't (re-)create server entries.
+exit 0


### PR DESCRIPTION
Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
resolves a bug where the -config container enters a crash loop when the framework is restarted,
because of an error when spire server entry already existing

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->