### PR TITLE
feat: use different consul service policy rule for service role

### DIFF
--- a/internal/constants.go
+++ b/internal/constants.go
@@ -18,11 +18,12 @@ const (
 	BootTimeoutSecondsDefault = 30
 	BootRetrySecondsDefault   = 1
 	ConfigFileName            = "configuration.toml"
-	ConfigStemApp             = "edgex/appservices/"
-	ConfigStemCore            = "edgex/core/"
-	ConfigStemDevice          = "edgex/devices/"
-	ConfigStemSecurity        = "edgex/security/"
-	LogDurationKey            = "duration"
+	// TODO: move the config stem constants in go-mod-contracts
+	ConfigStemApp      = "edgex/appservices/"
+	ConfigStemCore     = "edgex/core/"
+	ConfigStemDevice   = "edgex/devices/"
+	ConfigStemSecurity = "edgex/security/"
+	LogDurationKey     = "duration"
 )
 
 const (

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -18,7 +18,9 @@ const (
 	BootTimeoutSecondsDefault = 30
 	BootRetrySecondsDefault   = 1
 	ConfigFileName            = "configuration.toml"
+	ConfigStemApp             = "edgex/appservices/"
 	ConfigStemCore            = "edgex/core/"
+	ConfigStemDevice          = "edgex/devices/"
 	ConfigStemSecurity        = "edgex/security/"
 	LogDurationKey            = "duration"
 )


### PR DESCRIPTION
Closes: #3257

Signed-off-by: Jim Wang (Intel) <yutsung.jim.wang@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) same unit test for regression and make test still works
- [x ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. git clone this branch and build security-bootstrapper docker image: `make docker_security_bootstrapper`
2. go to `edgex-compse` repo and use this local built image for security-bootstrapper in the docker-compose file, i.e.: `make gen dev` or run it with `make run dev`
3. run it up with docker-compose or `make run dev`
4. once the stack is up, please obtain the consul admin token via `make get-consul-acl-token` and we will use it to verify policies and tokens were generated by login into consul UI and check them.
5. Use consul admin token to login consul in any browser at `http://localhost:8500`
6. After login, go to Policy view (click on `Policies` hyperlink on the left panel) and check that policies were generated for all services, something looks like the following:
![consul_policies_per_service](https://user-images.githubusercontent.com/25697718/181113040-872cefbc-b82e-4c31-b58e-62ae11611805.PNG)

8. Then go to Token view (click on `Tokens` hyperlink on the left panel)  and check that consul tokens were generated per service policy:
 ![consul_tokens_per_service](https://user-images.githubusercontent.com/25697718/181113152-58c87902-6ae3-4941-b6bc-340f02461d9b.PNG)

9. Now we can test the key-value store only accessible to its own service per kv api point of view: copy the app-http-export's consul token and export it and then use it to read some key of its own:
```
# use http-export's consul token
export CONSUL_TOKEN=057fcff7-2a4e-15ab-a115-e64cda7f28b9
curl -H "X-Consul-Token:${CONSUL_TOKEN}" -X GET "http://localhost:8500/v1/kv/edgex/appservices/2.0/app-http-export/Database/Host"

[{"LockIndex":0,"Key":"edgex/appservices/2.0/app-http-export/Database/Host","Flags":0,"Value":"ZWRnZXgtcmVkaXM=","CreateIndex":548,"ModifyIndex":548}]
```
as we can see its own consul token works for kv read, now we can also test kv write for its own key:
```
curl -H "X-Consul-Token:${CONSUL_TOKEN}" -X PUT "http://localhost:8500/v1/kv/edgex/appservices/2.0/app-http-export/Database/Host" -d 'test consul'

true
```
10. Now we use different consul token from other service to test if kv read is restricted or not:
```
export CONSUL_TOKEN=3c7f7fd0-7170-4c8a-4c4c-f36f5a672f15
try to read app-http-export:
curl -H "X-Consul-Token:${CONSUL_TOKEN}" -X GET "http://localhost:8500/v1/kv/edgex/appservices/2.0/app-http-export/Database/Host"
Permission denied: token with AccessorID '154e821e-325b-2681-a45f-6e3ca6141b77' lacks permission 'key:read' on "edgex/appservices/2.0/app-http-export/Database/Host"
```
so kv read is permission denied when we use other's consul token to access read it.

12. And we can also test the kv write using other consul token:
```
curl -H "X-Consul-Token:${CONSUL_TOKEN}" -X PUT "http://localhost:8500/v1/kv/edgex/appservices/2.0/app-http-export/Database/Host" -d 'edgex-redis'
Permission denied: token with AccessorID '154e821e-325b-2681-a45f-6e3ca6141b77' lacks permission 'key:write' on "edgex/appservices/2.0/app-http-export/Database/Host"
```
again, the kv write permission is denied as we intended it to.


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->