### PR TITLE
fix(security): add secure mqtt support to eKuiper

### DIFF
--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -499,7 +499,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 		}
 	}
 
-	err = ConfigureSecureMessageBus(configuration.SecureMessageBus, redisCredentials, lc)
+	err = ConfigureSecureMessageBus(configuration.SecureMessageBus, creds, lc)
 	if err != nil {
 		lc.Errorf("failed to configure for Secure Message Bus: %s", err.Error())
 		return false


### PR DESCRIPTION
Closes: #4147

Signed-off-by: intel <joshua.silverio@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Can gen compose file with https://github.com/joshua-silverio/edgex-compose/tree/secure-ekuiper-mqtt
- make gen dev ds-virtual mqtt-bus 
- make up 
- check kuiper container and app rules engine container to see the mqtt-bus connection success and flowing data
- shell in to kuiper container and cat /kuiper/etc/sources/edgex.yaml to confirm usr/pass of mqtt-bus is configured correctly 
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->