### PR TITLE
build(snap): exclude redundant eKuiper dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -848,11 +848,22 @@ parts:
     organize: 
       bin/setup-redis-credentials.sh: bin/kuiper-setup-redis-credentials.sh
     stage:
-      # Exclude redundant curl files
+      # Exclude redundant files
       - -usr/bin/curl
       - -usr/lib/*/libcurl*
+      - -usr/lib/*/liblber*
+      - -usr/lib/*/libldap*
+      - -usr/lib/*/libnorm*
+      - -usr/lib/*/libpgm*
+      - -usr/lib/*/libsodium*
+      - -usr/lib/*/libzmq*
       - -usr/share/doc/libcurl*
       - -usr/share/doc/curl
+      - -usr/share/doc/libldap*
+      - -usr/share/doc/libnorm*
+      - -usr/share/doc/libpgm*
+      - -usr/share/doc/libsodium*
+      - -usr/share/doc/libzmq*
 
   metadata:
     plugin: nil


### PR DESCRIPTION
Parts 'kuiper' and 'postgres' have some files with same file name, but with different contents

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->