### PR TITLE
refactor: Move all the db related check to the infrastructure layer

### DIFF
--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -32,19 +32,6 @@ func AddDevice(d models.Device, ctx context.Context, dic *di.Container) (id stri
 	dbClient := container.DBClientFrom(dic.Get)
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 
-	exists, edgeXerr := dbClient.DeviceServiceNameExists(d.ServiceName)
-	if edgeXerr != nil {
-		return id, errors.NewCommonEdgeXWrapper(edgeXerr)
-	} else if !exists {
-		return id, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device service '%s' does not exists", d.ServiceName), nil)
-	}
-	exists, edgeXerr = dbClient.DeviceProfileNameExists(d.ProfileName)
-	if edgeXerr != nil {
-		return id, errors.NewCommonEdgeXWrapper(edgeXerr)
-	} else if !exists {
-		return id, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exists", d.ProfileName), nil)
-	}
-
 	err := validateDeviceCallback(ctx, dic, dtos.FromDeviceModelToDTO(d))
 	if err != nil {
 		return "", errors.NewCommonEdgeXWrapper(err)
@@ -129,23 +116,6 @@ func DeviceNameExists(name string, dic *di.Container) (exists bool, err errors.E
 func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container) errors.EdgeX {
 	dbClient := container.DBClientFrom(dic.Get)
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-
-	if dto.ServiceName != nil {
-		exists, edgeXerr := dbClient.DeviceServiceNameExists(*dto.ServiceName)
-		if edgeXerr != nil {
-			return errors.NewCommonEdgeX(errors.Kind(edgeXerr), fmt.Sprintf("device service '%s' existence check failed", *dto.ServiceName), edgeXerr)
-		} else if !exists {
-			return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device service '%s' does not exists", *dto.ServiceName), nil)
-		}
-	}
-	if dto.ProfileName != nil {
-		exists, edgeXerr := dbClient.DeviceProfileNameExists(*dto.ProfileName)
-		if edgeXerr != nil {
-			return errors.NewCommonEdgeX(errors.Kind(edgeXerr), fmt.Sprintf("device profile '%s' existence check failed", *dto.ProfileName), edgeXerr)
-		} else if !exists {
-			return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exists", *dto.ProfileName), nil)
-		}
-	}
 
 	device, err := deviceByDTO(dbClient, dto)
 	if err != nil {

--- a/internal/core/metadata/application/deviceprofile.go
+++ b/internal/core/metadata/application/deviceprofile.go
@@ -97,24 +97,7 @@ func DeleteDeviceProfileByName(name string, ctx context.Context, dic *di.Contain
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
 	}
 	dbClient := container.DBClientFrom(dic.Get)
-
-	// Check the associated Device and ProvisionWatcher existence
-	devices, err := dbClient.DevicesByProfileName(0, 1, name)
-	if err != nil {
-		return errors.NewCommonEdgeXWrapper(err)
-	}
-	if len(devices) > 0 {
-		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device profile when associated device exists", nil)
-	}
-	provisionWatchers, err := dbClient.ProvisionWatchersByProfileName(0, 1, name)
-	if err != nil {
-		return errors.NewCommonEdgeXWrapper(err)
-	}
-	if len(provisionWatchers) > 0 {
-		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device profile when associated provisionWatcher exists", nil)
-	}
-
-	err = dbClient.DeleteDeviceProfileByName(name)
+	err := dbClient.DeleteDeviceProfileByName(name)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/core/metadata/application/deviceservice.go
+++ b/internal/core/metadata/application/deviceservice.go
@@ -111,24 +111,7 @@ func DeleteDeviceServiceByName(name string, ctx context.Context, dic *di.Contain
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "name is empty", nil)
 	}
 	dbClient := container.DBClientFrom(dic.Get)
-
-	// Check the associated Device and ProvisionWatcher existence
-	devices, err := dbClient.DevicesByServiceName(0, 1, name)
-	if err != nil {
-		return errors.NewCommonEdgeXWrapper(err)
-	}
-	if len(devices) > 0 {
-		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device service when associated device exists", nil)
-	}
-	provisionWatchers, err := dbClient.ProvisionWatchersByServiceName(0, 1, name)
-	if err != nil {
-		return errors.NewCommonEdgeXWrapper(err)
-	}
-	if len(provisionWatchers) > 0 {
-		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device service when associated provisionWatcher exists", nil)
-	}
-
-	err = dbClient.DeleteDeviceServiceByName(name)
+	err := dbClient.DeleteDeviceServiceByName(name)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/core/metadata/application/provisionwatcher.go
+++ b/internal/core/metadata/application/provisionwatcher.go
@@ -28,19 +28,6 @@ func AddProvisionWatcher(pw models.ProvisionWatcher, ctx context.Context, dic *d
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	correlationId := correlation.FromContext(ctx)
 
-	exists, err := dbClient.DeviceServiceNameExists(pw.ServiceName)
-	if err != nil {
-		return "", errors.NewCommonEdgeXWrapper(err)
-	} else if !exists {
-		return "", errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device service '%s' does not exists", pw.ServiceName), nil)
-	}
-	exists, err = dbClient.DeviceProfileNameExists(pw.ProfileName)
-	if err != nil {
-		return "", errors.NewCommonEdgeXWrapper(err)
-	} else if !exists {
-		return "", errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exists", pw.ProfileName), nil)
-	}
-
 	addProvisionWatcher, err := dbClient.AddProvisionWatcher(pw)
 	if err != nil {
 		return "", errors.NewCommonEdgeXWrapper(err)
@@ -151,23 +138,6 @@ func DeleteProvisionWatcherByName(ctx context.Context, name string, dic *di.Cont
 func PatchProvisionWatcher(ctx context.Context, dto dtos.UpdateProvisionWatcher, dic *di.Container) errors.EdgeX {
 	dbClient := container.DBClientFrom(dic.Get)
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-
-	if dto.ServiceName != nil {
-		exists, edgeXerr := dbClient.DeviceServiceNameExists(*dto.ServiceName)
-		if edgeXerr != nil {
-			return errors.NewCommonEdgeX(errors.Kind(edgeXerr), fmt.Sprintf("device service '%s' existence check failed", *dto.ServiceName), edgeXerr)
-		} else if !exists {
-			return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device service '%s' does not exist", *dto.ServiceName), nil)
-		}
-	}
-	if dto.ProfileName != nil {
-		exists, edgeXerr := dbClient.DeviceProfileNameExists(*dto.ProfileName)
-		if edgeXerr != nil {
-			return errors.NewCommonEdgeX(errors.Kind(edgeXerr), fmt.Sprintf("device profile '%s' existence check failed", *dto.ProfileName), edgeXerr)
-		} else if !exists {
-			return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exist", *dto.ProfileName), nil)
-		}
-	}
 
 	pw, err := provisionWatcherByDTO(dbClient, dto)
 	if err != nil {

--- a/internal/core/metadata/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/controller/http/deviceprofile_test.go
@@ -1072,8 +1072,10 @@ func TestDeleteDeviceProfileByName(t *testing.T) {
 	dbClientMock.On("DevicesByProfileName", 0, 1, notFoundName).Return([]models.Device{}, nil)
 	dbClientMock.On("ProvisionWatchersByProfileName", 0, 1, notFoundName).Return([]models.ProvisionWatcher{}, nil)
 	dbClientMock.On("DeleteDeviceProfileByName", notFoundName).Return(errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "device profile doesn't exist in the database", nil))
-	dbClientMock.On("DevicesByProfileName", 0, 1, deviceExists).Return([]models.Device{models.Device{}}, nil)
-	dbClientMock.On("DevicesByProfileName", 0, 1, provisionWatcherExists).Return([]models.Device{}, nil)
+	dbClientMock.On("DeleteDeviceProfileByName", deviceExists).Return(errors.NewCommonEdgeX(
+		errors.KindStatusConflict, "fail to delete the device profile when associated device exists", nil))
+	dbClientMock.On("DeleteDeviceProfileByName", provisionWatcherExists).Return(errors.NewCommonEdgeX(
+		errors.KindStatusConflict, "fail to delete the device profile when associated provisionWatcher exists", nil))
 	dbClientMock.On("ProvisionWatchersByProfileName", 0, 1, provisionWatcherExists).Return([]models.ProvisionWatcher{models.ProvisionWatcher{}}, nil)
 	dic.Update(di.ServiceConstructorMap{
 		container.DBClientInterfaceName: func(get di.Get) interface{} {

--- a/internal/core/metadata/controller/http/deviceservice_test.go
+++ b/internal/core/metadata/controller/http/deviceservice_test.go
@@ -485,8 +485,10 @@ func TestDeleteDeviceServiceByName(t *testing.T) {
 	dbClientMock.On("DevicesByServiceName", 0, 1, notFoundName).Return([]models.Device{}, nil)
 	dbClientMock.On("ProvisionWatchersByServiceName", 0, 1, notFoundName).Return([]models.ProvisionWatcher{}, nil)
 	dbClientMock.On("DeleteDeviceServiceByName", notFoundName).Return(errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "device service doesn't exist in the database", nil))
-	dbClientMock.On("DevicesByServiceName", 0, 1, deviceExists).Return([]models.Device{models.Device{}}, nil)
-	dbClientMock.On("DevicesByServiceName", 0, 1, provisionWatcherExists).Return([]models.Device{}, nil)
+	dbClientMock.On("DeleteDeviceServiceByName", deviceExists).Return(errors.NewCommonEdgeX(
+		errors.KindStatusConflict, "fail to delete the device service when associated device exists", nil))
+	dbClientMock.On("DeleteDeviceServiceByName", provisionWatcherExists).Return(errors.NewCommonEdgeX(
+		errors.KindStatusConflict, "fail to delete the device service when associated provisionWatcher exists", nil))
 	dbClientMock.On("ProvisionWatchersByServiceName", 0, 1, provisionWatcherExists).Return([]models.ProvisionWatcher{models.ProvisionWatcher{}}, nil)
 	dic.Update(di.ServiceConstructorMap{
 		container.DBClientInterfaceName: func(get di.Get) interface{} {

--- a/internal/pkg/infrastructure/redis/device_profile.go
+++ b/internal/pkg/infrastructure/redis/device_profile.go
@@ -199,6 +199,23 @@ func deleteDeviceProfileByName(conn redis.Conn, name string) errors.EdgeX {
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+
+	// Check the associated Device and ProvisionWatcher existence
+	devices, err := devicesByProfileName(conn, 0, 1, name)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if len(devices) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device profile when associated device exists", nil)
+	}
+	provisionWatchers, err := provisionWatchersByProfileName(conn, 0, 1, name)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if len(provisionWatchers) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device profile when associated provisionWatcher exists", nil)
+	}
+
 	err = deleteDeviceProfile(conn, deviceProfile)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)

--- a/internal/pkg/infrastructure/redis/device_service.go
+++ b/internal/pkg/infrastructure/redis/device_service.go
@@ -157,6 +157,23 @@ func deleteDeviceServiceByName(conn redis.Conn, name string) errors.EdgeX {
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+
+	// Check the associated Device and ProvisionWatcher existence
+	devices, err := devicesByServiceName(conn, 0, 1, name)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if len(devices) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device service when associated device exists", nil)
+	}
+	provisionWatchers, err := provisionWatchersByServiceName(conn, 0, 1, name)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	if len(provisionWatchers) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device service when associated provisionWatcher exists", nil)
+	}
+
 	err = deleteDeviceService(conn, deviceService)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)

--- a/internal/pkg/infrastructure/redis/interval.go
+++ b/internal/pkg/infrastructure/redis/interval.go
@@ -126,6 +126,13 @@ func deleteIntervalByName(conn redis.Conn, name string) errors.EdgeX {
 	if edgeXerr != nil {
 		return errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
+	actions, edgeXerr := intervalActionsByIntervalName(conn, 0, 1, name)
+	if edgeXerr != nil {
+		return errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+	if len(actions) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the interval when associated intervalAction exists", nil)
+	}
 	storedKey := intervalStoredKey(interval.Id)
 	_ = conn.Send(MULTI)
 	sendDeleteIntervalCmd(conn, storedKey, interval)
@@ -141,6 +148,13 @@ func updateInterval(conn redis.Conn, interval models.Interval) errors.EdgeX {
 	oldInterval, edgeXerr := intervalByName(conn, interval.Name)
 	if edgeXerr != nil {
 		return errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+	actions, edgeXerr := intervalActionsByIntervalName(conn, 0, 1, interval.Name)
+	if edgeXerr != nil {
+		return errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+	if len(actions) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to patch the interval when associated intervalAction exists", nil)
 	}
 
 	interval.Modified = pkgCommon.MakeTimestamp()

--- a/internal/support/scheduler/application/interval.go
+++ b/internal/support/scheduler/application/interval.go
@@ -83,16 +83,7 @@ func DeleteIntervalByName(name string, ctx context.Context, dic *di.Container) e
 	}
 	dbClient := container.DBClientFrom(dic.Get)
 	schedulerManager := container.SchedulerManagerFrom(dic.Get)
-
-	actions, err := dbClient.IntervalActionsByIntervalName(0, 1, name)
-	if err != nil {
-		return errors.NewCommonEdgeXWrapper(err)
-	}
-	if len(actions) > 0 {
-		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the interval when associated intervalAction exists", nil)
-	}
-
-	err = dbClient.DeleteIntervalByName(name)
+	err := dbClient.DeleteIntervalByName(name)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
@@ -112,14 +103,6 @@ func PatchInterval(dto dtos.UpdateInterval, ctx context.Context, dic *di.Contain
 	interval, err := intervalByDTO(dbClient, dto)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
-	}
-
-	actions, err := dbClient.IntervalActionsByIntervalName(0, 1, interval.Name)
-	if err != nil {
-		return errors.NewCommonEdgeXWrapper(err)
-	}
-	if len(actions) > 0 {
-		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to patch the interval when associated intervalAction exists", nil)
 	}
 
 	requests.ReplaceIntervalModelFieldsWithDTO(&interval, dto)

--- a/internal/support/scheduler/application/intervalaction.go
+++ b/internal/support/scheduler/application/intervalaction.go
@@ -29,12 +29,6 @@ func AddIntervalAction(action models.IntervalAction, ctx context.Context, dic *d
 	schedulerManager := container.SchedulerManagerFrom(dic.Get)
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 
-	// checks the interval existence by name
-	_, edgeXerr = dbClient.IntervalByName(action.IntervalName)
-	if edgeXerr != nil {
-		return id, errors.NewCommonEdgeXWrapper(edgeXerr)
-	}
-
 	addedAction, err := dbClient.AddIntervalAction(action)
 	if err != nil {
 		return "", errors.NewCommonEdgeXWrapper(err)
@@ -110,14 +104,6 @@ func PatchIntervalAction(dto dtos.UpdateIntervalAction, ctx context.Context, dic
 	action, err := intervalActionByDTO(dbClient, dto)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
-	}
-
-	// checks the interval existence by name
-	if dto.IntervalName != nil {
-		_, err = dbClient.IntervalByName(*dto.IntervalName)
-		if err != nil {
-			return errors.NewCommonEdgeXWrapper(err)
-		}
 	}
 
 	requests.ReplaceIntervalActionModelFieldsWithDTO(&action, dto)

--- a/internal/support/scheduler/controller/http/intervalaction_test.go
+++ b/internal/support/scheduler/controller/http/intervalaction_test.go
@@ -388,6 +388,11 @@ func TestPatchIntervalAction(t *testing.T) {
 	dbClientMock.On("IntervalByName", intervalNotFoundName).Return(models.Interval{}, intervalNotFoundNameError)
 	invalidIntervalNotFound := testReq
 	invalidIntervalNotFound.Action.IntervalName = &intervalNotFoundName
+	invalidIntervalNotFoundModel := model
+	invalidIntervalNotFoundModel.IntervalName = intervalNotFoundName
+	invalidIntervalNotFound.Action.Id = nil
+	dbClientMock.On("IntervalActionByName", intervalNotFoundName).Return(invalidIntervalNotFoundModel, nil)
+	dbClientMock.On("UpdateIntervalAction", invalidIntervalNotFoundModel).Return(errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("%s doesn't exist in the database", intervalNotFoundName), nil))
 
 	dic.Update(di.ServiceConstructorMap{
 		container.DBClientInterfaceName: func(get di.Get) interface{} {


### PR DESCRIPTION
close #4094

Signed-off-by: Felix Ting <felix@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) update the existing unit test
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?) no docs change
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. run core-metadata, support-scheduler, and device-virtual(or device-simple)
2. try the following REST APIs with the given conditions and verify the response
  - POST /device (non-existent device service name)
  - POST /device (non-existent device profile name)
  - PATCH /device (non-existent device service name)
  - PATCH /device (non-existent device profile name)
  - DELETE /deviceprofile/name/{name} (associated device exists)
  - DELETE /deviceprofile/name/{name} (associated provisionWatcher exists)
  - DELETE /deviceservice/name/{name} (associated device exists)
  - DELETE /deviceservice/name/{name} (associated provisionWatcher exists)
  - POST /provisionwatcher (non-existent device service name)
  - POST /provisionwatcher (non-existent device profile name)
  - PATCH /provisionwatcher/name/{name} (non-existent device service name)
  - PATCH /provisionwatcher/name/{name} (non-existent device profile name)
  - PATCH /interval (associated intervalAction exists)
  - DELETE /interval (associated intervalAction exists)
  - POST /intervalaction (intervalAction exists)
  - PATCH /intervalaction (non-existent interval name)

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->