### PR TITLE
fix(command): update message queue bootstrap order

### DIFF
--- a/internal/core/command/controller/messaging/external.go
+++ b/internal/core/command/controller/messaging/external.go
@@ -15,6 +15,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
@@ -55,6 +56,7 @@ func OnConnectHandler(router MessagingRouter, dic *di.Container) mqtt.OnConnectH
 func commandQueryHandler(responseTopic string, qos byte, retain bool, dic *di.Container) mqtt.MessageHandler {
 	return func(client mqtt.Client, message mqtt.Message) {
 		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+		lc.Debugf("Received command query request from external message queue on topic '%s' with %d bytes", message.Topic(), len(message.Payload()))
 
 		requestEnvelope, err := types.NewMessageEnvelopeFromJSON(message.Payload())
 		if err != nil {
@@ -83,6 +85,8 @@ func commandQueryHandler(responseTopic string, qos byte, retain bool, dic *di.Co
 func commandRequestHandler(router MessagingRouter, dic *di.Container) mqtt.MessageHandler {
 	return func(client mqtt.Client, message mqtt.Message) {
 		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+		lc.Debugf("Received command request from external message queue on topic '%s' with %d bytes", message.Topic(), len(message.Payload()))
+
 		messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
 		qos := messageBusInfo.External.QoS
 		retain := messageBusInfo.External.Retain

--- a/internal/core/command/controller/messaging/internal.go
+++ b/internal/core/command/controller/messaging/internal.go
@@ -13,6 +13,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
@@ -59,11 +60,13 @@ func SubscribeCommandResponses(ctx context.Context, router MessagingRouter, dic 
 					continue
 				}
 
+				// original request is from external MQTT
 				if external {
 					publishMessage(externalMQTT, responseTopic, qos, retain, msgEnvelope, lc)
 					continue
 				}
 
+				// original request is from internal MessageBus
 				err = messageBus.Publish(msgEnvelope, responseTopic)
 				if err != nil {
 					lc.Errorf("Could not publish to internal MessageBus topic '%s': %s", responseTopic, err.Error())

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -94,6 +94,11 @@ func MessageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startup
 	router := messaging.NewMessagingRouter()
 
 	if configuration.RequireMessageBus {
+		if configuration.MessageQueue.External.Enabled {
+			if !handlers.NewExternalMQTT(messaging.OnConnectHandler(router, dic)).BootstrapHandler(ctx, wg, startupTimer, dic) {
+				return false
+			}
+		}
 		if !handlers.MessagingBootstrapHandler(ctx, wg, startupTimer, dic) {
 			return false
 		}
@@ -108,11 +113,6 @@ func MessageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startup
 		if err := messaging.SubscribeCommandQueryRequests(ctx, dic); err != nil {
 			lc.Errorf("Failed to subscribe command query request from internal message bus, %v", err)
 			return false
-		}
-		if configuration.MessageQueue.External.Enabled {
-			if !handlers.NewExternalMQTT(messaging.OnConnectHandler(router, dic)).BootstrapHandler(ctx, wg, startupTimer, dic) {
-				return false
-			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

fix #4194 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core-command from this branch with `MESSAGEQUEUE_EXTERNAL_ENABLED=true` environment variable
2. Send command request from external MQTT
3. Verified there's no error:
```
level=DEBUG ts=2022-10-12T03:16:28.400503727Z app=core-command source=external.go:88 msg="Received command request from external message queue on topic 'edgex/command/request/Random-Boolean-Device/Bool/get' with 303 bytes"
level=DEBUG ts=2022-10-12T03:16:28.414620847Z app=core-command source=external.go:137 msg="Command request sent to internal MessageBus. Topic: edgex/device/command/request/device-virtual/Random-Boolean-Device/Bool/get, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835"
level=DEBUG ts=2022-10-12T03:16:28.415261074Z app=core-command source=internal.go:55 msg="Command response received on internal MessageBus. Topic: edgex/device/command/response/device-virtual/Random-Boolean-Device/Bool/get, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835 "
level=DEBUG ts=2022-10-12T03:16:28.415402117Z app=core-command source=external.go:152 msg="Published response message to external message queue on topic 'edgex/command/response/Random-Boolean-Device/Bool/get' with 900 bytes"

```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->