### PR TITLE
fix(snap): Apply proxy's runtime config options after startup (Jakarta)

### DIFF
--- a/snap/local/hooks/cmd/configure/main.go
+++ b/snap/local/hooks/cmd/configure/main.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package main
+
+import (
+	"os"
+
+	hooks "github.com/canonical/edgex-snap-hooks/v2"
+)
+
+var cli *hooks.CtlCli = hooks.NewSnapCtl()
+
+func main() {
+	// no subcommand, as called by snapd
+	if len(os.Args) == 1 {
+		// configure everything
+		configure()
+		return
+	}
+
+	subCommand := os.Args[1]
+	switch subCommand {
+	case "options":
+		// configure options
+		options()
+	default:
+		panic("Unknown CLI sub-command: " + subCommand)
+	}
+}

--- a/snap/local/hooks/cmd/configure/options.go
+++ b/snap/local/hooks/cmd/configure/options.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0'
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	hooks "github.com/canonical/edgex-snap-hooks/v2"
+)
+
+func applyConfigOptions(service string) error {
+	envJSON, err := cli.Config(hooks.EnvConfig + "." + service)
+	if err != nil {
+		return fmt.Errorf("failed to read config options for %s: %v", service, err)
+	}
+
+	if envJSON != "" {
+		hooks.Debug(fmt.Sprintf("edgexfoundry:configure-options: service: %s envJSON: %s", service, envJSON))
+		if err := hooks.HandleEdgeXConfig(service, envJSON, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// options is called by the main function to configure options
+func options() {
+	flagset := flag.NewFlagSet("options", flag.ExitOnError)
+	service := flagset.String("service", "", "Handle config options of a single service only")
+	flagset.Parse(os.Args[2:])
+
+	fmt.Println("Configuring options for service: " + *service)
+
+	debug, err := cli.Config("debug")
+	if err != nil {
+		fmt.Println(fmt.Sprintf("edgexfoundry:configure-options: can't read value of 'debug': %v", err))
+		os.Exit(1)
+	}
+
+	if err = hooks.Init(debug == "true", "edgexfoundry"); err != nil {
+		fmt.Println(fmt.Sprintf("edgexfoundry:configure-options: initialization failure: %v", err))
+		os.Exit(1)
+	}
+
+	hooks.Info("edgexfoundry:configure-options: handling config options for a single service: " + *service)
+
+	if err := applyConfigOptions(*service); err != nil {
+		hooks.Error(fmt.Sprintf("edgexfoundry:configure-options: error handling config options for %s: %v", *service, err))
+		os.Exit(1)
+	}
+}

--- a/snap/local/hooks/go.mod
+++ b/snap/local/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/edgex-go/hooks
 
-require github.com/canonical/edgex-snap-hooks/v2 v2.1.1
+require github.com/canonical/edgex-snap-hooks/v2 v2.1.3
 
 go 1.16

--- a/snap/local/hooks/go.sum
+++ b/snap/local/hooks/go.sum
@@ -1,5 +1,5 @@
-github.com/canonical/edgex-snap-hooks/v2 v2.1.1 h1:qmDJ2RYd19I/NYwIdjqC/kWGVJWLcrT+h9NevB+Gz/A=
-github.com/canonical/edgex-snap-hooks/v2 v2.1.1/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
+github.com/canonical/edgex-snap-hooks/v2 v2.1.3 h1:mcV/atn6k6sN6Uik+lSQGEZi4Q6r96epgBW+u6AGZ3Y=
+github.com/canonical/edgex-snap-hooks/v2 v2.1.3/go.mod h1:rOxrwdYL7hJDhxFH3uV+nVgLPjWOhJWgM5PRD5YG1jI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/snap/local/runtime-helpers/bin/security-proxy-post-setup.sh
+++ b/snap/local/runtime-helpers/bin/security-proxy-post-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+# This script is called as a post-stop-command when
+# security-proxy-setup oneshot service stops.
+
+logger "edgexfoundry:security-proxy-post-setup"
+
+# add bin directory to have e.g. secret-config in PATH
+export PATH="$SNAP/bin:$PATH"
+
+# Several config options depend on resources that only exist after proxy 
+# setup. This re-applies the config options logic after deferred startup:
+$SNAP/snap/hooks/configure options --service=security-proxy

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -223,6 +223,7 @@ apps:
     command: bin/security-proxy-setup -confdir $SNAP_DATA/config/security-proxy-setup/res $INIT_ARG
     command-chain:
       - bin/service-config-overrides.sh
+    post-stop-command: bin/security-proxy-post-setup.sh
     environment:
       INIT_ARG: "--init=true"
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/security-proxy-setup/secrets-token.json


### PR DESCRIPTION
Cherry picked commit from Kamakura PR:
- #3856
---
Fixes https://github.com/edgexfoundry/edgex-go/issues/3863

* fix: add options subcommand to apply partial configuration
* build: bump github.com/canonical/edgex-snap-hooks/v2 to skip runtime config during defer-startup install mode
* feat: apply security-proxy runtime configurations after startup

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>
(cherry picked from commit 3825f82a080d30abbb2fcfe4d8a2f0ca2c9aa8e0)

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->