### PR TITLE
fix(metadata): not trigger DS callback if only lastConnected is updated

### DIFF
--- a/internal/core/metadata/application/deviceservice.go
+++ b/internal/core/metadata/application/deviceservice.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,6 +12,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/container"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/infrastructure/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/utils"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
@@ -77,6 +78,10 @@ func PatchDeviceService(dto dtos.UpdateDeviceService, ctx context.Context, dic *
 		"DeviceService patched on DB successfully. Correlation-ID: %s ",
 		correlation.FromContext(ctx),
 	)
+	// Don't invoke callback if only lastConnected field is updated
+	if dto.LastConnected != nil && utils.OnlyOneFieldUpdated("LastConnected", dto) {
+		return nil
+	}
 	go updateDeviceServiceCallback(ctx, dic, deviceService)
 	return nil
 }

--- a/internal/pkg/utils/struct.go
+++ b/internal/pkg/utils/struct.go
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2022 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"reflect"
+)
+
+func OnlyOneFieldUpdated(fieldName string, model interface{}) bool {
+	res := true
+
+	t := reflect.TypeOf(model)
+	v := reflect.ValueOf(model)
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Name != fieldName && f.Name != "Name" && f.Name != "Id" {
+			if !v.FieldByName(f.Name).IsNil() {
+				res = false
+				break
+			}
+		}
+	}
+
+	return res
+}

--- a/internal/pkg/utils/struct_test.go
+++ b/internal/pkg/utils/struct_test.go
@@ -1,0 +1,41 @@
+//
+// Copyright (C) 2022 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOnlyOneFieldUpdated(t *testing.T) {
+	testService := "test-service"
+	testDescription := "test-description"
+	testAdminState := models.Locked
+	oneUpdated := dtos.UpdateDeviceService{
+		Name:        &testService,
+		Description: &testDescription,
+	}
+	twoUpdated := oneUpdated
+	twoUpdated.AdminState = &testAdminState
+
+	tests := []struct {
+		name      string
+		fieldName string
+		model     interface{}
+		expected  bool
+	}{
+		{"valid", "Description", oneUpdated, true},
+		{"invalid - two fields are updated", "Description", twoUpdated, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, OnlyOneFieldUpdated(tt.fieldName, tt.model))
+		})
+	}
+}


### PR DESCRIPTION
fix #3641

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) n/a
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. run metadata from this branch
2. run device-virtual with `DEBUG` log level
3. verify PATCH `/api/v2/deviceprofile` will not trigger DS callback if only updating `lastConnected` field

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->