### PR TITLE
fix: adjust redis maxclients to 1000 as default value

### DIFF
--- a/cmd/security-bootstrapper/res-bootstrap-redis/configuration.toml
+++ b/cmd/security-bootstrapper/res-bootstrap-redis/configuration.toml
@@ -27,3 +27,4 @@ Type = "redisdb"
 [DatabaseConfig]
   Path = "/path/to/redis/conf/dir"
   Name = "redis.conf"
+  MaxClients = 1000

--- a/internal/security/bootstrapper/redis/config/config.go
+++ b/internal/security/bootstrapper/redis/config/config.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021 Intel Corporation
+ * Copyright 2023 Intel Corporation
  * Copyright 2020 Redis Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -29,8 +29,9 @@ type ConfigurationStruct struct {
 
 // DatabaseBootstrapConfigInfo contains the configuration properties for bootstrapping the database
 type DatabaseBootstrapConfigInfo struct {
-	Path string
-	Name string
+	Path       string
+	Name       string
+	MaxClients int
 }
 
 // Implement interface.Configuration

--- a/internal/security/bootstrapper/redis/handlers/handlers.go
+++ b/internal/security/bootstrapper/redis/handlers/handlers.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021 Intel Corporation
+* Copyright 2023 Intel Corporation
 * Copyright 2020 Redis Labs
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -124,7 +124,7 @@ func (handler *Handler) SetupConfFiles(ctx context.Context, _ *sync.WaitGroup, _
 
 	edgeXRedisACLFilePath := filepath.Join(dbConfigDir, redisACLFileName)
 	// writing the config file
-	if err := helper.GenerateRedisConfig(confFile, edgeXRedisACLFilePath); err != nil {
+	if err := helper.GenerateRedisConfig(confFile, edgeXRedisACLFilePath, config.DatabaseConfig.MaxClients); err != nil {
 		lc.Errorf("cannot write the db config file %s: %v", confFile.Name(), err)
 		return false
 	}


### PR DESCRIPTION
Add configuration of maxclients to redis.conf and set it to 1000 as the default value

Closes: #3594

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [x ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- pull this branch and build docker_security_bootstrapper
- make test should work
- go to docker-compose-builder to run EdgeX stack and redis should still run work 
- snap also runs ok

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->