### PR TITLE
fix(security): Workaround for inconsistent app service naming in docker-compose

### DIFF
--- a/cmd/security-spire-config/seed_builtin_entries.sh
+++ b/cmd/security-spire-config/seed_builtin_entries.sh
@@ -26,12 +26,15 @@ echo "SPIFFE_SERVER_SOCKET=${SPIFFE_SERVER_SOCKET}"
 echo "SPIFFE_EDGEX_SVID_BASE=${SPIFFE_EDGEX_SVID_BASE}"
 
 # add pre-authorized services into spire server entry
-for service in security-spiffe-token-provider notifications scheduler \
+for dockerservice in security-spiffe-token-provider notifications scheduler \
     device-bacnet device-camera device-grove device-modbus device-mqtt device-rest device-snmp \
     device-virtual device-rfid-llrp device-coap device-gpio \
     app-service-http-export app-service-mqtt-export app-service-sample app-rfid-llrp-inventory \
     app-service-external-mqtt-trigger; do
-    spire-server entry create -socketPath "${SPIFFE_SERVER_SOCKET}" -parentID "${local_agent_svid}" -dns "edgex-${service}" -spiffeID "${SPIFFE_EDGEX_SVID_BASE}/${service}" -selector "docker:label:com.docker.compose.service:${service}"
+    # Temporary workaround because service name in dockerfile is not consistent with service key.
+    # TAF scripts depend on legacy docker-compose service name. Fix in EdgeX 3.0.
+    service=`echo -n ${dockerservice} | sed -e 's/app-service-/app-/'` 
+    spire-server entry create -socketPath "${SPIFFE_SERVER_SOCKET}" -parentID "${local_agent_svid}" -dns "edgex-${service}" -spiffeID "${SPIFFE_EDGEX_SVID_BASE}/${service}" -selector "docker:label:com.docker.compose.service:${dockerservice}"
 done
 
 # Always exit successfully even if couldn't (re-)create server entries.


### PR DESCRIPTION
app-service-http-export was unable to obtain a secret-store token because the SPIFFE token provided to the service contained app-service-http-export, but the service key for the service is app-http-export.  The inconsistency resulted in the request for a secret store token being denied.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Run docker-compose while enabling delayed start for app-service-http-export

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->