### PR TITLE
feat: Tweak security-bootscrapper to make it easier to disable kong/ko…

### DIFF
--- a/internal/security/bootstrapper/command/gate/command.go
+++ b/internal/security/bootstrapper/command/gate/command.go
@@ -95,16 +95,6 @@ func (c *cmd) Execute() (statusCode int, err error) {
 	c.loggingClient.Info("Registry is ready")
 
 	if err := tcp.DialTcp(
-		c.config.StageGate.KongDB.Host,
-		c.config.StageGate.KongDB.ReadyPort,
-		c.loggingClient); err != nil {
-		retErr := fmt.Errorf("found error while waiting for readiness of KongDB at %s:%d, err: %v",
-			c.config.StageGate.KongDB.Host, c.config.StageGate.KongDB.ReadyPort, err)
-		return interfaces.StatusCodeExitWithError, retErr
-	}
-	c.loggingClient.Info("KongDB is ready")
-
-	if err := tcp.DialTcp(
 		c.config.StageGate.Database.Host,
 		c.config.StageGate.Database.ReadyPort,
 		c.loggingClient); err != nil {


### PR DESCRIPTION
…ng-db

Closes #4032

Signed-off-by: Valina Li <valina.li@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
edgex-go: make docker
edgex-compose/compose-builder: make run
check bootstrapper log without "KongDB is ready"

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->