### PR TITLE
ci: add local cache to optimize local docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 docs
 *.snap
+.git


### PR DESCRIPTION
This PR adds a local docker image as a cache layer when using the make docker* targets. The local cache image uses this [Dockerfile](https://github.com/edgexfoundry/ci-build-images/blob/golang-1.18/Dockerfile) and if the Dockerfile is not available for some reason will fallback to building the image from the `golang:1.18-alpine` image. This local caching layer greatly increases the current local `make docker` speed from ~15m for a clean build down to ~7m. This solution was presented in the last DevOps WG meeting and more information on the change can be seen in the recording [here](https://zoom.us/rec/share/7nAS0u0iQFCPyxPvWK96xPEb1iS0TwLj5zk_csnBIXXua8hW8uPrtWvPQF8a4-Jk.KrPKufpGdX7Gg-SH?startTime=1658419196000).

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->