### PR TITLE
feat(command): subscribe command request via internal messaging

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -57,7 +57,7 @@ Type = "consul"
     RequestTopicPrefix = "edgex/command/request"    # for publishing requests to the device service; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
     ResponseTopic = "edgex/command/response/#"      # for subscribing to device service responses
     InternalRequestCommandTopic = "/command/request/#"     # for subscribing to internal command requests
-    InternalResponseCommandTopicPrefix = "/command/response/"    # for publishing responses back to internal service /<device-name>/<command-name>/<method> will be added to this publish topic prefix
+    InternalResponseCommandTopicPrefix = "/command/response"     # for publishing responses back to internal service /<device-name>/<command-name>/<method> will be added to this publish topic prefix
     InternalRequestQueryTopic = "/commandquery/request"   # for subscribing to internal command query requests
     InternalResponseQueryTopic = "/commandquery/response"   # for publishing reponsses back to internal service
     [MessageQueue.Internal.Optional]

--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -54,12 +54,12 @@ Type = "consul"
   AuthMode = "usernamepassword"                   # required for redis messagebus (secure or insecure).
   SecretName = "redisdb"
     [MessageQueue.Internal.Topics]
-    RequestTopicPrefix = "edgex/command/request"    # for publishing requests to the device service; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
-    ResponseTopic = "edgex/command/response/#"      # for subscribing to device service responses
-    InternalRequestCommandTopic = "/command/request/#"     # for subscribing to internal command requests
-    InternalResponseCommandTopicPrefix = "/command/response"     # for publishing responses back to internal service /<device-name>/<command-name>/<method> will be added to this publish topic prefix
-    InternalRequestQueryTopic = "/commandquery/request"   # for subscribing to internal command query requests
-    InternalResponseQueryTopic = "/commandquery/response"   # for publishing reponsses back to internal service
+    DeviceRequestTopicPrefix = "edgex/command/request"    # for publishing requests to the device service; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
+    DeviceResponseTopic = "edgex/command/response/#"      # for subscribing to device service responses
+    CommandRequestTopic = "/command/request/#"     # for subscribing to internal command requests
+    CommandResponseTopicPrefix = "/command/response"     # for publishing responses back to internal service /<device-name>/<command-name>/<method> will be added to this publish topic prefix
+    QueryRequestTopic = "/commandquery/request"   # for subscribing to internal command query requests
+    QueryResponseTopic = "/commandquery/response"   # for publishing reponsses back to internal service
     [MessageQueue.Internal.Optional]
     # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
     ClientId ="core-command"
@@ -90,10 +90,10 @@ Type = "consul"
   SecretPath = "mqtt"
   AuthMode = "none"
     [MessageQueue.External.Topics]
-    RequestCommandTopic = "edgex/command/request/#"           # for subscribing to 3rd party command requests
-    ResponseCommandTopicPrefix = "edgex/command/response"     # for publishing responses back to 3rd party systems /<device-name>/<command-name>/<method> will be added to this publish topic prefix
-    RequestQueryTopic = "edgex/commandquery/request/#"        # for subscribing to 3rd party command query request
-    ResponseQueryTopic = "edgex/commandquery/response"        # for publishing responses back to 3rd party systems
+    CommandRequestTopic = "edgex/command/request/#"           # for subscribing to 3rd party command requests
+    CommandResponseTopicPrefix = "edgex/command/response"     # for publishing responses back to 3rd party systems /<device-name>/<command-name>/<method> will be added to this publish topic prefix
+    QueryRequestTopic = "edgex/commandquery/request/#"        # for subscribing to 3rd party command query request
+    QueryResponseTopic = "edgex/commandquery/response"        # for publishing responses back to 3rd party systems
 
 [SecretStore]
 Type = "vault"

--- a/internal/core/command/controller/messaging/external_test.go
+++ b/internal/core/command/controller/messaging/external_test.go
@@ -67,10 +67,10 @@ func TestOnConnectHandler(t *testing.T) {
 					Required: false,
 					External: bootstrapConfig.ExternalMQTTInfo{
 						Topics: map[string]string{
-							RequestQueryTopic:          testQueryRequestTopic,
-							ResponseQueryTopic:         testQueryResponseTopic,
-							RequestCommandTopic:        testExternalCommandRequestTopic,
-							ResponseCommandTopicPrefix: testExternalCommandResponseTopicPrefix,
+							QueryRequestTopic:          testQueryRequestTopic,
+							QueryResponseTopic:         testQueryResponseTopic,
+							CommandRequestTopic:        testExternalCommandRequestTopic,
+							CommandResponseTopicPrefix: testExternalCommandResponseTopicPrefix,
 						},
 						QoS:    0,
 						Retain: true,
@@ -291,14 +291,14 @@ func Test_commandRequestHandler(t *testing.T) {
 					Required: true,
 					Internal: bootstrapConfig.MessageBusInfo{
 						Topics: map[string]string{
-							RequestTopicPrefix: testInternalCommandRequestTopicPrefix,
+							DeviceRequestTopicPrefix: testInternalCommandRequestTopicPrefix,
 						},
 					},
 					External: bootstrapConfig.ExternalMQTTInfo{
 						QoS:    0,
 						Retain: true,
 						Topics: map[string]string{
-							ResponseCommandTopicPrefix: testExternalCommandResponseTopicPrefix,
+							CommandResponseTopicPrefix: testExternalCommandResponseTopicPrefix,
 						},
 					},
 				},

--- a/internal/core/command/controller/messaging/internal.go
+++ b/internal/core/command/controller/messaging/internal.go
@@ -7,6 +7,7 @@ package messaging
 
 import (
 	"context"
+	"strings"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
@@ -16,6 +17,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
 )
 
+// SubscribeCommandResponses subscribes command responses from device services via internal MessageBus
 func SubscribeCommandResponses(ctx context.Context, router MessagingRouter, dic *di.Container) errors.EdgeX {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
@@ -48,7 +50,7 @@ func SubscribeCommandResponses(ctx context.Context, router MessagingRouter, dic 
 			case err = <-messageErrors:
 				lc.Error(err.Error())
 			case msgEnvelope := <-messages:
-				lc.Debugf("Command response received on message queue. Topic: %s, Correlation-id: %s ", msgEnvelope.ReceivedTopic, msgEnvelope.CorrelationID)
+				lc.Debugf("Command response received on internal MessageBus. Topic: %s, Correlation-id: %s ", msgEnvelope.ReceivedTopic, msgEnvelope.CorrelationID)
 
 				responseTopic, external, err := router.ResponseTopic(msgEnvelope.RequestID)
 				if err != nil {
@@ -58,7 +60,95 @@ func SubscribeCommandResponses(ctx context.Context, router MessagingRouter, dic 
 
 				if external {
 					publishMessage(externalMQTT, responseTopic, qos, retain, msgEnvelope, lc)
+					continue
 				}
+
+				err = messageBus.Publish(msgEnvelope, responseTopic)
+				if err != nil {
+					lc.Errorf("Could not publish to internal MessageBus topic '%s': %s", responseTopic, err.Error())
+					continue
+				}
+				lc.Debugf("Published response message to internal MessageBus on topic '%s'", responseTopic)
+			}
+		}
+	}()
+
+	return nil
+}
+
+// SubscribeCommandRequests subscribes command requests from EdgeX service (e.g., Application Service)
+// via internal MessageBus
+func SubscribeCommandRequests(ctx context.Context, router MessagingRouter, dic *di.Container) errors.EdgeX {
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
+	internalRequestCommandTopic := messageBusInfo.Internal.Topics[InternalRequestCommandTopic]
+
+	messages := make(chan types.MessageEnvelope)
+	messageErrors := make(chan error)
+	topics := []types.TopicChannel{
+		{
+			Topic:    internalRequestCommandTopic,
+			Messages: messages,
+		},
+	}
+
+	messageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
+	err := messageBus.Subscribe(topics, messageErrors)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				lc.Infof("Exiting waiting for MessageBus '%s' topic messages", internalRequestCommandTopic)
+				return
+			case err = <-messageErrors:
+				lc.Error(err.Error())
+			case requestEnvelope := <-messages:
+				lc.Debugf("Command request received on internal MessageBus. Topic: %s, Correlation-id: %s ", requestEnvelope.ReceivedTopic, requestEnvelope.CorrelationID)
+
+				topicLevels := strings.Split(requestEnvelope.ReceivedTopic, "/")
+				length := len(topicLevels)
+				if length < 3 {
+					lc.Error("Failed to parse and construct internal command response topic scheme, expected request topic scheme: '#/<device-name>/<command-name>/<method>'")
+					lc.Warn("Not publishing error message back due to insufficient information on response topic")
+					continue
+				}
+
+				// expected internal command request/response topic scheme: #/<device>/<command-name>/<method>
+				deviceName := topicLevels[length-3]
+				commandName := topicLevels[length-2]
+				method := topicLevels[length-1]
+				if !strings.EqualFold(method, "get") && !strings.EqualFold(method, "set") {
+					lc.Errorf("Unknown request method: %s, only 'get' or 'set' is allowed", method)
+					lc.Warn("Not publishing error message back due to insufficient information on response topic")
+					continue
+				}
+				internalResponseTopic := strings.Join([]string{messageBusInfo.Internal.Topics[InternalResponseCommandTopicPrefix], deviceName, commandName, method}, "/")
+
+				deviceRequestTopic, err := validateRequestTopic(messageBusInfo.Internal.Topics[RequestTopicPrefix], deviceName, commandName, method, dic)
+				if err != nil {
+					lc.Errorf("invalid request topic: %s", err.Error())
+					responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, err.Error())
+					err = messageBus.Publish(responseEnvelope, internalResponseTopic)
+					if err != nil {
+						lc.Errorf("Could not publish to topic '%s': %s", internalResponseTopic, err.Error())
+					}
+
+					continue
+				}
+
+				// expected internal command request topic scheme: #/<device-service>/<device>/<command-name>/<method>
+				err = messageBus.Publish(requestEnvelope, deviceRequestTopic)
+				if err != nil {
+					lc.Errorf("Could not publish to topic '%s': %s", deviceRequestTopic, err.Error())
+					continue
+				}
+
+				lc.Debugf("Command request sent to internal MessageBus. Topic: %s, Correlation-id: %s", deviceRequestTopic, requestEnvelope.CorrelationID)
+				router.SetResponseTopic(requestEnvelope.RequestID, internalResponseTopic, false)
 			}
 		}
 	}()

--- a/internal/core/command/controller/messaging/internal.go
+++ b/internal/core/command/controller/messaging/internal.go
@@ -21,7 +21,7 @@ import (
 func SubscribeCommandResponses(ctx context.Context, router MessagingRouter, dic *di.Container) errors.EdgeX {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
-	internalResponseTopic := messageBusInfo.Internal.Topics[ResponseTopic]
+	internalResponseTopic := messageBusInfo.Internal.Topics[DeviceResponseTopic]
 
 	messages := make(chan types.MessageEnvelope)
 	messageErrors := make(chan error)
@@ -81,7 +81,7 @@ func SubscribeCommandResponses(ctx context.Context, router MessagingRouter, dic 
 func SubscribeCommandRequests(ctx context.Context, router MessagingRouter, dic *di.Container) errors.EdgeX {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
-	internalRequestCommandTopic := messageBusInfo.Internal.Topics[InternalRequestCommandTopic]
+	internalRequestCommandTopic := messageBusInfo.Internal.Topics[CommandRequestTopic]
 
 	messages := make(chan types.MessageEnvelope)
 	messageErrors := make(chan error)
@@ -126,9 +126,9 @@ func SubscribeCommandRequests(ctx context.Context, router MessagingRouter, dic *
 					lc.Warn("Not publishing error message back due to insufficient information on response topic")
 					continue
 				}
-				internalResponseTopic := strings.Join([]string{messageBusInfo.Internal.Topics[InternalResponseCommandTopicPrefix], deviceName, commandName, method}, "/")
+				internalResponseTopic := strings.Join([]string{messageBusInfo.Internal.Topics[CommandResponseTopicPrefix], deviceName, commandName, method}, "/")
 
-				deviceRequestTopic, err := validateRequestTopic(messageBusInfo.Internal.Topics[RequestTopicPrefix], deviceName, commandName, method, dic)
+				deviceRequestTopic, err := validateRequestTopic(messageBusInfo.Internal.Topics[DeviceRequestTopicPrefix], deviceName, commandName, method, dic)
 				if err != nil {
 					lc.Errorf("invalid request topic: %s", err.Error())
 					responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, err.Error())

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -97,9 +97,14 @@ func MessageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startup
 		if !handlers.NewExternalMQTT(messaging.OnConnectHandler(router, dic)).BootstrapHandler(ctx, wg, startupTimer, dic) {
 			return false
 		}
+		if err := messaging.SubscribeCommandRequests(ctx, router, dic); err != nil {
+			lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+			lc.Errorf("Failed to subscribe commands request from internal message bus, %v", err)
+			return false
+		}
 		if err := messaging.SubscribeCommandResponses(ctx, router, dic); err != nil {
 			lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-			lc.Errorf("Failed to subscribe commands from message bus, %v", err)
+			lc.Errorf("Failed to subscribe commands response from internal message bus, %v", err)
 			return false
 		}
 	}


### PR DESCRIPTION
core-command subscribes to internal command requests and publishes requests to the to the appropriate device service via messaging

Signed-off-by: Chris Hung <chris@iotechsys.com>

fix #4170

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core-command from this branch with `MESSAGEQUEUE_REQUIRED=true` environment variable
2. Send command requests via `redis` container to InternalRequestCommandTopic, for example:
```shell
/data # redis-cli
127.0.0.1:6379> PUBLISH .command.request.Random-Boolean-Device.Bool.get '{"CorrelationID": "14a42ea6-c394-41c3-8bcd-a29b9f5e6835", "ApiVersion": "v2", "RequestId": "e6e8a2f4-eb14-4649-9e2b-175247911369", "Content-Type": "application/json"}'
(integer) 1
```
3. Verified core-command receives the request, propagates to device service, receives the response and send back to internal messaging (`redis` container) on InternalResponseCommandTopicPrefix topic:
```
level=DEBUG ts=2022-10-03T05:53:17.983273178Z app=core-command source=internal.go:107 msg="Command request received on message queue. Topic: /command/request/Random-Boolean-Device/Bool/get, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835 "
level=DEBUG ts=2022-10-03T05:53:17.987350115Z app=core-command source=internal.go:147 msg="Command request sent to message queue. Topic: edgex/command/request/device-virtual/Random-Boolean-Device/Bool/get, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835"
level=DEBUG ts=2022-10-03T05:53:17.987990896Z app=core-command source=internal.go:52 msg="Command response received on message queue. Topic: edgex/command/response/device-virtual/Random-Boolean-Device/Bool/get, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835 "
level=DEBUG ts=2022-10-03T05:53:17.988207693Z app=core-command source=internal.go:70 msg="Published response message on topic '/command/response/Random-Boolean-Device/Bool/get'"
```
`redis`:
```shell
/data # redis-cli
127.0.0.1:6379> PSUBSCRIBE .command.response.*
Reading messages... (press Ctrl-C to quit)
1) "psubscribe"
2) ".command.response.*"
3) (integer) 1
1) "pmessage"
2) ".command.response.*"
3) ".command.response.Random-Boolean-Device.Bool.get"
4) "{\"ReceivedTopic\":\"edgex/command/response/device-virtual/Random-Boolean-Device/Bool/get\",\"CorrelationID\":\"14a42ea6-c394-41c3-8bcd-a29b9f5e6835\",\"ApiVersion\":\"v2\",\"RequestID\":\"e6e8a2f4-eb14-4649-9e2b-175247911369\",\"ErrorCode\":0,\"Payload\":\"eyJhcGlWZXJzaW9uIjoidjIiLCJzdGF0dXNDb2RlIjoyMDAsImV2ZW50Ijp7ImFwaVZlcnNpb24iOiJ2MiIsImlkIjoiZmI3OWUwZWItMTBkYi00NWRjLTkzM2MtMGFjNjlmZjk0MzNjIiwiZGV2aWNlTmFtZSI6IlJhbmRvbS1Cb29sZWFuLURldmljZSIsInByb2ZpbGVOYW1lIjoiUmFuZG9tLUJvb2xlYW4tRGV2aWNlIiwic291cmNlTmFtZSI6IkJvb2wiLCJvcmlnaW4iOjE2NjQ3NzY0ODA1NTkwOTU1MjYsInJlYWRpbmdzIjpbeyJpZCI6Ijk4MjU5MWRlLTNlNDYtNGI0YS04Mjc5LTg2NDNkODVhYTM3MSIsIm9yaWdpbiI6MTY2NDc3NjQ4MDU1OTA5NTUyNiwiZGV2aWNlTmFtZSI6IlJhbmRvbS1Cb29sZWFuLURldmljZSIsInJlc291cmNlTmFtZSI6IkJvb2wiLCJwcm9maWxlTmFtZSI6IlJhbmRvbS1Cb29sZWFuLURldmljZSIsInZhbHVlVHlwZSI6IkJvb2wiLCJ2YWx1ZSI6InRydWUifV19fQ==\",\"ContentType\":\"application/json\",\"QueryParams\":{}}"

```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->