### PR TITLE
feat: remove UseMessageBus from common config

### DIFF
--- a/cmd/core-common-config-bootstrapper/res/configuration.yaml
+++ b/cmd/core-common-config-bootstrapper/res/configuration.yaml
@@ -108,10 +108,6 @@ device-services:
         EventsSent: false
         ReadingsSent: false
   Clients:
-    core-data:
-      Protocol: "http"
-      Host: "localhost"
-      Port: 59880
     core-metadata:
       Protocol: "http"
       Host: "localhost"
@@ -127,7 +123,6 @@ device-services:
     EnableAsyncReadings: true
     AsyncBufferSize: 16
     Labels: []
-    UseMessageBus: true
     Discovery:
       Enabled: false
       Interval: "30s"


### PR DESCRIPTION
SDK was modified to remove UseMessageBus and REST calls to Core Data to push Events. New Common config is now in sync with SDK.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **N/A**
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->