### PR TITLE
feat(command): command request from external MQTT to internal MessageBus

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -54,7 +54,7 @@ Type = "consul"
   AuthMode = "usernamepassword"                   # required for redis messagebus (secure or insecure).
   SecretName = "redisdb"
     [MessageQueue.Internal.Topics]
-    RequestTopicPrefix = "edgex/command/request/"   # for publishing requests to the device service; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
+    RequestTopicPrefix = "edgex/command/request"    # for publishing requests to the device service; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
     ResponseTopic = "edgex/command/response/#"      # for subscribing to device service responses
     InternalRequestCommandTopic = "/command/request/#"     # for subscribing to internal command requests
     InternalResponseCommandTopicPrefix = "/command/response/"    # for publishing responses back to internal service /<device-name>/<command-name>/<method> will be added to this publish topic prefix
@@ -90,7 +90,7 @@ Type = "consul"
   AuthMode = "none"
     [MessageQueue.External.Topics]
     RequestCommandTopic = "edgex/command/request/#"           # for subscribing to 3rd party command requests
-    ResponseCommandTopicPrefix = "edgex/command/response/"    # for publishing responses back to 3rd party systems /<device-name>/<command-name>/<method> will be added to this publish topic prefix
+    ResponseCommandTopicPrefix = "edgex/command/response"     # for publishing responses back to 3rd party systems /<device-name>/<command-name>/<method> will be added to this publish topic prefix
     RequestQueryTopic = "edgex/commandquery/request/#"        # for subscribing to 3rd party command query request
     ResponseQueryTopic = "edgex/commandquery/response"        # for publishing responses back to 3rd party systems
 

--- a/internal/core/command/controller/messaging/external/external.go
+++ b/internal/core/command/controller/messaging/external/external.go
@@ -148,7 +148,7 @@ func commandRequestHandler(dic *di.Container) mqtt.MessageHandler {
 		commandName := topicLevels[length-2]
 		method := topicLevels[length-1]
 		// expected command response topic scheme: #/<device>/<command-name>/<method>
-		externalResponseTopic := messageBusInfo.External.Topics[ResponseCommandTopicPrefix] + strings.Join([]string{deviceName, commandName, method}, "/")
+		externalResponseTopic := strings.Join([]string{messageBusInfo.External.Topics[ResponseCommandTopicPrefix], deviceName, commandName, method}, "/")
 
 		requestEnvelope, err := types.NewMessageEnvelopeFromJSON(message.Payload())
 		if err != nil {
@@ -158,7 +158,7 @@ func commandRequestHandler(dic *di.Container) mqtt.MessageHandler {
 		}
 
 		if !strings.EqualFold(method, "get") && !strings.EqualFold(method, "set") {
-			responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, "unknown command method")
+			responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, fmt.Sprintf("unknown command method %s received", method))
 			publishMessage(client, externalResponseTopic, qos, retain, responseEnvelope, lc)
 			return
 		}
@@ -194,7 +194,7 @@ func commandRequestHandler(dic *di.Container) mqtt.MessageHandler {
 		}
 
 		// expected internal command request topic scheme: #/<device-service>/<device>/<command-name>/<method>
-		internalRequestTopic := messageBusInfo.Internal.Topics[RequestTopicPrefix] + strings.Join([]string{deviceServiceResponse.Service.Name, deviceName, commandName, method}, "/")
+		internalRequestTopic := strings.Join([]string{messageBusInfo.Internal.Topics[RequestTopicPrefix], deviceServiceResponse.Service.Name, deviceName, commandName, method}, "/")
 		internalMessageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
 		err = internalMessageBus.Publish(requestEnvelope, internalRequestTopic)
 		if err != nil {


### PR DESCRIPTION
core-command subscribes to 3rd-party command requests and publishes to the appropriate device service via messaging

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core-command from this branch with external MQTT broker and `MESSAGEQUEUE_REQUIRED=true` environment variable
2. Run `PSUBSCRIBE edgex.command.request.*` in `redis` container to subscribe to the forwarded request
3. send command request to `edgex/command/request/<device>/<command>/<method> topic.
For example send following message to `edgex/command/request/Random-Boolean-Device/Bool/get`:
```json
{
  "CorrelationID": "14a42ea6-c394-41c3-8bcd-a29b9f5e6835",
  "ApiVersion": "v2",
  "RequestId": "e6e8a2f4-eb14-4649-9e2b-175247911369",
  "ContentType": "application/json",
  "QueryParams": {
    "ds-pushevent":"yes",
    "ds-returnevent":"yes"
  }
}
```

4. check the message is received by `redis` container: 
```shell
/data # redis-cli
127.0.0.1:6379> PSUBSCRIBE edgex.command.request.*
Reading messages... (press Ctrl-C to quit)
1) "psubscribe"
2) "edgex.command.request.*"
3) (integer) 1
1) "pmessage"
2) "edgex.command.request.*"
3) "edgex.command.request.device-virtual.Random-Boolean-Device.Bool.get"
4) "{\"ReceivedTopic\":\"\",\"CorrelationID\":\"14a42ea6-c394-41c3-8bcd-a29b9f5e6835\",\"ApiVersion\":\"v2\",\"RequestID\":\"e6e8a2f4-eb14-4649-9e2b-175247911369\",\"ErrorCode\":0,\"Payload\":null,\"ContentType\":\"application/json\",\"QueryParams\":{\"ds-pushevent\":\"yes\",\"ds-returnevent\":\"yes\"}}"

```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->