### PR TITLE
build(snap): Remove helper scripts from staged snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -793,6 +793,11 @@ parts:
       - -usr/share/doc/libpgm-5.2-0/*
       - -usr/share/doc/libsodium23/*
       - -usr/share/doc/libzmq5/*
+      # Exclude snap extras
+      - -bin/helper-go
+      - -bin/source-env-file.sh
+      - -bin/service-wrapper.sh
+
   # Deprecated
   kuiper:
     plugin: nil
@@ -801,7 +806,7 @@ parts:
     organize: 
       bin/setup-redis-credentials.sh: bin/kuiper-setup-redis-credentials.sh
     stage:
-      # Exclude redundant files
+      # Exclude redundant dependencies
       - -usr/bin/curl
       - -usr/lib/*/libcurl*
       - -usr/lib/*/liblber*
@@ -828,6 +833,9 @@ parts:
       - -usr/share/doc/libzmq*
       - -usr/share/doc/libheimbase1-heimdal
       - -usr/share/doc/libroken18-heimdal
+      # Exclude snap extras
+      - -bin/helper-go
+      - -bin/source-env-file.sh
 
   metadata:
     plugin: nil


### PR DESCRIPTION
The 2.3 (latest/stable) App Service Configurable and eKuiper parts add files that have duplicate names with those in the edgexfoundry snap. Moreover, there are some files that are stages but never used. This PR unstages those files.

Duplicate file prevent the snap build. 

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->