### PR TITLE
chore: Update Alpine download mirror

### DIFF
--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /edgex-go
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make git
 

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /edgex-go
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache zeromq-dev libsodium-dev pkgconfig build-base git
 
@@ -47,7 +47,7 @@ EXPOSE $APP_PORT
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache zeromq dumb-init
 COPY --from=builder /edgex-go/Attribution.txt /

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /edgex-go
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make git
 

--- a/cmd/security-bootstrapper/Dockerfile
+++ b/cmd/security-bootstrapper/Dockerfile
@@ -22,7 +22,7 @@ FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make git
 

--- a/cmd/security-proxy-setup/Dockerfile
+++ b/cmd/security-proxy-setup/Dockerfile
@@ -21,7 +21,7 @@ FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make git
 

--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -21,7 +21,7 @@ FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make git
 

--- a/cmd/security-spiffe-token-provider/Dockerfile
+++ b/cmd/security-spiffe-token-provider/Dockerfile
@@ -35,7 +35,7 @@ FROM alpine:3.15
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2022 Intel Corporation'
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 RUN apk update && apk --no-cache --update add dumb-init curl gcompat
 
 COPY --from=builder /edgex-go/Attribution.txt /

--- a/cmd/security-spire-agent/Dockerfile
+++ b/cmd/security-spire-agent/Dockerfile
@@ -21,7 +21,7 @@ FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make git build-base curl
 
@@ -51,7 +51,7 @@ FROM alpine:3.15
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2022 Intel Corporation'
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 RUN apk update && apk --no-cache --update add dumb-init openssl gcompat
 
 COPY --from=builder /usr/local/bin/spire-agent /usr/local/bin

--- a/cmd/security-spire-config/Dockerfile
+++ b/cmd/security-spire-config/Dockerfile
@@ -21,7 +21,7 @@ FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make git build-base curl
 
@@ -51,7 +51,7 @@ FROM alpine:3.15
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2022 Intel Corporation'
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 RUN apk update && apk --no-cache --update add dumb-init gcompat
 
 COPY --from=builder /usr/local/bin/spire-server /usr/local/bin

--- a/cmd/security-spire-server/Dockerfile
+++ b/cmd/security-spire-server/Dockerfile
@@ -21,7 +21,7 @@ FROM ${BUILDER_BASE} AS builder
 
 WORKDIR /edgex-go
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make git build-base curl
 
@@ -51,7 +51,7 @@ FROM alpine:3.15
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2022 Intel Corporation'
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 RUN apk update && apk --no-cache --update add dumb-init openssl gcompat
 
 COPY --from=builder /usr/local/bin/spire-server /usr/local/bin

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /edgex-go
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make bash git ca-certificates
 

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /edgex-go
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
 
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make git
 

--- a/cmd/sys-mgmt-agent/Dockerfile
+++ b/cmd/sys-mgmt-agent/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
 # So we can try these.
-RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 RUN apk add --update --no-cache make bash git
 


### PR DESCRIPTION
This PR updates the Alpine Linux mirror from `nl.alpinelinux.org` to `dl-4.alpinelinux.org` due to inconsistency issues in the package index that causes builds to fail.  This new site is officially listed in the mirror list at https://mirrors.alpinelinux.org/#mirror3 while the old one no longer is.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) N/A
- [ ] I have opened a PR for the related docs change (if not, why?) N/A
  <link to docs PR>

## Testing Instructions
`make docker`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->