### PR TITLE
build(snap): Exclude redundant eKuiper dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -344,6 +344,8 @@ apps:
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/sys-mgmt-agent/secrets-token.json
     daemon: simple
     plugs: [network, network-bind]
+  # Deprecated
+  # Use standalone edgex-app-service-configurable snap
   app-service-configurable:
     adapter: full
     after:
@@ -442,6 +444,8 @@ apps:
       # who is initially created as a role with postgres
       - bin/drop-snap-daemon.sh
     plugs: [home, removable-media, network]
+  # Deprecated
+  # Use standalone edgex-ekuiper snap
   kuiper:
     adapter: full
     after:
@@ -458,6 +462,8 @@ apps:
       SOURCE_FILE: $SNAP_DATA/kuiper/etc/sources/edgex.yaml 
       CONNECTION_FILE: $SNAP_DATA/kuiper/etc/connections/connection.yaml
     plugs: [network, network-bind]
+  # Deprecated
+  # Use standalone edgex-ekuiper snap
   kuiper-cli:
     adapter: full
     command: bin/kuiper
@@ -768,8 +774,7 @@ parts:
     organize:
       vault: bin/vault
 
-  # DEVICE SERVICES parts
-  # TODO: vet all the correct files are available...
+  # Deprecated
   app-service-configurable:
     plugin: nil
     stage-snaps:
@@ -788,7 +793,7 @@ parts:
       - -usr/share/doc/libpgm-5.2-0/*
       - -usr/share/doc/libsodium23/*
       - -usr/share/doc/libzmq5/*
-
+  # Deprecated
   kuiper:
     plugin: nil
     stage-snaps:
@@ -805,6 +810,15 @@ parts:
       - -usr/lib/*/libpgm*
       - -usr/lib/*/libsodium*
       - -usr/lib/*/libzmq*
+      - -usr/lib/*/libasn1*
+      - -usr/lib/*/libgssapi*
+      - -usr/lib/*/libhcrypto*
+      - -usr/lib/*/libheimbase*
+      - -usr/lib/*/libheimntlm*
+      - -usr/lib/*/libhx509*
+      - -usr/lib/*/libkrb5*
+      - -usr/lib/*/libroken*
+      - -usr/lib/*/libwind*
       - -usr/share/doc/libcurl*
       - -usr/share/doc/curl
       - -usr/share/doc/libldap*
@@ -812,6 +826,8 @@ parts:
       - -usr/share/doc/libpgm*
       - -usr/share/doc/libsodium*
       - -usr/share/doc/libzmq*
+      - -usr/share/doc/libheimbase1-heimdal
+      - -usr/share/doc/libroken18-heimdal
 
   metadata:
     plugin: nil


### PR DESCRIPTION
The kuiper and postgres parts use redundant parts that have started to mismatch because the kuiper part stages the edgex-ekuiper snap which includes debs from several week ago. This usually happens when debs are updated without changing their versions. The eKuiper part is deprecated and would no longer cause issues once we remove it. 

This PR excludes the redundant packages, as seen in this failed test: https://github.com/edgexfoundry/edgex-go/actions/runs/3267839212/jobs/5376557476#step:2:3100

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->