### PR TITLE
refactor: Switch from docker to alpine base image for sys-mgmt-agent

### DIFF
--- a/cmd/sys-mgmt-agent/Dockerfile
+++ b/cmd/sys-mgmt-agent/Dockerfile
@@ -27,13 +27,13 @@ RUN make cmd/sys-mgmt-agent/sys-mgmt-agent
 RUN make cmd/sys-mgmt-executor/sys-mgmt-executor
 
 # Get the Docker-in-Docker image layered-in now.
-FROM docker:20.10.14
+FROM alpine:3.16
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2017-2019: Mainflux, Cavium, Dell, Copyright (c) 2021: Intel Corporation'
 
 # consul token needs to be security-bootstrappable and for security-bootstrappable, dumb-init is required
-RUN apk add --update --no-cache bash dumb-init py3-pip curl && \
+RUN apk add --update --no-cache bash dumb-init py3-pip curl docker-cli && \
       pip install --no-cache-dir docker-compose==1.23.2
 
 ENV APP_PORT=58890


### PR DESCRIPTION
Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

I got tired of having to update the Dockerfile for sys-mgmt-agent due to Snyk vulnerabilities in the docker base image.
I have switched to using the alpine base image with the docker-cli and docker-compose installed.
Image size is reduced from 294MB to 135MB, which is a 54% savings.
With the reduced number of dependencies, CVE exposure should be significantly curtailed;
otherwise, we need to update the base image AGAIN.

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) n/a
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) See testing note below.  Basic smoke test.
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
I spawned edge-ui-go and exercised system maangement functionality and  it doesn't appear to be impaired in any way.
More detailed testing is required.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->