### PR TITLE
build: Add option to build Core/Support services with NATS Capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,24 +89,27 @@ LOCAL_CACHE_IMAGE=edgex-go-local-cache
 
 build: $(MICROSERVICES)
 
+build-nats:
+	make -e ADD_BUILD_TAGS=include_nats_messaging build
+
 tidy:
 	go mod tidy
 
 metadata: cmd/core-metadata/core-metadata
 cmd/core-metadata/core-metadata:
-	$(GO) build -tags "$(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-metadata
+	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-metadata
 
 data: cmd/core-data/core-data
 cmd/core-data/core-data:
-	$(GOCGO) build -tags "$(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(CGOFLAGS) -o $@ ./cmd/core-data
+	$(GOCGO) build -tags "$(ADD_BUILD_TAGS) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(CGOFLAGS) -o $@ ./cmd/core-data
 
 command: cmd/core-command/core-command
 cmd/core-command/core-command:
-	$(GO) build -tags "$(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-command
+	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-command
 
 notifications: cmd/support-notifications/support-notifications
 cmd/support-notifications/support-notifications:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-notifications
+	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-notifications
 
 cmd/sys-mgmt-executor/sys-mgmt-executor:
 	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-executor
@@ -116,7 +119,7 @@ cmd/sys-mgmt-agent/sys-mgmt-agent:
 
 scheduler: cmd/support-scheduler/support-scheduler
 cmd/support-scheduler/support-scheduler:
-	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-scheduler
+	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-scheduler
 
 proxy: cmd/security-proxy-setup/security-proxy-setup
 cmd/security-proxy-setup/security-proxy-setup:
@@ -164,6 +167,9 @@ test: unittest hadolint lint
 
 docker: $(DOCKERS)
 
+docker-nats:
+	make -e ADD_BUILD_TAGS=include_nats_messaging docker
+
 clean_docker_base:
 	docker rmi -f $(LOCAL_CACHE_IMAGE) $(LOCAL_CACHE_IMAGE_BASE) 
 
@@ -182,6 +188,7 @@ docker_base:
 dmetadata: docker_core_metadata
 docker_core_metadata: docker_base
 	docker build \
+		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -194,6 +201,7 @@ docker_core_metadata: docker_base
 ddata: docker_core_data
 docker_core_data: docker_base
 	docker build \
+		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -206,6 +214,7 @@ docker_core_data: docker_base
 dcommand: docker_core_command
 docker_core_command: docker_base
 	docker build \
+		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -218,6 +227,7 @@ docker_core_command: docker_base
 dnotifications: docker_support_notifications
 docker_support_notifications: docker_base
 	docker build \
+		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -230,6 +240,7 @@ docker_support_notifications: docker_base
 dscheduler: docker_support_scheduler
 docker_support_scheduler: docker_base
 	docker build \
+		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 
 EdgeX Foundry is a vendor-neutral open source project hosted by The Linux Foundation building a common open framework for IoT edge computing.  At the heart of the project is an interoperability framework hosted within a full hardware- and OS-agnostic reference software platform to enable an ecosystem of plug-and-play components that unifies the marketplace and accelerates the deployment of IoT solutions.  This repository contains the Go implementation of EdgeX Foundry microservices.  It also includes files for building the services, containerizing the services, and initializing (bootstrapping) the services.
 
+## Build with NATS Messaging
+Currently, the NATS Messaging capability (NATS MessageBus) is opt-in at build time. This means that the published Docker images and Snaps do not include the NATS messaging capability.
+
+The following make commands will build the local binaries or local Docker images with NATS messaging capability included for the Core and Support services.
+
+```makefile
+make build-nats
+make docker-nats
+```
+
+The locally built Docker images can then be used in place of the published Docker images in your compose file.
+See [Compose Builder](https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder#gen) `nat-bus` option to generate compose file for NATS and local dev images.
+
 ## Get Started
 
 EdgeX provides docker images in our organization's [DockerHub page](https://hub.docker.com/u/edgexfoundry/).

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -19,6 +19,8 @@
 ARG BUILDER_BASE=golang:1.18-alpine3.16
 FROM ${BUILDER_BASE} AS builder
 
+ARG ADD_BUILD_TAGS=""
+
 WORKDIR /edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -32,7 +34,7 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
-RUN make cmd/core-command/core-command
+RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS  cmd/core-command/core-command
 
 FROM alpine:3.16
 

--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -61,16 +61,22 @@ Type = "consul"
     InternalRequestQueryTopic = "/commandquery/request"   # for subscribing to internal command query requests
     InternalResponseQueryTopic = "/commandquery/response"   # for publishing reponsses back to internal service
     [MessageQueue.Internal.Optional]
-    # Client Identifiers
+    # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
     ClientId ="core-command"
-    # Connection information
-    Qos          =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
-    KeepAlive    =  "10" # Seconds (must be 2 or greater)
-    Retained     = "false"
-    AutoReconnect  = "true"
+    Qos =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+    KeepAlive = "10" # Seconds (must be 2 or greater)
+    Retained = "false"
+    AutoReconnect = "true"
     ConnectTimeout = "5" # Seconds
-    # TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified
     SkipCertVerify = "false"
+    # Additional Default NATS Specific options that need to be here to enable evnironment variable overrides of them
+    Format = "nats"
+    RetryOnFailedConnect = "true"
+    QueueGroup = ""
+    Durable = ""
+    AutoProvision = "true"
+    Deliver = "new"
+    DefaultPubRetryAttempts = "2"
   [MessageQueue.External]
   Url = "tcp://localhost:1883"
   ClientId = "core-command"

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -20,6 +20,8 @@
 ARG BUILDER_BASE=golang:1.18-alpine3.16
 FROM ${BUILDER_BASE} AS builder
 
+ARG ADD_BUILD_TAGS=""
+
 WORKDIR /edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -33,7 +35,7 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
-RUN make cmd/core-data/core-data
+RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/core-data/core-data
 
 #Next image - Copy built Go binary into new workspace
 FROM alpine:3.16

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -62,16 +62,21 @@ SubscribeEnabled = true
 SubscribeTopic = "edgex/events/device/#"  # required for subscribing to Events from MessageBus
   [MessageQueue.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
-  # Client Identifiers
   ClientId ="core-data"
-  # Connection information
-  Qos          =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
-  KeepAlive    =  "10" # Seconds (must be 2 or greater)
-  Retained     = "false"
-  AutoReconnect  = "true"
+  Qos =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+  KeepAlive = "10" # Seconds (must be 2 or greater)
+  Retained = "false"
+  AutoReconnect = "true"
   ConnectTimeout = "5" # Seconds
-  # TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified
   SkipCertVerify = "false"
+  # Additional Default NATS Specific options that need to be here to enable evnironment variable overrides of them
+  Format = "nats"
+  RetryOnFailedConnect = "true"
+  QueueGroup = ""
+  Durable = ""
+  AutoProvision = "true"
+  Deliver = "new"
+  DefaultPubRetryAttempts = "2"
 
 [SecretStore]
 Type = "vault"

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -19,6 +19,8 @@
 ARG BUILDER_BASE=golang:1.18-alpine3.16
 FROM ${BUILDER_BASE} AS builder
 
+ARG ADD_BUILD_TAGS=""
+
 WORKDIR /edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.
@@ -32,7 +34,7 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
-RUN make cmd/core-metadata/core-metadata
+RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/core-metadata/core-metadata
 
 #Next image - Copy built Go binary into new workspace
 FROM alpine:3.16

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -76,16 +76,21 @@ AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecu
 SecretName = "redisdb"
   [MessageQueue.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
-  # Client Identifiers
   ClientId ="core-metadata"
-  # Connection information
-  Qos          =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
-  KeepAlive    =  "10" # Seconds (must be 2 or greater)
-  Retained     = "false"
-  AutoReconnect  = "true"
+  Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+  KeepAlive = "10" # Seconds (must be 2 or greater)
+  Retained = "false"
+  AutoReconnect = "true"
   ConnectTimeout = "5" # Seconds
-  # TLS configuration - Only used if Cert/Key file or Cert/Key PEMblock are specified
   SkipCertVerify = "false"
+  # Additional Default NATS Specific options that need to be here to enable evnironment variable overrides of them
+  Format = "nats"
+  RetryOnFailedConnect = "true"
+  QueueGroup = ""
+  Durable = ""
+  AutoProvision = "true"
+  Deliver = "new"
+  DefaultPubRetryAttempts = "2"
 
 [SecretStore]
 Type = "vault"

--- a/cmd/support-notifications/Dockerfile
+++ b/cmd/support-notifications/Dockerfile
@@ -18,6 +18,8 @@
 ARG BUILDER_BASE=golang:1.18-alpine3.16
 FROM ${BUILDER_BASE} AS builder
 
+ARG ADD_BUILD_TAGS=""
+
 WORKDIR /edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.

--- a/cmd/support-scheduler/Dockerfile
+++ b/cmd/support-scheduler/Dockerfile
@@ -19,6 +19,8 @@
 ARG BUILDER_BASE=golang:1.18-alpine3.16
 FROM ${BUILDER_BASE} AS builder
 
+ARG ADD_BUILD_TAGS=""
+
 WORKDIR /edgex-go
 
 # The main mirrors are giving us timeout issues on builds periodically.


### PR DESCRIPTION
Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)  ** README updated**
  <link to docs PR>

## Testing Instructions
Run the following commands and verify each Go build step includes `-tags "include_nats_messaging ...`
```
make build-nats
make docker-nats
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->