### PR TITLE
fix: take out parallel running in unit tests to avoid timing issue

### DIFF
--- a/internal/security/bootstrapper/command/setupacl/command_test.go
+++ b/internal/security/bootstrapper/command/setupacl/command_test.go
@@ -118,7 +118,6 @@ func TestExecute(t *testing.T) {
 	for _, tt := range tests {
 		test := tt // capture as local copy
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			// prepare test
 			testSrvOptions := serverOptions{
 				aclBootstrapOkResponse:  test.aclOkResponse,
@@ -209,7 +208,6 @@ func TestMultipleExecuteCalls(t *testing.T) {
 	for _, tt := range tests {
 		test := tt // capture as local copy
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			// prepare test
 			testSrvOptions := serverOptions{
 				aclBootstrapOkResponse:  true,


### PR DESCRIPTION
Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->