### PR TITLE
feat(snap): Add core-common-config-bootstrapper

### DIFF
--- a/snap/local/helper-go/common.go
+++ b/snap/local/helper-go/common.go
@@ -3,31 +3,31 @@ package main
 // snapped apps
 const (
 	// core services
-	coreData       = "core-data"
-	coreMetadata   = "core-metadata"
-	coreCommand    = "core-command"
-	consul         = "consul"
-	redis          = "redis"
-	registry       = consul
-	configProvider = consul
+	coreData                     = "core-data"
+	coreMetadata                 = "core-metadata"
+	coreCommand                  = "core-command"
+	consul                       = "consul"
+	redis                        = "redis"
+	registry                     = consul
+	configProvider               = consul
+	coreCommonConfigBootstrapper = "core-common-config-bootstrapper"
 	// support services
 	supportNotifications = "support-notifications"
 	supportScheduler     = "support-scheduler"
 	// security services
-	securitySecretStore          = "security-secret-store"
-	securitySecretStoreSetup     = "security-secretstore-setup"
-	securityProxy                = "security-proxy"
-	securityProxySetup           = "security-proxy-setup"
-	securityBootstrapper         = "security-bootstrapper"
-	securityBootstrapperRedis    = "security-bootstrapper-redis"
-	securityBootstrapperConsul   = "security-consul-bootstrapper"
-	securityFileTokenProvider    = "security-file-token-provider"
-	secretsConfig                = "secrets-config"
-	kong                         = "kong-daemon"
-	postgres                     = "postgres"
-	vault                        = "vault"
-	secretsConfigProcessor       = "secrets-config-processor"
-	coreCommonConfigBootstrapper = "core-common-config-bootstrapper"
+	securitySecretStore        = "security-secret-store"
+	securitySecretStoreSetup   = "security-secretstore-setup"
+	securityProxy              = "security-proxy"
+	securityProxySetup         = "security-proxy-setup"
+	securityBootstrapper       = "security-bootstrapper"
+	securityBootstrapperRedis  = "security-bootstrapper-redis"
+	securityBootstrapperConsul = "security-consul-bootstrapper"
+	securityFileTokenProvider  = "security-file-token-provider"
+	secretsConfig              = "secrets-config"
+	kong                       = "kong-daemon"
+	postgres                   = "postgres"
+	vault                      = "vault"
+	secretsConfigProcessor     = "secrets-config-processor"
 )
 
 var (
@@ -39,9 +39,11 @@ var (
 	securitySetupServices = []string{
 		securitySecretStoreSetup,
 		securityBootstrapperConsul,
-		coreCommonConfigBootstrapper,
 		securityProxySetup,
 		securityBootstrapperRedis,
+	}
+	coreSetupServices = []string{
+		coreCommonConfigBootstrapper,
 	}
 	coreServices = []string{
 		consul,
@@ -56,11 +58,15 @@ var (
 	}
 )
 
+func allOneshotServices() (s []string) {
+	return append(securitySetupServices, coreSetupServices...)
+}
+
 func allServices() (s []string) {
-	s = make([]string, len(coreServices)+len(supportServices)+len(securityServices)+len(securitySetupServices))
+	s = make([]string, len(coreServices)+len(supportServices)+len(securityServices)+len(allOneshotServices()))
 	s = append(s, coreServices...)
 	s = append(s, supportServices...)
 	s = append(s, securityServices...)
-	s = append(s, securitySetupServices...)
+	s = append(s, allOneshotServices()...)
 	return s
 }

--- a/snap/local/helper-go/common.go
+++ b/snap/local/helper-go/common.go
@@ -14,19 +14,20 @@ const (
 	supportNotifications = "support-notifications"
 	supportScheduler     = "support-scheduler"
 	// security services
-	securitySecretStore        = "security-secret-store"
-	securitySecretStoreSetup   = "security-secretstore-setup"
-	securityProxy              = "security-proxy"
-	securityProxySetup         = "security-proxy-setup"
-	securityBootstrapper       = "security-bootstrapper"
-	securityBootstrapperRedis  = "security-bootstrapper-redis"
-	securityBootstrapperConsul = "security-consul-bootstrapper"
-	securityFileTokenProvider  = "security-file-token-provider"
-	secretsConfig              = "secrets-config"
-	kong                       = "kong-daemon"
-	postgres                   = "postgres"
-	vault                      = "vault"
-	secretsConfigProcessor     = "secrets-config-processor"
+	securitySecretStore          = "security-secret-store"
+	securitySecretStoreSetup     = "security-secretstore-setup"
+	securityProxy                = "security-proxy"
+	securityProxySetup           = "security-proxy-setup"
+	securityBootstrapper         = "security-bootstrapper"
+	securityBootstrapperRedis    = "security-bootstrapper-redis"
+	securityBootstrapperConsul   = "security-consul-bootstrapper"
+	securityFileTokenProvider    = "security-file-token-provider"
+	secretsConfig                = "secrets-config"
+	kong                         = "kong-daemon"
+	postgres                     = "postgres"
+	vault                        = "vault"
+	secretsConfigProcessor       = "secrets-config-processor"
+	coreCommonConfigBootstrapper = "core-common-config-bootstrapper"
 )
 
 var (
@@ -38,6 +39,7 @@ var (
 	securitySetupServices = []string{
 		securitySecretStoreSetup,
 		securityBootstrapperConsul,
+		coreCommonConfigBootstrapper,
 		securityProxySetup,
 		securityBootstrapperRedis,
 	}

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -140,6 +140,7 @@ func configure() {
 		coreData,
 		coreMetadata,
 		coreCommand,
+		coreCommonConfigBootstrapper,
 		supportNotifications,
 		supportScheduler,
 		securitySecretStoreSetup,
@@ -160,7 +161,7 @@ func configure() {
 
 	// Unset autostart for oneshot services so they don't start again
 	var oneshotAutostart []string
-	for _, s := range securitySetupServices {
+	for _, s := range allOneshotServices() {
 		oneshotAutostart = append(oneshotAutostart, "apps."+s+".autostart")
 	}
 	if err = snapctl.Unset(oneshotAutostart...).Run(); err != nil {

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -98,6 +98,7 @@ func installConfFiles() error {
 		securityFileTokenProvider,
 		securityProxySetup,
 		securitySecretStoreSetup,
+		coreCommonConfigBootstrapper,
 		coreCommand,
 		coreData,
 		coreMetadata,
@@ -118,25 +119,9 @@ func installConfFiles() error {
 			srcDir = srcDir + v + "/res"
 		}
 
-		if err = os.MkdirAll(destDir, 0755); err != nil {
-			return err
-		}
-
-		srcPath := srcDir + "/configuration.toml"
-		destPath := destDir + "/configuration.toml"
-		err = hooks.CopyFile(srcPath, destPath)
+		err = hooks.CopyDir(srcDir, destDir)
 		if err != nil {
 			return err
-		}
-
-		// copy additional files
-		if v == coreMetadata {
-			uomSrcPath := srcDir + "/uom.toml"
-			uomDestPath := destDir + "/uom.toml"
-			err = hooks.CopyFile(uomSrcPath, uomDestPath)
-			if err != nil {
-				return err
-			}
 		}
 	}
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -358,10 +358,9 @@ apps:
   core-common-config-bootstrapper:
     after:
       - security-consul-bootstrapper
-    command: bin/core-common-config-bootstrapper --configDir $SNAP_DATA/config/core-command/res --configProvider --registry 
-    daemon: simple
+    command: bin/core-common-config-bootstrapper --configDir $SNAP_DATA/config/core-common-config-bootstrapper/res --configProvider consul.http://localhost:8500 --registry 
+    daemon: oneshot
     install-mode: disable
-    start-timeout: 15m
     plugs: [network]
   # helper commands the snap exposes
   security-proxy-setup-cmd:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -358,7 +358,7 @@ apps:
   core-common-config-bootstrapper:
     after:
       - security-consul-bootstrapper
-    command: bin/core-common-config-bootstrapper --configDir $SNAP_DATA/config/core-common-config-bootstrapper/res --configProvider consul.http://localhost:8500 --registry 
+    command: bin/core-common-config-bootstrapper --configDir $SNAP_DATA/config/core-common-config-bootstrapper/res --configFile configuration.yaml --configProvider consul.http://localhost:8500 --registry 
     daemon: oneshot
     install-mode: disable
     plugs: [network]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -169,7 +169,7 @@ apps:
     adapter: full
     after: [vault]
     command: >-
-      bin/security-secretstore-setup -configDir $SNAP_DATA/config/security-secretstore-setup/res $VAULT_INTERVAL
+      bin/security-secretstore-setup --configDir $SNAP_DATA/config/security-secretstore-setup/res $VAULT_INTERVAL
     command-chain:
       - bin/service-config-overrides.sh
     post-stop-command: bin/security-secretstore-post-setup.sh
@@ -204,7 +204,7 @@ apps:
       - security-secretstore-setup
       - security-consul-bootstrapper
       - kong-daemon
-    command: bin/security-proxy-setup -configDir $SNAP_DATA/config/security-proxy-setup/res $INIT_ARG
+    command: bin/security-proxy-setup --configDir $SNAP_DATA/config/security-proxy-setup/res $INIT_ARG
     command-chain:
       - bin/service-config-overrides.sh
     post-stop-command: bin/security-proxy-post-setup.sh
@@ -264,7 +264,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/core-data -configDir $SNAP_DATA/config/core-data/res --configProvider consul.http://localhost:8500 --registry
+    command: bin/core-data --configDir $SNAP_DATA/config/core-data/res --configProvider --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -284,7 +284,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/core-metadata -configDir $SNAP_DATA/config/core-metadata/res --configProvider consul.http://localhost:8500 --registry
+    command: bin/core-metadata --configDir $SNAP_DATA/config/core-metadata/res --configProvider consul.http://localhost:8500 --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -302,7 +302,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/core-command -configDir $SNAP_DATA/config/core-command/res --configProvider consul.http://localhost:8500 --registry
+    command: bin/core-command --configDir $SNAP_DATA/config/core-command/res --configProvider consul.http://localhost:8500 --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -319,7 +319,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/support-notifications -configDir $SNAP_DATA/config/support-notifications/res --configProvider consul.http://localhost:8500 --registry
+    command: bin/support-notifications --configDir $SNAP_DATA/config/support-notifications/res --configProvider consul.http://localhost:8500 --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -378,7 +378,7 @@ apps:
     # double-check with bnevis that this is OK, as there is an individual config.toml
     # file for the secrets-config command
     # not a mistake--secrets-config re-uses security-proxy-setup's configuration.toml
-    command: bin/secrets-config -configDir $SNAP_DATA/config/security-proxy-setup/res
+    command: bin/secrets-config --configDir $SNAP_DATA/config/security-proxy-setup/res
     plugs: [home, removable-media, network]
   redis-cli:
     adapter: full

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -263,7 +263,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/core-data -configDir $SNAP_DATA/config/core-data/res -cp -r
+    command: bin/core-data -configDir $SNAP_DATA/config/core-data/res --configProvider consul.http://localhost:8500 --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -282,7 +282,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/core-metadata -configDir $SNAP_DATA/config/core-metadata/res -cp -r
+    command: bin/core-metadata -configDir $SNAP_DATA/config/core-metadata/res --configProvider consul.http://localhost:8500 --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -299,7 +299,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/core-command -configDir $SNAP_DATA/config/core-command/res -cp -r
+    command: bin/core-command -configDir $SNAP_DATA/config/core-command/res --configProvider consul.http://localhost:8500 --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -315,7 +315,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/support-notifications -configDir $SNAP_DATA/config/support-notifications/res -cp -r
+    command: bin/support-notifications -configDir $SNAP_DATA/config/support-notifications/res --configProvider consul.http://localhost:8500 --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -331,7 +331,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/support-scheduler -configDir $SNAP_DATA/config/support-scheduler/res -cp -r
+    command: bin/support-scheduler --configDir $SNAP_DATA/config/support-scheduler/res --configProvider consul.http://localhost:8500 --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -348,6 +348,15 @@ apps:
     daemon: oneshot
     install-mode: disable
     start-timeout: 1m
+    plugs: [network]
+  # this service pushes common configuration source into Configuration Provider
+  core-common-config-bootstrapper:
+    after:
+      - security-consul-bootstrapper
+    command: bin/core-common-config-bootstrapper --configDir $SNAP_DATA/config/core-command/res --configProvider --registry 
+    daemon: simple
+    install-mode: disable
+    start-timeout: 15m
     plugs: [network]
   # helper commands the snap exposes
   security-proxy-setup-cmd:
@@ -588,7 +597,7 @@ parts:
       # copy service binaries, configuration, and license files into the snap install
       for service in core-command core-data core-metadata support-notifications support-scheduler \
           security-proxy-setup security-secretstore-setup security-file-token-provider \
-          security-bootstrapper secrets-config; do
+          security-bootstrapper secrets-config core-common-config-bootstrapper; do
 
           install -DT "./cmd/$service/$service" "$SNAPCRAFT_PART_INSTALL/bin/$service"
 
@@ -596,6 +605,10 @@ parts:
           "core-metadata")
               install -DT "./cmd/core-metadata/res/configuration.toml" "$SNAPCRAFT_PART_INSTALL/config/core-metadata/res/configuration.toml"
               install -DT "./cmd/core-metadata/res/uom.toml" "$SNAPCRAFT_PART_INSTALL/config/core-metadata/res/uom.toml"
+          ;;
+          "core-common-config-bootstrapper")
+              install -DT "./cmd/core-common-config-bootstrapper/res/configuration.yaml" \
+                  "$SNAPCRAFT_PART_INSTALL/config/core-common-config-bootstrapper/res/configuration.yaml"
           ;;
           "security-file-token-provider")
               install -DT "./cmd/security-secretstore-setup/res-file-token-provider/configuration.toml" \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -359,6 +359,8 @@ apps:
     after:
       - security-consul-bootstrapper
     command: bin/core-common-config-bootstrapper --configDir $SNAP_DATA/config/core-common-config-bootstrapper/res --configFile configuration.yaml --configProvider consul.http://localhost:8500 --registry 
+    environment:
+      SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/core-common-config-bootstrapper/secrets-token.json
     daemon: oneshot
     install-mode: disable
     plugs: [network]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -260,6 +260,7 @@ apps:
     adapter: full
     after:
       - security-bootstrapper-redis
+      - core-common-config-bootstrapper
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
@@ -279,6 +280,7 @@ apps:
     adapter: none
     after:
       - security-bootstrapper-redis
+      - core-common-config-bootstrapper
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
@@ -296,6 +298,7 @@ apps:
     adapter: none
     after:
       - security-bootstrapper-redis
+      - core-common-config-bootstrapper
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
@@ -312,6 +315,7 @@ apps:
     adapter: none
     after:
       - security-bootstrapper-redis
+      - core-common-config-bootstrapper
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
@@ -328,6 +332,7 @@ apps:
     adapter: none
     after:
       - security-bootstrapper-redis
+      - core-common-config-bootstrapper
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup


### PR DESCRIPTION
A component called "core-common-config-bootstrapper" has been added through PR https://github.com/edgexfoundry/edgex-go/pull/4292, which pushes the common configuration to the Config Provider. This PR adds it into snap packaging.

Additionally, the command-line flags have been updated by this PR to use preferred options for apps.

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->