### PR TITLE
fix(snap): Bind redis server to loopback interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -84,12 +84,12 @@ apps:
   redis:
     adapter: full
     after: [security-bootstrapper-redis]
-    command: bin/redis-server $CONFIG_FILE $DIR_OPT $SAVE_OPT1 $SAVE_OPT2
+    command: bin/redis-server $CONFIG_FILE $DIR_ARG $SAVE_ARG $BIND_ARG
     environment:
-      DIR_OPT: "--dir $SNAP_DATA/redis"
-      SAVE_OPT1: "--save 900 1"
-      SAVE_OPT2: "--save 300 10"
-      CONFIG_FILE: "$SNAP_DATA/redis/conf/redis.conf"
+      DIR_ARG: --dir $SNAP_DATA/redis
+      SAVE_ARG: --save 900 1 --save 300 10
+      BIND_ARG: --bind 127.0.0.1
+      CONFIG_FILE: $SNAP_DATA/redis/conf/redis.conf
     daemon: simple
     plugs: [network, network-bind]
   postgres:


### PR DESCRIPTION
By default, Redis server bind to all available interfaces. The docker containers have additional control over this using the port mappings but this isn't the case when running snaps. This change will replace the default bind configuration for the snaps from all interfaces IPv4/IPv6 to just the loopback interface and IPv4.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix - see https://github.com/canonical/edgex-snap-testing/pull/120
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

```
# install and check the latest dev version
$ snap install edgexfoundry --edge
edgexfoundry (edge) 2.3.0-dev.61 from Canonical✓ installed

$ sudo lsof -nPi :6379
COMMAND      PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
redis-ser 182698 root    6u  IPv4 645403      0t0  TCP *:6379 (LISTEN)
redis-ser 182698 root    7u  IPv6 645404      0t0  TCP *:6379 (LISTEN)
...

# build locally and install
$ snapcraft && snap install --dangerous ./edgexfoundry_2.3.0-dev.61_amd64.snap

# recheck:
$ sudo lsof -nPi :6379
COMMAND      PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
redis-ser 193798 root    6u  IPv4 739855      0t0  TCP 127.0.0.1:6379 (LISTEN)
...
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->