### PR TITLE
fix(snap): Install Unit of Measure config file on upgrade

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -2,19 +2,21 @@
 
 TAG=$SNAP_INSTANCE_NAME.$(basename "$0")
 
-# read the version info set in the pre-refresh hook
-lastrev=$(snapctl get lastrev)
-lastver=$(snapctl get lastver)
+# read revision/version of the previous installation, set in the pre-refresh hook
+pre_rev=$(snapctl get pre-refresh.revision)
+pre_ver=$(snapctl get pre-refresh.version)
+# read the revision from the legacy lastrev option (EdgeX <2.3)
+[ -z "$pre_rev" ] && pre_rev=$(snapctl get lastrev)
 
-logger --tag $TAG "Refreshing from $lastver ($lastrev) to $SNAP_VERSION ($SNAP_REVISION)"
+logger --tag $TAG "Refreshing from $pre_ver ($pre_rev) to $SNAP_VERSION ($SNAP_REVISION)"
 
 # set up postgres, if we are upgrading it
 $SNAP/bin/kong-postgres-setup.sh "post-refresh"
 
 # Install the Unit of Measure config file when upgrading from an old version
-# UoM was added in v2.3.0-dev.45 (snap revision 3900)
+# UoM was added in v2.3.0-dev.45 (snap revision 3900):
 # https://github.com/edgexfoundry/edgex-go/pull/4119
-if (( lastrev < 3900 )); then
+if (( pre_rev < 3900 )); then
     uom="config/core-metadata/res/uom.toml"
     logger --tag $TAG "Installing $SNAP/$uom"
     if [ -f "$SNAP/$uom" ]; then

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,4 +1,26 @@
 #!/bin/bash -e
 
+TAG=$SNAP_INSTANCE_NAME.$(basename "$0")
+
+# read the version info set in the pre-refresh hook
+lastrev=$(snapctl get lastrev)
+lastver=$(snapctl get lastver)
+
+logger --tag $TAG "Refreshing from $lastver ($lastrev) to $SNAP_VERSION ($SNAP_REVISION)"
+
 # set up postgres, if we are upgrading it
 $SNAP/bin/kong-postgres-setup.sh "post-refresh"
+
+# Install the Unit of Measure config file when upgrading from an old version
+# UoM was added in v2.3.0-dev.45 (snap revision 3900)
+# https://github.com/edgexfoundry/edgex-go/pull/4119
+if (( lastrev < 3900 )); then
+    uom="config/core-metadata/res/uom.toml"
+    logger --tag $TAG "Installing $SNAP/$uom"
+    if [ -f "$SNAP/$uom" ]; then
+        # --no-clobber: copy if missing from target
+        cp --no-clobber "$SNAP/$uom" "$SNAP_DATA/$uom"
+    else
+        logger --stderr --tag $TAG "$SNAP/$uom does not exit."
+    fi
+fi

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -5,7 +5,7 @@ snapctl set pre-refresh.revision=$SNAP_REVISION
 snapctl set pre-refresh.version=$SNAP_VERSION
 
 # unset legacy EdgeX <2.3 options
-snapctl unset lastrev refresh
+snapctl unset lastrev release
 
  # back up the Kong database, so that if the new snap contains a newer
  # postgresql, then the configuration can be imported into the new database

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,9 +1,8 @@
 #!/bin/bash -e
 
-# save this revision for when we run again in the post-refresh
+# save these for use in the post-refresh hook
 snapctl set lastrev="$SNAP_REVISION"
-
-snapctl set release="jakarta"
+snapctl set lastver=$SNAP_VERSION
  
  # back up the Kong database, so that if the new snap contains a newer
  # postgresql, then the configuration can be imported into the new database

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,9 +1,12 @@
 #!/bin/bash -e
 
 # save these for use in the post-refresh hook
-snapctl set lastrev="$SNAP_REVISION"
-snapctl set lastver=$SNAP_VERSION
- 
+snapctl set pre-refresh.revision=$SNAP_REVISION
+snapctl set pre-refresh.version=$SNAP_VERSION
+
+# unset legacy EdgeX <2.3 options
+snapctl unset lastrev refresh
+
  # back up the Kong database, so that if the new snap contains a newer
  # postgresql, then the configuration can be imported into the new database
  # in the post-refresh hook.


### PR DESCRIPTION
PR #4119 added the following environment variable:
https://github.com/edgexfoundry/edgex-go/blob/166620d9f56c7df6403b4f88f57b6f2fdd40f3fd/snap/snapcraft.yaml#L278

This makes the edge releases of snap backward incompatible as of v2.3.0-dev.45 because this file doesn't exist when upgrading from an older version. The latest snap beta release which isn't broken is 2.3.0-dev.44 (snap rev 5898/5899). This fix works when upgrading from the latest beta or older.

This PR adds the logic to add the configuration file when upgrading (i.e. using `snap refresh`).

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Reproduce the error:
```
$ snap install edgexfoundry --channel=latest/stable
edgexfoundry 2.2.0+2 from Canonical✓ installed

$ snap refresh edgexfoundry --channel=latest/edge
edgexfoundry (edge) 2.3.0-dev.46 from Canonical✓ refreshed

$ snap logs -n 100 edgexfoundry.core-metadata | grep -i ERROR
2022-08-15T16:16:26+02:00 edgexfoundry.core-metadata[386550]: level=ERROR ts=2022-08-15T14:16:26.714636738Z app=core-metadata source=httpserver.go:143 msg="Web server failed: http: Server closed"
2022-08-15T16:17:40+02:00 edgexfoundry.core-metadata[388065]: level=ERROR ts=2022-08-15T14:17:40.24683483Z app=core-metadata source=bootstrap.go:42 msg="could not load unit of measure configuration file (/var/snap/edgexfoundry/3904/config/core-metadata/res/uom.toml): open /var/snap/edgexfoundry/3904/config/core-metadata/res/uom.toml: no such file or directory"
```

Test the changes using the snap built from this branch:
```
$ snap install edgexfoundry --channel=latest/stable
edgexfoundry 2.2.0+2 from Canonical✓ installed

$ snap refresh edgexfoundry --channel=latest/edge/pr-4125
edgexfoundry (edge/pr-4125) 2.3.0-dev.46 from Canonical✓ refreshed

$ snap logs -n 2 edgexfoundry.core-metadata 
2022-08-15T16:25:57+02:00 edgexfoundry.core-metadata[395550]: level=INFO ts=2022-08-15T14:25:57.308622394Z app=core-metadata source=message.go:55 msg="This is the EdgeX Core Metadata Microservice"
2022-08-15T16:25:57+02:00 edgexfoundry.core-metadata[395550]: level=INFO ts=2022-08-15T14:25:57.308628766Z app=core-metadata source=message.go:58 msg="Service started in: 85.428935ms"

$ sudo journalctl -n 100 | grep post-refresh
systemd[1]: Started snap.edgexfoundry.hook.post-refresh.0409b2f7-0d0b-42dd-97e5-e865eaf1dece.scope.
edgexfoundry.post-refresh[394831]: Refreshing from  (3722) to 2.3.0-dev.46 (3912)
...
edgexfoundry.post-refresh[394843]: Installing /snap/edgexfoundry/3912/config/core-metadata/res/uom.toml
systemd[1]: snap.edgexfoundry.hook.post-refresh.0409b2f7-0d0b-42dd-97e5-e865eaf1dece.scope: Deactivated successfully.
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->