### PR TITLE
fix(snap): Copy UoM file if not exist during upgrade

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -2,27 +2,17 @@
 
 TAG=$SNAP_INSTANCE_NAME.$(basename "$0")
 
-# read revision/version of the previous installation, set in the pre-refresh hook
-pre_rev=$(snapctl get pre-refresh.revision)
-pre_ver=$(snapctl get pre-refresh.version)
-# read the revision from the legacy lastrev option (EdgeX <2.3)
-[ -z "$pre_rev" ] && pre_rev=$(snapctl get lastrev)
-
-logger --tag $TAG "Refreshing from $pre_ver ($pre_rev) to $SNAP_VERSION ($SNAP_REVISION)"
-
 # set up postgres, if we are upgrading it
 $SNAP/bin/kong-postgres-setup.sh "post-refresh"
 
 # Install the Unit of Measure config file when upgrading from an old version
 # UoM was added in v2.3.0-dev.45 (snap revision 3900):
 # https://github.com/edgexfoundry/edgex-go/pull/4119
-if (( pre_rev < 3900 )); then
-    uom="config/core-metadata/res/uom.toml"
-    logger --tag $TAG "Installing $SNAP/$uom"
-    if [ -f "$SNAP/$uom" ]; then
-        # --no-clobber: copy if missing from target
-        cp --no-clobber "$SNAP/$uom" "$SNAP_DATA/$uom"
-    else
-        logger --stderr --tag $TAG "$SNAP/$uom does not exit."
-    fi
+uom="config/core-metadata/res/uom.toml"
+logger --tag $TAG "Installing $SNAP/$uom"
+if [ -f "$SNAP/$uom" ]; then
+    # --no-clobber: copy if missing from target
+    cp --no-clobber "$SNAP/$uom" "$SNAP_DATA/$uom"
+else
+    logger --stderr --tag $TAG "$SNAP/$uom does not exit."
 fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -6,7 +6,7 @@ TAG=$SNAP_INSTANCE_NAME.$(basename "$0")
 $SNAP/bin/kong-postgres-setup.sh "post-refresh"
 
 # Install the Unit of Measure config file when upgrading from an old version
-# UoM was added in v2.3.0-dev.45 (snap revision 3900):
+# UoM was added in v2.3.0-dev.45:
 # https://github.com/edgexfoundry/edgex-go/pull/4119
 uom="config/core-metadata/res/uom.toml"
 logger --tag $TAG "Installing $SNAP/$uom"


### PR DESCRIPTION
This PR builds on top of #4125 to correctly deploy Unit of Measure config file during an upgrade. 

When we upgrade from a channel that contains an old version with revision number larger than 3900 (for example a recent build of latest/stable), the current [post-refresh](https://github.com/edgexfoundry/edgex-go/blob/a8eb28e71f5ba3ef86e818c168e1634e95121d28/snap/hooks/post-refresh#L19) falsely assumes that the upgrade is from a new version that already has the UOM file. As a result, the UoM file does not get added during the upgrade which leads to the missing UoM file error.

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Reproduce the error:
```
$ snap install edgexfoundry --channel=latest/stable
edgexfoundry 2.2.0+2 from Canonical✓ installed

$ snap refresh edgexfoundry --channel=latest/edge
edgexfoundry (edge) 2.3.0-dev.72 from Canonical✓ refreshed

$ snap logs -n 100 edgexfoundry.core-metadata | grep -i ERROR
2022-09-27T11:48:55+02:00 edgexfoundry.core-metadata[83029]: level=ERROR ts=2022-09-27T09:48:55.217940206Z app=core-metadata source=httpserver.go:143 msg="Web server failed: http: Server closed"
2022-09-27T11:49:20+02:00 edgexfoundry.core-metadata[84575]: level=ERROR ts=2022-09-27T09:49:20.3662794Z app=core-metadata source=bootstrap.go:42 msg="could not load unit of measure configuration file (/var/snap/edgexfoundry/4011/config/core-metadata/res/uom.toml): open /var/snap/edgexfoundry/4011/config/core-metadata/res/uom.toml: no such file or directory"
```

Test the changes using the snap built from this branch:
```
$ snap install edgexfoundry --channel=latest/stable
edgexfoundry 2.2.0+2 from Canonical✓ installed

$ snap refresh edgexfoundry --channel=latest/edge/pr-4168
edgexfoundry (edge/pr-4168) 2.3.0-dev.72 from Canonical✓ refreshed

$ snap logs -n 2 edgexfoundry.core-metadata 
2022-09-27T14:09:44+02:00 edgexfoundry.core-metadata[146976]: level=INFO ts=2022-09-27T12:09:44.802964433Z app=core-metadata source=message.go:55 msg="This is the EdgeX Core Metadata Microservice"
2022-09-27T14:09:44+02:00 edgexfoundry.core-metadata[146976]: level=INFO ts=2022-09-27T12:09:44.802968612Z app=core-metadata source=message.go:58 msg="Service started in: 64.783227ms"

$ journalctl -n 5000 | grep post-refresh
Sep 27 14:14:32 ubuntu systemd[1]: Started snap.edgexfoundry.hook.post-refresh.c23bba37-fdb7-4c19-9979-be6b1f16f05e.scope.
...
Sep 27 14:14:33 ubuntu edgexfoundry.post-refresh[151597]: Installing /snap/edgexfoundry/4014/config/core-metadata/res/uom.toml
Sep 27 14:14:33 ubuntu systemd[1]: snap.edgexfoundry.hook.post-refresh.c23bba37-fdb7-4c19-9979-be6b1f16f05e.scope: Succeeded.
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->