### PR TITLE
feat: initial core common config bootstrapper and config implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __debug_bin
 
 # binary files
 cmd/core-command/core-command
+cmd/core-common-config-bootstrapper/core-common-config-bootstrapper
 cmd/core-data/core-data
 cmd/core-metadata/core-metadata
 cmd/security-proxy-setup/security-proxy-setup

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ command: cmd/core-command/core-command
 cmd/core-command/core-command:
 	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-command
 
-common_config: cmd/core-common-config-bootstrapper/core-common-config-bootstrapper
+common-config: cmd/core-common-config-bootstrapper/core-common-config-bootstrapper
 cmd/core-common-config-bootstrapper/core-common-config-bootstrapper:
 	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-common-config-bootstrapper
 
@@ -217,14 +217,14 @@ docker_core_command: docker_base
 		-t edgexfoundry/core-command:$(DOCKER_TAG) \
 		.
 
-dcommon_config: docker_core_common_config
+dcommon-config: docker_core_common_config
 docker_core_common_config: docker_base
 	docker build \
 		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
-		-f cmd/core-command/Dockerfile \
+		-f cmd/core-common-config-bootstrapper/Dockerfile \
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/core-common-config-bootstrapper:$(GIT_SHA) \
 		-t edgexfoundry/core-common-config-bootstrapper:$(DOCKER_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ DOCKERS= \
 	docker_core_data \
 	docker_core_metadata \
 	docker_core_command  \
+	docker_core_common_config_bootstrapper \
 	docker_support_notifications \
 	docker_support_scheduler \
 	docker_security_proxy_setup \
@@ -34,6 +35,7 @@ MICROSERVICES= \
 	cmd/core-data/core-data \
 	cmd/core-metadata/core-metadata \
 	cmd/core-command/core-command \
+	cmd/core-common-config-bootstrapper/core-common-config-bootstrapper \
 	cmd/support-notifications/support-notifications \
 	cmd/support-scheduler/support-scheduler \
 	cmd/security-proxy-setup/security-proxy-setup \
@@ -95,6 +97,10 @@ cmd/core-data/core-data:
 command: cmd/core-command/core-command
 cmd/core-command/core-command:
 	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-command
+
+common_config: cmd/core-common-config-bootstrapper/core-common-config-bootstrapper
+cmd/core-common-config-bootstrapper/core-common-config-bootstrapper:
+	$(GO) build -tags "$(ADD_BUILD_TAGS) $(NON_DELAYED_START_GO_BUILD_TAG_FOR_CORE)" $(GOFLAGS) -o $@ ./cmd/core-common-config-bootstrapper
 
 support: notifications scheduler
 
@@ -209,6 +215,19 @@ docker_core_command: docker_base
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/core-command:$(GIT_SHA) \
 		-t edgexfoundry/core-command:$(DOCKER_TAG) \
+		.
+
+dcommon_config: docker_core_common_config
+docker_core_common_config: docker_base
+	docker build \
+		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
+		--build-arg http_proxy \
+		--build-arg https_proxy \
+		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
+		-f cmd/core-command/Dockerfile \
+		--label "git_sha=$(GIT_SHA)" \
+		-t edgexfoundry/core-common-config-bootstrapper:$(GIT_SHA) \
+		-t edgexfoundry/core-common-config-bootstrapper:$(DOCKER_TAG) \
 		.
 
 dsupport: dnotifications dscheduler

--- a/cmd/core-common-config-bootstrapper/Dockerfile
+++ b/cmd/core-common-config-bootstrapper/Dockerfile
@@ -16,8 +16,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #  ----------------------------------------------------------------------------------
 
-
-# Docker image for Golang Core Data micro service
+# Docker image for Golang Core common config bootstrapper service
 ARG BUILDER_BASE=golang:1.18-alpine3.16
 FROM ${BUILDER_BASE} AS builder
 

--- a/cmd/core-common-config-bootstrapper/Dockerfile
+++ b/cmd/core-common-config-bootstrapper/Dockerfile
@@ -31,7 +31,7 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
-RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/core-common_config-bootstrapper/core-common_config-bootstrapper
+RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/core-common-config-bootstrapper/core-common-config-bootstrapper
 
 #Next image - Copy built Go binary into new workspace
 FROM alpine:3.16
@@ -43,7 +43,7 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
 RUN apk add --update --no-cache dumb-init
 COPY --from=builder /edgex-go/Attribution.txt /
 COPY --from=builder /edgex-go/cmd/core-common-config-bootstrapper/core-common-config-bootstrapper /
-COPY --from=builder /edgex-go/cmd/core-common-config-bootstrapper/res/configuration.toml /res/configuration.toml
+COPY --from=builder /edgex-go/cmd/core-common-config-bootstrapper/res/configuration.yaml /res/configuration.yaml
 
 COPY --from=builder /edgex-go/cmd/core-common-config-bootstrapper/entrypoint.sh /usr/local/bin/
 RUN chmod 755 /usr/local/bin/entrypoint.sh \

--- a/cmd/core-common-config-bootstrapper/Dockerfile
+++ b/cmd/core-common-config-bootstrapper/Dockerfile
@@ -1,0 +1,53 @@
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2023 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  ----------------------------------------------------------------------------------
+
+
+# Docker image for Golang Core Data micro service
+ARG BUILDER_BASE=golang:1.18-alpine3.16
+FROM ${BUILDER_BASE} AS builder
+
+ARG ADD_BUILD_TAGS=""
+
+WORKDIR /edgex-go
+
+RUN apk add --update --no-cache make git
+
+COPY go.mod vendor* ./
+RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
+
+COPY . .
+RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/core-common_config-bootstrapper/core-common_config-bootstrapper
+
+#Next image - Copy built Go binary into new workspace
+FROM alpine:3.16
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2023: Intel Corporation'
+
+
+RUN apk add --update --no-cache dumb-init
+COPY --from=builder /edgex-go/Attribution.txt /
+COPY --from=builder /edgex-go/cmd/core-common-config-bootstrapper/core-common-config-bootstrapper /
+COPY --from=builder /edgex-go/cmd/core-common-config-bootstrapper/res/configuration.toml /res/configuration.toml
+
+COPY --from=builder /edgex-go/cmd/core-common-config-bootstrapper/entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/entrypoint.sh \
+    && ln -s /usr/local/bin/entrypoint.sh /
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["/core-common-config-bootstrapper", "-cp=consul.http://edgex-core-consul:8500"]

--- a/cmd/core-common-config-bootstrapper/entrypoint.sh
+++ b/cmd/core-common-config-bootstrapper/entrypoint.sh
@@ -19,4 +19,4 @@
 
 set -e
 
-$@ && exec tail -f /dev/null
+"$@" && exec tail -f /dev/null

--- a/cmd/core-common-config-bootstrapper/entrypoint.sh
+++ b/cmd/core-common-config-bootstrapper/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/dumb-init /bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2023 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  ----------------------------------------------------------------------------------
+
+set -e
+
+$@ && exec tail -f /dev/null

--- a/cmd/core-common-config-bootstrapper/main.go
+++ b/cmd/core-common-config-bootstrapper/main.go
@@ -16,10 +16,9 @@ package main
 import (
 	"context"
 	"github.com/edgexfoundry/edgex-go/internal/core/common_config"
-	"github.com/gorilla/mux"
 )
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	common_config.Main(ctx, cancel, mux.NewRouter())
+	common_config.Main(ctx, cancel)
 }

--- a/cmd/core-common-config-bootstrapper/main.go
+++ b/cmd/core-common-config-bootstrapper/main.go
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package main
+
+import (
+	"context"
+	"github.com/edgexfoundry/edgex-go/internal/core/common_config"
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	common_config.Main(ctx, cancel, mux.NewRouter())
+}

--- a/cmd/core-common-config-bootstrapper/res/configuration.yaml
+++ b/cmd/core-common-config-bootstrapper/res/configuration.yaml
@@ -61,7 +61,6 @@ all-services:
       SubscribeTopic: "edgex/events/device/#"  # required for subscribing to Events from MessageBus
     Optional:
       # Default MQTT Specific options that need to be here to enable environment variable overrides of them
-      ClientId: "core-data"
       Qos:  "0" # Quality of Service values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
       KeepAlive: "10" # Seconds (must be 2 or greater)
       Retained: "false"

--- a/cmd/core-common-config-bootstrapper/res/configuration.yaml
+++ b/cmd/core-common-config-bootstrapper/res/configuration.yaml
@@ -1,0 +1,135 @@
+all-services:
+  Writable:
+    LogLevel: "INFO"
+    
+    InsecureSecrets:
+      DB:
+        path: "redisdb"
+        Secrets:
+          username: ""
+          password: ""
+    
+    Telemetry:
+      Interval: "30s"
+      PublishTopicPrefix : "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
+      Metrics:
+        # Common Security Service Metrics
+        SecuritySecretsRequested: false
+        SecuritySecretsStored: false
+        SecurityConsulTokensRequested: false
+        SecurityConsulTokenDuration: false
+      Tags: # Contains the service level tags to be attached to all the service's metrics
+      #  Gateway: "my-iot-gateway" # Tag must be added here or via Consul Env Override can only change existing value, not added new ones.
+      
+  Service:
+    HealthCheckInterval: "10s"
+    Host: "localhost"
+    ServerBindAddr: "" # Leave blank so default to Host value unless different value is needed.
+    MaxResultCount: 1024
+    MaxRequestSize: 0 # Not currently used. Defines the maximum size of http request body in bytes
+    RequestTimeout: "5s"
+    CORSConfiguration:
+      EnableCORS: false
+      CORSAllowCredentials: false
+      CORSAllowedOrigin: "https://localhost"
+      CORSAllowedMethods: "GET, POST, PUT, PATCH, DELETE"
+      CORSAllowedHeaders: "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+      CORSExposeHeaders: "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+      CORSMaxAge: 3600
+
+  Registry:
+    Host: "localhost"
+    Port: 8500
+    Type: "consul"
+  
+  Databases:
+    Primary:
+      Host: "localhost"
+      Port: 6379
+      Timeout: 5000
+      Type: "redisdb"
+  
+  MessageBus:
+    Protocol: "redis"
+    Host: "localhost"
+    Port: 6379
+    Type: "redis"
+    AuthMode: "usernamepassword"  # required for redis MessageBus (secure or insecure).
+    SecretName: "redisdb"
+    Topics:
+      PublishTopicPrefix: "edgex/events/core" # /<device-profile-name>/<device-name> will be added to this Publish Topic prefix
+      SubscribeTopic: "edgex/events/device/#"  # required for subscribing to Events from MessageBus
+    Optional:
+      # Default MQTT Specific options that need to be here to enable environment variable overrides of them
+      ClientId: "core-data"
+      Qos:  "0" # Quality of Service values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+      KeepAlive: "10" # Seconds (must be 2 or greater)
+      Retained: "false"
+      AutoReconnect: "true"
+      ConnectTimeout: "5" # Seconds
+      SkipCertVerify: "false"
+      # Additional Default NATS Specific options that need to be here to enable environment variable overrides of them
+      Format: "nats"
+      RetryOnFailedConnect: "true"
+      QueueGroup: ""
+      Durable: ""
+      AutoProvision: "true"
+      Deliver: "new"
+      DefaultPubRetryAttempts: "2"
+      Subject: "edgex/#" # Required for NATS JetStream only for stream auto-provisioning
+
+app-services:
+  Writable:
+    StoreAndForward:
+      Enabled: false
+      RetryInterval: "5m"
+      MaxRetryCount: 10
+    Telemetry:
+      Metrics:
+        MessagesReceived: true
+        InvalidMessagesReceived: true
+        PipelineMessagesProcessed: true # Pipeline IDs are added as the tag for the metric for each pipeline defined
+        PipelineMessageProcessingTime: true # Pipeline IDs are added as the tag for the metric for each pipeline defined
+        PipelineProcessingErrors: true # Pipeline IDs are added as the tag for the metric for each pipeline defined
+        HttpExportSize: true # Single metric used for all HTTP Exports
+        MqttExportSize: true # BrokerAddress and Topic are added as the tag for this metric for each MqttExport defined
+  Clients:
+    core-metadata:
+      Protocol: "http"
+      Host: "localhost"
+      Port: 59881
+  Trigger:
+    Type: "edgex-messagebus"
+
+device-services:
+  Writable:
+    Reading:
+      ReadingUnits: true
+    Telemetry:
+      Metrics:
+        EventsSent: false
+        ReadingsSent: false
+  Clients:
+    core-data:
+      Protocol: "http"
+      Host: "localhost"
+      Port: 59880
+    core-metadata:
+      Protocol: "http"
+      Host: "localhost"
+      Port: 59881
+  Device:
+    DataTransform: true
+    MaxCmdOps: 128
+    MaxCmdValueLen: 256
+    ProfilesDir: "./res/profiles"
+    DevicesDir: "./res/devices"
+    ProvisionWatchersDir: "./res/provisionwatchers"
+    UpdateLastConnected: false
+    EnableAsyncReadings: true
+    AsyncBufferSize: 16
+    Labels: []
+    UseMessageBus: true
+    Discovery:
+      Enabled: false
+      Interval: "30s"

--- a/cmd/security-bootstrapper/res/configuration.toml
+++ b/cmd/security-bootstrapper/res/configuration.toml
@@ -43,6 +43,8 @@ LogLevel = "INFO"
           Description = "role for metadata"
         [StageGate.Registry.ACL.Roles.core-command]
           Description = "role for command"
+        [StageGate.Registry.ACL.Roles.core-common-config-bootstrapper]
+          Description = "role for common config"
         [StageGate.Registry.ACL.Roles.support-notifications]
           Description = "role for notifications"
         [StageGate.Registry.ACL.Roles.support-scheduler]

--- a/cmd/security-file-token-provider/res/token-config.json
+++ b/cmd/security-file-token-provider/res/token-config.json
@@ -8,6 +8,9 @@
   "core-metadata": {
     "edgex_use_defaults": true
   },
+  "core-common-config-bootstrapper": {
+    "edgex_use_defaults": true
+  },
   "security-bootstrapper-redis": {
     "edgex_use_defaults": true
   },

--- a/internal/core/common_config/README.md
+++ b/internal/core/common_config/README.md
@@ -1,0 +1,59 @@
+# EdgeX Foundry Core Command Service
+[![license](https://img.shields.io/badge/license-Apache%20v2.0-blue.svg)](LICENSE)
+
+Core Common Config Bootstrapper pushes the common settings into the Configuration Provider on start-up and provides the override flag common to all services to force re-pushing the configuration into the Configuration Provider.
+
+# Install and Deploy Native #
+
+### Prerequisites ###
+Several EdgeX Foundry services depend on ZeroMQ for communications by default.  The easiest way to get and install ZeroMQ is to use or follow the following setup script:  https://gist.github.com/katopz/8b766a5cb0ca96c816658e9407e83d00.
+
+**Note**: Setup of the ZeroMQ library is not supported on Windows platforms.
+
+### Installation and Execution ###
+To fetch the code and build the microservice execute the following:
+
+```
+cd $GOPATH/src
+go get github.com/edgexfoundry/edgex-go
+cd $GOPATH/src/github.com/edgexfoundry/edgex-go
+# pull the 3rd party / vendor packages
+make prepare
+# build the microservice
+make common_config
+# get to the command microservice executable
+cd cmd/core-common-config-bootstrapper
+# run the microservice (may require other dependent services to run correctly)
+./core-common-config-bootstrapper
+```
+
+# Install and Deploy via Docker Container #
+This project has facilities to create and run Docker containers.  A Dockerfile is included in the repo. Make sure you have already run make prepare to update the dependencies. To do a Docker build using the included Docker file, run the following:
+
+### Prerequisites ###
+See https://docs.docker.com/install/ to learn how to obtain and install Docker.
+
+### Installation and Execution ###
+
+```
+cd $GOPATH/src
+go get github.com/edgexfoundry/edgex-go
+cd $GOPATH/src/github.com/edgexfoundry/edgex-go
+# To create the Docker image
+sudo make docker_core_common_config
+# To create a containter from the image
+sudo docker create --name "[DOCKER_CONTAINER_NAME]" --network "[DOCKER_NETWORK]" [DOCKER_IMAGE_NAME]
+# To run the container
+sudo docker start [DOCKER_CONTAINER_NAME]
+```
+
+*Note* - creating and running the container above requires Docker network setup, may require dependent containers to be setup on that network, and appropriate port access configuration (among other start up parameters).  For this reason, EdgeX recommends use of Docker Compose for pulling, building, and running containers.  See The Getting Started Guides for more detail.
+ 
+
+## Community
+- Chat: [https://edgexfoundry.slack.com](https://join.slack.com/t/edgexfoundry/shared_invite/enQtNDgyODM5ODUyODY0LWVhY2VmOTcyOWY2NjZhOWJjOGI1YzQ2NzYzZmIxYzAzN2IzYzY0NTVmMWZhZjNkMjVmODNiZGZmYTkzZDE3MTA)
+- Mailing lists: https://lists.edgexfoundry.org/mailman/listinfo
+
+## License
+[Apache-2.0](LICENSE)
+

--- a/internal/core/common_config/README.md
+++ b/internal/core/common_config/README.md
@@ -5,11 +5,6 @@ Core Common Config Bootstrapper pushes the common settings into the Configuratio
 
 # Install and Deploy Native #
 
-### Prerequisites ###
-Several EdgeX Foundry services depend on ZeroMQ for communications by default.  The easiest way to get and install ZeroMQ is to use or follow the following setup script:  https://gist.github.com/katopz/8b766a5cb0ca96c816658e9407e83d00.
-
-**Note**: Setup of the ZeroMQ library is not supported on Windows platforms.
-
 ### Installation and Execution ###
 To fetch the code and build the microservice execute the following:
 
@@ -23,8 +18,8 @@ make prepare
 make common_config
 # get to the command microservice executable
 cd cmd/core-common-config-bootstrapper
-# run the microservice (may require other dependent services to run correctly)
-./core-common-config-bootstrapper
+# run the microservice (may require other dependent services to run correctly) and provide the configuration provider using -cp
+./core-common-config-bootstrapper -cp
 ```
 
 # Install and Deploy via Docker Container #

--- a/internal/core/common_config/README.md
+++ b/internal/core/common_config/README.md
@@ -1,4 +1,4 @@
-# EdgeX Foundry Core Command Service
+# EdgeX Foundry Core Common Config Bootstrapper Service
 [![license](https://img.shields.io/badge/license-Apache%20v2.0-blue.svg)](LICENSE)
 
 Core Common Config Bootstrapper pushes the common settings into the Configuration Provider on start-up and provides the override flag common to all services to force re-pushing the configuration into the Configuration Provider.

--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -44,7 +44,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 	// TODO: figure out how to eliminate registry and profile flags
 	f := flags.New()
 	f.Parse(os.Args[1:])
-	
+
 	var wg sync.WaitGroup
 	translateInterruptToCancel(ctx, &wg, cancel)
 
@@ -65,13 +65,13 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 
 	lc.Info("Secret Provider created")
 
-	accessToken, err := secretProvider.GetAccessToken("consul", common.CoreCommonConfigServiceKey)
+	_, err = secretProvider.GetAccessToken("consul", common.CoreCommonConfigServiceKey)
 	if err != nil {
 		lc.Errorf("failed to get Access Token for config provider: %v", err)
 		os.Exit(1)
 	}
 
-	lc.Infof("Got Config Provider Access Token: '%s'", accessToken)
+	lc.Info("Got Config Provider Access Token")
 	lc.Info("Core Common Config Ready for stage two")
 	lc.Info("Core Common Config exiting")
 	os.Exit(0)

--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package common_config
+
+import (
+	"context"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/flags"
+	"os"
+
+	"github.com/gorilla/mux"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
+
+	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
+	// by inserting service specific flag prior to call to commonFlags.Parse().
+	// Example:
+	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
+	//      ....
+	//      flags.Parse(os.Args[1:])
+	//
+
+	// TODO: figure out how to eliminate registry and profile flags
+	f := flags.New()
+	f.Parse(os.Args[1:])
+
+	// code here!
+}

--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -16,13 +16,22 @@ package common_config
 
 import (
 	"context"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/environment"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/flags"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/secret"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 	"os"
-
-	"github.com/gorilla/mux"
+	"os/signal"
+	"sync"
+	"syscall"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
+func Main(ctx context.Context, cancel context.CancelFunc) {
 
 	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
 	// by inserting service specific flag prior to call to commonFlags.Parse().
@@ -35,6 +44,58 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 	// TODO: figure out how to eliminate registry and profile flags
 	f := flags.New()
 	f.Parse(os.Args[1:])
+	
+	var wg sync.WaitGroup
+	translateInterruptToCancel(ctx, &wg, cancel)
 
-	// code here!
+	lc := logger.NewClient(common.CoreCommonConfigServiceKey, models.InfoLog)
+	lc.Info("Core Common Config is starting")
+	startupTimer := startup.NewStartUpTimer(common.CoreCommonConfigServiceKey)
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return lc
+		},
+	})
+
+	secretProvider, err := secret.NewSecretProvider(nil, environment.NewVariables(lc), ctx, startupTimer, dic, common.CoreCommonConfigServiceKey)
+	if err != nil {
+		lc.Errorf("failed to create Secret Provider: %v", err)
+		os.Exit(1)
+	}
+
+	lc.Info("Secret Provider created")
+
+	accessToken, err := secretProvider.GetAccessToken("consul", common.CoreCommonConfigServiceKey)
+	if err != nil {
+		lc.Errorf("failed to get Access Token for config provider: %v", err)
+		os.Exit(1)
+	}
+
+	lc.Infof("Got Config Provider Access Token: '%s'", accessToken)
+	lc.Info("Core Common Config Ready for stage two")
+	lc.Info("Core Common Config exiting")
+	os.Exit(0)
+}
+
+// translateInterruptToCancel spawns a go routine to translate the receipt of a SIGTERM signal to a call to cancel
+// the context used by the bootstrap implementation.
+func translateInterruptToCancel(ctx context.Context, wg *sync.WaitGroup, cancel context.CancelFunc) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		signalStream := make(chan os.Signal, 1)
+		defer func() {
+			signal.Stop(signalStream)
+			close(signalStream)
+		}()
+		signal.Notify(signalStream, os.Interrupt, syscall.SIGTERM)
+		select {
+		case <-signalStream:
+			cancel()
+			return
+		case <-ctx.Done():
+			return
+		}
+	}()
 }


### PR DESCRIPTION
Signed-off-by: Elizabeth J Lee <elizabeth.j.lee@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) - initial structure for new service
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) - new documentation will need to be added for common config


## Testing Instructions
1. run `make common-config` to ensure the binary builds
3. run in non-secure mode `export EDGEX_SECURITY_SECRET_STORE=false; ./cmd/core-common-config-bootstrapper/core-common-config-bootstrapper`
4. build the docker images `make docker`
5. run in secure mode `export EDGEX_SECURITY_SECRET_STORE=true`
6. use compose builder and run `make run dev`
7. run the core common config bootstrapper from `cmd/core-common-config-bootstrapper` by running `sudo ./core-common-config-bootstrapper`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->