### PR TITLE
feat: Publish Update Device Profile System Event for Each Device Service

### DIFF
--- a/internal/core/metadata/application/devicecommand.go
+++ b/internal/core/metadata/application/devicecommand.go
@@ -7,8 +7,6 @@ package application
 
 import (
 	"context"
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
-
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/container"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
@@ -44,7 +42,7 @@ func AddDeviceProfileDeviceCommand(profileName string, deviceCommand models.Devi
 	}
 
 	lc.Debugf("DeviceProfile deviceCommands added on DB successfully. Correlation-id: %s ", correlation.FromContext(ctx))
-	go publishSystemEvent(common.DeviceProfileSystemEventType, common.SystemEventActionUpdate, common.CoreMetaDataServiceKey, profileDTO, ctx, dic)
+	go publishUpdateDeviceProfileSystemEvent(profileDTO, ctx, dic)
 
 	return nil
 }
@@ -79,7 +77,7 @@ func PatchDeviceProfileDeviceCommand(profileName string, dto dtos.UpdateDeviceCo
 
 	lc.Debugf("DeviceProfile deviceCommands patched on DB successfully. Correlation-id: %s ", correlation.FromContext(ctx))
 	profileDTO := dtos.FromDeviceProfileModelToDTO(profile)
-	go publishSystemEvent(common.DeviceProfileSystemEventType, common.SystemEventActionUpdate, common.CoreMetaDataServiceKey, profileDTO, ctx, dic)
+	go publishUpdateDeviceProfileSystemEvent(profileDTO, ctx, dic)
 
 	return nil
 }
@@ -134,6 +132,6 @@ func DeleteDeviceCommandByName(profileName string, commandName string, ctx conte
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 
-	go publishSystemEvent(common.DeviceProfileSystemEventType, common.SystemEventActionUpdate, common.CoreMetaDataServiceKey, profileDTO, ctx, dic)
+	go publishUpdateDeviceProfileSystemEvent(profileDTO, ctx, dic)
 	return nil
 }

--- a/internal/core/metadata/application/deviceprofile.go
+++ b/internal/core/metadata/application/deviceprofile.go
@@ -79,7 +79,7 @@ func UpdateDeviceProfile(d models.DeviceProfile, ctx context.Context, dic *di.Co
 	}
 
 	profileDTO := dtos.FromDeviceProfileModelToDTO(profile)
-	go publishSystemEvent(common.DeviceProfileSystemEventType, common.SystemEventActionUpdate, common.CoreMetaDataServiceKey, profileDTO, ctx, dic)
+	go publishUpdateDeviceProfileSystemEvent(profileDTO, ctx, dic)
 
 	return nil
 }
@@ -221,7 +221,7 @@ func PatchDeviceProfileBasicInfo(ctx context.Context, dto dtos.UpdateDeviceProfi
 	)
 
 	profileDTO := dtos.FromDeviceProfileModelToDTO(deviceProfile)
-	go publishSystemEvent(common.DeviceProfileSystemEventType, common.SystemEventActionUpdate, common.CoreMetaDataServiceKey, profileDTO, ctx, dic)
+	go publishUpdateDeviceProfileSystemEvent(profileDTO, ctx, dic)
 
 	return nil
 }

--- a/internal/core/metadata/application/deviceresource.go
+++ b/internal/core/metadata/application/deviceresource.go
@@ -14,7 +14,6 @@ import (
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
@@ -80,7 +79,7 @@ func AddDeviceProfileResource(profileName string, resource models.DeviceResource
 	}
 
 	lc.Debugf("DeviceProfile deviceResources added on DB successfully. Correlation-id: %s ", correlation.FromContext(ctx))
-	go publishSystemEvent(common.DeviceProfileSystemEventType, common.SystemEventActionUpdate, common.CoreMetaDataServiceKey, profileDTO, ctx, dic)
+	go publishUpdateDeviceProfileSystemEvent(profileDTO, ctx, dic)
 
 	return nil
 }
@@ -115,7 +114,7 @@ func PatchDeviceProfileResource(profileName string, dto dtos.UpdateDeviceResourc
 
 	lc.Debugf("DeviceProfile deviceResources patched on DB successfully. Correlation-id: %s ", correlation.FromContext(ctx))
 	profileDTO := dtos.FromDeviceProfileModelToDTO(profile)
-	go publishSystemEvent(common.DeviceProfileSystemEventType, common.SystemEventActionUpdate, common.CoreMetaDataServiceKey, profileDTO, ctx, dic)
+	go publishUpdateDeviceProfileSystemEvent(profileDTO, ctx, dic)
 
 	return nil
 }
@@ -170,7 +169,7 @@ func DeleteDeviceResourceByName(profileName string, resourceName string, ctx con
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 
-	go publishSystemEvent(common.DeviceProfileSystemEventType, common.SystemEventActionUpdate, common.CoreMetaDataServiceKey, profileDTO, ctx, dic)
+	go publishUpdateDeviceProfileSystemEvent(profileDTO, ctx, dic)
 	return nil
 }
 

--- a/internal/core/metadata/controller/http/devicecommand_test.go
+++ b/internal/core/metadata/controller/http/devicecommand_test.go
@@ -82,6 +82,8 @@ func TestAddDeviceProfileDeviceCommand(t *testing.T) {
 	dbClientMock := &dbMock.DBClient{}
 	dbClientMock.On("DeviceProfileByName", valid.ProfileName).Return(deviceProfile, nil)
 	dbClientMock.On("UpdateDeviceProfile", mock.Anything).Return(nil)
+	dbClientMock.On("DevicesByProfileName", 0, -1, TestDeviceProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DeviceCountByProfileName", TestDeviceProfileName).Return(uint32(1), nil)
 	dic.Update(di.ServiceConstructorMap{
 		container.DBClientInterfaceName: func(get di.Get) interface{} {
 			return dbClientMock
@@ -198,8 +200,9 @@ func TestPatchDeviceProfileDeviceCommand(t *testing.T) {
 	dbClientMock := &dbMock.DBClient{}
 	dbClientMock.On("DeviceProfileByName", valid.ProfileName).Return(deviceProfile, nil)
 	dbClientMock.On("UpdateDeviceProfile", mock.Anything).Return(nil)
-
 	dbClientMock.On("DeviceProfileByName", notFound).Return(deviceProfile, notFoundDBError)
+	dbClientMock.On("DevicesByProfileName", 0, -1, TestDeviceProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DeviceCountByProfileName", TestDeviceProfileName).Return(uint32(1), nil)
 	dic.Update(di.ServiceConstructorMap{
 		container.DBClientInterfaceName: func(get di.Get) interface{} {
 			return dbClientMock
@@ -274,7 +277,8 @@ func TestDeleteDeviceCommandByName(t *testing.T) {
 
 	dic := mockDic()
 	dbClientMock := &dbMock.DBClient{}
-	dbClientMock.On("DevicesByProfileName", 0, 1, TestDeviceProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DevicesByProfileName", 0, mock.Anything, TestDeviceProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DeviceCountByProfileName", TestDeviceProfileName).Return(uint32(1), nil)
 	dbClientMock.On("DeviceProfileByName", TestDeviceProfileName).Return(dpModel, nil)
 	dbClientMock.On("UpdateDeviceProfile", mock.Anything).Return(nil)
 

--- a/internal/core/metadata/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/controller/http/deviceprofile_test.go
@@ -626,6 +626,8 @@ func TestPatchDeviceProfileBasicInfo(t *testing.T) {
 	dbClientMock.On("DeviceProfileByName", *valid.BasicInfo.Name).Return(dpModel, nil)
 	dbClientMock.On("DeviceProfileByName", notFoundName).Return(dpModel, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "not found", nil))
 	dbClientMock.On("UpdateDeviceProfile", mock.Anything).Return(nil)
+	dbClientMock.On("DeviceCountByProfileName", *valid.BasicInfo.Name).Return(uint32(1), nil)
+	dbClientMock.On("DevicesByProfileName", 0, -1, *valid.BasicInfo.Name).Return([]models.Device{{ServiceName: testDeviceServiceName}}, nil)
 	dic.Update(di.ServiceConstructorMap{
 		container.DBClientInterfaceName: func(get di.Get) interface{} {
 			return dbClientMock

--- a/internal/core/metadata/controller/http/deviceresource_test.go
+++ b/internal/core/metadata/controller/http/deviceresource_test.go
@@ -156,6 +156,8 @@ func TestAddDeviceProfileResource(t *testing.T) {
 	dbClientMock.On("DeviceProfileByName", valid.ProfileName).Return(deviceProfile, nil)
 	dbClientMock.On("DeviceProfileByName", notFoundProfileName.ProfileName).Return(deviceProfile, notFoundDBError)
 	dbClientMock.On("UpdateDeviceProfile", mock.Anything).Return(nil)
+	dbClientMock.On("DevicesByProfileName", 0, -1, TestDeviceProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DeviceCountByProfileName", TestDeviceProfileName).Return(uint32(1), nil)
 	dic.Update(di.ServiceConstructorMap{
 		container.DBClientInterfaceName: func(get di.Get) interface{} {
 			return dbClientMock
@@ -261,6 +263,8 @@ func TestAddDeviceProfileResource_UnitsOfMeasure_Validation(t *testing.T) {
 	dbClientMock := &mocks.DBClient{}
 	dbClientMock.On("DeviceProfileByName", validReq.ProfileName).Return(deviceProfile, nil)
 	dbClientMock.On("UpdateDeviceProfile", mock.Anything).Return(nil)
+	dbClientMock.On("DevicesByProfileName", 0, -1, validReq.ProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DeviceCountByProfileName", validReq.ProfileName).Return(uint32(1), nil)
 	uomMock := &mocks.UnitsOfMeasure{}
 	uomMock.On("Validate", TestUnits).Return(true)
 	uomMock.On("Validate", "").Return(true)
@@ -341,11 +345,13 @@ func TestPatchDeviceProfileResource(t *testing.T) {
 	dic := mockDic()
 	dbClientMock := &mocks.DBClient{}
 	dbClientMock.On("DeviceProfileByName", valid.ProfileName).Return(deviceProfile, nil)
-	dbClientMock.On("DevicesByProfileName", 0, 1, valid.ProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DevicesByProfileName", 0, mock.Anything, valid.ProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DeviceCountByProfileName", TestDeviceProfileName).Return(uint32(1), nil)
 	dbClientMock.On("UpdateDeviceProfile", mock.Anything).Return(nil)
 
 	dbClientMock.On("DeviceProfileByName", deviceExistsProfileName).Return(deviceExistsProfile, nil)
-	dbClientMock.On("DevicesByProfileName", 0, 1, deviceExistsProfileName).Return([]models.Device{{}}, nil)
+	dbClientMock.On("DevicesByProfileName", 0, -1, deviceExistsProfileName).Return([]models.Device{{}}, nil)
+	dbClientMock.On("DeviceCountByProfileName", deviceExistsProfileName).Return(uint32(1), nil)
 
 	dbClientMock.On("DeviceProfileByName", notFound).Return(deviceProfile, notFoundDBError)
 	dic.Update(di.ServiceConstructorMap{
@@ -423,7 +429,8 @@ func TestDeleteDeviceResourceByName(t *testing.T) {
 
 	dic := mockDic()
 	dbClientMock := &mocks.DBClient{}
-	dbClientMock.On("DevicesByProfileName", 0, 1, TestDeviceProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DevicesByProfileName", 0, mock.Anything, TestDeviceProfileName).Return([]models.Device{}, nil)
+	dbClientMock.On("DeviceCountByProfileName", TestDeviceProfileName).Return(uint32(1), nil)
 	dbClientMock.On("DeviceProfileByName", TestDeviceProfileName).Return(dpModel, nil)
 	dbClientMock.On("UpdateDeviceProfile", mock.Anything).Return(nil)
 


### PR DESCRIPTION
publish update device profile system events to device services

related #4273

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. build and run core-metadata with other services
2. create two devices for different device services with the same profile (device-simple and device-virtual in this case)
3. find the correct logs
4. (optional) subscribe the redis messagebus system event topic and receive the correct messages

The logs after updating the device profile
```
level=DEBUG ts=2023-02-13T04:28:03.758651759Z app=core-metadata source=deviceresource.go:81 msg="DeviceProfile deviceResources added on DB successfully. Correlation-id: e7a53825-7f34-4c95-94c2-79e59fdcc492 "
level=DEBUG ts=2023-02-13T04:28:03.760350526Z app=core-metadata source=notify.go:220 msg="Published the 'update' System Event for deviceprofile 'Random-Boolean-Device' to topic 'edgex/system-events/core-metadata/deviceprofile/update/core-metadata/Random-Boolean-Device'"
level=DEBUG ts=2023-02-13T04:28:03.760800438Z app=core-metadata source=notify.go:220 msg="Published the 'update' System Event for deviceprofile 'Random-Boolean-Device' to topic 'edgex/system-events/core-metadata/deviceprofile/update/device-simple/Random-Boolean-Device'"
level=DEBUG ts=2023-02-13T04:28:03.761388536Z app=core-metadata source=notify.go:220 msg="Published the 'update' System Event for deviceprofile 'Random-Boolean-Device' to topic 'edgex/system-events/core-metadata/deviceprofile/update/device-virtual/Random-Boolean-Device'"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->