### PR TITLE
fix(snap): source security-bootstrapper config overrides from env file

### DIFF
--- a/snap/local/runtime-helpers/bin/service-config-overrides.sh
+++ b/snap/local/runtime-helpers/bin/service-config-overrides.sh
@@ -8,7 +8,9 @@ BINPATH="${ARGV[0]}"
 
 # binary name == service name/key
 SERVICE=$(basename "$BINPATH")
-ENV_FILE="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
+if [ -z $ENV_FILE ]; then
+    ENV_FILE="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
+fi
 TAG="edgex-$SERVICE."$(basename "$0")
 
 if [ -f "$ENV_FILE" ]; then
@@ -16,6 +18,8 @@ if [ -f "$ENV_FILE" ]; then
     set -o allexport
     source "$ENV_FILE" set
     set +o allexport 
+else
+    logger --tag=$TAG --stderr "sourcing $ENV_FILE: not found!"
 fi
 
 exec "$@"

--- a/snap/local/runtime-helpers/bin/setup-consul-acl.sh
+++ b/snap/local/runtime-helpers/bin/setup-consul-acl.sh
@@ -3,16 +3,6 @@
 # we don't want to exit out the whole Consul process when ACL bootstrapping failed, just that
 # Consul won't have ACL to be used
 
-# TODO: determine if this script is really necessary. I'm not sure why the command below isn't
-# simply specified as the service command, with the command-chain service-overrides script to
-# handle sourcing the .env file
-
-SERVICE_ENV="$SNAP_DATA/config/security-bootstrapper/res/security-bootstrapper.env"
-if [ -f "$SERVICE_ENV" ]; then
-    logger "edgex service override: : sourcing $SERVICE_ENV"
-    source "$SERVICE_ENV"
-fi
-
 # setup Consul's ACL via security-bootstrapper's subcommand
 "$SNAP"/bin/security-bootstrapper -configDir "$SNAP_DATA"/config/security-bootstrapper/res setupRegistryACL
 setupACL_code=$?

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -227,8 +227,10 @@ apps:
     after:
       - security-secretstore-setup
     command: bin/setup-redis-acl.sh
+    command-chain:
+      - bin/service-config-overrides.sh
     environment:
-      # TODO: determine the correct cmd-line args & env var overrides...
+      ENV_FILE: $SNAP_DATA/config/security-bootstrapper/res/security-bootstrapper.env
       SECRETSTORE_SERVERNAME: localhost
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/security-bootstrapper-redis/secrets-token.json
       DATABASECONFIG_PATH: $SNAP_DATA/redis/conf
@@ -242,7 +244,10 @@ apps:
     after:
       - security-secretstore-setup
     command: bin/setup-consul-acl.sh
+    command-chain:
+      - bin/service-config-overrides.sh
     environment:
+      ENV_FILE: $SNAP_DATA/config/security-bootstrapper/res/security-bootstrapper.env
       STAGEGATE_REGISTRY_HOST: localhost
       STAGEGATE_REGISTRY_ACL_BOOTSTRAPTOKENPATH: $SNAP_DATA/secrets/consul-acl-token/bootstrap_token.json
       STAGEGATE_REGISTRY_ACL_MANAGEMENTTOKENPATH: $SNAP_DATA/secrets/consul-acl-token/mgmt_token.json


### PR DESCRIPTION
The PR https://github.com/edgexfoundry/edgex-go/pull/4071 upgraded the library to generate correct environment files, and updated the env loader script accordingly. However, another env file loader logic was in the consul security bootstrapper script which was left out.

This PR removes the duplicate logic and makes the bootstrapper use the generic env file loader script.

Fixes https://github.com/edgexfoundry/edgex-go/issues/4284

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Download the snap from GH action snap builds or build it locally
2. Install Device MQTT and connect `sudo snap install edgex-device-mqtt --edge && sudo snap connect edgexfoundry:edgex-secretstore-token edgex-device-mqtt:edgex-secretstore-token`
3. (Install mosquitto `sudo snap install mosquitto`)
4. Start `sudo snap start edgex-device-mqtt`
5. Check the logs to make sure you don't see consul-related errors as reported in https://github.com/edgexfoundry/edgex-go/issues/4284

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->