### PR TITLE
refactor!: Rework code for refactored MessageBus Configuration

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -1,8 +1,3 @@
-# This is required for backwards compatibility so new version of sevice using older 2.x configuration will not fail bootstrapping
-# This will default to false if not provided in old config. Messagebus is now needed by North-South Messaging
-# TODO: Remove this setting EdgeX 3.0
-RequireMessageBus = true
-
 [Writable]
 LogLevel = "INFO"
   [Writable.InsecureSecrets]
@@ -60,22 +55,22 @@ Type = "consul"
   Host = "localhost"
   Port = 59881
 
-[MessageQueue]
-  [MessageQueue.Internal]
+[MessageBus]
+  [MessageBus.Internal]
   Type = "redis"
   Protocol = "redis"
   Host = "localhost"
   Port = 6379
   AuthMode = "usernamepassword"                   # required for redis messagebus (secure or insecure).
   SecretName = "redisdb"
-    [MessageQueue.Internal.Topics]
+    [MessageBus.Internal.Topics]
     DeviceRequestTopicPrefix = "edgex/device/command/request"    # for publishing requests to the device service; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
     DeviceResponseTopic = "edgex/device/command/response/#"      # for subscribing to device service responses
     CommandRequestTopic = "edgex/core/command/request/#"         # for subscribing to internal command requests
     CommandResponseTopicPrefix = "edgex/core/command/response"   # for publishing responses back to internal service /<device-name>/<command-name>/<method> will be added to this publish topic prefix
     QueryRequestTopic = "edgex/core/commandquery/request/#"      # for subscribing to internal command query requests
     QueryResponseTopic = "edgex/core/commandquery/response"      # for publishing reponsses back to internal service
-    [MessageQueue.Internal.Optional]
+    [MessageBus.Internal.Optional]
     # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
     ClientId ="core-command"
     Qos =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
@@ -93,7 +88,7 @@ Type = "consul"
     Deliver = "new"
     DefaultPubRetryAttempts = "2"
     Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
-  [MessageQueue.External]
+  [MessageBus.External]
   Enabled = false
   Url = "tcp://localhost:1883"
   ClientId = "core-command"
@@ -105,7 +100,7 @@ Type = "consul"
   SkipCertVerify = false
   SecretPath = "mqtt"
   AuthMode = "none"
-    [MessageQueue.External.Topics]
+    [MessageBus.External.Topics]
     CommandRequestTopic = "edgex/command/request/#"           # for subscribing to 3rd party command requests
     CommandResponseTopicPrefix = "edgex/command/response"     # for publishing responses back to 3rd party systems /<device-name>/<command-name>/<method> will be added to this publish topic prefix
     QueryRequestTopic = "edgex/commandquery/request/#"        # for subscribing to 3rd party command query request

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -56,17 +56,17 @@ Type = "consul"
   Timeout = 5000
   Type = "redisdb"
 
-[MessageQueue]
+[MessageBus]
 Protocol = "redis"
 Host = "localhost"
 Port = 6379
 Type = "redis"
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
-PublishTopicPrefix = "edgex/events/core" # /<device-profile-name>/<device-name> will be added to this Publish Topic prefix
-SubscribeEnabled = true
-SubscribeTopic = "edgex/events/device/#"  # required for subscribing to Events from MessageBus
-  [MessageQueue.Optional]
+  [MessageBus.Topics]
+  PublishTopicPrefix = "edgex/events/core" # /<device-profile-name>/<device-name> will be added to this Publish Topic prefix
+  SubscribeTopic = "edgex/events/device/#"  # required for subscribing to Events from MessageBus
+  [MessageBus.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
   ClientId ="core-data"
   Qos =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -1,8 +1,3 @@
-# This is required for backwards compatibility so new version of sevice using older 2.x configuration will not fail bootstrapping
-# This will default to false if not provided in old config. Messagebus is now needed by Device System Events and Service Metrics
-# TODO: Remove this setting EdgeX 3.0
-RequireMessageBus = true
-
 [Writable]
 LogLevel = "INFO"
   [Writable.ProfileChange]
@@ -77,15 +72,16 @@ Sender = "core-metadata"
 Description = "Metadata change notice"
 Label = "metadata"
 
-[MessageQueue]
+[MessageBus]
 Protocol = "redis"
 Host = "localhost"
 Port = 6379
 Type = "redis"
-PublishTopicPrefix = "edgex/system-events" # /<source>/<type>/<action>/<owner>/<profile> will be added to this Publish Topic prefix
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
-  [MessageQueue.Optional]
+  [MessageBus.Topics]
+  PublishTopicPrefix = "edgex/system-events" # /<source>/<type>/<action>/<owner>/<profile> will be added to this Publish Topic prefix
+  [MessageBus.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
   ClientId ="core-metadata"
   Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -1,8 +1,3 @@
-# This is required for backwards compatibility so new version of sevice using older 2.x configuration will not fail bootstrapping
-# This will default to false if not provided in old config. Messagebus is now needed by Device System Events and Service Metrics
-# TODO: Remove this setting EdgeX 3.0
-RequireMessageBus = true
-
 [Writable]
 LogLevel = "INFO"
 ResendLimit = 2
@@ -73,14 +68,16 @@ Type = "consul"
   # AuthMode is the SMTP authentication mechanism. Currently, "usernamepassword" is the only AuthMode supported by this service, and the secret keys are "username" and "password".
   AuthMode = "usernamepassword"
 
-[MessageQueue]
+[MessageBus]
 Protocol = "redis"
 Host = "localhost"
 Port = 6379
 Type = "redis"
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
-  [MessageQueue.Optional]
+  [MessageBus.Topics]
+  # No topic yet. Metrics topic is handler in [Writable.Telemetry] above
+  [MessageBus.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
   ClientId ="support-notifications"
   Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -76,7 +76,7 @@ Type = "redis"
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
   [MessageBus.Topics]
-  # No topic yet. Metrics topic is handler in [Writable.Telemetry] above
+  # No topic yet. Metrics topic is handled in [Writable.Telemetry] above
   [MessageBus.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
   ClientId ="support-notifications"

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -73,14 +73,16 @@ Type = "consul"
     Interval = "midnight"
     AdminState = "UNLOCKED"
 
-[MessageQueue]
+[MessageBus]
 Protocol = "redis"
 Host = "localhost"
 Port = 6379
 Type = "redis"
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
-  [MessageQueue.Optional]
+  [MessageBus.Topics]
+  # No topic yet. Metrics topic is handler in [Writable.Telemetry] above
+  [MessageBus.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
   ClientId ="support-scheduler"
   Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -81,7 +81,7 @@ Type = "redis"
 AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
   [MessageBus.Topics]
-  # No topic yet. Metrics topic is handler in [Writable.Telemetry] above
+  # No topic yet. Metrics topic is handled in [Writable.Telemetry] above
   [MessageBus.Optional]
   # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
   ClientId ="support-scheduler"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.6
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.7
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.3
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.1

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.6 h1:N85znWmxV1qNpp889YmVOCa5aw18fN3wcAWdYfIbFnY=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.6/go.mod h1:yW5dumg9IyfrHx4NYC5Ii0WVVB5OjTXQ/8/NkHHif5Q=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.7 h1:e0H7V7aFl9vC06ZUUQUzNpjqTQWs/XvdV/EKmk8zF/E=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.7/go.mod h1:yW5dumg9IyfrHx4NYC5Ii0WVVB5OjTXQ/8/NkHHif5Q=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 h1:xp5MsP+qf/fuJxy8fT7k1N+c4j4C6w04qMCBXm6id7o=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2/go.mod h1:1Vv4uWAo6r7k6jUlqVJW8JOL6YKVBc6sRL8Al3DrMck=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2 h1:tleTxhbBISfDNn596rU71n+GOy27dMIme+v8Vl0uhpw=

--- a/internal/core/command/config/config.go
+++ b/internal/core/command/config/config.go
@@ -21,15 +21,13 @@ import (
 
 // ConfigurationStruct contains the configuration properties for the core-command service.
 type ConfigurationStruct struct {
-	//TODO: Remove in EdgeX 3.0 - Is needed now for backward compatability in 2.0
-	RequireMessageBus bool
-	Writable          WritableInfo
-	Clients           map[string]bootstrapConfig.ClientInfo
-	Databases         map[string]bootstrapConfig.Database
-	Registry          bootstrapConfig.RegistryInfo
-	Service           bootstrapConfig.ServiceInfo
-	MessageQueue      MessageQueue
-	SecretStore       bootstrapConfig.SecretStoreInfo
+	Writable    WritableInfo
+	Clients     map[string]bootstrapConfig.ClientInfo
+	Databases   map[string]bootstrapConfig.Database
+	Registry    bootstrapConfig.RegistryInfo
+	Service     bootstrapConfig.ServiceInfo
+	MessageBus  MessageBus
+	SecretStore bootstrapConfig.SecretStoreInfo
 }
 
 // WritableInfo contains configuration properties that can be updated and applied without restarting the service.
@@ -39,7 +37,7 @@ type WritableInfo struct {
 	Telemetry       bootstrapConfig.TelemetryInfo
 }
 
-type MessageQueue struct {
+type MessageBus struct {
 	Internal bootstrapConfig.MessageBusInfo
 	External bootstrapConfig.ExternalMQTTInfo
 }
@@ -84,8 +82,8 @@ func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfigurat
 		Service:      c.Service,
 		Registry:     c.Registry,
 		SecretStore:  c.SecretStore,
-		MessageQueue: c.MessageQueue.Internal,
-		ExternalMQTT: c.MessageQueue.External,
+		MessageBus:   c.MessageBus.Internal,
+		ExternalMQTT: c.MessageBus.External,
 	}
 }
 

--- a/internal/core/command/controller/messaging/external.go
+++ b/internal/core/command/controller/messaging/external.go
@@ -33,8 +33,8 @@ func OnConnectHandler(router MessagingRouter, dic *di.Container) mqtt.OnConnectH
 	return func(client mqtt.Client) {
 		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 		config := container.ConfigurationFrom(dic.Get)
-		externalTopics := config.MessageQueue.External.Topics
-		qos := config.MessageQueue.External.QoS
+		externalTopics := config.MessageBus.External.Topics
+		qos := config.MessageBus.External.QoS
 
 		requestQueryTopic := externalTopics[QueryRequestTopic]
 		if token := client.Subscribe(requestQueryTopic, qos, commandQueryHandler(dic)); token.Wait() && token.Error() != nil {
@@ -64,7 +64,7 @@ func commandQueryHandler(dic *di.Container) mqtt.MessageHandler {
 			return
 		}
 
-		messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
+		messageBusInfo := container.ConfigurationFrom(dic.Get).MessageBus
 		responseTopic := messageBusInfo.External.Topics[QueryResponseTopic]
 		if responseTopic == "" {
 			lc.Error("QueryResponseTopic not provided in External.Topics")
@@ -96,7 +96,7 @@ func commandRequestHandler(router MessagingRouter, dic *di.Container) mqtt.Messa
 		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 		lc.Debugf("Received command request from external message queue on topic '%s' with %d bytes", message.Topic(), len(message.Payload()))
 
-		messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
+		messageBusInfo := container.ConfigurationFrom(dic.Get).MessageBus
 		qos := messageBusInfo.External.QoS
 		retain := messageBusInfo.External.Retain
 

--- a/internal/core/command/controller/messaging/external_test.go
+++ b/internal/core/command/controller/messaging/external_test.go
@@ -65,7 +65,7 @@ func TestOnConnectHandler(t *testing.T) {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return &config.ConfigurationStruct{
-				MessageQueue: config.MessageQueue{
+				MessageBus: config.MessageBus{
 					External: bootstrapConfig.ExternalMQTTInfo{
 						Topics: map[string]string{
 							QueryRequestTopic:          testQueryRequestTopic,
@@ -171,7 +171,7 @@ func Test_commandQueryHandler(t *testing.T) {
 					Port:           mockPort,
 					MaxResultCount: 20,
 				},
-				MessageQueue: config.MessageQueue{
+				MessageBus: config.MessageBus{
 					Internal: bootstrapConfig.MessageBusInfo{},
 					External: bootstrapConfig.ExternalMQTTInfo{
 						QoS:    0,
@@ -298,7 +298,7 @@ func Test_commandRequestHandler(t *testing.T) {
 					Port:           mockPort,
 					MaxResultCount: 20,
 				},
-				MessageQueue: config.MessageQueue{
+				MessageBus: config.MessageBus{
 					Internal: bootstrapConfig.MessageBusInfo{
 						Topics: map[string]string{
 							DeviceRequestTopicPrefix: testInternalCommandRequestTopicPrefix,

--- a/internal/core/command/controller/messaging/internal.go
+++ b/internal/core/command/controller/messaging/internal.go
@@ -23,7 +23,7 @@ import (
 // SubscribeCommandResponses subscribes command responses from device services via internal MessageBus
 func SubscribeCommandResponses(ctx context.Context, router MessagingRouter, dic *di.Container) errors.EdgeX {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
+	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageBus
 	internalResponseTopic := messageBusInfo.Internal.Topics[DeviceResponseTopic]
 
 	messages := make(chan types.MessageEnvelope)
@@ -85,7 +85,7 @@ func SubscribeCommandResponses(ctx context.Context, router MessagingRouter, dic 
 // via internal MessageBus
 func SubscribeCommandRequests(ctx context.Context, router MessagingRouter, dic *di.Container) errors.EdgeX {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
+	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageBus
 	internalRequestCommandTopic := messageBusInfo.Internal.Topics[CommandRequestTopic]
 
 	messages := make(chan types.MessageEnvelope)
@@ -177,7 +177,7 @@ func SubscribeCommandRequests(ctx context.Context, router MessagingRouter, dic *
 // via internal MessageBus
 func SubscribeCommandQueryRequests(ctx context.Context, dic *di.Container) errors.EdgeX {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
+	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageBus
 	internalQueryRequestTopic := messageBusInfo.Internal.Topics[QueryRequestTopic]
 	internalQueryResponseTopic := messageBusInfo.Internal.Topics[QueryResponseTopic]
 

--- a/internal/core/data/application/event.go
+++ b/internal/core/data/application/event.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/v3/pkg/types"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
@@ -79,7 +80,8 @@ func (a *CoreDataApp) PublishEvent(data []byte, profileName string, deviceName s
 	configuration := container.ConfigurationFrom(dic.Get)
 	correlationId := correlation.FromContext(ctx)
 
-	publishTopic := fmt.Sprintf("%s/%s/%s/%s", configuration.MessageQueue.PublishTopicPrefix, profileName, deviceName, sourceName)
+	publishPrefix := configuration.MessageBus.Topics[config.MessageBusPublishTopicPrefix]
+	publishTopic := fmt.Sprintf("%s/%s/%s/%s", publishPrefix, profileName, deviceName, sourceName)
 	lc.Debugf("Publishing V2 AddEventRequest to message queue. Topic: %s; %s: %s", publishTopic, common.CorrelationHeader, correlationId)
 
 	msgEnvelope := msgTypes.NewMessageEnvelope(data, ctx)

--- a/internal/core/data/config/config.go
+++ b/internal/core/data/config/config.go
@@ -20,7 +20,7 @@ import (
 
 type ConfigurationStruct struct {
 	Writable     WritableInfo
-	MessageQueue bootstrapConfig.MessageBusInfo
+	MessageBus   bootstrapConfig.MessageBusInfo
 	Clients      map[string]bootstrapConfig.ClientInfo
 	Databases    map[string]bootstrapConfig.Database
 	Registry     bootstrapConfig.RegistryInfo
@@ -73,11 +73,11 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:      c.Clients,
-		Service:      c.Service,
-		Registry:     c.Registry,
-		SecretStore:  c.SecretStore,
-		MessageQueue: c.MessageQueue,
+		Clients:     c.Clients,
+		Service:     c.Service,
+		Registry:    c.Registry,
+		SecretStore: c.SecretStore,
+		MessageBus:  c.MessageBus,
 	}
 }
 

--- a/internal/core/data/init.go
+++ b/internal/core/data/init.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"sync"
 
-	dataContainer "github.com/edgexfoundry/edgex-go/internal/core/data/container"
 	"github.com/edgexfoundry/edgex-go/internal/core/data/controller/messaging"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
@@ -46,15 +45,12 @@ func NewBootstrap(router *mux.Router, serviceName string) *Bootstrap {
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	LoadRestRoutes(b.router, dic, b.serviceName)
 
-	configuration := dataContainer.ConfigurationFrom(dic.Get)
 	lc := container.LoggingClientFrom(dic.Get)
 
-	if configuration.MessageQueue.SubscribeEnabled {
-		err := messaging.SubscribeEvents(ctx, dic)
-		if err != nil {
-			lc.Errorf("Failed to subscribe events from message bus, %v", err)
-			return false
-		}
+	err := messaging.SubscribeEvents(ctx, dic)
+	if err != nil {
+		lc.Errorf("Failed to subscribe events from message bus, %v", err)
+		return false
 	}
 
 	return true

--- a/internal/core/metadata/application/device_test.go
+++ b/internal/core/metadata/application/device_test.go
@@ -60,8 +60,11 @@ func TestPublishDeviceSystemEvent(t *testing.T) {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return &config.ConfigurationStruct{
-				MessageQueue: bootstrapConfig.MessageBusInfo{
-					PublishTopicPrefix: expectedPublishTopicPrefix},
+				MessageBus: bootstrapConfig.MessageBusInfo{
+					Topics: map[string]string{
+						bootstrapConfig.MessageBusPublishTopicPrefix: expectedPublishTopicPrefix,
+					},
+				},
 			}
 		},
 	})
@@ -106,8 +109,7 @@ func TestPublishDeviceSystemEvent(t *testing.T) {
 			}
 
 			if test.ClientMissing {
-				// TODO: Change to Errorf in EdgeX 3.0
-				mockLogger.On("Warnf", mock.Anything, mock.Anything).Return()
+				mockLogger.On("Errorf", mock.Anything, mock.Anything).Return()
 				dic.Update(di.ServiceConstructorMap{
 					bootstrapContainer.MessagingClientName: func(get di.Get) interface{} {
 						return nil
@@ -132,8 +134,7 @@ func TestPublishDeviceSystemEvent(t *testing.T) {
 			publishDeviceSystemEvent(test.Action, expectedDevice.ServiceName, expectedDevice, ctx, mockLogger, dic)
 
 			if test.ClientMissing {
-				// TODO: Change to Errorf in EdgeX 3.0
-				mockLogger.AssertCalled(t, "Warnf", mock.Anything, noMessagingClientError)
+				mockLogger.AssertCalled(t, "Errorf", mock.Anything, noMessagingClientError)
 				return
 			}
 

--- a/internal/core/metadata/config/config.go
+++ b/internal/core/metadata/config/config.go
@@ -20,17 +20,15 @@ import (
 
 // Struct used to parse the JSON configuration file
 type ConfigurationStruct struct {
-	//TODO: Remove in EdgeX 3.0 - Is needed now for backward compatability in 2.0
-	RequireMessageBus bool
-	Writable          WritableInfo
-	Clients           map[string]bootstrapConfig.ClientInfo
-	Databases         map[string]bootstrapConfig.Database
-	Notifications     NotificationInfo
-	Registry          bootstrapConfig.RegistryInfo
-	Service           bootstrapConfig.ServiceInfo
-	MessageQueue      bootstrapConfig.MessageBusInfo
-	SecretStore       bootstrapConfig.SecretStoreInfo
-	UoM               UoM
+	Writable      WritableInfo
+	Clients       map[string]bootstrapConfig.ClientInfo
+	Databases     map[string]bootstrapConfig.Database
+	Notifications NotificationInfo
+	Registry      bootstrapConfig.RegistryInfo
+	Service       bootstrapConfig.ServiceInfo
+	MessageBus    bootstrapConfig.MessageBusInfo
+	SecretStore   bootstrapConfig.SecretStoreInfo
+	UoM           UoM
 }
 
 type WritableInfo struct {
@@ -101,11 +99,11 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:      c.Clients,
-		Service:      c.Service,
-		Registry:     c.Registry,
-		SecretStore:  c.SecretStore,
-		MessageQueue: c.MessageQueue,
+		Clients:     c.Clients,
+		Service:     c.Service,
+		Registry:    c.Registry,
+		SecretStore: c.SecretStore,
+		MessageBus:  c.MessageBus,
 	}
 }
 

--- a/internal/core/metadata/main.go
+++ b/internal/core/metadata/main.go
@@ -17,7 +17,6 @@ package metadata
 import (
 	"context"
 	"os"
-	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/config"
@@ -74,7 +73,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		[]interfaces.BootstrapHandler{
 			uom.BootstrapHandler,
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
-			MessageBusBootstrapHandler,
+			handlers.MessagingBootstrapHandler,
 			handlers.NewServiceMetrics(common.CoreMetaDataServiceKey).BootstrapHandler, // Must be after Messaging
 			NewBootstrap(router, common.CoreMetaDataServiceKey).BootstrapHandler,
 			telemetry.BootstrapHandler,
@@ -102,17 +101,4 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 	if deferred != nil {
 		deferred()
 	}
-}
-
-// MessageBusBootstrapHandler sets up the MessageBus connection if MessageBus required is true.
-// This is required for backwards compatability with older versions of 2.x configuration
-// TODO: Remove in EdgeX 3.0
-func MessageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
-	configuration := container.ConfigurationFrom(dic.Get)
-	if configuration.RequireMessageBus {
-		return handlers.MessagingBootstrapHandler(ctx, wg, startupTimer, dic)
-	}
-
-	// Not required so do nothing
-	return true
 }

--- a/internal/security/spiffetokenprovider/config/config.go
+++ b/internal/security/spiffetokenprovider/config/config.go
@@ -28,14 +28,14 @@ type SpiffeInfo struct {
 }
 
 type ConfigurationStruct struct {
-	Writable     WritableInfo
-	MessageQueue bootstrapConfig.MessageBusInfo
-	Clients      map[string]bootstrapConfig.ClientInfo
-	Databases    map[string]bootstrapConfig.Database
-	Registry     bootstrapConfig.RegistryInfo
-	Service      bootstrapConfig.ServiceInfo
-	SecretStore  bootstrapConfig.SecretStoreInfo
-	Spiffe       SpiffeInfo
+	Writable    WritableInfo
+	MessageBus  bootstrapConfig.MessageBusInfo
+	Clients     map[string]bootstrapConfig.ClientInfo
+	Databases   map[string]bootstrapConfig.Database
+	Registry    bootstrapConfig.RegistryInfo
+	Service     bootstrapConfig.ServiceInfo
+	SecretStore bootstrapConfig.SecretStoreInfo
+	Spiffe      SpiffeInfo
 }
 
 type WritableInfo struct {

--- a/internal/support/notifications/config/config.go
+++ b/internal/support/notifications/config/config.go
@@ -20,16 +20,14 @@ import (
 )
 
 type ConfigurationStruct struct {
-	//TODO: Remove in EdgeX 3.0 - Is needed now for backward compatability in 2.0
-	RequireMessageBus bool
-	Writable          WritableInfo
-	Clients           map[string]bootstrapConfig.ClientInfo
-	Databases         map[string]bootstrapConfig.Database
-	Registry          bootstrapConfig.RegistryInfo
-	Service           bootstrapConfig.ServiceInfo
-	MessageQueue      bootstrapConfig.MessageBusInfo
-	Smtp              SmtpInfo
-	SecretStore       bootstrapConfig.SecretStoreInfo
+	Writable    WritableInfo
+	Clients     map[string]bootstrapConfig.ClientInfo
+	Databases   map[string]bootstrapConfig.Database
+	Registry    bootstrapConfig.RegistryInfo
+	Service     bootstrapConfig.ServiceInfo
+	MessageBus  bootstrapConfig.MessageBusInfo
+	Smtp        SmtpInfo
+	SecretStore bootstrapConfig.SecretStoreInfo
 }
 
 type WritableInfo struct {
@@ -104,11 +102,11 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:      c.Clients,
-		Service:      c.Service,
-		Registry:     c.Registry,
-		SecretStore:  c.SecretStore,
-		MessageQueue: c.MessageQueue,
+		Clients:     c.Clients,
+		Service:     c.Service,
+		Registry:    c.Registry,
+		SecretStore: c.SecretStore,
+		MessageBus:  c.MessageBus,
 	}
 }
 

--- a/internal/support/notifications/main.go
+++ b/internal/support/notifications/main.go
@@ -24,7 +24,6 @@ package notifications
 import (
 	"context"
 	"os"
-	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
 	pkgHandlers "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
@@ -76,7 +75,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		true,
 		[]interfaces.BootstrapHandler{
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
-			MessageBusBootstrapHandler,
+			handlers.MessagingBootstrapHandler,
 			handlers.NewServiceMetrics(common.SupportNotificationsServiceKey).BootstrapHandler, // Must be after Messaging
 			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, common.SupportNotificationsServiceKey).BootstrapHandler,
@@ -84,17 +83,4 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 			httpServer.BootstrapHandler,
 			handlers.NewStartMessage(common.SupportNotificationsServiceKey, edgex.Version).BootstrapHandler,
 		})
-}
-
-// MessageBusBootstrapHandler sets up the MessageBus connection if MessageBus required is true.
-// This is required for backwards compatability with older versions of 2.x configuration
-// TODO: Remove in EdgeX 3.0
-func MessageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
-	configuration := container.ConfigurationFrom(dic.Get)
-	if configuration.RequireMessageBus {
-		return handlers.MessagingBootstrapHandler(ctx, wg, startupTimer, dic)
-	}
-
-	// Not required so do nothing
-	return true
 }

--- a/internal/support/scheduler/config/config.go
+++ b/internal/support/scheduler/config/config.go
@@ -22,17 +22,15 @@ import (
 
 // Configuration V2 for the Support Scheduler Service
 type ConfigurationStruct struct {
-	//TODO: Remove in EdgeX 3.0 - Is needed now for backward compatability in 2.0
-	RequireMessageBus bool
-	Writable          WritableInfo
-	Clients           map[string]bootstrapConfig.ClientInfo
-	Databases         map[string]bootstrapConfig.Database
-	Registry          bootstrapConfig.RegistryInfo
-	Service           bootstrapConfig.ServiceInfo
-	MessageQueue      bootstrapConfig.MessageBusInfo
-	Intervals         map[string]IntervalInfo
-	IntervalActions   map[string]IntervalActionInfo
-	SecretStore       bootstrapConfig.SecretStoreInfo
+	Writable        WritableInfo
+	Clients         map[string]bootstrapConfig.ClientInfo
+	Databases       map[string]bootstrapConfig.Database
+	Registry        bootstrapConfig.RegistryInfo
+	Service         bootstrapConfig.ServiceInfo
+	MessageBus      bootstrapConfig.MessageBusInfo
+	Intervals       map[string]IntervalInfo
+	IntervalActions map[string]IntervalActionInfo
+	SecretStore     bootstrapConfig.SecretStoreInfo
 	// ScheduleIntervalTime is a time(Millisecond) to create a ticker to delay the scheduler loop
 	ScheduleIntervalTime int
 }
@@ -128,11 +126,11 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:      c.Clients,
-		Service:      c.Service,
-		Registry:     c.Registry,
-		SecretStore:  c.SecretStore,
-		MessageQueue: c.MessageQueue,
+		Clients:     c.Clients,
+		Service:     c.Service,
+		Registry:    c.Registry,
+		SecretStore: c.SecretStore,
+		MessageBus:  c.MessageBus,
 	}
 }
 

--- a/internal/support/scheduler/main.go
+++ b/internal/support/scheduler/main.go
@@ -18,7 +18,6 @@ package scheduler
 import (
 	"context"
 	"os"
-	"sync"
 
 	"github.com/edgexfoundry/edgex-go"
 	pkgHandlers "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
@@ -70,7 +69,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		true,
 		[]interfaces.BootstrapHandler{
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
-			MessageBusBootstrapHandler,
+			handlers.MessagingBootstrapHandler,
 			handlers.NewServiceMetrics(common.SupportSchedulerServiceKey).BootstrapHandler, // Must be after Messaging
 			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, common.SupportSchedulerServiceKey).BootstrapHandler,
@@ -78,17 +77,4 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 			httpServer.BootstrapHandler,
 			handlers.NewStartMessage(common.SupportSchedulerServiceKey, edgex.Version).BootstrapHandler,
 		})
-}
-
-// MessageBusBootstrapHandler sets up the MessageBus connection if MessageBus required is true.
-// This is required for backwards compatability with older versions of 2.x configuration
-// TODO: Remove in EdgeX 3.0
-func MessageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
-	configuration := container.ConfigurationFrom(dic.Get)
-	if configuration.RequireMessageBus {
-		return handlers.MessagingBootstrapHandler(ctx, wg, startupTimer, dic)
-	}
-
-	// Not required so do nothing
-	return true
 }

--- a/openapi/v2/core-data.yaml
+++ b/openapi/v2/core-data.yaml
@@ -1825,12 +1825,14 @@ paths:
                   Writeable:
                     PersistData: true
                     LogLevel: "INFO"
-                  MessageQueue:
-                    Host: "*"
-                    Port: 5563
-                    Protocol: "tcp"
-                    Type: "zero"
-                    Topic: "events"
+                  MessageBus:
+                    Host: "localhost"
+                    Port: 6379
+                    Protocol: "redis"
+                    Type: "redis"
+                    Topics:
+                      PublishTopicPrefix: "edgex/events/core"
+                      SubscribeTopic: "edgex/events/device/#"
                     Optional:
                       AutoReconnect: "true"
                       ClientId: "core-data"


### PR DESCRIPTION
BREAKING CHANGE: MessageQueue renamed to MessageBus and fields changed. See v3 Migration guide.

This PR is dependent on https://github.com/edgexfoundry/go-mod-bootstrap/pull/410 

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  TBD

## Testing Instructions
Run non-secure Edgex Stack with device virtual and stop all core/support services.
Build core/support services locally
Run core/support services locally with DEBUG log level
Verify core/support services bootstrap properly and connect to the MessageBus
Verify Core Data is receiving events.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->