### PR TITLE
fix: Add missing 'core' to event publish topic

### DIFF
--- a/internal/core/data/application/event.go
+++ b/internal/core/data/application/event.go
@@ -25,6 +25,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const CoreDataEventTopicPrefix = "core"
+
 // ValidateEvent validates if e is a valid event with corresponding device profile name and device name and source name
 // ValidateEvent throws error when profileName or deviceName doesn't match to e
 func (a *CoreDataApp) ValidateEvent(e models.Event, profileName string, deviceName string, sourceName string, _ context.Context, _ *di.Container) errors.EdgeX {
@@ -80,7 +82,7 @@ func (a *CoreDataApp) PublishEvent(data []byte, serviceName string, profileName 
 	correlationId := correlation.FromContext(ctx)
 
 	basePrefix := configuration.MessageBus.GetBaseTopicPrefix()
-	publishTopic := common.BuildTopic(basePrefix, common.EventsPublishTopic, serviceName, profileName, deviceName, sourceName)
+	publishTopic := common.BuildTopic(basePrefix, common.EventsPublishTopic, CoreDataEventTopicPrefix, serviceName, profileName, deviceName, sourceName)
 	lc.Debugf("Publishing AddEventRequest to MessageBus. Topic: %s; %s: %s", publishTopic, common.CorrelationHeader, correlationId)
 
 	msgEnvelope := msgTypes.NewMessageEnvelope(data, ctx)


### PR DESCRIPTION
Previous refactoring missed adding 'core' to event publish topic


<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->