### PR TITLE
build(snap): kong migrations up before Kong startup

### DIFF
--- a/snap/local/runtime-helpers/bin/kong-daemon.sh
+++ b/snap/local/runtime-helpers/bin/kong-daemon.sh
@@ -2,12 +2,12 @@
 
 KONG=/usr/local/bin/kong
 
-# run kong migrations up to bootstrap the cassandra database
-# note that sometimes cassandra can be in a "starting up" state, etc.
+# run kong migrations up to bootstrap the database
+# note that sometimes the database can be in a "starting up" state, etc.
 # and in this case we should just loop and keep trying
 # we don't implement a timeout here because systemd will kill us if we 
 # don't succeed in 15 minutes (or whatever the configured stop-timeout is)
-until "$KONG" migrations bootstrap --conf "$KONG_CONF"; do
+until "$KONG" migrations up --conf "$KONG_CONF"; do
     sleep 5
 done
 

--- a/snap/local/runtime-helpers/bin/kong-daemon.sh
+++ b/snap/local/runtime-helpers/bin/kong-daemon.sh
@@ -2,14 +2,17 @@
 
 KONG=/usr/local/bin/kong
 
-# run kong migrations up to bootstrap the database
+# bootstrap the database
 # note that sometimes the database can be in a "starting up" state, etc.
 # and in this case we should just loop and keep trying
 # we don't implement a timeout here because systemd will kill us if we 
 # don't succeed in 15 minutes (or whatever the configured stop-timeout is)
-until "$KONG" migrations up --conf "$KONG_CONF"; do
+until "$KONG" migrations bootstrap --conf "$KONG_CONF"; do
     sleep 5
 done
+
+# perform migration for upgrades
+"$KONG" migrations up --conf "$KONG_CONF"
 
 # set up Kong's admin API plugins via kong.yml:
 "$KONG" config db_import "$KONGADMIN_CONFIGFILEPATH" || true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -696,23 +696,23 @@ parts:
       - perl
       - zlib1g-dev
     override-build: |
-      VERSION=2.8.0
+      VERSION=2.8.2
 
       # use dpkg architecture to figure out our target arch
       case "$(dpkg --print-architecture)" in
         amd64)
           FILE_NAME=kong_${VERSION}_amd64.deb
-          FILE_HASH=5715ec10547a2de9e7534d0af402fc8dbdad7145d4b43bbccc7bb960152b0314
+          FILE_HASH=d600227d07cb862b2dd2de3925eca5841b2292ef838af21ddf5f412c9ab0f3ee
           ;;
         arm64)
           FILE_NAME=kong_${VERSION}_arm64.deb
-          FILE_HASH=d980f5c106a36142dd86c04bee4adc0deec3470970f8b0f6d3024c17e13d83d6
+          FILE_HASH=c23b22bf34df1f3a8428c998875e868025557d5f9599fd9bed10b12c9fb8ed57
           ;;
       esac
 
       # download the archive and verify the checksum
       curl --silent --show-error --location --output $FILE_NAME \
-        https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong/$FILE_NAME
+        https://download.konghq.com/gateway-2.x-ubuntu-focal/pool/all/k/kong/$FILE_NAME
       echo "$FILE_HASH $FILE_NAME" > sha256
       sha256sum -c sha256 | grep OK
       


### PR DESCRIPTION
Fixes #4221 

Also, bumps to latest stable kong, i.e. 2.8.2.

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```
snap install edgexfoundry --channel=latest/stable

# build and install on top
snapcraft
snap install <name>.snap --dangerous

# OR refresh from the snap build from this PR
snap refresh edgexfoundry --channel=latest/edge/pr-4223
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->