### PR TITLE
feat: Enable common security secret service metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ build-nats:
 tidy:
 	go mod tidy
 
+core: metadata data command
+
 metadata: cmd/core-metadata/core-metadata
 cmd/core-metadata/core-metadata:
 	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-metadata
@@ -107,19 +109,21 @@ command: cmd/core-command/core-command
 cmd/core-command/core-command:
 	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-command
 
+support: notifications scheduler
+
 notifications: cmd/support-notifications/support-notifications
 cmd/support-notifications/support-notifications:
 	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-notifications
+
+scheduler: cmd/support-scheduler/support-scheduler
+cmd/support-scheduler/support-scheduler:
+	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-scheduler
 
 cmd/sys-mgmt-executor/sys-mgmt-executor:
 	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-executor
 
 cmd/sys-mgmt-agent/sys-mgmt-agent:
 	$(GO) build -tags "$(NO_MESSAGEBUS_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/sys-mgmt-agent
-
-scheduler: cmd/support-scheduler/support-scheduler
-cmd/support-scheduler/support-scheduler:
-	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NO_ZMQ_GO_BUILD_TAG) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_SUPPORT)" $(GOFLAGS) -o $@ ./cmd/support-scheduler
 
 proxy: cmd/security-proxy-setup/security-proxy-setup
 cmd/security-proxy-setup/security-proxy-setup:
@@ -185,6 +189,8 @@ docker_base:
 		echo "FROM golang:$(GO_VERSION)-alpine\nRUN apk add --update make git\nWORKDIR /edgex-go\nCOPY go.mod .\nRUN go mod download" | docker build -t $(LOCAL_CACHE_IMAGE) -f - .; \
 	fi
 
+dcore: dmetadata ddata dcommand
+
 dmetadata: docker_core_metadata
 docker_core_metadata: docker_base
 	docker build \
@@ -223,6 +229,8 @@ docker_core_command: docker_base
 		-t edgexfoundry/core-command:$(GIT_SHA) \
 		-t edgexfoundry/core-command:$(DOCKER_TAG) \
 		.
+
+dsupport: dnotifications dscheduler
 
 dnotifications: docker_support_notifications
 docker_support_notifications: docker_base

--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -19,6 +19,14 @@ LogLevel = "INFO"
       cacert = ""
       clientcert = ""
       clientkey = ""
+  [Writable.Telemetry]
+  Interval = "30s"
+  PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
+    [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
+    SecuritySecretsRequested = true
+    SecuritySecretsStored = true
+    [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
+#    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 
 [Service]
 HealthCheckInterval = "10s"

--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -23,8 +23,8 @@ LogLevel = "INFO"
   Interval = "30s"
   PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
     [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
-    SecuritySecretsRequested = true
-    SecuritySecretsStored = true
+    SecuritySecretsRequested = false
+    SecuritySecretsStored = false
     [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
 #    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -15,6 +15,8 @@ LogLevel = "INFO"
     [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
     EventsPersisted = false
     ReadingsPersisted = false
+    SecuritySecretsRequested = true
+    SecuritySecretsStored = true
     [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
 #    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 [Service]

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -15,8 +15,8 @@ LogLevel = "INFO"
     [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
     EventsPersisted = false
     ReadingsPersisted = false
-    SecuritySecretsRequested = true
-    SecuritySecretsStored = true
+    SecuritySecretsRequested = false
+    SecuritySecretsStored = false
     [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
 #    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 [Service]

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -16,6 +16,14 @@ LogLevel = "INFO"
       [Writable.InsecureSecrets.DB.Secrets]
       username = ""
       password = ""
+  [Writable.Telemetry]
+  Interval = "30s"
+  PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
+    [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
+    SecuritySecretsRequested = true
+    SecuritySecretsStored = true
+    [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
+#    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 
 [Service]
 HealthCheckInterval = "10s"

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -20,8 +20,8 @@ LogLevel = "INFO"
   Interval = "30s"
   PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
     [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
-    SecuritySecretsRequested = true
-    SecuritySecretsStored = true
+    SecuritySecretsRequested = false
+    SecuritySecretsStored = false
     [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
 #    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -22,8 +22,8 @@ ResendInterval = "5s"
   Interval = "30s"
   PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
     [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
-    SecuritySecretsRequested = true
-    SecuritySecretsStored = true
+    SecuritySecretsRequested = false
+    SecuritySecretsStored = false
     [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
 #    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -1,3 +1,8 @@
+# This is required for backwards compatibility so new version of sevice using older 2.x configuration will not fail bootstrapping
+# This will default to false if not provided in old config. Messagebus is now needed by Device System Events and Service Metrics
+# TODO: Remove this setting EdgeX 3.0
+RequireMessageBus = true
+
 [Writable]
 LogLevel = "INFO"
 ResendLimit = 2
@@ -13,6 +18,14 @@ ResendInterval = "5s"
       [Writable.InsecureSecrets.SMTP.Secrets]
       username = "username@mail.example.com"
       password = ""
+  [Writable.Telemetry]
+  Interval = "30s"
+  PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
+    [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
+    SecuritySecretsRequested = true
+    SecuritySecretsStored = true
+    [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
+#    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 
 [Service]
 HealthCheckInterval = "10s"
@@ -57,6 +70,31 @@ Type = "consul"
   # AuthMode is the SMTP authentication mechanism. Currently, "usernamepassword" is the only AuthMode supported by this service, and the secret keys are "username" and "password".
   AuthMode = "usernamepassword"
 
+[MessageQueue]
+Protocol = "redis"
+Host = "localhost"
+Port = 6379
+Type = "redis"
+AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
+SecretName = "redisdb"
+  [MessageQueue.Optional]
+  # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
+  ClientId ="support-notifications"
+  Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+  KeepAlive = "10" # Seconds (must be 2 or greater)
+  Retained = "false"
+  AutoReconnect = "true"
+  ConnectTimeout = "5" # Seconds
+  SkipCertVerify = "false"
+  # Additional Default NATS Specific options that need to be here to enable evnironment variable overrides of them
+  Format = "nats"
+  RetryOnFailedConnect = "true"
+  QueueGroup = ""
+  Durable = ""
+  AutoProvision = "true"
+  Deliver = "new"
+  DefaultPubRetryAttempts = "2"
+  Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
 
 [SecretStore]
 Type = "vault"

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -17,8 +17,8 @@ LogLevel = "INFO"
   Interval = "30s"
   PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
     [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
-    SecuritySecretsRequested = true
-    SecuritySecretsStored = true
+    SecuritySecretsRequested = false
+    SecuritySecretsStored = false
     [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
 #    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -1,3 +1,8 @@
+# This is required for backwards compatibility so new version of sevice using older 2.x configuration will not fail bootstrapping
+# This will default to false if not provided in old config. Messagebus is now needed by Device System Events and Service Metrics
+# TODO: Remove this setting EdgeX 3.0
+RequireMessageBus = true
+
 ScheduleIntervalTime = 500
 
 [Writable]
@@ -8,6 +13,14 @@ LogLevel = "INFO"
             [Writable.InsecureSecrets.DB.Secrets]
             username = ""
             password = ""
+  [Writable.Telemetry]
+  Interval = "30s"
+  PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
+    [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
+    SecuritySecretsRequested = true
+    SecuritySecretsStored = true
+    [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
+#    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 
 [Service]
 HealthCheckInterval = "10s"
@@ -56,6 +69,32 @@ Type = "consul"
     Path = "/api/v2/event/age/604800000000000" # Remove events older than 7 days
     Interval = "midnight"
     AdminState = "UNLOCKED"
+
+[MessageQueue]
+Protocol = "redis"
+Host = "localhost"
+Port = 6379
+Type = "redis"
+AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
+SecretName = "redisdb"
+  [MessageQueue.Optional]
+  # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
+  ClientId ="support-scheduler"
+  Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+  KeepAlive = "10" # Seconds (must be 2 or greater)
+  Retained = "false"
+  AutoReconnect = "true"
+  ConnectTimeout = "5" # Seconds
+  SkipCertVerify = "false"
+  # Additional Default NATS Specific options that need to be here to enable evnironment variable overrides of them
+  Format = "nats"
+  RetryOnFailedConnect = "true"
+  QueueGroup = ""
+  Durable = ""
+  AutoProvision = "true"
+  Deliver = "new"
+  DefaultPubRetryAttempts = "2"
+  Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
 
 [SecretStore]
 Type = "vault"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.4.1
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.19
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.18
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.3.0-dev.18
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.3.0-dev.20
 	github.com/edgexfoundry/go-mod-registry/v2 v2.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.4.1
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.18
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.20
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.3.0-dev.18
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.3.0-dev.20
 	github.com/edgexfoundry/go-mod-registry/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.1 h1:tUSpviiL5G3P9SZZJPC4ZULZJsxQKXxfENpMvdbAXAI=
 github.com/eclipse/paho.mqtt.golang v1.4.1/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.18 h1:ZX9wGoIE+ngrAEr2LYTif0EGQG34PDY/VQrH92lNopw=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.18/go.mod h1:QQPtK75bGbYH42tLrwgIV1xpiXufOR5mE/Wby/cxBqQ=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.20 h1:VGH0kc3YFkb3gO0PToagQtb/QCfWRqqK94xhOJvxNhs=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.20/go.mod h1:QQPtK75bGbYH42tLrwgIV1xpiXufOR5mE/Wby/cxBqQ=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0 h1:AZeaAPJM5X93ITFgwbwluYDtYEJ7tkCMSlj35GwfLLU=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0/go.mod h1:YP17JhMnXTitowXE13QJwFaKo0oc03iyoKLjWAYl4FE=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.3.0-dev.18 h1:Smkhoqq9+XsMcs0B3JokAmIT7hXJy9eQWk6SYk9z4yE=

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.1 h1:tUSpviiL5G3P9SZZJPC4ZULZJsxQKXxfENpMvdbAXAI=
 github.com/eclipse/paho.mqtt.golang v1.4.1/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.19 h1:ACFIR+5hHBr9rp0n2PajvAnk011RDGW+9Y/AoBQRv1c=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.19/go.mod h1:QQPtK75bGbYH42tLrwgIV1xpiXufOR5mE/Wby/cxBqQ=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.18 h1:ZX9wGoIE+ngrAEr2LYTif0EGQG34PDY/VQrH92lNopw=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.18/go.mod h1:QQPtK75bGbYH42tLrwgIV1xpiXufOR5mE/Wby/cxBqQ=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0 h1:AZeaAPJM5X93ITFgwbwluYDtYEJ7tkCMSlj35GwfLLU=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0/go.mod h1:YP17JhMnXTitowXE13QJwFaKo0oc03iyoKLjWAYl4FE=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.3.0-dev.18 h1:Smkhoqq9+XsMcs0B3JokAmIT7hXJy9eQWk6SYk9z4yE=

--- a/internal/core/command/config/config.go
+++ b/internal/core/command/config/config.go
@@ -36,6 +36,7 @@ type ConfigurationStruct struct {
 type WritableInfo struct {
 	LogLevel        string
 	InsecureSecrets bootstrapConfig.InsecureSecrets
+	Telemetry       bootstrapConfig.TelemetryInfo
 }
 
 type MessageQueue struct {
@@ -110,7 +111,5 @@ func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecre
 
 // GetTelemetryInfo returns the service's Telemetry settings.
 func (c *ConfigurationStruct) GetTelemetryInfo() *bootstrapConfig.TelemetryInfo {
-	// TODO: return services actual TelemetryInfo once updated
-	return &bootstrapConfig.TelemetryInfo{}
-	//return &c.Writable.Telemetry
+	return &c.Writable.Telemetry
 }

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -75,6 +75,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		[]interfaces.BootstrapHandler{
 			handlers.NewClientsBootstrap().BootstrapHandler,
 			MessageBusBootstrapHandler,
+			handlers.NewServiceMetrics(common.CoreCommandServiceKey).BootstrapHandler, // Must be after Messaging
 			NewBootstrap(router, common.CoreCommandServiceKey).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,

--- a/internal/core/metadata/config/config.go
+++ b/internal/core/metadata/config/config.go
@@ -38,6 +38,7 @@ type WritableInfo struct {
 	ProfileChange   ProfileChange
 	UoM             WritableUoM
 	InsecureSecrets bootstrapConfig.InsecureSecrets
+	Telemetry       bootstrapConfig.TelemetryInfo
 }
 
 type ProfileChange struct {
@@ -130,7 +131,5 @@ func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecre
 
 // GetTelemetryInfo returns the service's Telemetry settings.
 func (c *ConfigurationStruct) GetTelemetryInfo() *bootstrapConfig.TelemetryInfo {
-	// TODO: return services actual TelemetryInfo once updated
-	return &bootstrapConfig.TelemetryInfo{}
-	//return &c.Writable.Telemetry
+	return &c.Writable.Telemetry
 }

--- a/internal/core/metadata/main.go
+++ b/internal/core/metadata/main.go
@@ -76,6 +76,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 			uom.BootstrapHandler,
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
 			MessageBusBootstrapHandler,
+			handlers.NewServiceMetrics(common.CoreMetaDataServiceKey).BootstrapHandler, // Must be after Messaging
 			NewBootstrap(router, common.CoreMetaDataServiceKey).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,

--- a/internal/support/notifications/config/config.go
+++ b/internal/support/notifications/config/config.go
@@ -20,13 +20,16 @@ import (
 )
 
 type ConfigurationStruct struct {
-	Writable    WritableInfo
-	Clients     map[string]bootstrapConfig.ClientInfo
-	Databases   map[string]bootstrapConfig.Database
-	Registry    bootstrapConfig.RegistryInfo
-	Service     bootstrapConfig.ServiceInfo
-	Smtp        SmtpInfo
-	SecretStore bootstrapConfig.SecretStoreInfo
+	//TODO: Remove in EdgeX 3.0 - Is needed now for backward compatability in 2.0
+	RequireMessageBus bool
+	Writable          WritableInfo
+	Clients           map[string]bootstrapConfig.ClientInfo
+	Databases         map[string]bootstrapConfig.Database
+	Registry          bootstrapConfig.RegistryInfo
+	Service           bootstrapConfig.ServiceInfo
+	MessageQueue      bootstrapConfig.MessageBusInfo
+	Smtp              SmtpInfo
+	SecretStore       bootstrapConfig.SecretStoreInfo
 }
 
 type WritableInfo struct {
@@ -36,6 +39,7 @@ type WritableInfo struct {
 	// ResendInterval is the default interval of resending the notification. The format of this field is to be an unsigned integer followed by a unit which may be "ns", "us" (or "µs"), "ms", "s", "m", "h" representing nanoseconds, microseconds, milliseconds, seconds, minutes or hours. Eg, "100ms", "24h"
 	ResendInterval  string
 	InsecureSecrets bootstrapConfig.InsecureSecrets
+	Telemetry       bootstrapConfig.TelemetryInfo
 }
 
 type SmtpInfo struct {
@@ -100,10 +104,11 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:     c.Clients,
-		Service:     c.Service,
-		Registry:    c.Registry,
-		SecretStore: c.SecretStore,
+		Clients:      c.Clients,
+		Service:      c.Service,
+		Registry:     c.Registry,
+		SecretStore:  c.SecretStore,
+		MessageQueue: c.MessageQueue,
 	}
 }
 
@@ -129,7 +134,5 @@ func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecre
 
 // GetTelemetryInfo returns the service's Telemetry settings.
 func (c *ConfigurationStruct) GetTelemetryInfo() *bootstrapConfig.TelemetryInfo {
-	// TODO: return services actual TelemetryInfo once updated
-	return &bootstrapConfig.TelemetryInfo{}
-	//return &c.Writable.Telemetry
+	return &c.Writable.Telemetry
 }

--- a/internal/support/notifications/main.go
+++ b/internal/support/notifications/main.go
@@ -24,6 +24,7 @@ package notifications
 import (
 	"context"
 	"os"
+	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
@@ -76,10 +77,25 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		true,
 		[]interfaces.BootstrapHandler{
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
+			MessageBusBootstrapHandler,
+			handlers.NewServiceMetrics(common.SupportNotificationsServiceKey).BootstrapHandler, // Must be after Messaging
 			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, common.SupportNotificationsServiceKey).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,
 			handlers.NewStartMessage(common.SupportNotificationsServiceKey, edgex.Version).BootstrapHandler,
 		})
+}
+
+// MessageBusBootstrapHandler sets up the MessageBus connection if MessageBus required is true.
+// This is required for backwards compatability with older versions of 2.x configuration
+// TODO: Remove in EdgeX 3.0
+func MessageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
+	configuration := container.ConfigurationFrom(dic.Get)
+	if configuration.RequireMessageBus {
+		return handlers.MessagingBootstrapHandler(ctx, wg, startupTimer, dic)
+	}
+
+	// Not required so do nothing
+	return true
 }

--- a/internal/support/scheduler/config/config.go
+++ b/internal/support/scheduler/config/config.go
@@ -22,14 +22,17 @@ import (
 
 // Configuration V2 for the Support Scheduler Service
 type ConfigurationStruct struct {
-	Writable        WritableInfo
-	Clients         map[string]bootstrapConfig.ClientInfo
-	Databases       map[string]bootstrapConfig.Database
-	Registry        bootstrapConfig.RegistryInfo
-	Service         bootstrapConfig.ServiceInfo
-	Intervals       map[string]IntervalInfo
-	IntervalActions map[string]IntervalActionInfo
-	SecretStore     bootstrapConfig.SecretStoreInfo
+	//TODO: Remove in EdgeX 3.0 - Is needed now for backward compatability in 2.0
+	RequireMessageBus bool
+	Writable          WritableInfo
+	Clients           map[string]bootstrapConfig.ClientInfo
+	Databases         map[string]bootstrapConfig.Database
+	Registry          bootstrapConfig.RegistryInfo
+	Service           bootstrapConfig.ServiceInfo
+	MessageQueue      bootstrapConfig.MessageBusInfo
+	Intervals         map[string]IntervalInfo
+	IntervalActions   map[string]IntervalActionInfo
+	SecretStore       bootstrapConfig.SecretStoreInfo
 	// ScheduleIntervalTime is a time(Millisecond) to create a ticker to delay the scheduler loop
 	ScheduleIntervalTime int
 }
@@ -37,6 +40,7 @@ type ConfigurationStruct struct {
 type WritableInfo struct {
 	LogLevel        string
 	InsecureSecrets bootstrapConfig.InsecureSecrets
+	Telemetry       bootstrapConfig.TelemetryInfo
 }
 
 type IntervalInfo struct {
@@ -124,10 +128,11 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:     c.Clients,
-		Service:     c.Service,
-		Registry:    c.Registry,
-		SecretStore: c.SecretStore,
+		Clients:      c.Clients,
+		Service:      c.Service,
+		Registry:     c.Registry,
+		SecretStore:  c.SecretStore,
+		MessageQueue: c.MessageQueue,
 	}
 }
 
@@ -153,7 +158,5 @@ func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecre
 
 // GetTelemetryInfo returns the service's Telemetry settings.
 func (c *ConfigurationStruct) GetTelemetryInfo() *bootstrapConfig.TelemetryInfo {
-	// TODO: return services actual TelemetryInfo once updated
-	return &bootstrapConfig.TelemetryInfo{}
-	//return &c.Writable.Telemetry
+	return &c.Writable.Telemetry
 }

--- a/internal/support/scheduler/main.go
+++ b/internal/support/scheduler/main.go
@@ -18,6 +18,7 @@ package scheduler
 import (
 	"context"
 	"os"
+	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal"
@@ -70,10 +71,25 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		true,
 		[]interfaces.BootstrapHandler{
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
+			MessageBusBootstrapHandler,
+			handlers.NewServiceMetrics(common.SupportSchedulerServiceKey).BootstrapHandler, // Must be after Messaging
 			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, common.SupportSchedulerServiceKey).BootstrapHandler,
 			telemetry.BootstrapHandler,
 			httpServer.BootstrapHandler,
 			handlers.NewStartMessage(common.SupportSchedulerServiceKey, edgex.Version).BootstrapHandler,
 		})
+}
+
+// MessageBusBootstrapHandler sets up the MessageBus connection if MessageBus required is true.
+// This is required for backwards compatability with older versions of 2.x configuration
+// TODO: Remove in EdgeX 3.0
+func MessageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
+	configuration := container.ConfigurationFrom(dic.Get)
+	if configuration.RequireMessageBus {
+		return handlers.MessagingBootstrapHandler(ctx, wg, startupTimer, dic)
+	}
+
+	// Not required so do nothing
+	return true
 }


### PR DESCRIPTION
Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

part of https://github.com/edgexfoundry/go-mod-bootstrap/issues/374
also addresses https://github.com/edgexfoundry/go-mod-bootstrap/issues/379
by using latest go-mod-bootstrap

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/877

## Testing Instructions
Build docker images from this branch
Use compose builder run `make run dev`
Verify all service bootstrap properly
Verify Core and Support service have the following log messages
```
 "SecuritySecretsStored metric registered and will be reported (if enabled)"
"SecuritySecretsRequested metric registered and will be reported (if enabled)"
```
From Consul,  enable Debug logging on Core Metadata and enable the security metrics to be reported by setting the following to `true`
```
edgex/core/2.0/core-metadata/Writable/Telemetry/Metrics/SecuritySecretsRequested
edgex/core/2.0/core-metadata/Writable/Telemetry/Metrics/SecuritySecretsStored
```
Verify has the following log message every 30 secs
```
"Publish 2 metrics to the 'edgex/telemetry/core-metadata' base topic"
```


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->