### PR TITLE
refactor!: Replace SecretStore service config with default values and overrides

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -105,17 +105,3 @@ Type = "consul"
     CommandResponseTopicPrefix = "edgex/command/response"     # for publishing responses back to 3rd party systems /<device-name>/<command-name>/<method> will be added to this publish topic prefix
     QueryRequestTopic = "edgex/commandquery/request/#"        # for subscribing to 3rd party command query request
     QueryResponseTopic = "edgex/commandquery/response"        # for publishing responses back to 3rd party systems
-
-[SecretStore]
-Type = "vault"
-Protocol = "http"
-Host = "localhost"
-Port = 8200
-# Use the core-meta data secrets due to core-command using core-meta-data's database for persistance.
-Path = "core-command/"
-TokenFile = "/tmp/edgex/secrets/core-command/secrets-token.json"
-RootCaCertPath = ""
-ServerName = ""
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
-

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -84,23 +84,3 @@ SecretName = "redisdb"
   Deliver = "new"
   DefaultPubRetryAttempts = "2"
   Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
-
-[SecretStore]
-Type = "vault"
-Protocol = "http"
-Host = "localhost"
-Port = 8200
-Path = "core-data/"
-TokenFile = "/tmp/edgex/secrets/core-data/secrets-token.json"
-RootCaCertPath = ""
-ServerName = ""
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
-  [SecretStore.RuntimeTokenProvider]
-  Enabled = false
-  Protocol = "https"
-  Host = "localhost"
-  Port = 59841
-  TrustDomain = "edgexfoundry.org"
-  EndpointSocket = "/tmp/edgex/secrets/spiffe/public/api.sock"
-  RequiredSecrets = "redisdb"

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -99,23 +99,3 @@ SecretName = "redisdb"
   Deliver = "new"
   DefaultPubRetryAttempts = "2"
   Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
-
-[SecretStore]
-Type = "vault"
-Protocol = "http"
-Host = "localhost"
-Port = 8200
-Path = "core-metadata/"
-TokenFile = "/tmp/edgex/secrets/core-metadata/secrets-token.json"
-RootCaCertPath = ""
-ServerName = ""
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
-  [SecretStore.RuntimeTokenProvider]
-  Enabled = false
-  Protocol = "https"
-  Host = "localhost"
-  Port = 59841
-  TrustDomain = "edgexfoundry.org"
-  EndpointSocket = "/tmp/edgex/secrets/spiffe/public/api.sock"
-  RequiredSecrets = "redisdb"

--- a/cmd/security-bootstrapper/res-bootstrap-mosquitto/configuration.toml
+++ b/cmd/security-bootstrapper/res-bootstrap-mosquitto/configuration.toml
@@ -13,19 +13,7 @@
 #
 #################################################################################
 
-LogLevel = "DEBUG"
-
-[SecretStore]
-Type = "vault"
-Protocol = "http"
-Host = "localhost"          ## Override in environment variables, if necessary
-Port = 8200
-Path = "security-bootstrapper-messagebus/"
-TokenFile = "/tmp/edgex/secrets/security-bootstrapper-messagebus/secrets-token.json"
-RootCaCertPath = ""
-ServerName = ""
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
+LogLevel = "INFO"
 
 [SecureMosquitto]
 Port = 1883

--- a/cmd/security-bootstrapper/res-bootstrap-redis/configuration.toml
+++ b/cmd/security-bootstrapper/res-bootstrap-redis/configuration.toml
@@ -15,18 +15,6 @@
 
 LogLevel = "INFO"
 
-[SecretStore]
-Type = "vault"
-Protocol = "http"
-Host = "localhost"          ## Override in environment variables, if necessary
-Port = 8200
-Path = "security-bootstrapper-redis/"
-TokenFile = "/tmp/edgex/secrets/security-bootstrapper-redis/secrets-token.json"
-RootCaCertPath = ""
-ServerName = ""
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
-
 [Databases]
   [Databases.Primary]
   Host = "localhost"

--- a/cmd/security-spiffe-token-provider/res/configuration.toml
+++ b/cmd/security-spiffe-token-provider/res/configuration.toml
@@ -39,26 +39,6 @@ Type = "consul"
   Timeout = 5000
   Type = "redisdb"
 
-[SecretStore]
-Type = "vault"
-Protocol = "http"
-Host = "localhost"
-Port = 8200
-Path = "security-spiffe-token-provider/"
-TokenFile = "/tmp/edgex/secrets/security-spiffe-token-provider/secrets-token.json"
-RootCaCertPath = ""
-ServerName = ""
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
-  [SecretStore.RuntimeTokenProvider]
-  Enabled = false # This is the implementation of RuntimeTokenProvider; must always be false!
-  Protocol = ""
-  Host = ""
-  Port = 0
-  TrustDomain = ""
-  EndpointSocket = ""
-  RequiredSecrets = ""
-
 [SPIFFE]
   EndpointSocket = "/tmp/edgex/secrets/spiffe/public/api.sock"
   TrustDomain = "edgexfoundry.org"

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -95,25 +95,3 @@ SecretName = "redisdb"
   Deliver = "new"
   DefaultPubRetryAttempts = "2"
   Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
-
-[SecretStore]
-Type = "vault"
-Protocol = "http"
-Host = "localhost"
-Port = 8200
-Path = "support-notifications/"
-TokenFile = "/tmp/edgex/secrets/support-notifications/secrets-token.json"
-RootCaCertPath = ""
-ServerName = ""
-SecretsFile = ""
-DisableScrubSecretsFile = false
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
-  [SecretStore.RuntimeTokenProvider]
-  Enabled = false
-  Protocol = "https"
-  Host = "localhost"
-  Port = 59841
-  TrustDomain = "edgexfoundry.org"
-  EndpointSocket = "/tmp/edgex/secrets/spiffe/public/api.sock"
-  RequiredSecrets = "redisdb"

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -100,23 +100,3 @@ SecretName = "redisdb"
   Deliver = "new"
   DefaultPubRetryAttempts = "2"
   Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
-
-[SecretStore]
-Type = "vault"
-Protocol = "http"
-Host = "localhost"
-Port = 8200
-Path = "support-scheduler/"
-TokenFile = "/tmp/edgex/secrets/support-scheduler/secrets-token.json"
-RootCaCertPath = ""
-ServerName = ""
-  [SecretStore.Authentication]
-  AuthType = "X-Vault-Token"
-  [SecretStore.RuntimeTokenProvider]
-  Enabled = false
-  Protocol = "https"
-  Host = "localhost"
-  Port = 59841
-  TrustDomain = "edgexfoundry.org"
-  EndpointSocket = "/tmp/edgex/secrets/spiffe/public/api.sock"
-  RequiredSecrets = "redisdb"

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.9
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.11
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.4
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.4
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.2
 	github.com/fxamacker/cbor/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -28,12 +28,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.9 h1:YQRmArf08iSHOJ1xIXMchxfsbeguUPbG1Q1E0IVAUZA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.9/go.mod h1:lJI+SO9B3dWOn/UfJ90fYQVR4wYddjEkvmAJqt/WdxA=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.11 h1:PHkcIC9hwOG2XyumsdO4hfavzd96GHs7kJZE8Ih9/cY=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.11/go.mod h1:UjrW9GZ5UjKZLF1EzEtAjvrgOvgQz3FGyVyAAX+fXW4=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 h1:xp5MsP+qf/fuJxy8fT7k1N+c4j4C6w04qMCBXm6id7o=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2/go.mod h1:1Vv4uWAo6r7k6jUlqVJW8JOL6YKVBc6sRL8Al3DrMck=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3 h1:Ia/y/w9w3SmXqIqJ+Vjmv6QrP49YJDpTY6262C1Jrzs=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.3/go.mod h1:7RwSq896VqelvSU7zYKs2tpZhgELVFECkiGf6XGLKfQ=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.4 h1:J1G1Fd0wKsr2FNqansSOvfErvUrYanR/9tKbp0VpcRo=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.4/go.mod h1:7RwSq896VqelvSU7zYKs2tpZhgELVFECkiGf6XGLKfQ=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.4 h1:swPZOjoQ/IUIWSJpZCmQENtP/plFRx5tgiCEZgnfxFU=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.4/go.mod h1:8pxuYvh2zcq1GuKqmk1MAuH1yuN40iOMmL0g2myIfwk=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3 h1:QgZF9f70Cwpvkjw3tP1aiVGHc+yNFJNzW6hO8pDs3fg=

--- a/internal/core/command/config/config.go
+++ b/internal/core/command/config/config.go
@@ -21,13 +21,12 @@ import (
 
 // ConfigurationStruct contains the configuration properties for the core-command service.
 type ConfigurationStruct struct {
-	Writable    WritableInfo
-	Clients     map[string]bootstrapConfig.ClientInfo
-	Databases   map[string]bootstrapConfig.Database
-	Registry    bootstrapConfig.RegistryInfo
-	Service     bootstrapConfig.ServiceInfo
-	MessageBus  MessageBus
-	SecretStore bootstrapConfig.SecretStoreInfo
+	Writable   WritableInfo
+	Clients    map[string]bootstrapConfig.ClientInfo
+	Databases  map[string]bootstrapConfig.Database
+	Registry   bootstrapConfig.RegistryInfo
+	Service    bootstrapConfig.ServiceInfo
+	MessageBus MessageBus
 }
 
 // WritableInfo contains configuration properties that can be updated and applied without restarting the service.
@@ -81,7 +80,6 @@ func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfigurat
 		Clients:      c.Clients,
 		Service:      c.Service,
 		Registry:     c.Registry,
-		SecretStore:  c.SecretStore,
 		MessageBus:   c.MessageBus.Internal,
 		ExternalMQTT: c.MessageBus.External,
 	}

--- a/internal/core/data/config/config.go
+++ b/internal/core/data/config/config.go
@@ -25,7 +25,6 @@ type ConfigurationStruct struct {
 	Databases    map[string]bootstrapConfig.Database
 	Registry     bootstrapConfig.RegistryInfo
 	Service      bootstrapConfig.ServiceInfo
-	SecretStore  bootstrapConfig.SecretStoreInfo
 	MaxEventSize int64
 }
 
@@ -73,11 +72,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:     c.Clients,
-		Service:     c.Service,
-		Registry:    c.Registry,
-		SecretStore: c.SecretStore,
-		MessageBus:  c.MessageBus,
+		Clients:    c.Clients,
+		Service:    c.Service,
+		Registry:   c.Registry,
+		MessageBus: c.MessageBus,
 	}
 }
 

--- a/internal/core/metadata/config/config.go
+++ b/internal/core/metadata/config/config.go
@@ -27,7 +27,6 @@ type ConfigurationStruct struct {
 	Registry      bootstrapConfig.RegistryInfo
 	Service       bootstrapConfig.ServiceInfo
 	MessageBus    bootstrapConfig.MessageBusInfo
-	SecretStore   bootstrapConfig.SecretStoreInfo
 	UoM           UoM
 }
 
@@ -99,11 +98,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:     c.Clients,
-		Service:     c.Service,
-		Registry:    c.Registry,
-		SecretStore: c.SecretStore,
-		MessageBus:  c.MessageBus,
+		Clients:    c.Clients,
+		Service:    c.Service,
+		Registry:   c.Registry,
+		MessageBus: c.MessageBus,
 	}
 }
 

--- a/internal/pkg/controller/http/secret_test.go
+++ b/internal/pkg/controller/http/secret_test.go
@@ -7,17 +7,17 @@ package http
 
 import (
 	"encoding/json"
-	"github.com/google/uuid"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
-	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
@@ -113,15 +113,7 @@ func TestAddSecret(t *testing.T) {
 func mockDic() *di.Container {
 	return di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return &config.ConfigurationStruct{
-				SecretStore: bootstrapConfig.SecretStoreInfo{
-					Type:     "vault",
-					Host:     "localhost",
-					Port:     8200,
-					Path:     "/v1/secret/edgex/device-simple/",
-					Protocol: "http",
-				},
-			}
+			return &config.ConfigurationStruct{}
 		},
 		container.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return logger.NewMockClient()

--- a/internal/security/bootstrapper/command/setupacl/stubregistryserver_test.go
+++ b/internal/security/bootstrapper/command/setupacl/stubregistryserver_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Intel Corporation
+ * Copyright 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path"
 	"strconv"
 	"testing"
@@ -361,10 +362,11 @@ func (registry *registryTestServer) getRegistryServerConf(t *testing.T) *config.
 	registryTestConf.StageGate.WaitFor.Timeout = "1m"
 	registryTestConf.StageGate.WaitFor.RetryInterval = "1s"
 	// for the sake of simplicity, we use the same test server as the secret store server
-	registryTestConf.SecretStore.Type = "vault"
-	registryTestConf.SecretStore.Protocol = tsURL.Scheme
-	registryTestConf.SecretStore.Host = tsURL.Hostname()
-	registryTestConf.SecretStore.Port = portNum
+	os.Setenv("SECRETSTORE_PROTOCOL", tsURL.Scheme)
+	os.Setenv("SECRETSTORE_HOST", tsURL.Hostname())
+	os.Setenv("SECRETSTORE_PORT", tsURL.Port())
+
 	registry.server = testSrv
 	return registryTestConf
+
 }

--- a/internal/security/bootstrapper/config/config.go
+++ b/internal/security/bootstrapper/config/config.go
@@ -22,9 +22,8 @@ import (
 )
 
 type ConfigurationStruct struct {
-	LogLevel    string
-	StageGate   StageGateInfo
-	SecretStore bootstrapConfig.SecretStoreInfo
+	LogLevel  string
+	StageGate StageGateInfo
 }
 
 // UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is

--- a/internal/security/bootstrapper/mosquitto/config/config.go
+++ b/internal/security/bootstrapper/mosquitto/config/config.go
@@ -23,7 +23,6 @@ import (
 // the runtime extension of the static configuration.
 type ConfigurationStruct struct {
 	LogLevel        string
-	SecretStore     bootstrapConfig.SecretStoreInfo
 	SecureMosquitto SecureMosquittoInfo
 }
 type SecureMosquittoInfo struct {
@@ -61,9 +60,7 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 // bootstrapConfig.BootstrapConfiguration struct contained within ConfigurationStruct).
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
-	return bootstrapConfig.BootstrapConfiguration{
-		SecretStore: c.SecretStore,
-	}
+	return bootstrapConfig.BootstrapConfiguration{}
 }
 
 // GetLogLevel returns the current ConfigurationStruct's log level.

--- a/internal/security/bootstrapper/redis/config/config.go
+++ b/internal/security/bootstrapper/redis/config/config.go
@@ -23,7 +23,6 @@ import (
 // the runtime extension of the static configuration.
 type ConfigurationStruct struct {
 	LogLevel       string
-	SecretStore    bootstrapConfig.SecretStoreInfo
 	Databases      map[string]bootstrapConfig.Database
 	DatabaseConfig DatabaseBootstrapConfigInfo
 }
@@ -62,9 +61,7 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 // bootstrapConfig.BootstrapConfiguration struct contained within ConfigurationStruct).
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
-	return bootstrapConfig.BootstrapConfiguration{
-		SecretStore: c.SecretStore,
-	}
+	return bootstrapConfig.BootstrapConfiguration{}
 }
 
 // GetLogLevel returns the current ConfigurationStruct's log level.

--- a/internal/security/proxy/config/config.go
+++ b/internal/security/proxy/config/config.go
@@ -34,7 +34,6 @@ type ConfigurationStruct struct {
 	KongURL           KongUrlInfo
 	KongAuth          KongAuthInfo
 	CORSConfiguration bootstrapConfig.CORSConfigurationInfo
-	SecretStore       bootstrapConfig.SecretStoreInfo
 	Routes            map[string]models.KongService
 }
 
@@ -103,9 +102,7 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(_ interface{}) bool {
 // GetBootstrap returns the configuration elements required by the bootstrap.
 // Not needed for this service, so return empty struct
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
-	return bootstrapConfig.BootstrapConfiguration{
-		SecretStore: c.SecretStore,
-	}
+	return bootstrapConfig.BootstrapConfiguration{}
 }
 
 // GetLogLevel returns the current ConfigurationStruct's log level.

--- a/internal/security/spiffetokenprovider/config/config.go
+++ b/internal/security/spiffetokenprovider/config/config.go
@@ -28,14 +28,13 @@ type SpiffeInfo struct {
 }
 
 type ConfigurationStruct struct {
-	Writable    WritableInfo
-	MessageBus  bootstrapConfig.MessageBusInfo
-	Clients     map[string]bootstrapConfig.ClientInfo
-	Databases   map[string]bootstrapConfig.Database
-	Registry    bootstrapConfig.RegistryInfo
-	Service     bootstrapConfig.ServiceInfo
-	SecretStore bootstrapConfig.SecretStoreInfo
-	Spiffe      SpiffeInfo
+	Writable   WritableInfo
+	MessageBus bootstrapConfig.MessageBusInfo
+	Clients    map[string]bootstrapConfig.ClientInfo
+	Databases  map[string]bootstrapConfig.Database
+	Registry   bootstrapConfig.RegistryInfo
+	Service    bootstrapConfig.ServiceInfo
+	Spiffe     SpiffeInfo
 }
 
 type WritableInfo struct {
@@ -81,10 +80,9 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:     c.Clients,
-		Service:     c.Service,
-		Registry:    c.Registry,
-		SecretStore: c.SecretStore,
+		Clients:  c.Clients,
+		Service:  c.Service,
+		Registry: c.Registry,
 	}
 }
 

--- a/internal/support/notifications/config/config.go
+++ b/internal/support/notifications/config/config.go
@@ -20,14 +20,13 @@ import (
 )
 
 type ConfigurationStruct struct {
-	Writable    WritableInfo
-	Clients     map[string]bootstrapConfig.ClientInfo
-	Databases   map[string]bootstrapConfig.Database
-	Registry    bootstrapConfig.RegistryInfo
-	Service     bootstrapConfig.ServiceInfo
-	MessageBus  bootstrapConfig.MessageBusInfo
-	Smtp        SmtpInfo
-	SecretStore bootstrapConfig.SecretStoreInfo
+	Writable   WritableInfo
+	Clients    map[string]bootstrapConfig.ClientInfo
+	Databases  map[string]bootstrapConfig.Database
+	Registry   bootstrapConfig.RegistryInfo
+	Service    bootstrapConfig.ServiceInfo
+	MessageBus bootstrapConfig.MessageBusInfo
+	Smtp       SmtpInfo
 }
 
 type WritableInfo struct {
@@ -102,11 +101,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:     c.Clients,
-		Service:     c.Service,
-		Registry:    c.Registry,
-		SecretStore: c.SecretStore,
-		MessageBus:  c.MessageBus,
+		Clients:    c.Clients,
+		Service:    c.Service,
+		Registry:   c.Registry,
+		MessageBus: c.MessageBus,
 	}
 }
 

--- a/internal/support/scheduler/config/config.go
+++ b/internal/support/scheduler/config/config.go
@@ -30,7 +30,6 @@ type ConfigurationStruct struct {
 	MessageBus      bootstrapConfig.MessageBusInfo
 	Intervals       map[string]IntervalInfo
 	IntervalActions map[string]IntervalActionInfo
-	SecretStore     bootstrapConfig.SecretStoreInfo
 	// ScheduleIntervalTime is a time(Millisecond) to create a ticker to delay the scheduler loop
 	ScheduleIntervalTime int
 }
@@ -126,11 +125,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:     c.Clients,
-		Service:     c.Service,
-		Registry:    c.Registry,
-		SecretStore: c.SecretStore,
-		MessageBus:  c.MessageBus,
+		Clients:    c.Clients,
+		Service:    c.Service,
+		Registry:   c.Registry,
+		MessageBus: c.MessageBus,
 	}
 }
 


### PR DESCRIPTION
BREAKING CHANGE: SecretStore config no longer in service configuration file. Changes must be done via use of environment variable overrides of default values

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  TBD

## Testing Instructions
Run `make docker` from this branch
From compose builder run `make run ds-virtual delayed-start dev`
Verify all core/support services bootstrapped and running properly
Verify Device Virtual bootstrapped and running properly using runtime token provider. Log should contain:
```
level=INFO ts=2023-01-17T20:47:10.1690972Z app=device-virtual source=secret.go:173 msg="runtime token provider enabled"
level=INFO ts=2023-01-17T20:47:10.1691067Z app=device-virtual source=methods.go:138 msg="using Unix Domain Socket at unix:///tmp/edgex/secrets/spiffe/public/api.sock"
level=INFO ts=2023-01-17T20:47:10.2535458Z app=device-virtual source=methods.go:150 msg="workload got X509 source"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->