### PR TITLE
refactor(snap): environment variable usage and const definitions

### DIFF
--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -496,11 +496,11 @@ func configure() {
 	log.SetComponentName("configure")
 	log.Debug("Start")
 
-	installMode, err := snapctl.Get(installModeOption).Run()
+	installMode, err := snapctl.Get("install-mode").Run()
 	if err != nil {
 		log.Fatalf("error reading 'install-mode': %v", err)
 	}
-	deferStartup := (installMode == installModeDeferStartup)
+	deferStartup := (installMode == "defer-startup")
 	log.Infof("Defer startup: %t", deferStartup)
 
 	// process the EdgeX >=2.2 app options

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -84,7 +84,7 @@ func snapService(app string) string {
 }
 
 func isDisableAllowed(s string) error {
-	for _, v := range referenceServices {
+	for _, v := range requiredServices {
 		if s == v {
 			return fmt.Errorf("can't disable required service: %s", s)
 		}

--- a/snap/local/helper-go/const.go
+++ b/snap/local/helper-go/const.go
@@ -33,8 +33,3 @@ const (
 	// management services
 	systemManagementAgent = "sys-mgmt-agent"
 )
-
-const (
-	installModeOption       = "install-mode"
-	installModeDeferStartup = "defer-startup"
-)

--- a/snap/local/helper-go/const.go
+++ b/snap/local/helper-go/const.go
@@ -1,0 +1,40 @@
+package main
+
+// snapped apps
+const (
+	// core services
+	coreData       = "core-data"
+	coreMetadata   = "core-metadata"
+	coreCommand    = "core-command"
+	consul         = "consul"
+	redis          = "redis"
+	registry       = consul
+	configProvider = consul
+	// support services
+	supportNotifications = "support-notifications"
+	supportScheduler     = "support-scheduler"
+	eKuiper              = "kuiper"
+	rulesEngine          = eKuiper
+	// security services
+	securitySecretStore        = "security-secret-store"
+	securitySecretStoreSetup   = "security-secretstore-setup"
+	securityProxy              = "security-proxy"
+	securityProxySetup         = "security-proxy-setup"
+	securityBootstrapper       = "security-bootstrapper"
+	securityBootstrapperRedis  = "security-bootstrapper-redis"
+	securityBootstrapperConsul = "security-consul-bootstrapper"
+	securityFileTokenProvider  = "security-file-token-provider"
+	secretsConfig              = "secrets-config"
+	kong                       = "kong-daemon"
+	postgres                   = "postgres"
+	vault                      = "vault"
+	// app services
+	appServiceConfigurable = "app-service-configurable"
+	// management services
+	systemManagementAgent = "sys-mgmt-agent"
+)
+
+const (
+	installModeOption       = "install-mode"
+	installModeDeferStartup = "defer-startup"
+)

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -87,23 +87,6 @@ var secretStoreKnownSecrets = []string{
 	"redisdb[edgex-ekuiper]",
 }
 
-// services w/configuration that needs to be copied
-// to $SNAP_DATA
-var servicesWithConfig = []string{
-	"security-bootstrapper",
-	"security-bootstrap-redis",
-	"security-file-token-provider",
-	"security-proxy-setup",
-	"security-secretstore-setup",
-	"core-command",
-	"core-data",
-	"core-metadata",
-	"support-notifications",
-	"support-scheduler",
-	"sys-mgmt-agent",
-	"app-service-configurable",
-}
-
 var (
 	snapConf     = env.Snap + "/config"
 	snapDataConf = env.SnapData + "/config"
@@ -113,15 +96,32 @@ var (
 func installConfFiles() error {
 	var err error
 
+	// services w/configuration that needs to be copied
+	// to $SNAP_DATA
+	var servicesWithConfig = []string{
+		securityBootstrapper,
+		securityBootstrapperRedis,
+		securityFileTokenProvider,
+		securityProxySetup,
+		securitySecretStoreSetup,
+		coreCommand,
+		coreData,
+		coreMetadata,
+		supportNotifications,
+		supportScheduler,
+		systemManagementAgent,
+		appServiceConfigurable,
+	}
+
 	for _, v := range servicesWithConfig {
 		destDir := snapDataConf + "/"
 		srcDir := snapConf + "/"
 
 		// handle exceptions (i.e. config in non-std dirs)
-		if v == "security-bootstrap-redis" {
+		if v == securityBootstrapperRedis {
 			destDir = destDir + "security-bootstrapper/res-bootstrap-redis"
 			srcDir = srcDir + "security-bootstrapper/res-bootstrap-redis"
-		} else if v == "app-service-configurable" {
+		} else if v == appServiceConfigurable {
 			destDir = destDir + v + "/res/rules-engine"
 			srcDir = srcDir + "/res/rules-engine"
 		} else {
@@ -133,21 +133,21 @@ func installConfFiles() error {
 			return err
 		}
 
-		if v == "core-metadata" {
+		srcPath := srcDir + "/configuration.toml"
+		destPath := destDir + "/configuration.toml"
+		err = hooks.CopyFile(srcPath, destPath)
+		if err != nil {
+			return err
+		}
+
+		// copy additional files
+		if v == coreMetadata {
 			uomSrcPath := srcDir + "/uom.toml"
 			uomDestPath := destDir + "/uom.toml"
 			err = hooks.CopyFile(uomSrcPath, uomDestPath)
 			if err != nil {
 				return err
 			}
-		}
-
-		srcPath := srcDir + "/configuration.toml"
-		destPath := destDir + "/configuration.toml"
-
-		err = hooks.CopyFile(srcPath, destPath)
-		if err != nil {
-			return err
 		}
 	}
 

--- a/snap/local/helper-go/main.go
+++ b/snap/local/helper-go/main.go
@@ -18,9 +18,14 @@ package main
 
 import (
 	"os"
+
+	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
 )
 
 func main() {
+	// uncomment to enable snap debugging during development
+	snapctl.Set("debug", "true").Run()
+
 	subCommand := os.Args[1]
 	switch subCommand {
 	case "install": // snap install hook

--- a/snap/local/helper-go/main.go
+++ b/snap/local/helper-go/main.go
@@ -18,13 +18,11 @@ package main
 
 import (
 	"os"
-
-	"github.com/canonical/edgex-snap-hooks/v2/snapctl"
 )
 
 func main() {
 	// uncomment to enable snap debugging during development
-	snapctl.Set("debug", "true").Run()
+	// snapctl.Set("debug", "true").Run()
 
 	subCommand := os.Args[1]
 	switch subCommand {


### PR DESCRIPTION
- Switch to use the hooks/env package for snap envs
- Move constants and lists specific to this snap from hooks library to this package
- Refactor service lists to have consistent style

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Mostly refactoring. The review could do a side-by-side diff comparison. The snap tests in this PR has good coverage for the affected code. To run the snap test on a pre-built snap locally, run the following from the top level directory of [edgex-snap-testing](https://github.com/canonical/edgex-snap-testing) repo:
```bash
$ SERVICE_CHANNEL=edge/pr-4207 FULL_CONFIG_TEST=true go test -p 1 --count=1 ./test/suites/edgexfoundry
ok      edgex-snap-testing/test/suites/edgexfoundry     438.634s
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->