### PR TITLE
feat: Push common config to config provider

### DIFF
--- a/cmd/core-common-config-bootstrapper/Dockerfile
+++ b/cmd/core-common-config-bootstrapper/Dockerfile
@@ -49,4 +49,4 @@ RUN chmod 755 /usr/local/bin/entrypoint.sh \
     && ln -s /usr/local/bin/entrypoint.sh /
 
 ENTRYPOINT ["entrypoint.sh"]
-CMD ["/core-common-config-bootstrapper", "-cp=consul.http://edgex-core-consul:8500"]
+CMD ["/core-common-config-bootstrapper", "-cp=consul.http://edgex-core-consul:8500", "-cf=configuration.yaml"]

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/edgexfoundry/edgex-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.12
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.16
+	github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.6
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.4
-	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.4
+	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.5
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/gomodule/redigo v1.8.9
@@ -27,7 +28,6 @@ require (
 	github.com/armon/go-metrics v0.3.10 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 // indirect
 	github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.12 h1:kLllnz4O5QRa2SPALhEIanzL20DtczsJYL5+NGKNz3o=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.12/go.mod h1:JqdvZ2lSGydoHC++jlvfeawlB5ogFRCmWeYkoW+HHMo=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.16 h1:MN6dOZHbYkW8JRDlEin/7T9nInOwpikZhthH0QaMksQ=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.16/go.mod h1:G2C3aUWZ96nZU03XRvCBntU13eUjXGIB9KqRKrhI8h8=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 h1:xp5MsP+qf/fuJxy8fT7k1N+c4j4C6w04qMCBXm6id7o=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2/go.mod h1:1Vv4uWAo6r7k6jUlqVJW8JOL6YKVBc6sRL8Al3DrMck=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.6 h1:RQFs/HjVOi1X3YxJ8sm4vuX8nhKgH0caSf9RtjQvdeI=
@@ -38,8 +38,8 @@ github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.4 h1:swPZOjoQ/IUIWSJpZCmQ
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.4/go.mod h1:8pxuYvh2zcq1GuKqmk1MAuH1yuN40iOMmL0g2myIfwk=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3 h1:QgZF9f70Cwpvkjw3tP1aiVGHc+yNFJNzW6hO8pDs3fg=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3/go.mod h1:2w8v0sv+i21nY+DY6JV4PFxsNTuxpGAjlNFlFMTfZkk=
-github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.4 h1:IbgRyTFy7cDkXX4VZGeAnxKrTXkjQo3qrk+/UkYxug8=
-github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.4/go.mod h1:PU+4VEoB0MTETAM+m28bUXyU0dekzkkwusUuht6HQV4=
+github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.5 h1:tEo8BVH4OZuJ/q9ii1H4PdtxlXLh/kOKpRuWFTHOcBc=
+github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.5/go.mod h1:wYgPDiVaalEUzBkKoZox3OvcpY52GsMAGJWvX/H+MJg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=

--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/edgexfoundry/go-mod-configuration/v3/configuration"
-	"github.com/edgexfoundry/go-mod-configuration/v3/pkg/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
@@ -74,11 +73,9 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 
 	lc.Info("Secret Provider created")
 
-	var getAccessToken types.GetAccessTokenCallback
-
 	// need to use in-line function to set the callback type for getAccessToken used in CreateProviderClient to allow
 	// access to the config provider in secure mode
-	getAccessToken = func() (string, error) {
+	getAccessToken := func() (string, error) {
 		accessToken, err := secretProvider.GetAccessToken("consul", common.CoreCommonConfigServiceKey)
 		if err != nil {
 			return "", fmt.Errorf("failed to get Configuration Provider access token: %s", err.Error())
@@ -195,7 +192,7 @@ func buildKeyValues(data map[string]interface{}, kv map[string]interface{}, orig
 	key := origKey
 	for k, v := range data {
 		if len(key) == 0 {
-			key = fmt.Sprintf("%s", k)
+			key = fmt.Sprint(k)
 		} else {
 			key = fmt.Sprintf("%s/%s", key, k)
 		}

--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -16,19 +16,29 @@ package common_config
 
 import (
 	"context"
+	"fmt"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/environment"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/flags"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/secret"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	"github.com/edgexfoundry/go-mod-configuration/v3/configuration"
+	"github.com/edgexfoundry/go-mod-configuration/v3/pkg/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+	"gopkg.in/yaml.v3"
 	"os"
 	"os/signal"
+	"sort"
 	"sync"
 	"syscall"
+)
+
+const (
+	commonConfigDone = "isCommonConfigReady"
 )
 
 func Main(ctx context.Context, cancel context.CancelFunc) {
@@ -56,7 +66,6 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 			return lc
 		},
 	})
-
 	secretProvider, err := secret.NewSecretProvider(nil, environment.NewVariables(lc), ctx, startupTimer, dic, common.CoreCommonConfigServiceKey)
 	if err != nil {
 		lc.Errorf("failed to create Secret Provider: %v", err)
@@ -64,15 +73,55 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 	}
 
 	lc.Info("Secret Provider created")
+	var accessToken string
+	var getAccessToken types.GetAccessTokenCallback
 
-	_, err = secretProvider.GetAccessToken("consul", common.CoreCommonConfigServiceKey)
-	if err != nil {
-		lc.Errorf("failed to get Access Token for config provider: %v", err)
-		os.Exit(1)
+	if secretProvider != nil {
+		getAccessToken = func() (string, error) {
+			accessToken, err = secretProvider.GetAccessToken("consul", common.CoreCommonConfigServiceKey)
+			if err != nil {
+				return "", fmt.Errorf("failed to get Configuration Provider access token: %s", err.Error())
+			}
+			return accessToken, err
+		}
+		_, err = getAccessToken()
+		if err != nil {
+			lc.Errorf("failed to get Access Token for config provider: %s", err.Error())
+			os.Exit(1)
+		}
 	}
 
 	lc.Info("Got Config Provider Access Token")
-	lc.Info("Core Common Config Ready for stage two")
+	// create config client
+	envVars := environment.NewVariables(lc)
+	configProviderInfo, err := config.NewProviderInfo(envVars, f.ConfigProviderUrl())
+	if err != nil {
+		lc.Errorf("failed to get Provider Info for the common configuration: %s", err.Error())
+		os.Exit(1)
+	}
+	configClient, err := config.CreateProviderClient(lc, common.CoreCommonConfigServiceKey, common.ConfigStemCore, getAccessToken, configProviderInfo.ServiceConfig())
+	if err != nil {
+		lc.Errorf("failed to create provider client for the common configuration: %s", err.Error())
+		os.Exit(1)
+	}
+	// check to see if the configuration exists in the config provider
+	hasConfig, err := configClient.HasConfiguration()
+	if err != nil {
+		lc.Errorf("failed to determine if configuration exists in the provider: %s", err.Error())
+		os.Exit(1)
+	}
+	lc.Infof("configuration exists: %v", hasConfig)
+	// load the yaml file and push it using the config client
+	if !hasConfig || f.OverwriteConfig() {
+		yamlFile := config.GetConfigLocation(lc, f)
+		lc.Infof("parsing %s for configuration", yamlFile)
+		err = loadYaml(lc, yamlFile, configClient)
+		if err != nil {
+			lc.Error(err.Error())
+			os.Exit(1)
+		}
+	}
+
 	lc.Info("Core Common Config exiting")
 	os.Exit(0)
 }
@@ -98,4 +147,75 @@ func translateInterruptToCancel(ctx context.Context, wg *sync.WaitGroup, cancel 
 			return
 		}
 	}()
+}
+
+func loadYaml(lc logger.LoggingClient, yamlFile string, configClient configuration.Client) error {
+	// push not done flag to configClient
+	err := configClient.PutConfigurationValue(commonConfigDone, []byte("false"))
+	if err != nil {
+		return fmt.Errorf("failed to push %s on startup: %s", commonConfigDone, err.Error())
+	}
+	lc.Infof("reading %s", yamlFile)
+	contents, err := os.ReadFile(yamlFile)
+	if err != nil {
+		return fmt.Errorf("failed to read common configuration file %s: %s", yamlFile, err.Error())
+	}
+
+	data := make(map[string]interface{})
+	kv := make(map[string]interface{})
+
+	err = yaml.Unmarshal(contents, &data)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshall common configuration file %s: %s", yamlFile, err.Error())
+	}
+
+	kv = buildKeyValues(data, kv, "")
+
+	keys := make([]string, 0, len(kv))
+
+	for k := range kv {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := kv[k]
+		// Push key/value into Consul rather than print
+		err = configClient.PutConfigurationValue(k, []byte(fmt.Sprint(v)))
+		if err != nil {
+			return fmt.Errorf("failed to push common configuration key %s with value %v: %s", k, v, err.Error())
+		}
+	}
+
+	// push done flag to config client
+	err = configClient.PutConfigurationValue(commonConfigDone, []byte("true"))
+	if err != nil {
+		return fmt.Errorf("failed to push %s on completion: %s", commonConfigDone, err.Error())
+	}
+	return nil
+}
+
+// buildKeyValues is a helper function to parse the configuration yaml file
+func buildKeyValues(data map[string]interface{}, kv map[string]interface{}, origKey string) map[string]interface{} {
+	key := origKey
+	for k, v := range data {
+		if len(key) == 0 {
+			key = fmt.Sprintf("%s", k)
+		} else {
+			key = fmt.Sprintf("%s/%s", key, k)
+		}
+
+		vdata, ok := v.(map[string]interface{})
+		if !ok {
+			kv[key] = v
+			key = origKey
+			continue
+		}
+
+		kv = buildKeyValues(vdata, kv, key)
+		key = origKey
+	}
+
+	return kv
 }

--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -73,25 +73,20 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 	}
 
 	lc.Info("Secret Provider created")
-	var accessToken string
+
 	var getAccessToken types.GetAccessTokenCallback
 
 	// need to use in-line function to set the callback type for getAccessToken used in CreateProviderClient to allow
 	// access to the config provider in secure mode
 	getAccessToken = func() (string, error) {
-		accessToken, err = secretProvider.GetAccessToken("consul", common.CoreCommonConfigServiceKey)
+		accessToken, err := secretProvider.GetAccessToken("consul", common.CoreCommonConfigServiceKey)
 		if err != nil {
 			return "", fmt.Errorf("failed to get Configuration Provider access token: %s", err.Error())
 		}
+		lc.Infof("Got Config Provider Access Token with length %d", len(accessToken))
 		return accessToken, err
 	}
-	_, err = getAccessToken()
-	if err != nil {
-		lc.Errorf("failed to get Access Token for config provider: %s", err.Error())
-		os.Exit(1)
-	}
 
-	lc.Infof("Got Config Provider Access Token with length %d", len(accessToken))
 	// create config client
 	envVars := environment.NewVariables(lc)
 	configProviderInfo, err := config.NewProviderInfo(envVars, f.ConfigProviderUrl())


### PR DESCRIPTION
Signed-off-by: Elizabeth J Lee <elizabeth.j.lee@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) - NA - added functionality to main
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) - docs will need to be added for common config when feature is complete
  <link to docs PR>

## Testing Instructions
1. run `make common-config` to ensure the binary builds
3. run in non-secure mode `export EDGEX_SECURITY_SECRET_STORE=false`
4. run edgex core services from compose builder `make run no-secty`
5. `./core-common-config-bootstrapper -cp=consul.http://localhost:8500 -cf=configuration.yaml`
6. check that the config is loaded into Consul [http://localhost:8500/ui/dc1/kv/edgex/v3/core-common-config-bootstrapper/](http://localhost:8500/ui/dc1/kv/edgex/v3/core-common-config-bootstrapper/)
7. bring down the services `make down`
8. build the docker images `make docker`
9. run in secure mode `export EDGEX_SECURITY_SECRET_STORE=true`
10. use compose builder and run `make run dev`
11. run the core common config bootstrapper from `cmd/core-common-config-bootstrapper` by running `sudo ./core-common-config-bootstrapper -cp=consul.http://localhost:8500 -cf=configuration.yaml`
12. verify that the config is loaded into Consul

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->