### PR TITLE
feat: Make support services include spiffe in buildtime from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ GIT_SHA=$(shell git rev-parse HEAD)
 ARCH=$(shell uname -m)
 
 # DO NOT change the following flag, as it is automatically set based on the boolean switch INCLUDE_DELAYED_START_BUILD_CORE
-NON_DELAYED_START_GO_BUILD_TAG:=non_delayedstart
+NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE:=non_delayedstart
 ifeq ($(INCLUDE_DELAYED_START_BUILD_CORE),"true")
-	NON_DELAYED_START_GO_BUILD_TAG:=
+	NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE:=
 endif
 NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT:=
 ifeq ($(INCLUDE_DELAYED_START_BUILD_SUPPORT),"false")
@@ -86,43 +86,43 @@ tidy:
 	go mod tidy -compat=1.17
 
 cmd/core-metadata/core-metadata:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/core-metadata
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-metadata
 
 cmd/core-data/core-data:
-	$(GOCGO) build -tags "$(NON_DELAYED_START_GO_BUILD_TAG)" $(CGOFLAGS) -o $@ ./cmd/core-data
+	$(GOCGO) build -tags "$(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(CGOFLAGS) -o $@ ./cmd/core-data
 
 cmd/core-command/core-command:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/core-command
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-command
 
 cmd/support-notifications/support-notifications:
 	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-notifications
 
 cmd/sys-mgmt-executor/sys-mgmt-executor:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-executor
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-executor
 
 cmd/sys-mgmt-agent/sys-mgmt-agent:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-agent
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-agent
 
 cmd/support-scheduler/support-scheduler:
 	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-scheduler
 
 cmd/security-proxy-setup/security-proxy-setup:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/security-proxy-setup/security-proxy-setup ./cmd/security-proxy-setup
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o ./cmd/security-proxy-setup/security-proxy-setup ./cmd/security-proxy-setup
 
 cmd/security-secretstore-setup/security-secretstore-setup:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/security-secretstore-setup/security-secretstore-setup ./cmd/security-secretstore-setup
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o ./cmd/security-secretstore-setup/security-secretstore-setup ./cmd/security-secretstore-setup
 
 cmd/security-file-token-provider/security-file-token-provider:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/security-file-token-provider/security-file-token-provider ./cmd/security-file-token-provider
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o ./cmd/security-file-token-provider/security-file-token-provider ./cmd/security-file-token-provider
 
 cmd/secrets-config/secrets-config:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/secrets-config ./cmd/secrets-config
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o ./cmd/secrets-config ./cmd/secrets-config
 
 cmd/security-bootstrapper/security-bootstrapper:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/security-bootstrapper/security-bootstrapper ./cmd/security-bootstrapper
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o ./cmd/security-bootstrapper/security-bootstrapper ./cmd/security-bootstrapper
 
 cmd/security-spiffe-token-provider/security-spiffe-token-provider:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/security-spiffe-token-provider
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/security-spiffe-token-provider
 
 clean:
 	rm -f $(MICROSERVICES)

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@
 
 .PHONY: build clean unittest hadolint lint test docker run
 
-# change the following boolean flag to include or exclude the delayed start libs for builds
-INCLUDE_DELAYED_START_BUILD:="false"
+# change the following boolean flag to include or exclude the delayed start libs for builds for most of core services except support services
+INCLUDE_DELAYED_START_BUILD_CORE:="false"
+# change the following boolean flag to include or exclude the delayed start libs for builds for support services exculsively
+INCLUDE_DELAYED_START_BUILD_SUPPORT:="true"
 
 GO=CGO_ENABLED=0 GO111MODULE=on go
 
@@ -65,10 +67,14 @@ GIT_SHA=$(shell git rev-parse HEAD)
 
 ARCH=$(shell uname -m)
 
-# DO NOT change the following flag, as it is automatically set based on the boolean switch INCLUDE_DELAYED_START_BUILD
+# DO NOT change the following flag, as it is automatically set based on the boolean switch INCLUDE_DELAYED_START_BUILD_CORE
 NON_DELAYED_START_GO_BUILD_TAG:=non_delayedstart
-ifeq ($(INCLUDE_DELAYED_START_BUILD),"true")
+ifeq ($(INCLUDE_DELAYED_START_BUILD_CORE),"true")
 	NON_DELAYED_START_GO_BUILD_TAG:=
+endif
+NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT:=
+ifeq ($(INCLUDE_DELAYED_START_BUILD_SUPPORT),"false")
+	NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT:=non_delayedstart
 endif
 
 NO_MESSAGEBUS_GO_BUILD_TAG:=no_messagebus
@@ -89,7 +95,7 @@ cmd/core-command/core-command:
 	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/core-command
 
 cmd/support-notifications/support-notifications:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/support-notifications
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-notifications
 
 cmd/sys-mgmt-executor/sys-mgmt-executor:
 	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-executor
@@ -98,7 +104,7 @@ cmd/sys-mgmt-agent/sys-mgmt-agent:
 	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-agent
 
 cmd/support-scheduler/support-scheduler:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o $@ ./cmd/support-scheduler
+	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-scheduler
 
 cmd/security-proxy-setup/security-proxy-setup:
 	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG)" $(GOFLAGS) -o ./cmd/security-proxy-setup/security-proxy-setup ./cmd/security-proxy-setup

--- a/README.md
+++ b/README.md
@@ -117,11 +117,17 @@ make docker
 
 #### Delayed Start Go Builds For Developers
 
-Currently for EdgeX core services, the delayed start feature from the dependency go-mod-bootstrap / go-mod-secrets modules are excluded in go builds.
-If you want to **include** the delayed start feature in the builds, please change the [Makefile in this directory](Makefile). In particular, change the following boolean flag from `false` to `true` before the whole docker builds.
+Currently for EdgeX core services except support services (support-notification and support-scheduler services), the delayed start feature from the dependency go-mod-bootstrap / go-mod-secrets modules are excluded in go builds by default.
+If you want to **include** the delayed start feature in the builds for these services, please change the [Makefile in this directory](Makefile). In particular, change the following boolean flag from `false` to `true` before the whole docker builds.
 
 ```text
-INCLUDE_DELAYED_START_BUILD:="false"
+INCLUDE_DELAYED_START_BUILD_CORE:="false"
+```
+
+For support services, the delayed start feature is included by default as the default behavior of them are not started right away in Snap. Similarly, you can change the default and **exclude** it by modifying the boolean flag from `true` to `false` in the Makefile:
+
+```text
+INCLUDE_DELAYED_START_BUILD_SUPPORT:="true"
 ```
 
 #### Run 

--- a/cmd/security-spire-config/seed_builtin_entries.sh
+++ b/cmd/security-spire-config/seed_builtin_entries.sh
@@ -26,7 +26,7 @@ echo "SPIFFE_SERVER_SOCKET=${SPIFFE_SERVER_SOCKET}"
 echo "SPIFFE_EDGEX_SVID_BASE=${SPIFFE_EDGEX_SVID_BASE}"
 
 # add pre-authorized services into spire server entry
-for service in security-spiffe-token-provider \
+for service in security-spiffe-token-provider notifications scheduler \
     device-bacnet device-camera device-grove device-modbus device-mqtt device-rest device-snmp \
     device-virtual device-rfid-llrp device-coap device-gpio \
     app-service-http-export app-service-mqtt-export app-service-sample app-rfid-llrp-inventory \


### PR DESCRIPTION
- Add another variable flag for support serivces in makefile
- make support services use the default enabled delayed start in build time

Closes: #3968

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
run `make build` to see the size difference on the built images.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->