### PR TITLE
feat: Implement Provision Watcher System Events

### DIFF
--- a/internal/core/metadata/application/notify.go
+++ b/internal/core/metadata/application/notify.go
@@ -62,64 +62,6 @@ func validateDeviceCallback(ctx context.Context, dic *di.Container, device dtos.
 	return nil
 }
 
-// addProvisionWatcherCallback invoke device service's callback function for adding new provision watcher
-func addProvisionWatcherCallback(ctx context.Context, dic *di.Container, pw dtos.ProvisionWatcher) {
-	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-	deviceServiceCallbackClient, err := newDeviceServiceCallbackClient(ctx, dic, pw.ServiceName)
-	if err != nil {
-		lc.Errorf("fail to new a device service callback client by serviceName %s, err: %v", pw.ServiceName, err)
-		return
-	}
-
-	request := requests.NewAddProvisionWatcherRequest(pw)
-	response, err := deviceServiceCallbackClient.AddProvisionWatcherCallback(ctx, request)
-	if err != nil {
-		lc.Errorf("fail to invoke device service callback for adding  provision watcher %s, err: %v", pw.Name, err)
-		return
-	}
-	if response.StatusCode != http.StatusOK {
-		lc.Errorf("fail to invoke device service callback for adding  provision watcher %s, err: %s", pw.Name, response.Message)
-	}
-}
-
-// updateProvisionWatcherCallback invoke device service's callback function for updating provision watcher
-func updateProvisionWatcherCallback(ctx context.Context, dic *di.Container, serviceName string, pw models.ProvisionWatcher) {
-	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-	deviceServiceCallbackClient, err := newDeviceServiceCallbackClient(ctx, dic, serviceName)
-	if err != nil {
-		lc.Errorf("fail to new a device service callback client by serviceName %s, err: %v", serviceName, err)
-		return
-	}
-
-	request := requests.NewUpdateProvisionWatcherRequest(dtos.FromProvisionWatcherModelToUpdateDTO(pw))
-	response, err := deviceServiceCallbackClient.UpdateProvisionWatcherCallback(ctx, request)
-	if err != nil {
-		lc.Errorf("fail to invoke device service callback for updating provision watcher %s, err: %v", pw.Name, err)
-		return
-	}
-	if response.StatusCode != http.StatusOK {
-		lc.Errorf("fail to invoke device service callback for updating provision watcher %s, err: %s", pw.Name, response.Message)
-	}
-}
-
-// deleteProvisionWatcherCallback invoke device service's callback function for deleting provision watcher
-func deleteProvisionWatcherCallback(ctx context.Context, dic *di.Container, pw models.ProvisionWatcher) {
-	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-	deviceServiceCallbackClient, err := newDeviceServiceCallbackClient(ctx, dic, pw.ServiceName)
-	if err != nil {
-		lc.Errorf("fail to new a device service callback client by serviceName %s, err: %v", pw.ServiceName, err)
-		return
-	}
-	response, err := deviceServiceCallbackClient.DeleteProvisionWatcherCallback(ctx, pw.Name)
-	if err != nil {
-		lc.Errorf("fail to invoke device service callback for deleting provision watcher %s, err: %v", pw.Name, err)
-		return
-	}
-	if response.StatusCode != http.StatusOK {
-		lc.Errorf("fail to invoke device service callback for deleting provision watcher %s, err: %s", pw.Name, response.Message)
-	}
-}
-
 // updateDeviceServiceCallback invoke device service's callback function for updating device service
 func updateDeviceServiceCallback(ctx context.Context, dic *di.Container, ds models.DeviceService) {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
@@ -188,6 +130,14 @@ func publishSystemEvent(eventType, action, owner string, dto any, ctx context.Co
 			detailName = profile.Name
 		} else {
 			lc.Errorf("can not convert to device profile DTO")
+			return
+		}
+	case common.ProvisionWatcherSystemEventType:
+		if pw, ok := dto.(dtos.ProvisionWatcher); ok {
+			profileName = pw.ProfileName
+			detailName = pw.Name
+		} else {
+			lc.Errorf("can not convert to provision watcher DTO")
 			return
 		}
 	default:

--- a/internal/core/metadata/application/provisionwatcher.go
+++ b/internal/core/metadata/application/provisionwatcher.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,6 +15,7 @@ import (
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
@@ -37,7 +38,7 @@ func AddProvisionWatcher(pw models.ProvisionWatcher, ctx context.Context, dic *d
 		addProvisionWatcher.Id,
 		correlationId,
 	)
-	go addProvisionWatcherCallback(ctx, dic, dtos.FromProvisionWatcherModelToDTO(pw))
+	go publishSystemEvent(common.ProvisionWatcherSystemEventType, common.SystemEventActionAdd, pw.ServiceName, dtos.FromProvisionWatcherModelToDTO(pw), ctx, dic)
 	return addProvisionWatcher.Id, nil
 }
 
@@ -130,7 +131,7 @@ func DeleteProvisionWatcherByName(ctx context.Context, name string, dic *di.Cont
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
-	go deleteProvisionWatcherCallback(ctx, dic, pw)
+	go publishSystemEvent(common.ProvisionWatcherSystemEventType, common.SystemEventActionDelete, pw.ServiceName, dtos.FromProvisionWatcherModelToDTO(pw), ctx, dic)
 	return nil
 }
 
@@ -160,9 +161,9 @@ func PatchProvisionWatcher(ctx context.Context, dto dtos.UpdateProvisionWatcher,
 	lc.Debugf("ProvisionWatcher patched on DB successfully. Correlation-ID: %s ", correlation.FromContext(ctx))
 
 	if oldServiceName != "" {
-		go updateProvisionWatcherCallback(ctx, dic, oldServiceName, pw)
+		go publishSystemEvent(common.ProvisionWatcherSystemEventType, common.SystemEventActionUpdate, oldServiceName, dtos.FromProvisionWatcherModelToDTO(pw), ctx, dic)
 	}
-	go updateProvisionWatcherCallback(ctx, dic, pw.ServiceName, pw)
+	go publishSystemEvent(common.ProvisionWatcherSystemEventType, common.SystemEventActionUpdate, pw.ServiceName, dtos.FromProvisionWatcherModelToDTO(pw), ctx, dic)
 	return nil
 }
 


### PR DESCRIPTION
- publish system events for provision watcher add/update/delete
- remove the REST callbacks

close #4329

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/960

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. build and run core-metadata with other services
2. find the correct logs
3. (optional) subscribe the redis messagebus system event topic and receive the correct messages

- add a provision watcher 
```
level=DEBUG ts=2023-02-13T09:48:21.487595056Z app=core-metadata source=provisionwatcher.go:37 msg="ProvisionWatcher created on DB successfully. ProvisionWatcher ID: 705136c5-6228-494a-8e27-f0946e1d2554, Correlation-ID: 71129ebb-344b-4799-96ec-150cd7028705 "
level=DEBUG ts=2023-02-13T09:48:21.488277751Z app=core-metadata source=notify.go:225 msg="Published the 'add' System Event for provisionwatcher 'provisionwatcher-1' to topic 'edgex/system-events/core-metadata/provisionwatcher/add/device-simple/Simple-Device'"
```
- update a provision watcher
```
level=DEBUG ts=2023-02-13T09:50:54.282282186Z app=core-metadata source=provisionwatcher.go:163 msg="ProvisionWatcher patched on DB successfully. Correlation-ID: 08da17e3-2bf8-4fc2-8800-952ea5d9c9e4 "
level=DEBUG ts=2023-02-13T09:50:54.283518303Z app=core-metadata source=notify.go:225 msg="Published the 'update' System Event for provisionwatcher 'provisionwatcher-1' to topic 'edgex/system-events/core-metadata/provisionwatcher/update/device-simple/Simple-Device'"
```
- delete a provision watcher
```
level=DEBUG ts=2023-02-13T09:54:02.068393209Z app=core-metadata source=notify.go:225 msg="Published the 'delete' System Event for provisionwatcher 'provisionwatcher-1' to topic 'edgex/system-events/core-metadata/provisionwatcher/delete/device-simple/Simple-Device'"
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->