### PR TITLE
feat(command): command query via internal messaging

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -58,7 +58,7 @@ Type = "consul"
     DeviceResponseTopic = "edgex/command/response/#"      # for subscribing to device service responses
     CommandRequestTopic = "/command/request/#"     # for subscribing to internal command requests
     CommandResponseTopicPrefix = "/command/response"     # for publishing responses back to internal service /<device-name>/<command-name>/<method> will be added to this publish topic prefix
-    QueryRequestTopic = "/commandquery/request"   # for subscribing to internal command query requests
+    QueryRequestTopic = "/commandquery/request/#"   # for subscribing to internal command query requests
     QueryResponseTopic = "/commandquery/response"   # for publishing reponsses back to internal service
     [MessageQueue.Internal.Optional]
     # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them

--- a/internal/core/command/controller/messaging/external.go
+++ b/internal/core/command/controller/messaging/external.go
@@ -6,11 +6,8 @@
 package messaging
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -18,11 +15,8 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
-	edgexErr "github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
-
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 
-	"github.com/edgexfoundry/edgex-go/internal/core/command/application"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
 )
 
@@ -60,8 +54,6 @@ func OnConnectHandler(router MessagingRouter, dic *di.Container) mqtt.OnConnectH
 
 func commandQueryHandler(responseTopic string, qos byte, retain bool, dic *di.Container) mqtt.MessageHandler {
 	return func(client mqtt.Client, message mqtt.Message) {
-		var errorMessage string
-		var responseEnvelope types.MessageEnvelope
 		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 
 		requestEnvelope, err := types.NewMessageEnvelopeFromJSON(message.Payload())
@@ -79,58 +71,11 @@ func commandQueryHandler(responseTopic string, qos byte, retain bool, dic *di.Co
 			deviceName = common.All
 		}
 
-		var commands any
-		var edgexErr edgexErr.EdgeX
-		switch deviceName {
-		case common.All:
-			offset, limit := common.DefaultOffset, common.DefaultLimit
-			if requestEnvelope.QueryParams != nil {
-				if offsetRaw, ok := requestEnvelope.QueryParams[common.Offset]; ok {
-					offset, err = strconv.Atoi(offsetRaw)
-					if err != nil {
-						errorMessage = fmt.Sprintf("Failed to convert 'offset' query parameter to intger: %s", err.Error())
-						responseEnvelope = types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
-						publishMessage(client, responseTopic, qos, retain, responseEnvelope, lc)
-						return
-					}
-				}
-				if limitRaw, ok := requestEnvelope.QueryParams[common.Limit]; ok {
-					limit, err = strconv.Atoi(limitRaw)
-					if err != nil {
-						errorMessage = fmt.Sprintf("Failed to convert 'limit' query parameter to integer: %s", err.Error())
-						responseEnvelope = types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
-						publishMessage(client, responseTopic, qos, retain, responseEnvelope, lc)
-						return
-					}
-				}
-			}
-
-			commands, _, edgexErr = application.AllCommands(offset, limit, dic)
-			if edgexErr != nil {
-				errorMessage = fmt.Sprintf("Failed to get all commands: %s", edgexErr.Error())
-				responseEnvelope = types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
-				publishMessage(client, responseTopic, qos, retain, responseEnvelope, lc)
-				return
-			}
-		default:
-			commands, edgexErr = application.CommandsByDeviceName(deviceName, dic)
-			if edgexErr != nil {
-				errorMessage = fmt.Sprintf("Failed to get commands by device name '%s': %s", deviceName, edgexErr.Error())
-				responseEnvelope = types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
-				publishMessage(client, responseTopic, qos, retain, responseEnvelope, lc)
-				return
-			}
+		responseEnvelope, edgexErr := getCommandQueryResponseEnvelope(requestEnvelope, deviceName, dic)
+		if edgexErr != nil {
+			responseEnvelope = types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, edgexErr.Error())
 		}
 
-		payloadBytes, err := json.Marshal(commands)
-		if err != nil {
-			errorMessage = fmt.Sprintf("Failed to json encoding deviceCommands payload: %s", err.Error())
-			responseEnvelope = types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
-			publishMessage(client, responseTopic, qos, retain, responseEnvelope, lc)
-			return
-		}
-
-		responseEnvelope, _ = types.NewMessageEnvelopeForResponse(payloadBytes, requestEnvelope.RequestID, requestEnvelope.CorrelationID, common.ContentTypeJSON)
 		publishMessage(client, responseTopic, qos, retain, responseEnvelope, lc)
 	}
 }
@@ -202,32 +147,4 @@ func publishMessage(client mqtt.Client, responseTopic string, qos byte, retain b
 	} else {
 		lc.Debugf("Published response message to external message queue on topic '%s' with %d bytes", responseTopic, len(envelopeBytes))
 	}
-}
-
-// validateRequestTopic validates the request topic by checking the existence of device and device service,
-// returns the internal device request topic to which the command request will be sent.
-func validateRequestTopic(prefix string, deviceName string, commandName string, method string, dic *di.Container) (string, error) {
-	// retrieve device information through Metadata DeviceClient
-	dc := bootstrapContainer.DeviceClientFrom(dic.Get)
-	if dc == nil {
-		return "", errors.New("nil Device Client")
-	}
-	deviceResponse, err := dc.DeviceByName(context.Background(), deviceName)
-	if err != nil {
-		return "", fmt.Errorf("failed to get Device by name %s: %v", deviceName, err)
-	}
-
-	// retrieve device service information through Metadata DeviceClient
-	dsc := bootstrapContainer.DeviceServiceClientFrom(dic.Get)
-	if dsc == nil {
-		return "", errors.New("nil DeviceService Client")
-	}
-	deviceServiceResponse, err := dsc.DeviceServiceByName(context.Background(), deviceResponse.Device.ServiceName)
-	if err != nil {
-		return "", fmt.Errorf("failed to get DeviceService by name %s: %v", deviceResponse.Device.ServiceName, err)
-	}
-
-	// expected internal command request topic scheme: #/<device-service>/<device>/<command-name>/<method>
-	return strings.Join([]string{prefix, deviceServiceResponse.Service.Name, deviceName, commandName, method}, "/"), nil
-
 }

--- a/internal/core/command/controller/messaging/utils.go
+++ b/internal/core/command/controller/messaging/utils.go
@@ -1,0 +1,99 @@
+//
+// Copyright (C) 2022 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	edgexErr "github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
+
+	"github.com/edgexfoundry/edgex-go/internal/core/command/application"
+)
+
+// validateRequestTopic validates the request topic by checking the existence of device and device service,
+// returns the internal device request topic to which the command request will be sent.
+func validateRequestTopic(prefix string, deviceName string, commandName string, method string, dic *di.Container) (string, error) {
+	// retrieve device information through Metadata DeviceClient
+	dc := bootstrapContainer.DeviceClientFrom(dic.Get)
+	if dc == nil {
+		return "", errors.New("nil Device Client")
+	}
+	deviceResponse, err := dc.DeviceByName(context.Background(), deviceName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Device by name %s: %v", deviceName, err)
+	}
+
+	// retrieve device service information through Metadata DeviceClient
+	dsc := bootstrapContainer.DeviceServiceClientFrom(dic.Get)
+	if dsc == nil {
+		return "", errors.New("nil DeviceService Client")
+	}
+	deviceServiceResponse, err := dsc.DeviceServiceByName(context.Background(), deviceResponse.Device.ServiceName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get DeviceService by name %s: %v", deviceResponse.Device.ServiceName, err)
+	}
+
+	// expected internal command request topic scheme: #/<device-service>/<device>/<command-name>/<method>
+	return strings.Join([]string{prefix, deviceServiceResponse.Service.Name, deviceName, commandName, method}, "/"), nil
+
+}
+
+// getCommandQueryResponseEnvelope returns the MessageEnvelope containing the DeviceCoreCommand payload bytes
+func getCommandQueryResponseEnvelope(requestEnvelope types.MessageEnvelope, deviceName string, dic *di.Container) (types.MessageEnvelope, edgexErr.EdgeX) {
+	var err error
+	var commands any
+	var edgexError edgexErr.EdgeX
+
+	switch deviceName {
+	case common.All:
+		offset, limit := common.DefaultOffset, common.DefaultLimit
+		if requestEnvelope.QueryParams != nil {
+			if offsetRaw, ok := requestEnvelope.QueryParams[common.Offset]; ok {
+				offset, err = strconv.Atoi(offsetRaw)
+				if err != nil {
+					return types.MessageEnvelope{}, edgexErr.NewCommonEdgeX(edgexErr.KindContractInvalid, fmt.Sprintf("Failed to convert 'offset' query parameter to intger: %s", err.Error()), err)
+				}
+			}
+			if limitRaw, ok := requestEnvelope.QueryParams[common.Limit]; ok {
+				limit, err = strconv.Atoi(limitRaw)
+				if err != nil {
+					return types.MessageEnvelope{}, edgexErr.NewCommonEdgeX(edgexErr.KindContractInvalid, fmt.Sprintf("Failed to convert 'limit' query parameter to integer: %s", err.Error()), err)
+				}
+			}
+		}
+
+		commands, _, edgexError = application.AllCommands(offset, limit, dic)
+		if edgexError != nil {
+			return types.MessageEnvelope{}, edgexErr.NewCommonEdgeX(edgexErr.KindServerError, fmt.Sprintf("Failed to get all commands: %s", edgexError.Error()), edgexError)
+		}
+	default:
+		commands, edgexError = application.CommandsByDeviceName(deviceName, dic)
+		if edgexError != nil {
+			return types.MessageEnvelope{}, edgexErr.NewCommonEdgeX(edgexErr.KindServerError, fmt.Sprintf("Failed to get commands by device name '%s': %s", deviceName, edgexError.Error()), edgexError)
+		}
+	}
+
+	responseBytes, err := json.Marshal(commands)
+	if err != nil {
+		return types.MessageEnvelope{}, edgexErr.NewCommonEdgeX(edgexErr.KindServerError, fmt.Sprintf("Failed to json encoding device commands payload: %s", err.Error()), err)
+	}
+
+	responseEnvelope, err := types.NewMessageEnvelopeForResponse(responseBytes, requestEnvelope.RequestID, requestEnvelope.CorrelationID, common.ContentTypeJSON)
+	if err != nil {
+		return types.MessageEnvelope{}, edgexErr.NewCommonEdgeX(edgexErr.KindServerError, fmt.Sprintf("Failed to create response MessageEnvelope: %s", err.Error()), err)
+	}
+
+	return responseEnvelope, nil
+}


### PR DESCRIPTION
fix #4176 

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core-command from this branch with `MESSAGEQUEUE_REQUIRED=true` environment variable
2. Send command query request via internal messaging, for example:
```shell
/data # redis-cli
127.0.0.1:6379> PUBLISH .commandquery.request.Random-Boolean-Device '{"CorrelationID": "14a42ea6-c394-41c3-8bcd-a29b9f5e6835", "ApiVersion": "v2", "RequestId": "e6e8a2f4-eb14-4649-9e2b-175247911369", "ContentType": "application/json"}'
(integer) 1
```
3. Verify core-command received the request and send the response back correctly:
```
level=DEBUG ts=2022-10-05T07:26:15.601091825Z app=core-command source=internal.go:196 msg="Command query request received on internal MessageBus. Topic: /commandquery/request/Random-Boolean-Device, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835 "
level=DEBUG ts=2022-10-05T07:26:15.606759825Z app=core-command source=internal.go:223 msg="Command query response sent to internal MessageBus. Topic: /commandquery/response, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->