### PR TITLE
fix: Add backwards compatability for Device System Events

### DIFF
--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -1,3 +1,8 @@
+# This is required for backwards compatibility so new version of sevice using older 2.x configuration will not fail bootstrapping
+# This will default to false if not provided in old config. Messagebus is now needed by Device System Events and Service Metrics
+# TODO: Remove this setting EdgeX 3.0
+RequireMessageBus = true
+
 [Writable]
 LogLevel = "INFO"
   [Writable.ProfileChange]

--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -256,7 +256,7 @@ func DevicesByProfileName(offset int, limit int, profileName string, dic *di.Con
 	return devices, totalCount, nil
 }
 
-var noMessagingClientError = goErrors.New(": MessageBus Client not available")
+var noMessagingClientError = goErrors.New("MessageBus Client not available. Please update RequireMessageBus and MessageQueue configuration to enable sending System Events via the EdgeX MessageBus")
 
 func publishDeviceSystemEvent(action string, owner string, d models.Device, ctx context.Context, lc logger.LoggingClient, dic *di.Container) {
 	device := dtos.FromDeviceModelToDTO(d)
@@ -264,7 +264,9 @@ func publishDeviceSystemEvent(action string, owner string, d models.Device, ctx 
 
 	messagingClient := bootstrapContainer.MessagingClientFrom(dic.Get)
 	if messagingClient == nil {
-		lc.Errorf("unable to publish Device System Event: %v", noMessagingClientError)
+		// For 2.x this is a warning due to backwards compatability
+		// TODO: For change this to be Errorf for EdgeX 3.0
+		lc.Warnf("unable to publish Device System Event: %v", noMessagingClientError)
 		return
 	}
 

--- a/internal/core/metadata/application/device_test.go
+++ b/internal/core/metadata/application/device_test.go
@@ -106,7 +106,8 @@ func TestPublishDeviceSystemEvent(t *testing.T) {
 			}
 
 			if test.ClientMissing {
-				mockLogger.On("Errorf", mock.Anything, mock.Anything).Return()
+				// TODO: Change to Errorf in EdgeX 3.0
+				mockLogger.On("Warnf", mock.Anything, mock.Anything).Return()
 				dic.Update(di.ServiceConstructorMap{
 					bootstrapContainer.MessagingClientName: func(get di.Get) interface{} {
 						return nil
@@ -131,7 +132,8 @@ func TestPublishDeviceSystemEvent(t *testing.T) {
 			publishDeviceSystemEvent(test.Action, expectedDevice.ServiceName, expectedDevice, ctx, mockLogger, dic)
 
 			if test.ClientMissing {
-				mockLogger.AssertCalled(t, "Errorf", mock.Anything, noMessagingClientError)
+				// TODO: Change to Errorf in EdgeX 3.0
+				mockLogger.AssertCalled(t, "Warnf", mock.Anything, noMessagingClientError)
 				return
 			}
 

--- a/internal/core/metadata/config/config.go
+++ b/internal/core/metadata/config/config.go
@@ -20,14 +20,16 @@ import (
 
 // Struct used to parse the JSON configuration file
 type ConfigurationStruct struct {
-	Writable      WritableInfo
-	Clients       map[string]bootstrapConfig.ClientInfo
-	Databases     map[string]bootstrapConfig.Database
-	Notifications NotificationInfo
-	Registry      bootstrapConfig.RegistryInfo
-	Service       bootstrapConfig.ServiceInfo
-	MessageQueue  bootstrapConfig.MessageBusInfo
-	SecretStore   bootstrapConfig.SecretStoreInfo
+	//TODO: Remove in EdgeX 3.0 - Is needed now for backward compatability in 2.0
+	RequireMessageBus bool
+	Writable          WritableInfo
+	Clients           map[string]bootstrapConfig.ClientInfo
+	Databases         map[string]bootstrapConfig.Database
+	Notifications     NotificationInfo
+	Registry          bootstrapConfig.RegistryInfo
+	Service           bootstrapConfig.ServiceInfo
+	MessageQueue      bootstrapConfig.MessageBusInfo
+	SecretStore       bootstrapConfig.SecretStoreInfo
 }
 
 type WritableInfo struct {

--- a/internal/core/metadata/main.go
+++ b/internal/core/metadata/main.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"context"
 	"os"
+	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
@@ -72,7 +73,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		true,
 		[]interfaces.BootstrapHandler{
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
-			handlers.MessagingBootstrapHandler,
+			MessageBusBootstrapHandler,
 			NewBootstrap(router, common.CoreMetaDataServiceKey).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,
@@ -99,4 +100,17 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 	if deferred != nil {
 		deferred()
 	}
+}
+
+// MessageBusBootstrapHandler sets up the MessageBus connection if MessageBus required is true.
+// This is required for backwards compatability with older versions of 2.x configuration
+// TODO: Remove in EdgeX 3.0
+func MessageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
+	configuration := container.ConfigurationFrom(dic.Get)
+	if configuration.RequireMessageBus {
+		return handlers.MessagingBootstrapHandler(ctx, wg, startupTimer, dic)
+	}
+
+	// Not required so do nothing
+	return true
 }


### PR DESCRIPTION
fixes #4117

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  TBD

## Testing Instructions
Run Non-secure EdgeX Stack from compose builder
```
make run no-secty ds-virtual ds-rest`
```
Stop Core Metadata
In Consul, remove `MessageQueue` configuration for Core Metadata
Using the branch for this PR
Remove `MessageQueue` and `RequireMessageBus` configuration from TOML file
Build Core Metadata docker image locally
Modify generated compose file to switch Core Metadata image to be local image
Restart local Core Metadata image using modified compose file
```
make up
```
Verify Core Metadata logs don't show anything about MessageBus and started without error 
Using Edgex UI delete a device
Verify that Core Metadata logs show warning that the Device System Event couldn't be published.

Stop Core Metadata image
Remove Core Metadata config from Consul
Restore local TOML file
Rebuild local Core Metadata image
Restart local Core Metadata image using modified compose file
```
make up
```
Verify Core Metadata logs do  show MessageBus connection info and started without error
Using Consul set Core Metadata log level to Debug
Using Edgex UI delete a device
Verify that Core Metadata logs show debug message that the Device System Event was published.



## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->