### PR TITLE
refactor: removing vault wait from consul start

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/consul_wait_install.sh
@@ -37,17 +37,6 @@ vault_ready()
 
 # env settings are populated from env files of docker-compose
 
-echo "Script for waiting security bootstrapping on Consul"
-
-echo "$(date) Consul waits on Vault to be initialized"
-# check the http status code from Vault using SECRETSTORE_HOST and SECRETSTORE_PORT as input to the function call
-vault_inited=$(vault_ready "${SECRETSTORE_HOST}" "${SECRETSTORE_PORT}")
-until [ "$vault_inited" -eq 1 ]; do
-    echo "$(date) waiting for Vault ${SECRETSTORE_HOST}:${SECRETSTORE_PORT} to be initialized";
-    sleep 1;
-    vault_inited=$(vault_ready "${SECRETSTORE_HOST}" "${SECRETSTORE_PORT}")
-done
-
 # only in json format according to Consul's documentation
 DEFAULT_CONSUL_LOCAL_CONFIG='
 {


### PR DESCRIPTION
removed the wait on vault to be initialized in order to begin starting consul

Closes: #3584

Signed-off-by: Rico Chavez-Lopez <rchavezlopez@ucdavis.edu>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Pull this branch, make docker_base; make docker. In compose-builder, run make dev. Verify in logs that consul and other containers proceed to start up as expected. 

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->