### PR TITLE
fix: Always run "kong migrations up"

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/kong_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/kong_wait_install.sh
@@ -69,16 +69,16 @@ export KONG_PG_PASSWORD_FILE
 # remove env KONG_PG_PASSWORD: only use KONG_PG_PASSWORD_FILE
 unset KONG_PG_PASSWORD
 
+set +e
 /docker-entrypoint.sh kong migrations bootstrap
-/docker-entrypoint.sh kong migrations list
+/docker-entrypoint.sh kong migrations up
+/docker-entrypoint.sh kong migrations finish
 code=$?
-if [ $code -eq 0 ]; then
-  echo "$(date) kong migrations bootstrap ok, doing migrations up and finish..."
-  /docker-entrypoint.sh kong migrations up && /docker-entrypoint.sh kong migrations finish
-else
+if [ $code -ne 0 ]; then
   echo "$(date) failed to kong migrations, returned code = " $code
+  exit $code
 fi
-
+set -e
 echo "$(date) Configuring Kong Admin API..."
 
 # Running "kong config db_import" will return a non-successful error code even though it 


### PR DESCRIPTION
This ensures any missing migration are run and doesn't hurt if there are none. No need to run `kong migrations list`

fixes #4171

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
Run Kamakura secure stack compose file
Get API Gateway token and verify API Gateway is functional
Stop (down) the services w/o clearing volumes
Run latest WIP secure stack compose file with Kong changed to version 2.8 and `restart: always` commented out.
Verify Kong remains running and the API Gateway is functional using the same token from the Kamakura stack
Stop (down) the services w/o clearing volumes
Run latest WIP secure stack compose file with Kong changed to version 2.8 and `restart: always` commented out.
Verify Kong still remains running and the API Gateway still is functional using the same token from the Kamakura stack

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->