### PR TITLE
fix: revert "build(deps): Bump github.com/edgexfoundry/go-mod-bootstrap/v2 from 2.3.0-dev.17 to 2.3.0-dev.19"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.4.1
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.19
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.17
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.3.0-dev.18
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.3.0-dev.20
 	github.com/edgexfoundry/go-mod-registry/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.1 h1:tUSpviiL5G3P9SZZJPC4ZULZJsxQKXxfENpMvdbAXAI=
 github.com/eclipse/paho.mqtt.golang v1.4.1/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.19 h1:ACFIR+5hHBr9rp0n2PajvAnk011RDGW+9Y/AoBQRv1c=
-github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.19/go.mod h1:QQPtK75bGbYH42tLrwgIV1xpiXufOR5mE/Wby/cxBqQ=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.17 h1:Zk0iY5NGfJztzgguuJG/w3OR98KqlGg1FbIRzcze3Ag=
+github.com/edgexfoundry/go-mod-bootstrap/v2 v2.3.0-dev.17/go.mod h1:QQPtK75bGbYH42tLrwgIV1xpiXufOR5mE/Wby/cxBqQ=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0 h1:AZeaAPJM5X93ITFgwbwluYDtYEJ7tkCMSlj35GwfLLU=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0/go.mod h1:YP17JhMnXTitowXE13QJwFaKo0oc03iyoKLjWAYl4FE=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.3.0-dev.18 h1:Smkhoqq9+XsMcs0B3JokAmIT7hXJy9eQWk6SYk9z4yE=


### PR DESCRIPTION
Reverts edgexfoundry/edgex-go#4188