### PR TITLE
refactor(command)!: separate and move MessageBus config to top level

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -56,52 +56,52 @@ Type = "consul"
   Port = 59881
 
 [MessageBus]
-  [MessageBus.Internal]
-  Type = "redis"
-  Protocol = "redis"
-  Host = "localhost"
-  Port = 6379
-  AuthMode = "usernamepassword"                   # required for redis messagebus (secure or insecure).
-  SecretName = "redisdb"
-    [MessageBus.Internal.Topics]
-    DeviceRequestTopicPrefix = "edgex/device/command/request"    # for publishing requests to the device service; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
-    DeviceResponseTopic = "edgex/device/command/response/#"      # for subscribing to device service responses
-    CommandRequestTopic = "edgex/core/command/request/#"         # for subscribing to internal command requests
-    CommandResponseTopicPrefix = "edgex/core/command/response"   # for publishing responses back to internal service /<device-name>/<command-name>/<method> will be added to this publish topic prefix
-    QueryRequestTopic = "edgex/core/commandquery/request/#"      # for subscribing to internal command query requests
-    QueryResponseTopic = "edgex/core/commandquery/response"      # for publishing reponsses back to internal service
-    [MessageBus.Internal.Optional]
-    # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
-    ClientId ="core-command"
-    Qos =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
-    KeepAlive = "10" # Seconds (must be 2 or greater)
-    Retained = "false"
-    AutoReconnect = "true"
-    ConnectTimeout = "5" # Seconds
-    SkipCertVerify = "false"
-    # Additional Default NATS Specific options that need to be here to enable evnironment variable overrides of them
-    Format = "nats"
-    RetryOnFailedConnect = "true"
-    QueueGroup = ""
-    Durable = ""
-    AutoProvision = "true"
-    Deliver = "new"
-    DefaultPubRetryAttempts = "2"
-    Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
-  [MessageBus.External]
-  Enabled = false
-  Url = "tcp://localhost:1883"
-  ClientId = "core-command"
-  ConnectTimeout = "5s"
-  AutoReconnect = true
-  KeepAlive = 10
-  QoS = 0
-  Retain = true
-  SkipCertVerify = false
-  SecretPath = "mqtt"
-  AuthMode = "none"
-    [MessageBus.External.Topics]
-    CommandRequestTopic = "edgex/command/request/#"           # for subscribing to 3rd party command requests
-    CommandResponseTopicPrefix = "edgex/command/response"     # for publishing responses back to 3rd party systems /<device-name>/<command-name>/<method> will be added to this publish topic prefix
-    QueryRequestTopic = "edgex/commandquery/request/#"        # for subscribing to 3rd party command query request
-    QueryResponseTopic = "edgex/commandquery/response"        # for publishing responses back to 3rd party systems
+Type = "redis"
+Protocol = "redis"
+Host = "localhost"
+Port = 6379
+AuthMode = "usernamepassword"                   # required for redis messagebus (secure or insecure).
+SecretName = "redisdb"
+  [MessageBus.Topics]
+  DeviceRequestTopicPrefix = "edgex/device/command/request"    # for publishing requests to the device service; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
+  DeviceResponseTopic = "edgex/device/command/response/#"      # for subscribing to device service responses
+  CommandRequestTopic = "edgex/core/command/request/#"         # for subscribing to internal command requests
+  CommandResponseTopicPrefix = "edgex/core/command/response"   # for publishing responses back to internal service /<device-name>/<command-name>/<method> will be added to this publish topic prefix
+  QueryRequestTopic = "edgex/core/commandquery/request/#"      # for subscribing to internal command query requests
+  QueryResponseTopic = "edgex/core/commandquery/response"      # for publishing reponsses back to internal service
+  [MessageBus.Optional]
+  # Default MQTT Specific options that need to be here to enable evnironment variable overrides of them
+  ClientId ="core-command"
+  Qos =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+  KeepAlive = "10" # Seconds (must be 2 or greater)
+  Retained = "false"
+  AutoReconnect = "true"
+  ConnectTimeout = "5" # Seconds
+  SkipCertVerify = "false"
+  # Additional Default NATS Specific options that need to be here to enable evnironment variable overrides of them
+  Format = "nats"
+  RetryOnFailedConnect = "true"
+  QueueGroup = ""
+  Durable = ""
+  AutoProvision = "true"
+  Deliver = "new"
+  DefaultPubRetryAttempts = "2"
+  Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
+
+[ExternalMQTT]
+Enabled = false
+Url = "tcp://localhost:1883"
+ClientId = "core-command"
+ConnectTimeout = "5s"
+AutoReconnect = true
+KeepAlive = 10
+QoS = 0
+Retain = true
+SkipCertVerify = false
+SecretPath = "mqtt"
+AuthMode = "none"
+  [ExternalMQTT.Topics]
+  CommandRequestTopic = "edgex/command/request/#"           # for subscribing to 3rd party command requests
+  CommandResponseTopicPrefix = "edgex/command/response"     # for publishing responses back to 3rd party systems /<device-name>/<command-name>/<method> will be added to this publish topic prefix
+  QueryRequestTopic = "edgex/commandquery/request/#"        # for subscribing to 3rd party command query request
+  QueryResponseTopic = "edgex/commandquery/response"        # for publishing responses back to 3rd party systems

--- a/internal/core/command/config/config.go
+++ b/internal/core/command/config/config.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2018 Dell Inc.
- * Copyright 2022 IOTech Ltd.
+ * Copyright 2022-2023 IOTech Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,12 +21,13 @@ import (
 
 // ConfigurationStruct contains the configuration properties for the core-command service.
 type ConfigurationStruct struct {
-	Writable   WritableInfo
-	Clients    map[string]bootstrapConfig.ClientInfo
-	Databases  map[string]bootstrapConfig.Database
-	Registry   bootstrapConfig.RegistryInfo
-	Service    bootstrapConfig.ServiceInfo
-	MessageBus MessageBus
+	Writable     WritableInfo
+	Clients      map[string]bootstrapConfig.ClientInfo
+	Databases    map[string]bootstrapConfig.Database
+	Registry     bootstrapConfig.RegistryInfo
+	Service      bootstrapConfig.ServiceInfo
+	MessageBus   bootstrapConfig.MessageBusInfo
+	ExternalMQTT bootstrapConfig.ExternalMQTTInfo
 }
 
 // WritableInfo contains configuration properties that can be updated and applied without restarting the service.
@@ -34,11 +35,6 @@ type WritableInfo struct {
 	LogLevel        string
 	InsecureSecrets bootstrapConfig.InsecureSecrets
 	Telemetry       bootstrapConfig.TelemetryInfo
-}
-
-type MessageBus struct {
-	Internal bootstrapConfig.MessageBusInfo
-	External bootstrapConfig.ExternalMQTTInfo
 }
 
 // UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
@@ -80,8 +76,8 @@ func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfigurat
 		Clients:      c.Clients,
 		Service:      c.Service,
 		Registry:     c.Registry,
-		MessageBus:   c.MessageBus.Internal,
-		ExternalMQTT: c.MessageBus.External,
+		MessageBus:   c.MessageBus,
+		ExternalMQTT: c.ExternalMQTT,
 	}
 }
 

--- a/internal/core/command/controller/messaging/external_test.go
+++ b/internal/core/command/controller/messaging/external_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 IOTech Ltd
+// Copyright (C) 2022-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -65,17 +65,15 @@ func TestOnConnectHandler(t *testing.T) {
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return &config.ConfigurationStruct{
-				MessageBus: config.MessageBus{
-					External: bootstrapConfig.ExternalMQTTInfo{
-						Topics: map[string]string{
-							QueryRequestTopic:          testQueryRequestTopic,
-							QueryResponseTopic:         testQueryResponseTopic,
-							CommandRequestTopic:        testExternalCommandRequestTopic,
-							CommandResponseTopicPrefix: testExternalCommandResponseTopicPrefix,
-						},
-						QoS:    0,
-						Retain: true,
+				ExternalMQTT: bootstrapConfig.ExternalMQTTInfo{
+					Topics: map[string]string{
+						QueryRequestTopic:          testQueryRequestTopic,
+						QueryResponseTopic:         testQueryResponseTopic,
+						CommandRequestTopic:        testExternalCommandRequestTopic,
+						CommandResponseTopicPrefix: testExternalCommandResponseTopicPrefix,
 					},
+					QoS:    0,
+					Retain: true,
 				},
 			}
 		},
@@ -171,14 +169,11 @@ func Test_commandQueryHandler(t *testing.T) {
 					Port:           mockPort,
 					MaxResultCount: 20,
 				},
-				MessageBus: config.MessageBus{
-					Internal: bootstrapConfig.MessageBusInfo{},
-					External: bootstrapConfig.ExternalMQTTInfo{
-						QoS:    0,
-						Retain: true,
-						Topics: map[string]string{
-							QueryResponseTopic: testQueryResponseTopic,
-						},
+				ExternalMQTT: bootstrapConfig.ExternalMQTTInfo{
+					QoS:    0,
+					Retain: true,
+					Topics: map[string]string{
+						QueryResponseTopic: testQueryResponseTopic,
 					},
 				},
 			}
@@ -298,18 +293,16 @@ func Test_commandRequestHandler(t *testing.T) {
 					Port:           mockPort,
 					MaxResultCount: 20,
 				},
-				MessageBus: config.MessageBus{
-					Internal: bootstrapConfig.MessageBusInfo{
-						Topics: map[string]string{
-							DeviceRequestTopicPrefix: testInternalCommandRequestTopicPrefix,
-						},
+				MessageBus: bootstrapConfig.MessageBusInfo{
+					Topics: map[string]string{
+						DeviceRequestTopicPrefix: testInternalCommandRequestTopicPrefix,
 					},
-					External: bootstrapConfig.ExternalMQTTInfo{
-						QoS:    0,
-						Retain: true,
-						Topics: map[string]string{
-							CommandResponseTopicPrefix: testExternalCommandResponseTopicPrefix,
-						},
+				},
+				ExternalMQTT: bootstrapConfig.ExternalMQTTInfo{
+					QoS:    0,
+					Retain: true,
+					Topics: map[string]string{
+						CommandResponseTopicPrefix: testExternalCommandResponseTopicPrefix,
 					},
 				},
 			}

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2020 Dell Inc.
- * Copyright 2022 IOTech Ltd.
+ * Copyright 2022-2023 IOTech Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -90,7 +90,7 @@ func MessagingBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupT
 	configuration := container.ConfigurationFrom(dic.Get)
 	router := messaging.NewMessagingRouter()
 
-	if configuration.MessageBus.External.Enabled {
+	if configuration.ExternalMQTT.Enabled {
 		if !handlers.NewExternalMQTT(messaging.OnConnectHandler(router, dic)).BootstrapHandler(ctx, wg, startupTimer, dic) {
 			return false
 		}


### PR DESCRIPTION
BREAKING CHANGE:
- MessageBus.Internal renamed to MessageBus and moved to top level.
- MessageBus.External renamed to ExternalMQTT and moved to top level.

closes #4259

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core-command from this branch with external MQTT broker
2. Verify commands via messaging is working correctly

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->