### PR TITLE
refactor!: Use common Config Stem constants for Core Contracts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.1
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.3
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2
-	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.1
+	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.2
 	github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.1
 	github.com/fxamacker/cbor/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -43,14 +43,14 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.1 h1:4Vgy7BJt1oLgLGBm97ePCzNIVxF08NcNYpTHqnOih5o=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.1/go.mod h1:hap7XdFAmfYRLRLn5H4Ebr97OlIpEvIpxSiGVR3CLig=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.3 h1:pR7Otb0KKE/AVDcVeQHgwtSAX6EL0J/4d75icwg+oSA=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.3/go.mod h1:cGXMUtbbzw+npJpMcFHPlXIN+ZPF71aiimhJ6v8kaSc=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 h1:xp5MsP+qf/fuJxy8fT7k1N+c4j4C6w04qMCBXm6id7o=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2/go.mod h1:1Vv4uWAo6r7k6jUlqVJW8JOL6YKVBc6sRL8Al3DrMck=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2 h1:tleTxhbBISfDNn596rU71n+GOy27dMIme+v8Vl0uhpw=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2/go.mod h1:7RwSq896VqelvSU7zYKs2tpZhgELVFECkiGf6XGLKfQ=
-github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.1 h1:TxRYbF8pWGsHHW8Q1i5uqudCNKsDZG5PR5NYwSRJTSg=
-github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.1/go.mod h1:8weo8jqtlN/lhglBEaFpysftIuFLkCmh6k/dHhPa7IY=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.2 h1:bNXJHfxTo/1SzQbiJQUnySUGVP5i2FNwFsXQ+RzqR8Q=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.2/go.mod h1:G0Vxoc8+JXwUqRH5ggyOZ/f/CIVPTswI5Ld7dI5uhIY=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3 h1:QgZF9f70Cwpvkjw3tP1aiVGHc+yNFJNzW6hO8pDs3fg=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3/go.mod h1:2w8v0sv+i21nY+DY6JV4PFxsNTuxpGAjlNFlFMTfZkk=
 github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.1 h1:dib+mZUuHqwVHt9pKAWC4lh60Fbc+6vKrD919LaknwI=
@@ -232,7 +232,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/jwt/v2 v2.3.0 h1:z2mA1a7tIf5ShggOFlR1oBPgd6hGqcDYsISxZByUzdI=
-github.com/nats-io/nats-server/v2 v2.9.8 h1:jgxZsv+A3Reb3MgwxaINcNq/za8xZInKhDg9Q0cGN1o=
+github.com/nats-io/nats-server/v2 v2.9.9 h1:bmj0RhvHOc8+z5/RuhI38GqPwtkFAHQuU3e99FVA/TI=
 github.com/nats-io/nats.go v1.20.0 h1:T8JJnQfVSdh1CzGiwAOv5hEobYCBho/0EupGznYw0oM=
 github.com/nats-io/nats.go v1.20.0/go.mod h1:tLqubohF7t4z3du1QDPYJIQQyhb4wl6DhjxEajSI7UA=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -18,12 +18,7 @@ const (
 	BootTimeoutSecondsDefault = 30
 	BootRetrySecondsDefault   = 1
 	ConfigFileName            = "configuration.toml"
-	// TODO: move the config stem constants in go-mod-contracts
-	ConfigStemApp      = "edgex/appservices/"
-	ConfigStemCore     = "edgex/core/"
-	ConfigStemDevice   = "edgex/devices/"
-	ConfigStemSecurity = "edgex/security/"
-	LogDurationKey     = "duration"
+	LogDurationKey            = "duration"
 )
 
 const (

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/config"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/controller/messaging"
@@ -67,7 +66,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		cancel,
 		f,
 		common.CoreCommandServiceKey,
-		internal.ConfigStemCore,
+		common.ConfigStemCore,
 		configuration,
 		startupTimer,
 		dic,

--- a/internal/core/data/main.go
+++ b/internal/core/data/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/application"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/config"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/container"
@@ -66,7 +65,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		cancel,
 		f,
 		common.CoreDataServiceKey,
-		internal.ConfigStemCore,
+		common.ConfigStemCore,
 		configuration,
 		startupTimer,
 		dic,

--- a/internal/core/metadata/main.go
+++ b/internal/core/metadata/main.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/config"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/container"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/uom"
@@ -66,7 +65,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		cancel,
 		f,
 		common.CoreMetaDataServiceKey,
-		internal.ConfigStemCore,
+		common.ConfigStemCore,
 		configuration,
 		nil,
 		startupTimer,

--- a/internal/security/bootstrapper/command/setupacl/command.go
+++ b/internal/security/bootstrapper/command/setupacl/command.go
@@ -37,16 +37,14 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/helper"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/interfaces"
 
-	baseBootStrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
-
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg"
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/token/authtokenloader"
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/token/fileioperformer"
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/types"
 	"github.com/edgexfoundry/go-mod-secrets/v3/secrets"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 )
 
 const (
@@ -356,19 +354,19 @@ func (c *cmd) createEdgeXACLTokenRoles(bootstrapACLTokenID, secretstoreToken str
 // if the input role name does not fall into the above types, then it is categorized into core type for the key prefix
 func (c *cmd) getKeyPrefix(roleName string) string {
 	if strings.HasPrefix(roleName, "app-") {
-		return internal.ConfigStemApp + baseBootStrapConfig.ConfigVersion + "/" + roleName
+		return common.ConfigStemApp + "/" + roleName
 	}
 
 	if strings.HasPrefix(roleName, "device-") {
-		return internal.ConfigStemDevice + baseBootStrapConfig.ConfigVersion + "/" + roleName
+		return common.ConfigStemDevice + "/" + roleName
 	}
 
 	if strings.HasPrefix(roleName, "security-") {
-		return internal.ConfigStemSecurity + baseBootStrapConfig.ConfigVersion + "/" + roleName
+		return common.ConfigStemSecurity + "/" + roleName
 	}
 
 	// anything else falls into the 3rd category: core bucket
-	return internal.ConfigStemCore + baseBootStrapConfig.ConfigVersion + "/" + roleName
+	return common.ConfigStemCore + "/" + roleName
 }
 
 func (c *cmd) getUniqueRoleNames() (map[string]struct{}, error) {

--- a/internal/security/bootstrapper/main.go
+++ b/internal/security/bootstrapper/main.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	bootstrapper "github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/command"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/container"
@@ -92,7 +91,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 		cancel,
 		f,
 		common.SecurityBootstrapperKey,
-		internal.ConfigStemSecurity,
+		common.ConfigStemSecurity,
 		configuration,
 		startupTimer,
 		dic,

--- a/internal/security/bootstrapper/mosquitto/configure.go
+++ b/internal/security/bootstrapper/mosquitto/configure.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/mosquitto/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/mosquitto/container"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/mosquitto/handlers"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/flags"
@@ -54,7 +55,7 @@ func Configure(ctx context.Context,
 		cancel,
 		flags,
 		internal.BootstrapMessageBusServiceKey,
-		internal.ConfigStemSecurity,
+		common.ConfigStemSecurity,
 		configuration,
 		nil,
 		startupTimer,

--- a/internal/security/bootstrapper/redis/configure.go
+++ b/internal/security/bootstrapper/redis/configure.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/redis/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/redis/container"
 	redisHandlers "github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/redis/handlers"
@@ -57,7 +56,7 @@ func Configure(ctx context.Context,
 		cancel,
 		flags,
 		common.SecurityBootstrapperRedisKey,
-		internal.ConfigStemCore,
+		common.ConfigStemCore,
 		configuration,
 		nil,
 		startupTimer,

--- a/internal/security/config/main.go
+++ b/internal/security/config/main.go
@@ -11,8 +11,8 @@ import (
 	"os"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/security/config/command"
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/container"
@@ -56,7 +56,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) int {
 		cancel,
 		f,
 		securitySecretsConfigServiceKey,
-		internal.ConfigStemSecurity,
+		common.ConfigStemSecurity,
 		configuration,
 		nil,
 		startupTimer,

--- a/internal/security/fileprovider/main.go
+++ b/internal/security/fileprovider/main.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/container"
 
@@ -60,7 +59,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 		cancel,
 		f,
 		common.SecurityFileTokenProviderServiceKey,
-		internal.ConfigStemSecurity,
+		common.ConfigStemSecurity,
 		configuration,
 		nil,
 		startupTimer,

--- a/internal/security/proxy/main.go
+++ b/internal/security/proxy/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/proxy/container"
 
@@ -67,7 +66,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 		cancel,
 		f,
 		common.SecurityProxySetupServiceKey,
-		internal.ConfigStemSecurity,
+		common.ConfigStemSecurity,
 		configuration,
 		nil,
 		startupTimer,

--- a/internal/security/secretstore/main.go
+++ b/internal/security/secretstore/main.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
 
@@ -71,7 +70,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 		cancel,
 		f,
 		common.SecuritySecretStoreSetupServiceKey,
-		internal.ConfigStemSecurity,
+		common.ConfigStemSecurity,
 		configuration,
 		nil,
 		startupTimer,

--- a/internal/security/spiffetokenprovider/main.go
+++ b/internal/security/spiffetokenprovider/main.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/security/spiffetokenprovider/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/spiffetokenprovider/container"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
@@ -49,7 +48,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 		cancel,
 		f,
 		common.SecuritySpiffeTokenProviderKey,
-		internal.ConfigStemSecurity,
+		common.ConfigStemSecurity,
 		configuration,
 		nil,
 		startupTimer,

--- a/internal/support/notifications/main.go
+++ b/internal/support/notifications/main.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	pkgHandlers "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	notificationsConfig "github.com/edgexfoundry/edgex-go/internal/support/notifications/config"
@@ -70,7 +69,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		cancel,
 		f,
 		common.SupportNotificationsServiceKey,
-		internal.ConfigStemCore,
+		common.ConfigStemCore,
 		configuration,
 		startupTimer,
 		dic,

--- a/internal/support/scheduler/main.go
+++ b/internal/support/scheduler/main.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	pkgHandlers "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/config"
@@ -64,7 +63,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		cancel,
 		f,
 		common.SupportSchedulerServiceKey,
-		internal.ConfigStemCore,
+		common.ConfigStemCore,
 		configuration,
 		startupTimer,
 		dic,

--- a/internal/system/agent/main.go
+++ b/internal/system/agent/main.go
@@ -19,7 +19,6 @@ import (
 	"os"
 
 	"github.com/edgexfoundry/edgex-go"
-	"github.com/edgexfoundry/edgex-go/internal"
 	agentConfig "github.com/edgexfoundry/edgex-go/internal/system/agent/config"
 	"github.com/edgexfoundry/edgex-go/internal/system/agent/container"
 
@@ -62,7 +61,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		cancel,
 		f,
 		common.SystemManagementAgentServiceKey,
-		internal.ConfigStemCore,
+		common.ConfigStemCore,
 		configuration,
 		startupTimer,
 		dic,


### PR DESCRIPTION
BREAKING CHANGE: Location of service configuration in Consul changed

closes #4242

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

Note: this PR is dependent on the following PR being merged first.

- https://github.com/edgexfoundry/go-mod-core-contracts/pull/776
- https://github.com/edgexfoundry/go-mod-bootstrap/pull/401

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)

## Testing Instructions
  Build and run core/support services with edgex stack running (core/support services stopped)
  Verify configuration is pushed to /edgex/3.0/<service-key>

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->