### PR TITLE
fix(command): validate query params in command handler

### DIFF
--- a/internal/core/command/controller/messaging/external.go
+++ b/internal/core/command/controller/messaging/external.go
@@ -128,7 +128,13 @@ func commandRequestHandler(router MessagingRouter, dic *di.Container) mqtt.Messa
 
 		deviceRequestTopic, err := validateRequestTopic(messageBusInfo.Internal.Topics[DeviceRequestTopicPrefix], deviceName, commandName, method, dic)
 		if err != nil {
-			lc.Errorf("invalid request topic: %s", err.Error())
+			responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, err.Error())
+			publishMessage(client, externalResponseTopic, qos, retain, responseEnvelope, lc)
+			return
+		}
+
+		err = validateGetCommandQueryParameters(requestEnvelope.QueryParams)
+		if err != nil {
 			responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, err.Error())
 			publishMessage(client, externalResponseTopic, qos, retain, responseEnvelope, lc)
 			return

--- a/internal/core/command/controller/messaging/external_test.go
+++ b/internal/core/command/controller/messaging/external_test.go
@@ -331,6 +331,9 @@ func Test_commandRequestHandler(t *testing.T) {
 	validPayload := testCommandRequestPayload()
 	invalidRequestPayload := testCommandRequestPayload()
 	invalidRequestPayload.ApiVersion = "v1"
+	invalidQueryParamsPayload := testCommandQueryPayload()
+	invalidQueryParamsPayload.QueryParams[common.PushEvent] = "invalid"
+	invalidQueryParamsPayload.QueryParams[common.ReturnEvent] = "invalid"
 
 	tests := []struct {
 		name                 string
@@ -345,6 +348,7 @@ func Test_commandRequestHandler(t *testing.T) {
 		{"invalid - unrecognized command method", "unittest/request/testDevice/testCommand/invalid", validPayload, true, false},
 		{"invalid - device not found", "unittest/request/unknown-device/testCommand/get", validPayload, true, true},
 		{"invalid - device service not found", "unittest/request/unknownService-device/testCommand/get", validPayload, true, true},
+		{"invalid - invalid device service reserved query parameters", testExternalCommandRequestTopicExample, invalidQueryParamsPayload, true, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/core/command/controller/messaging/internal.go
+++ b/internal/core/command/controller/messaging/internal.go
@@ -145,6 +145,18 @@ func SubscribeCommandRequests(ctx context.Context, router MessagingRouter, dic *
 					continue
 				}
 
+				err = validateGetCommandQueryParameters(requestEnvelope.QueryParams)
+				if err != nil {
+					lc.Errorf(err.Error())
+					responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, err.Error())
+					err = messageBus.Publish(responseEnvelope, internalResponseTopic)
+					if err != nil {
+						lc.Errorf("Could not publish to topic '%s': %s", internalResponseTopic, err.Error())
+					}
+
+					continue
+				}
+
 				// expected internal command request topic scheme: #/<device-service>/<device>/<command-name>/<method>
 				err = messageBus.Publish(requestEnvelope, deviceRequestTopic)
 				if err != nil {

--- a/internal/core/command/controller/messaging/utils.go
+++ b/internal/core/command/controller/messaging/utils.go
@@ -51,6 +51,22 @@ func validateRequestTopic(prefix string, deviceName string, commandName string, 
 
 }
 
+// validateGetCommandQueryParameters validates the value is valid for device service's reserved query parameters
+func validateGetCommandQueryParameters(queryParams map[string]string) error {
+	if dsReturnEvent, ok := queryParams[common.ReturnEvent]; ok {
+		if dsReturnEvent != common.ValueYes && dsReturnEvent != common.ValueNo {
+			return fmt.Errorf("invalid query parameter, %s has to be '%s' or '%s'", common.ReturnEvent, common.ValueYes, common.ValueNo)
+		}
+	}
+	if dsPushEvent, ok := queryParams[common.PushEvent]; ok {
+		if dsPushEvent != common.ValueYes && dsPushEvent != common.ValueNo {
+			return fmt.Errorf("invalid query parameter, %s has to be '%s' or '%s'", common.PushEvent, common.ValueYes, common.ValueNo)
+		}
+	}
+
+	return nil
+}
+
 // getCommandQueryResponseEnvelope returns the MessageEnvelope containing the DeviceCoreCommand payload bytes
 func getCommandQueryResponseEnvelope(requestEnvelope types.MessageEnvelope, deviceName string, dic *di.Container) (types.MessageEnvelope, error) {
 	var commandsResponse any


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

fix #4214 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core-command from this branch
2. Send command request with invalid query params value to external MQTT broker
3. Should receive response message with `ErrorCode: 1`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->