### PR TITLE
feat(snap): Add support for environment variable injection

### DIFF
--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
-	snaphookoptions "github.com/canonical/edgex-snap-hooks/v2/options"
 )
 
 const ( // iota is reset to 0
@@ -601,27 +600,4 @@ func configure() {
 			os.Exit(1)
 		}
 	}
-}
-
-func configureApps() {
-	hooks.Info("edgexfoundry:configure Processing apps.* and config.* configuration")
-	err := snaphookoptions.ProcessAppConfig(
-		"core-data",
-		"core-metadata",
-		"core-command",
-		"support-notifications",
-		"support-scheduler",
-		"app-service-configurable",
-		"device-virtual",
-		"security-secret-store",
-		"security-secretstore-setup",
-		"security-proxy-setup",
-		"security-bootstrapper",
-		"sys-mgmgt-agent")
-
-	if err != nil {
-		hooks.Error(fmt.Sprintf("edgexfoundry:configure could not process options: %v", err))
-		os.Exit(1)
-	}
-
 }

--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -605,7 +605,7 @@ func configure() {
 
 func configureApps() {
 	hooks.Info("edgexfoundry:configure Processing apps.* and config.* configuration")
-	err := snaphookoptions.ProcessOptions(
+	err := snaphookoptions.ProcessAppConfig(
 		"core-data",
 		"core-metadata",
 		"core-command",

--- a/snap/local/hooks/cmd/configure/configure.go
+++ b/snap/local/hooks/cmd/configure/configure.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	hooks "github.com/canonical/edgex-snap-hooks/v2"
+	snaphookoptions "github.com/canonical/edgex-snap-hooks/v2/options"
 )
 
 const ( // iota is reset to 0
@@ -600,4 +601,27 @@ func configure() {
 			os.Exit(1)
 		}
 	}
+}
+
+func configureApps() {
+	hooks.Info("edgexfoundry:configure Processing apps.* and config.* configuration")
+	err := snaphookoptions.ProcessOptions(
+		"core-data",
+		"core-metadata",
+		"core-command",
+		"support-notifications",
+		"support-scheduler",
+		"app-service-configurable",
+		"device-virtual",
+		"security-secret-store",
+		"security-secretstore-setup",
+		"security-proxy-setup",
+		"security-bootstrapper",
+		"sys-mgmgt-agent")
+
+	if err != nil {
+		hooks.Error(fmt.Sprintf("edgexfoundry:configure could not process options: %v", err))
+		os.Exit(1)
+	}
+
 }

--- a/snap/local/hooks/cmd/configure/main.go
+++ b/snap/local/hooks/cmd/configure/main.go
@@ -27,9 +27,10 @@ var cli *hooks.CtlCli = hooks.NewSnapCtl()
 func main() {
 	// no subcommand, as called by snapd
 	if len(os.Args) == 1 {
-		// configure everything
+		// process the EdgeX >=2.2 snap options
+		processAppOptions()
+		// configure everything else, incl. the legacy snap options
 		configure()
-		configureApps()
 		return
 	}
 

--- a/snap/local/hooks/cmd/configure/main.go
+++ b/snap/local/hooks/cmd/configure/main.go
@@ -29,6 +29,7 @@ func main() {
 	if len(os.Args) == 1 {
 		// configure everything
 		configure()
+		configureApps()
 		return
 	}
 

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,6 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3
+
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,6 +1,8 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5
 
+// replace github.com/canonical/edgex-snap-hooks/v2 => ./edgex-snap-hooks
+// replace github.com/canonical/edgex-snap-hooks/v2 => github.com/farshidtz/edgex-snap-hooks/v2 d43ccc771100d663099c8ca8e3974d78076b2058
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.1.3
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2
 
 go 1.17

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3
+require github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4
 
 
 go 1.17

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta h1:FblUp4/cn7Qk1PJzXR6NfN8eFAHLilVHv7eFCp6Jvv0=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2 h1:HMh7QgZaJmlu3kAEGEgr1PJTr8nbfsQSWLmYuWeuPhI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4 h1:mbHxD8lIv3ewSUSkwqXj4SEVek2bvw5Nh/+gngInscI=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5 h1:EDFjmHy8CG4T8uFPqD+Per8Hgk250PvRsMgEDCXjYtE=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.5/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3 h1:kQ7tGjA7k6iAfsvLRKpdoLy0zwsG+4Wqn3DNkbJrhZ8=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4 h1:mbHxD8lIv3ewSUSkwqXj4SEVek2bvw5Nh/+gngInscI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.4/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2 h1:HMh7QgZaJmlu3kAEGEgr1PJTr8nbfsQSWLmYuWeuPhI=
-github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.2/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3 h1:kQ7tGjA7k6iAfsvLRKpdoLy0zwsG+4Wqn3DNkbJrhZ8=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.1.3 h1:mcV/atn6k6sN6Uik+lSQGEZi4Q6r96epgBW+u6AGZ3Y=
-github.com/canonical/edgex-snap-hooks/v2 v2.1.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta h1:FblUp4/cn7Qk1PJzXR6NfN8eFAHLilVHv7eFCp6Jvv0=
+github.com/canonical/edgex-snap-hooks/v2 v2.2.0-beta/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/runtime-helpers/bin/security-proxy-post-setup.sh
+++ b/snap/local/runtime-helpers/bin/security-proxy-post-setup.sh
@@ -11,3 +11,6 @@ export PATH="$SNAP/bin:$PATH"
 # Several config options depend on resources that only exist after proxy 
 # setup. This re-applies the config options logic after deferred startup:
 $SNAP/snap/hooks/configure options --service=security-proxy
+
+# Process the EdgeX >=2.2 snap options
+$SNAP/snap/hooks/configure options --service=secrets-config


### PR DESCRIPTION
Supersceding #3924

This PR updates the snap to support environment variable injection as part of introducing the following scheme:
```
apps.<app>.<type>.<key>
```
where:
- `<app>` is the name of the app (service, executable)
- `<type>` is the type of option with respect to the app
- `<key>` is key for the option. It could contain a path to set a value inside an object, e.g. `x.y=z` sets `{"x": {"y": "z"}}`.


This change effectively makes options prefixed with `env.` deprecated. Such options will continue to work but be removed as of EdgeX 3.

The reasons for the schema change is as follows:
- The existing options depended on hardcoded mappings from keys to environment variables that was extremely hard to maintain. The new feature allows passing any environment variable dynamically.
- The environment variable passing was mixed with secrets-config executions causing various technical challanges and usability issues. With this change, the app configurations (via env files) use the `apps.<app>.config.` and `config.` prefixes exclusively.
- This makes it possible to extend the options for other settings (beyond config and secrets-config proxy), e.g. for controlling default service startup.

#### Environment Variables
The environment variable injection key uses the the following format:
- `apps.<app>.config.<env-var>`: setting app-specific env var ENV_VAR (e.g. `apps.core-data.config.service-port=1000`).
- `config.<env-var>`: setting global env vars by omitting the `apps.<app>` prefix (e.g. `config.service-host=localhost`, [`config.writable-loglevel=DEBUG`](https://docs.edgexfoundry.org/2.2/microservices/configuration/CommonEnvironmentVariables/#configuration-overrides))

Other `<env-var>` mapping examples:
- `edgex-startup-duration`: [`EDGEX_STARTUP_DURATION`](https://docs.edgexfoundry.org/2.2/microservices/configuration/CommonEnvironmentVariables/#edgex_startup_duration)
- `add-secretstore-tokens`: [`ADD_SECRETSTORE_TOKENS`](https://docs.edgexfoundry.org/2.2/security/Ch-Configuring-Add-On-Services/#configure-the-services-secret-store-to-use).

> The above design is restricted by snapd which supports only keys with lower-case letters, hypens, and dots. A dot is to define a parent-child relationship (`x.y=z` = `x={"y": "z"}`).

#### Secrets Proxy Options
New [secrets-config proxy](https://docs.edgexfoundry.org/2.2/security/secrets-config-proxy/) options:
- `apps.secrets-config.proxy.tls.cert` equivalent to `env.security-proxy.tls-certificate`
- `apps.secrets-config.proxy.tls.key` equivalent to `env.security-proxy.tls-private-key`
- `apps.secrets-config.proxy.tls.snis` equivalent to `env.security-proxy.tls-sni`
- `apps.secrets-config.proxy.admin.public-key` equivalent to `env.security-proxy.public-key` and `env.security-proxy.user=admin,1,ES256`

For usability purposes, the username, userid, algorithm of the single user have been hardcoded to admin, 1, ES256. This should be sufficient since we don't allow setting multiple users using snap options. The algorithm is set to ES256 rather than RS256, because it is more secure. If needed, it can be made configurable in future using keys `apps.secrets-config.proxy.admin.{user|id|algorithm}`.

#### Usage
**The new scheme is allowed only after opting-in by setting `config-enabled=true`.** It will be enabled by default as of EdgeX 3. 

Setting `config-enabled=true` will:
1. unset existing `env.` options and ignore future sets. 
2. convert:
    - `env.security-secret-store.add-secretstore-tokens` -> `apps.security-secretstore-setup.config.add-secretstore-tokens`
    - `env.security-secret-store.add-known-secrets` -> `apps.security-secretstore-setup.config.add-known-secrets`
    - `env.security-bootstrapper.add-registry-acl-roles` -> `apps.security-bootstrapper.config.add-registry-acl-roles`

---

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?) - [unit tests](https://github.com/canonical/edgex-snap-hooks/blob/main/options/options_test.go), [smoke tests](https://github.com/canonical/edgex-snap-testing/pull/53)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) - snap/README and docs will be updated in separate, future PRs 
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Install
```
snap install edgexfoundry --channel=edge/pr-3986
```

Run
```
sudo snap set edgexfoundry apps.core-data.config.service-port=1234
```
It should be rejected because `config-enabled` is not set.

Run
```
sudo snap set edgexfoundry config-enabled=true
sudo snap set edgexfoundry apps.core-data.config.service-port=8080
sudo snap set edgexfoundry config.service-startupmsg="testing env injection"
```

1) Confirm that all .env files have SERVICE_STARTUPMSG="testing env injection"
2) Confirm that the core-data .env file also has both the SERVICE_STARTUPMSG and SERVICE_PORT settings

```
$ cat /var/snap/edgexfoundry/current/config/core-data/res/core-data.env 
export SERVICE_STARTUPMSG=testing env injection
export SERVICE_PORT=8080
$ cat /var/snap/edgexfoundry/current/config/core-command/res/core-command.env 
export SERVICE_STARTUPMSG=testing env injection
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->