### PR TITLE
 fix: added consul policy list check

### DIFF
--- a/internal/security/bootstrapper/command/setupacl/stubregistryserver_test.go
+++ b/internal/security/bootstrapper/command/setupacl/stubregistryserver_test.go
@@ -332,6 +332,22 @@ func (registry *registryTestServer) getRegistryServerConf(t *testing.T) *config.
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte("Invalid Policy: A Policy with Name " + edgeXServicePolicyName + " already exists"))
 			}
+		case consulPolicyListAPI:
+			require.Equal(t, http.MethodGet, r.Method)
+			w.WriteHeader(http.StatusOK)
+			jsonResponse := []map[string]interface{}{
+				{
+					"Name": "global-management",
+				},
+				{
+					"Name": "node-read",
+				},
+				{
+					"Name": "test-policy-name",
+				},
+			}
+			err := json.NewEncoder(w).Encode(jsonResponse)
+			require.NoError(t, err)
 		default:
 			t.Fatalf("Unexpected call to URL %s", r.URL.EscapedPath())
 		}


### PR DESCRIPTION
Added a check in getPolicyByName to see whether the policy exists in the policy list before attempting to get the policy. This prevents erroneous or unclear logging.

closes: #4108

Signed-off-by: Rico Chavez-Lopez <rchavezlopez@ucdavis.edu>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x ] I am not introducing a new dependency (add notes below if you are)
- [x ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- aclpolicies unit test
- creating policy not in consul policy list

