### PR TITLE
feat(metadata): add UoM validation to POST deviceresource API

### DIFF
--- a/internal/core/metadata/application/deviceprofile.go
+++ b/internal/core/metadata/application/deviceprofile.go
@@ -245,7 +245,7 @@ func deviceProfileUoMValidation(p models.DeviceProfile, dic *di.Container) error
 		uom := container.UnitsOfMeasureFrom(dic.Get)
 		for _, dr := range p.DeviceResources {
 			if ok := uom.Validate(dr.Properties.Units); !ok {
-				return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("DeviceResource %s units %s is invalid", dr.Name, dr.Properties.Units), nil)
+				return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("DeviceResource %s units %s is invalid", dr.Name, dr.Properties.Units), nil)
 			}
 		}
 	}

--- a/internal/core/metadata/application/deviceresource.go
+++ b/internal/core/metadata/application/deviceresource.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -56,6 +56,11 @@ func AddDeviceProfileResource(profileName string, resource models.DeviceResource
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 
 	profile, err := dbClient.DeviceProfileByName(profileName)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	err = deviceResourceUoMValidation(resource, dic)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
@@ -159,6 +164,17 @@ func DeleteDeviceResourceByName(profileName string, resourceName string, dic *di
 	err = dbClient.UpdateDeviceProfile(profile)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return nil
+}
+
+func deviceResourceUoMValidation(r models.DeviceResource, dic *di.Container) errors.EdgeX {
+	if container.ConfigurationFrom(dic.Get).Writable.UoM.Validation {
+		uom := container.UnitsOfMeasureFrom(dic.Get)
+		if ok := uom.Validate(r.Properties.Units); !ok {
+			return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("DeviceResource %s units %s is invalid", r.Name, r.Properties.Units), nil)
+		}
 	}
 
 	return nil

--- a/internal/core/metadata/application/deviceresource.go
+++ b/internal/core/metadata/application/deviceresource.go
@@ -173,7 +173,7 @@ func deviceResourceUoMValidation(r models.DeviceResource, dic *di.Container) err
 	if container.ConfigurationFrom(dic.Get).Writable.UoM.Validation {
 		uom := container.UnitsOfMeasureFrom(dic.Get)
 		if ok := uom.Validate(r.Properties.Units); !ok {
-			return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("DeviceResource %s units %s is invalid", r.Name, r.Properties.Units), nil)
+			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("DeviceResource %s units %s is invalid", r.Name, r.Properties.Units), nil)
 		}
 	}
 

--- a/internal/core/metadata/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/controller/http/deviceprofile_test.go
@@ -404,7 +404,7 @@ func TestAddDeviceProfile_UnitsOfMeasure_Validation(t *testing.T) {
 	}{
 		{"valid - expected units", []requests.DeviceProfileRequest{validReq}, http.StatusCreated},
 		{"valid - units not provided", []requests.DeviceProfileRequest{emptyUnitsReq}, http.StatusCreated},
-		{"invalid - unexpected units", []requests.DeviceProfileRequest{invalidUnitsReq}, http.StatusInternalServerError},
+		{"invalid - unexpected units", []requests.DeviceProfileRequest{invalidUnitsReq}, http.StatusBadRequest},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/core/metadata/controller/http/deviceresource_test.go
+++ b/internal/core/metadata/controller/http/deviceresource_test.go
@@ -284,7 +284,7 @@ func TestAddDeviceProfileResource_UnitsOfMeasure_Validation(t *testing.T) {
 	}{
 		{"valid - units not provided", []requests.AddDeviceResourceRequest{emptyUnitsReq}, http.StatusCreated},
 		{"valid - expected units", []requests.AddDeviceResourceRequest{validReq}, http.StatusCreated},
-		{"invalid - unexpected units", []requests.AddDeviceResourceRequest{invalidUnitsReq}, http.StatusInternalServerError},
+		{"invalid - unexpected units", []requests.AddDeviceResourceRequest{invalidUnitsReq}, http.StatusBadRequest},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
fix #4138

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run metadata from this branch with `WRITABLE_UOM_VALIDATION=true` environment variable
2. Verify POST `/api/v2/deviceprofile/resource` API is validating device resource units against `uom.toml` as expected

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->