### PR TITLE
feat(security): Use conditional go build tags for delayed start and no_messagebus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 #
+# Copyright 2022 Intel Corporation
 # Copyright (c) 2018 Cavium
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -6,6 +7,9 @@
 
 
 .PHONY: build clean unittest hadolint lint test docker run
+
+# change the following boolean flag to include or exclude the delayed start libs for builds
+INCLUDE_DELAYED_START_BUILD:="false"
 
 GO=CGO_ENABLED=0 GO111MODULE=on go
 
@@ -61,49 +65,58 @@ GIT_SHA=$(shell git rev-parse HEAD)
 
 ARCH=$(shell uname -m)
 
+# DO NOT change the following flag, as it is automatically set based on the boolean switch INCLUDE_DELAYED_START_BUILD
+NON_DELAYED_START_GO_BUILD_TAG:=non_delayedstart
+ifeq ($(INCLUDE_DELAYED_START_BUILD),"true")
+	NON_DELAYED_START_GO_BUILD_TAG:=
+endif
+
+NO_MESSAGEBUS_GO_BUILD_TAG:=no_messagebus
+
+
 build: $(MICROSERVICES)
 
 tidy:
 	go mod tidy -compat=1.17
 
 cmd/core-metadata/core-metadata:
-	$(GOCGO) build $(CGOFLAGS) -o $@ ./cmd/core-metadata
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/core-metadata
 
 cmd/core-data/core-data:
-	$(GOCGO) build $(CGOFLAGS) -o $@ ./cmd/core-data
+	$(GOCGO) build -tags "$(NON_DELAYED_START_GO_BUILD_TAG)" $(CGOFLAGS) -o $@ ./cmd/core-data
 
 cmd/core-command/core-command:
-	$(GOCGO) build $(CGOFLAGS) -o $@ ./cmd/core-command
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/core-command
 
 cmd/support-notifications/support-notifications:
-	$(GOCGO) build $(CGOFLAGS) -o $@ ./cmd/support-notifications
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/support-notifications
 
 cmd/sys-mgmt-executor/sys-mgmt-executor:
-	$(GO) build $(GOFLAGS) -o $@ ./cmd/sys-mgmt-executor
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-executor
 
 cmd/sys-mgmt-agent/sys-mgmt-agent:
-	$(GOCGO) build $(CGOFLAGS) -o $@ ./cmd/sys-mgmt-agent
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-agent
 
 cmd/support-scheduler/support-scheduler:
-	$(GOCGO) build $(CGOFLAGS) -o $@ ./cmd/support-scheduler
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/support-scheduler
 
 cmd/security-proxy-setup/security-proxy-setup:
-	$(GOCGO) build $(CGOFLAGS) -o ./cmd/security-proxy-setup/security-proxy-setup ./cmd/security-proxy-setup
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/security-proxy-setup/security-proxy-setup ./cmd/security-proxy-setup
 
 cmd/security-secretstore-setup/security-secretstore-setup:
-	$(GOCGO) build $(CGOFLAGS) -o ./cmd/security-secretstore-setup/security-secretstore-setup ./cmd/security-secretstore-setup
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/security-secretstore-setup/security-secretstore-setup ./cmd/security-secretstore-setup
 
 cmd/security-file-token-provider/security-file-token-provider:
-	$(GOCGO) build $(CGOFLAGS) -o ./cmd/security-file-token-provider/security-file-token-provider ./cmd/security-file-token-provider
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/security-file-token-provider/security-file-token-provider ./cmd/security-file-token-provider
 
 cmd/secrets-config/secrets-config:
-	$(GOCGO) build $(CGOFLAGS) -o ./cmd/secrets-config ./cmd/secrets-config
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/secrets-config ./cmd/secrets-config
 
 cmd/security-bootstrapper/security-bootstrapper:
-	$(GOCGO) build $(CGOFLAGS) -o ./cmd/security-bootstrapper/security-bootstrapper ./cmd/security-bootstrapper
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/security-bootstrapper/security-bootstrapper ./cmd/security-bootstrapper
 
 cmd/security-spiffe-token-provider/security-spiffe-token-provider:
-	$(GOCGO) build $(CGOFLAGS) -o $@ ./cmd/security-spiffe-token-provider
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/security-spiffe-token-provider
 
 clean:
 	rm -f $(MICROSERVICES)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ Follow the "Installation and Execution" steps above for obtaining and building t
 make docker 
 ```
 
+#### Delayed Start Go Builds For Developers
+
+Currently for EdgeX core services, the delayed start feature from the dependency go-mod-bootstrap / go-mod-secrets modules are excluded in go builds.
+If you want to **include** the delayed start feature in the builds, please change the [Makefile in this directory](Makefile). In particular, change the following boolean flag from `false` to `true` before the whole docker builds.
+
+```text
+INCLUDE_DELAYED_START_BUILD:="false"
+```
+
 #### Run 
 
 The **Compose Builder** tool has the `dev` option to generate and run EdgeX compose files using locally built images for above. See [Compose Builder README](https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder#readme) for more details.

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /edgex-go
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-RUN apk add --update --no-cache make git zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk add --update --no-cache make git
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -36,7 +36,7 @@ RUN make cmd/core-command/core-command
 
 FROM alpine:3.14
 
-RUN apk add --update --no-cache dumb-init zeromq
+RUN apk add --update --no-cache dumb-init
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Dell, Cavium, Copyright (c) 2021: Intel Corporation'

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /edgex-go
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-RUN apk add --update --no-cache make git zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk add --update --no-cache make git
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -37,7 +37,7 @@ RUN make cmd/core-metadata/core-metadata
 #Next image - Copy built Go binary into new workspace
 FROM alpine:3.14
 
-RUN apk add --update --no-cache dumb-init zeromq
+RUN apk add --update --no-cache dumb-init
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Dell, Cavium, Copyright (c) 2021: Intel Corporation'

--- a/cmd/security-bootstrapper/Dockerfile
+++ b/cmd/security-bootstrapper/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /edgex-go
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-RUN apk add --update --no-cache make git zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk add --update --no-cache make git
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -37,7 +37,7 @@ FROM alpine:3.14
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2021 Intel Corporation'
 
-RUN apk add --update --no-cache dumb-init su-exec zeromq
+RUN apk add --update --no-cache dumb-init su-exec
 
 ENV SECURITY_INIT_DIR /edgex-init
 ARG BOOTSTRAP_REDIS_DIR=${SECURITY_INIT_DIR}/bootstrap-redis

--- a/cmd/security-proxy-setup/Dockerfile
+++ b/cmd/security-proxy-setup/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /edgex-go
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-RUN apk add --update --no-cache make git zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk add --update --no-cache make git
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -33,7 +33,7 @@ RUN make cmd/security-proxy-setup/security-proxy-setup cmd/secrets-config/secret
 
 FROM alpine:3.14
 
-RUN apk add --update --no-cache curl dumb-init zeromq
+RUN apk add --update --no-cache curl dumb-init
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Dell Technologies, Inc.'

--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /edgex-go
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-RUN apk add --update --no-cache make git zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk add --update --no-cache make git
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -34,7 +34,7 @@ RUN make cmd/security-file-token-provider/security-file-token-provider \
 
 FROM alpine:3.14
 
-RUN apk add --update --no-cache ca-certificates dumb-init su-exec zeromq
+RUN apk add --update --no-cache ca-certificates dumb-init su-exec
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Dell Technologies, Inc.'

--- a/cmd/security-spiffe-token-provider/Dockerfile
+++ b/cmd/security-spiffe-token-provider/Dockerfile
@@ -21,7 +21,7 @@ FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go
 
-RUN apk update && apk --no-cache --update add build-base zeromq-dev libsodium-dev pkgconfig
+RUN apk update && apk --no-cache --update add build-base
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -36,7 +36,7 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2022 Intel Corporation'
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
-RUN apk update && apk --no-cache --update add dumb-init curl gcompat zeromq
+RUN apk update && apk --no-cache --update add dumb-init curl gcompat
 
 COPY --from=builder /edgex-go/Attribution.txt /
 COPY --from=builder /edgex-go/cmd/security-spiffe-token-provider/security-spiffe-token-provider /

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /edgex-go
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-RUN apk add --update --no-cache make bash git ca-certificates zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk add --update --no-cache make bash git ca-certificates
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -35,7 +35,7 @@ RUN make cmd/support-notifications/support-notifications
 
 FROM alpine:3.14
 
-RUN apk add --update --no-cache ca-certificates dumb-init zeromq
+RUN apk add --update --no-cache ca-certificates dumb-init
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Cavium, Copyright (c) 2021: Intel Corporation'

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /edgex-go
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-RUN apk add --update --no-cache make git zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk add --update --no-cache make git
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -36,7 +36,7 @@ RUN make cmd/support-scheduler/support-scheduler
 
 FROM alpine:3.14
 
-RUN apk add --update --no-cache dumb-init zeromq
+RUN apk add --update --no-cache dumb-init
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2018: Dell, Cavium, Copyright (c) 2021: Intel Corporation'

--- a/cmd/sys-mgmt-agent/Dockerfile
+++ b/cmd/sys-mgmt-agent/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /edgex-go
 # So we can try these.
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
-RUN apk add --update --no-cache make bash git zeromq-dev libsodium-dev pkgconfig build-base
+RUN apk add --update --no-cache make bash git
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -33,7 +33,7 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2017-2019: Mainflux, Cavium, Dell, Copyright (c) 2021: Intel Corporation'
 
 # consul token needs to be security-bootstrappable and for security-bootstrappable, dumb-init is required
-RUN apk add --update --no-cache bash dumb-init py3-pip curl zeromq && \
+RUN apk add --update --no-cache bash dumb-init py3-pip curl && \
       pip install --no-cache-dir docker-compose==1.23.2
 
 ENV APP_PORT=58890

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.11
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.24
-	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.10
+	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12
 	github.com/edgexfoundry/go-mod-registry/v2 v2.2.0-dev.3
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.2.0-dev.6
 	github.com/fxamacker/cbor/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3 h1:dTTExUFHza9eJmTA
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0-dev.3/go.mod h1:YP17JhMnXTitowXE13QJwFaKo0oc03iyoKLjWAYl4FE=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.24 h1:u/VM+gUF1udOWPXYJcDpfGSpplMnZ3xqEaZdhcfIxPE=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.24/go.mod h1:jyfVSx7mI3u/o/oo10COxBRBvJ8O/9I3z2xAwPmNt/Q=
-github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.10 h1:/9Z2w7ebwJV+BKQb5pEyPmwIUQjdTjNuSGoYuc9DBzA=
-github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.10/go.mod h1:+X6C0h8ZTJe+lLU2AGJfiAzCJK3zL+yM6cej9VC+79E=
+github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12 h1:u4ndXe8j1xYR1+axSgcgbD2OGvx7Z9v9thv0KBZp2TI=
+github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.12/go.mod h1:+X6C0h8ZTJe+lLU2AGJfiAzCJK3zL+yM6cej9VC+79E=
 github.com/edgexfoundry/go-mod-registry/v2 v2.2.0-dev.3 h1:Z1sR4g+guLsUNJw3z3gxaz472wt0gYu1XCQ4frqJl/o=
 github.com/edgexfoundry/go-mod-registry/v2 v2.2.0-dev.3/go.mod h1:DUQRnAd5fVzoROc5SI+PTFUD/vCNeZmZHBMrLElbmwI=
 github.com/edgexfoundry/go-mod-secrets/v2 v2.2.0-dev.6 h1:yd/0MXP1E8c+Fp1Jn79T10zeYUWAbbwOhGTrq6CbYs4=


### PR DESCRIPTION
- use one INCLUDE_DELAYED_START_BUILD to control make build flag to include/exclude non_delayedstart build tag
- add conditional go build tag for non_delayedstart if those services are not needed
- use go build tag for no_messagebus to avoid CGO for core-services
- update readme for developer notes

Closes: #3952

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
make build to see the binary image size difference with non_delayedstart go build tags:
```
Without non_delayedstart flag (ie. include the delayed start in the build):
$ ls -al cmd/core-data/core-data 
-rwxrwxr-x 1 jim jim 27882688 Apr 13 16:55 cmd/core-data/core-data

Versus with non_delayedstart flag (ie. exclude the delayed start in the build):

$ ls -al cmd/core-data/core-data 
-rwxrwxr-x 1 jim jim 14113856 Apr 13 16:54 cmd/core-data/core-data

```


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->