### PR TITLE
Fix: Delayed start services for support- services fail

### DIFF
--- a/cmd/security-spire-config/seed_builtin_entries.sh
+++ b/cmd/security-spire-config/seed_builtin_entries.sh
@@ -26,14 +26,16 @@ echo "SPIFFE_SERVER_SOCKET=${SPIFFE_SERVER_SOCKET}"
 echo "SPIFFE_EDGEX_SVID_BASE=${SPIFFE_EDGEX_SVID_BASE}"
 
 # add pre-authorized services into spire server entry
-for dockerservice in security-spiffe-token-provider notifications scheduler \
+for dockerservice in security-spiffe-token-provider support-notifications support-scheduler \
     device-bacnet device-camera device-grove device-modbus device-mqtt device-rest device-snmp \
     device-virtual device-rfid-llrp device-coap device-gpio \
     app-service-http-export app-service-mqtt-export app-service-sample app-rfid-llrp-inventory \
     app-service-external-mqtt-trigger; do
     # Temporary workaround because service name in dockerfile is not consistent with service key.
     # TAF scripts depend on legacy docker-compose service name. Fix in EdgeX 3.0.
-    service=`echo -n ${dockerservice} | sed -e 's/app-service-/app-/'` 
+    service=`echo -n ${dockerservice} | sed -e 's/app-service-/app-/'`
+    # support- services have the opposite problem.  service key is right, service name in docker isn't
+    dockerservice=`echo -n ${dockerservice} | sed -e 's/support-//'`
     spire-server entry create -socketPath "${SPIFFE_SERVER_SOCKET}" -parentID "${local_agent_svid}" -dns "edgex-${service}" -spiffeID "${SPIFFE_EDGEX_SVID_BASE}/${service}" -selector "docker:label:com.docker.compose.service:${dockerservice}"
 done
 


### PR DESCRIPTION
Delayed start is not working for support services. Among other problems, for support services,
the service key is support-servicename,
but the service key in docker-compose is just servicename.

Update pre-seeding script to account for this.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

Closes #4152

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) n/a
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) n/a
  <link to docs PR>

## Testing Instructions
(Update later with related edgex-compose change.)

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->