### PR TITLE
fix: add missing edgex/security config stem resolution in security-consul-bootstrapper

### DIFF
--- a/internal/security/bootstrapper/command/setupacl/command.go
+++ b/internal/security/bootstrapper/command/setupacl/command.go
@@ -301,8 +301,8 @@ func (c *cmd) createEdgeXACLTokenRoles(bootstrapACLTokenID, secretstoreToken str
 }
 
 // getKeyPrefix get the consul ACL key prefix for the service with the input roleName, ie. the service key-based
-// Currently we support 2 types of custom services: app and device services
-// if the input role name does not fall into the above two types, then it is categorized into core type for the key prefix
+// Currently we support 3 types of services: app services, device services, and security services
+// if the input role name does not fall into the above types, then it is categorized into core type for the key prefix
 func (c *cmd) getKeyPrefix(roleName string) string {
 	if strings.HasPrefix(roleName, "app-") {
 		return internal.ConfigStemApp + baseBootStrapConfig.ConfigVersion + "/" + roleName
@@ -310,6 +310,10 @@ func (c *cmd) getKeyPrefix(roleName string) string {
 
 	if strings.HasPrefix(roleName, "device-") {
 		return internal.ConfigStemDevice + baseBootStrapConfig.ConfigVersion + "/" + roleName
+	}
+
+	if strings.HasPrefix(roleName, "security-") {
+		return internal.ConfigStemSecurity + baseBootStrapConfig.ConfigVersion + "/" + roleName
 	}
 
 	// anything else falls into the 3rd category: core bucket


### PR DESCRIPTION
bug fixes

Fixes: #4109

Signed-off-by: Jim Wang (Intel) <yutsung.jim.wang@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) same unit tests for regression
- [x ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. when using docker-compose please include security-spiffe-token-provider in the edgex-compose builder, i.e.: `make run dev delayed-start`  or `make gen dev delayed-start`
2. compose it up if using make gen
3. observed that the spiffe-token-provider runs without error log message, ie. `docker logs edgex-security-spiffe-token-provider` 

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->