### PR TITLE
feat(metadata)!: remove Notifications config

### DIFF
--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -49,25 +49,12 @@ Host = "localhost"
 Port = 8500
 Type = "consul"
 
-[Clients]
-  [Clients.support-notifications]
-  Protocol = "http"
-  Host = "localhost"
-  Port = 59860
-
 [Database]
 Host = "localhost"
 Name = "metadata"
 Port = 6379
 Timeout = 5000
 Type = "redisdb"
-
-[Notifications]
-PostDeviceChanges = false
-Content = "Metadata notice: "
-Sender = "core-metadata"
-Description = "Metadata change notice"
-Label = "metadata"
 
 [MessageBus]
 Protocol = "redis"

--- a/internal/core/metadata/config/config.go
+++ b/internal/core/metadata/config/config.go
@@ -20,14 +20,12 @@ import (
 
 // Struct used to parse the JSON configuration file
 type ConfigurationStruct struct {
-	Writable      WritableInfo
-	Clients       map[string]bootstrapConfig.ClientInfo
-	Database      bootstrapConfig.Database
-	Notifications NotificationInfo
-	Registry      bootstrapConfig.RegistryInfo
-	Service       bootstrapConfig.ServiceInfo
-	MessageBus    bootstrapConfig.MessageBusInfo
-	UoM           UoM
+	Writable   WritableInfo
+	Database   bootstrapConfig.Database
+	Registry   bootstrapConfig.RegistryInfo
+	Service    bootstrapConfig.ServiceInfo
+	MessageBus bootstrapConfig.MessageBusInfo
+	UoM        UoM
 }
 
 type WritableInfo struct {
@@ -49,16 +47,6 @@ type WritableUoM struct {
 
 type UoM struct {
 	UoMFile string
-}
-
-// NotificationInfo provides properties related to the assembly of notification content
-type NotificationInfo struct {
-	Content           string
-	Description       string
-	Label             string
-	PostDeviceChanges bool
-	Sender            string
-	Slug              string
 }
 
 // UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
@@ -98,7 +86,6 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.toml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:    c.Clients,
 		Service:    c.Service,
 		Registry:   c.Registry,
 		MessageBus: c.MessageBus,


### PR DESCRIPTION
BREAKING CHANGE: Removed the 'Notifications' config and 'Clients.support-notifications' dependency

in EdgeX 3.0, metadata will leverage device system events to replace the original device change notifications

closes #4316

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-docs/pull/954

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->