### PR TITLE
feat!: Remove Notify field out of Device dto and add Properties field into ProvisionWatcher dto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.25
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.3
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.18
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.20
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.9
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.7
 	github.com/fxamacker/cbor/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.25 h1:PkmFk6qTwc4WHxAwRBY
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.25/go.mod h1:iv/czxi4ciFWMgrO+3nnanGfkT2X1QW5L3iCb+deewk=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.3 h1:0Ew4PzLSFJ+sb7AYtvb9m1mRN45Sh0ELU1HdMCel5t8=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.3/go.mod h1:ESOWI4GokQfQ3Bn2hGsdfOVx5idj7QEdCPT/SAQDd9M=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.18 h1:98BcSFWiuTYSls25hX73l0mDNNgh3Sd7L5mhLj6maG0=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.18/go.mod h1:4lpZUM54ZareGU/yuAJvLEw0BoJ43SvCj1LO+gsKm9c=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.20 h1:U1jnaIMecwReLJMnSibgwhlF8zDuSXbYjUbqjdDL/cE=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.20/go.mod h1:4lpZUM54ZareGU/yuAJvLEw0BoJ43SvCj1LO+gsKm9c=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.9 h1:CUUieXQ8roD4M770GXj1he707V3V9Jiygk302+dwvKk=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.9/go.mod h1:iKBxmZkc7jdOrT99+IR1nyg7PlRgooAQMhZxDh2mTUQ=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3 h1:QgZF9f70Cwpvkjw3tP1aiVGHc+yNFJNzW6hO8pDs3fg=

--- a/internal/core/metadata/controller/http/device_test.go
+++ b/internal/core/metadata/controller/http/device_test.go
@@ -32,6 +32,12 @@ import (
 
 var testDeviceLabels = []string{"MODBUS", "TEMP"}
 
+var testProperties = map[string]any{
+	"TestProperty1": "property1",
+	"TestProperty2": true,
+	"TestProperty3": 123.45,
+}
+
 func buildTestDeviceRequest() requests.AddDeviceRequest {
 	var testAutoEvents = []dtos.AutoEvent{
 		{SourceName: "TestResource", Interval: "300ms", OnChange: true},
@@ -59,6 +65,7 @@ func buildTestDeviceRequest() requests.AddDeviceRequest {
 			Location:       "{40lat;45long}",
 			AutoEvents:     testAutoEvents,
 			Protocols:      testProtocols,
+			Properties:     testProperties,
 		},
 	}
 
@@ -73,7 +80,6 @@ func buildTestUpdateDeviceRequest() requests.UpdateDeviceRequest {
 	testProfileName := TestDeviceProfileName
 	testAdminState := models.Unlocked
 	testOperatingState := models.Up
-	testNotify := false
 	var testAutoEvents = []dtos.AutoEvent{
 		{SourceName: "TestResource", Interval: "300ms", OnChange: true},
 	}
@@ -101,7 +107,7 @@ func buildTestUpdateDeviceRequest() requests.UpdateDeviceRequest {
 			Location:       "{40lat;45long}",
 			AutoEvents:     testAutoEvents,
 			Protocols:      testProtocols,
-			Notify:         &testNotify,
+			Properties:     testProperties,
 		},
 	}
 
@@ -471,7 +477,7 @@ func TestPatchDevice(t *testing.T) {
 		ProfileName:    *testReq.Device.ProfileName,
 		AutoEvents:     dtos.ToAutoEventModels(testReq.Device.AutoEvents),
 		Protocols:      dtos.ToProtocolModels(testReq.Device.Protocols),
-		Notify:         *testReq.Device.Notify,
+		Properties:     testProperties,
 	}
 
 	valid := testReq

--- a/internal/core/metadata/controller/http/deviceprofile_test.go
+++ b/internal/core/metadata/controller/http/deviceprofile_test.go
@@ -58,6 +58,7 @@ func buildTestDeviceProfileRequest() requests.DeviceProfileRequest {
 			ValueType: common.ValueTypeInt16,
 			ReadWrite: common.ReadWrite_RW,
 			Units:     TestUnits,
+			Others:    testProperties,
 		},
 		Tags: testTags,
 	}, {
@@ -68,6 +69,7 @@ func buildTestDeviceProfileRequest() requests.DeviceProfileRequest {
 			ValueType: common.ValueTypeInt16,
 			ReadWrite: common.ReadWrite_RW,
 			Units:     TestUnits,
+			Others:    testProperties,
 		},
 		Tags: testTags,
 	}}

--- a/internal/core/metadata/controller/http/provisionwatcher_test.go
+++ b/internal/core/metadata/controller/http/provisionwatcher_test.go
@@ -58,6 +58,7 @@ func buildTestAddProvisionWatcherRequest() requests.AddProvisionWatcherRequest {
 			ServiceName:         TestDeviceServiceName,
 			AdminState:          models.Unlocked,
 			AutoEvents:          testProvisionWatcherAutoEvents,
+			Properties:          testProperties,
 		},
 	}
 }
@@ -84,6 +85,7 @@ func buildTestUpdateProvisionWatcherRequest() requests.UpdateProvisionWatcherReq
 			ProfileName:         &testProfileName,
 			AdminState:          &testAdminState,
 			AutoEvents:          testProvisionWatcherAutoEvents,
+			Properties:          testProperties,
 		},
 	}
 
@@ -670,6 +672,7 @@ func TestProvisionWatcherController_PatchProvisionWatcher(t *testing.T) {
 		ServiceName:         *testReq.ProvisionWatcher.ServiceName,
 		ProfileName:         *testReq.ProvisionWatcher.ProfileName,
 		AutoEvents:          dtos.ToAutoEventModels(testReq.ProvisionWatcher.AutoEvents),
+		Properties:          testProperties,
 	}
 
 	valid := testReq

--- a/openapi/v3/core-metadata.yaml
+++ b/openapi/v3/core-metadata.yaml
@@ -167,9 +167,12 @@ components:
           description: A map of supported protocols for the given device
           additionalProperties:
             $ref: '#/components/schemas/ProtocolProperties'
-        notify:
-          type: boolean
-          description: If the 'notify' property is set to true, the device service managing the device will receive a notification
+        tags:
+          type: object
+          description: A map of tags used to tag the given device
+        properties:
+          type: object
+          description: A map of properties required to address the given device
     CreateDevice:
       type: object
       properties:
@@ -215,9 +218,12 @@ components:
           description: A map of supported protocols for the given device
           additionalProperties:
             $ref: '#/components/schemas/ProtocolProperties'
-        notify:
-          type: boolean
-          description: If the 'notify' property is set to true, the device service managing the device will receive a notification
+        tags:
+          type: object
+          description: A map of tags used to tag the given device
+        properties:
+          type: object
+          description: A map of properties required to address the given device
       required:
         - name
         - adminState
@@ -268,9 +274,13 @@ components:
           description: A map of supported protocols for the given device
           additionalProperties:
             $ref: '#/components/schemas/ProtocolProperties'
-        notify:
-          type: boolean
-          description: If the 'notify' property is set to true, the device service managing the device will receive a notification
+        tags:
+          type: object
+          description: A map of tags used to tag the given device
+        properties:
+          type: object
+          description: A map of properties required to address the given device
+
     DeviceProfileBasicInfo:
       description: "A profile basic information"
       type: object
@@ -628,6 +638,9 @@ components:
           description: Autoevents that allow device service to automatically start generating data from new devices
           items:
             $ref: '#/components/schemas/AutoEvent'
+        properties:
+          type: object
+          description: A map of properties required to address the given provision watcher
     CreateProvisionWatcher:
       description: "A ProvisionWatcher defines the filtering criteria for device auto discovery."
       type: object
@@ -666,6 +679,9 @@ components:
           description:  Autoevents that allow device service to automatically start generating data from new devices
           items:
             $ref: '#/components/schemas/AutoEvent'
+        properties:
+          type: object
+          description: A map of properties required to address the given provision watcher
       required:
         - name
         - identifiers
@@ -716,6 +732,9 @@ components:
           description:  Autoevents that allow device service to automatically start generating data from new devices
           items:
             $ref: '#/components/schemas/AutoEvent'
+        properties:
+          type: object
+          description: A map of properties required to address the given provision watcher
     ProvisionWatcherResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -927,7 +946,7 @@ components:
     UpdateDeviceRequest:
       allOf:
         - $ref: '#/components/schemas/BaseRequest'
-      description: "A request to update an existing device definition. 'id' and 'deviceName' must be populated in order to identify the device. If the 'notify' property is set to true, the device service managing the device will receive a notification. Any other property that is populated in the request will be updated. Empty/blank properties will not be considered."
+      description: "A request to update an existing device definition. 'id' and 'deviceName' must be populated in order to identify the device. Any other property that is populated in the request will be updated. Empty/blank properties will not be considered."
       type: object
       properties:
         device:
@@ -1167,7 +1186,21 @@ components:
                 Address: "localhost"
                 Port: "502"
                 UnitID: "1"
-            notify: false
+            tags:
+              - tag1:
+                  field1: "field1Value"
+                  field2: "field2Value"
+              - tag2:
+                  field3: "field3Value"
+                  field4: "field4Value"
+                  field5: "field5Value"
+            properties:
+              - DeviceInstance:
+                  instanceName: "myInstance"
+                  instanceId: "instance1"
+              - Firmware:
+                  firmwareId: "firmwareABC"
+                  firmwareVersion: "v1.1.2"
     UpdateDeviceRequest:
       value:
         - apiVersion: v3
@@ -1268,6 +1301,10 @@ components:
             profileName: "device-simple"
             serviceName: "device-simple"
             adminState: "UNLOCKED"
+            properties:
+              - DeviceNameTemplate:
+                  valueReplace: true
+                  template: "device-name-{{Address}}-{{Port}"
     GetAllDevicesResponse:
       value:
         apiVersion: "v3"
@@ -1295,6 +1332,21 @@ components:
               other:
                 Address: "device-virtual-bool-01"
                 Port: "300"
+            tags:
+              - tag1:
+                  field1: "field1Value"
+                  field2: "field2Value"
+              - tag2:
+                  field3: "field3Value"
+                  field4: "field4Value"
+                  field5: "field5Value"
+            properties:
+              - DeviceInstance:
+                  instanceName: "myInstance"
+                  instanceId: "instance1"
+              - Firmware:
+                  firmwareId: "firmwareABC"
+                  firmwareVersion: "v1.1.2"
           - id: "03bd5ce0-b967-4165-a335-775fea604142"
             name: "Random-UnsignedInteger-Device"
             description: "Example of Device Virtual"
@@ -1318,6 +1370,21 @@ components:
               other:
                 Address: "device-virtual-uint-01"
                 Port: "300"
+            tags:
+              - tag1:
+                  field1: "field1Value"
+                  field2: "field2Value"
+              - tag2:
+                  field3: "field3Value"
+                  field4: "field4Value"
+                  field5: "field5Value"
+            properties:
+              - DeviceInstance:
+                  instanceName: "myInstance"
+                  instanceId: "instance2"
+              - Firmware:
+                  firmwareId: "firmwareXYZ"
+                  firmwareVersion: "v3.1.0"
     GetAllDeviceProfilesResponse:
       value:
         apiVersion: "v3"
@@ -1397,6 +1464,10 @@ components:
               - sourceName: "Bool"
                 interval: "10s"
                 onChange: false
+            properties:
+              - DeviceNameTemplate:
+                  valueReplace: true
+                  template: "device-name-{{Address}}-{{Port}"
           - id: "90c971f0-cb84-4bda-a9f0-d9494196b54d"
             name: "simple-watcher"
             created: 0
@@ -3533,6 +3604,10 @@ paths:
                     - sourceName: "Bool"
                       interval: "10s"
                       onChange: false
+                  properties:
+                    - DeviceNameTemplate:
+                        valueReplace: true
+                        template: "device-name-{{Address}}-{{Port}"
         '400':
           description: "Request is in an invalid state"
           headers:


### PR DESCRIPTION
BREAKING CHANGE: Remove Notify field out of Device model/dto

Per https://github.com/edgexfoundry/go-mod-core-contracts/pull/807, the boolean field notify of Device DTO is removed as device creation notification is handled by system event message now.  

Per https://github.com/edgexfoundry/go-mod-core-contracts/pull/803, the ProvisionWatcher DTO is updated with a new Properties field.

This commit updates following material to reflect such changes:
1. update go.mod/go.sum to use go-mod-core-contracts v3.0.0-dev.20
2. update swagger file correspondingly (remove notify field out of Device dto and add properties field into ProvisionWatcher dto)
3. update unit test correspondingly

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->