### PR TITLE
refactor!: Use bool types for command parameters to be more consistent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.8
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.9
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3
-	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.3
+	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.4
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.2
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/golang-jwt/jwt/v4 v4.4.3
@@ -21,8 +21,6 @@ require (
 	gopkg.in/eapache/queue.v1 v1.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-replace github.com/edgexfoundry/go-mod-messaging/v3 => github.com/jinlinGuan/go-mod-messaging/v3 v3.0.0-20230112093353-d552b7cefe35
 
 require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.8
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.3
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.2
 	github.com/fxamacker/cbor/v2 v2.4.0
@@ -21,6 +21,8 @@ require (
 	gopkg.in/eapache/queue.v1 v1.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/edgexfoundry/go-mod-messaging/v3 => github.com/jinlinGuan/go-mod-messaging/v3 v3.0.0-20230112093353-d552b7cefe35
 
 require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,10 +32,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.8 h1:BvIM4O8edFi/nhtJmfy4
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.8/go.mod h1:2I6w1vDe1Hsq0woNy5L9SqRAho+xjpObhhlv1dI4avY=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 h1:xp5MsP+qf/fuJxy8fT7k1N+c4j4C6w04qMCBXm6id7o=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2/go.mod h1:1Vv4uWAo6r7k6jUlqVJW8JOL6YKVBc6sRL8Al3DrMck=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2 h1:tleTxhbBISfDNn596rU71n+GOy27dMIme+v8Vl0uhpw=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2/go.mod h1:7RwSq896VqelvSU7zYKs2tpZhgELVFECkiGf6XGLKfQ=
-github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.3 h1:+el2HxEt02uFXXBmHK8gWETPklNbPg4wvYln/4/ooHo=
-github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.3/go.mod h1:G0Vxoc8+JXwUqRH5ggyOZ/f/CIVPTswI5Ld7dI5uhIY=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3 h1:Ia/y/w9w3SmXqIqJ+Vjmv6QrP49YJDpTY6262C1Jrzs=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3/go.mod h1:7RwSq896VqelvSU7zYKs2tpZhgELVFECkiGf6XGLKfQ=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3 h1:QgZF9f70Cwpvkjw3tP1aiVGHc+yNFJNzW6hO8pDs3fg=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3/go.mod h1:2w8v0sv+i21nY+DY6JV4PFxsNTuxpGAjlNFlFMTfZkk=
 github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.2 h1:Lu1gJr2fAUTuogE/SwgVgGpxDlMsC4PLE0Y8oXRUvkI=
@@ -135,6 +133,8 @@ github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/jinlinGuan/go-mod-messaging/v3 v3.0.0-20230112093353-d552b7cefe35 h1:gxL7fwanJVfzNYRFkJ/RobH+6R5Rdl9JjkaIc61cgyc=
+github.com/jinlinGuan/go-mod-messaging/v3 v3.0.0-20230112093353-d552b7cefe35/go.mod h1:Gyj+AGZZY43ZaK7kn4bKWlNE5Tt9pEKgV9eqKY7Gmj8=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/go.sum
+++ b/go.sum
@@ -28,12 +28,14 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.8 h1:BvIM4O8edFi/nhtJmfy4lh+keYG3VbHvfWjyXoyiESU=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.8/go.mod h1:2I6w1vDe1Hsq0woNy5L9SqRAho+xjpObhhlv1dI4avY=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.9 h1:YQRmArf08iSHOJ1xIXMchxfsbeguUPbG1Q1E0IVAUZA=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.9/go.mod h1:lJI+SO9B3dWOn/UfJ90fYQVR4wYddjEkvmAJqt/WdxA=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 h1:xp5MsP+qf/fuJxy8fT7k1N+c4j4C6w04qMCBXm6id7o=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2/go.mod h1:1Vv4uWAo6r7k6jUlqVJW8JOL6YKVBc6sRL8Al3DrMck=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3 h1:Ia/y/w9w3SmXqIqJ+Vjmv6QrP49YJDpTY6262C1Jrzs=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3/go.mod h1:7RwSq896VqelvSU7zYKs2tpZhgELVFECkiGf6XGLKfQ=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.4 h1:swPZOjoQ/IUIWSJpZCmQENtP/plFRx5tgiCEZgnfxFU=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.4/go.mod h1:8pxuYvh2zcq1GuKqmk1MAuH1yuN40iOMmL0g2myIfwk=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3 h1:QgZF9f70Cwpvkjw3tP1aiVGHc+yNFJNzW6hO8pDs3fg=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3/go.mod h1:2w8v0sv+i21nY+DY6JV4PFxsNTuxpGAjlNFlFMTfZkk=
 github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.2 h1:Lu1gJr2fAUTuogE/SwgVgGpxDlMsC4PLE0Y8oXRUvkI=
@@ -133,8 +135,6 @@ github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/jinlinGuan/go-mod-messaging/v3 v3.0.0-20230112093353-d552b7cefe35 h1:gxL7fwanJVfzNYRFkJ/RobH+6R5Rdl9JjkaIc61cgyc=
-github.com/jinlinGuan/go-mod-messaging/v3 v3.0.0-20230112093353-d552b7cefe35/go.mod h1:Gyj+AGZZY43ZaK7kn4bKWlNE5Tt9pEKgV9eqKY7Gmj8=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/internal/core/command/controller/http/command.go
+++ b/internal/core/command/controller/http/command.go
@@ -79,13 +79,13 @@ func (cc *CommandController) CommandsByDeviceName(w http.ResponseWriter, r *http
 }
 
 func validateGetCommandParameters(r *http.Request) (err errors.EdgeX) {
-	dsReturnEvent := utils.ParseQueryStringToString(r, common.ReturnEvent, common.ValueYes)
-	dsPushEvent := utils.ParseQueryStringToString(r, common.PushEvent, common.ValueNo)
-	if dsReturnEvent != common.ValueYes && dsReturnEvent != common.ValueNo {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid query parameter, %s has to be %s or %s", dsReturnEvent, common.ValueYes, common.ValueNo), nil)
+	dsReturnEvent := utils.ParseQueryStringToString(r, common.ReturnEvent, common.ValueTrue)
+	dsPushEvent := utils.ParseQueryStringToString(r, common.PushEvent, common.ValueFalse)
+	if dsReturnEvent != common.ValueTrue && dsReturnEvent != common.ValueFalse {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid query parameter, %s has to be %s or %s", dsReturnEvent, common.ValueTrue, common.ValueFalse), nil)
 	}
-	if dsPushEvent != common.ValueYes && dsPushEvent != common.ValueNo {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid query parameter, %s has to be %s or %s", dsPushEvent, common.ValueYes, common.ValueNo), nil)
+	if dsPushEvent != common.ValueTrue && dsPushEvent != common.ValueFalse {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid query parameter, %s has to be %s or %s", dsPushEvent, common.ValueTrue, common.ValueFalse), nil)
 	}
 	return nil
 }

--- a/internal/core/command/controller/http/command_test.go
+++ b/internal/core/command/controller/http/command_test.go
@@ -46,7 +46,7 @@ const (
 	testDeviceServiceName = "testDeviceService"
 	testCommandName       = "testCommand"
 	testBaseAddress       = "http://localhost:49990"
-	testQueryStrings      = "a=1&b=2&ds-pushevent=no"
+	testQueryStrings      = "a=1&b=2&ds-pushevent=false"
 )
 
 // NewMockDIC function returns a mock bootstrap di Container

--- a/internal/core/command/controller/messaging/external_test.go
+++ b/internal/core/command/controller/messaging/external_test.go
@@ -392,8 +392,8 @@ func testCommandQueryPayload() types.MessageEnvelope {
 
 func testCommandRequestPayload() types.MessageEnvelope {
 	payload := types.NewMessageEnvelopeForRequest(nil, map[string]string{
-		"ds-pushevent":   "yes",
-		"ds-returnevent": "yes",
+		"ds-pushevent":   common.ValueTrue,
+		"ds-returnevent": common.ValueTrue,
 	})
 
 	return payload

--- a/internal/core/command/controller/messaging/utils.go
+++ b/internal/core/command/controller/messaging/utils.go
@@ -54,13 +54,13 @@ func validateRequestTopic(prefix string, deviceName string, commandName string, 
 // validateGetCommandQueryParameters validates the value is valid for device service's reserved query parameters
 func validateGetCommandQueryParameters(queryParams map[string]string) error {
 	if dsReturnEvent, ok := queryParams[common.ReturnEvent]; ok {
-		if dsReturnEvent != common.ValueYes && dsReturnEvent != common.ValueNo {
-			return fmt.Errorf("invalid query parameter, %s has to be '%s' or '%s'", common.ReturnEvent, common.ValueYes, common.ValueNo)
+		if dsReturnEvent != common.ValueTrue && dsReturnEvent != common.ValueFalse {
+			return fmt.Errorf("invalid query parameter, %s has to be '%s' or '%s'", common.ReturnEvent, common.ValueTrue, common.ValueFalse)
 		}
 	}
 	if dsPushEvent, ok := queryParams[common.PushEvent]; ok {
-		if dsPushEvent != common.ValueYes && dsPushEvent != common.ValueNo {
-			return fmt.Errorf("invalid query parameter, %s has to be '%s' or '%s'", common.PushEvent, common.ValueYes, common.ValueNo)
+		if dsPushEvent != common.ValueTrue && dsPushEvent != common.ValueFalse {
+			return fmt.Errorf("invalid query parameter, %s has to be '%s' or '%s'", common.PushEvent, common.ValueTrue, common.ValueFalse)
 		}
 	}
 

--- a/openapi/v2/core-command.yaml
+++ b/openapi/v2/core-command.yaml
@@ -564,21 +564,21 @@ paths:
           schema:
             type: string
             enum:
-              - yes
-              - no
-            default: no
-          example: yes
-          description: "If set to yes, a successful GET will result in an event being pushed to the EdgeX system"
+              - true
+              - false
+            default: false
+          example: true
+          description: "If set to true, a successful GET will result in an event being pushed to the EdgeX system"
         - in: query
           name: ds-returnevent
           schema:
             type: string
             enum:
-              - yes
-              - no
-            default: yes
-          example: no
-          description: "If set to no, there will be no Event returned in the http response"
+              - true
+              - false
+            default: true
+          example: false
+          description: "If set to false, there will be no Event returned in the http response"
       responses:
         '200':
           description: "OK"


### PR DESCRIPTION
BREAKING CHANGE: ds-pushevent and ds-returnevent to use bool true/false instead of yes/no
    
related: https://github.com/edgexfoundry/go-mod-core-contracts/pull/782
    
Signed-off-by: Ginny Guan <ginny@iotechsys.com>
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/917 and the core-command Swagger file in this repo

## Testing Instructions
<!-- How can the reviewers test your change? -->
build core-command and device-virtual docker images based on the changes and run docker-compose.yml
The following commands work as expected:
```
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=true
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=false
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=true
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=false
```
and the following commands return errors as expected:
```
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=yes
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=no
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=yes
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=no
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->