### PR TITLE
feat: Accept URL escape for device command name and resource name

### DIFF
--- a/internal/core/command/controller/messaging/utils.go
+++ b/internal/core/command/controller/messaging/utils.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
@@ -47,7 +48,7 @@ func validateRequestTopic(prefix string, deviceName string, commandName string, 
 	}
 
 	// expected internal command request topic scheme: <prefix>/<device-service>/<device>/<command-name>/<method>
-	return deviceServiceResponse.Service.Name, common.BuildTopic(prefix, deviceServiceResponse.Service.Name, deviceName, commandName, method), nil
+	return deviceServiceResponse.Service.Name, common.BuildTopic(prefix, deviceServiceResponse.Service.Name, deviceName, url.QueryEscape(commandName), method), nil
 
 }
 

--- a/internal/core/command/router.go
+++ b/internal/core/command/router.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,6 +19,8 @@ import (
 )
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
+	// r.UseEncodedPath() tells the router to match the encoded original path to the routes
+	r.UseEncodedPath()
 	// Common
 	cc := commonController.NewCommonController(dic, serviceName)
 	r.HandleFunc(common.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
@@ -34,4 +36,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))
+	r.Use(correlation.UrlDecodeMiddleware(container.LoggingClientFrom(dic.Get)))
 }

--- a/internal/core/data/application/event.go
+++ b/internal/core/data/application/event.go
@@ -8,6 +8,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/v3/pkg/types"
@@ -82,7 +83,7 @@ func (a *CoreDataApp) PublishEvent(data []byte, serviceName string, profileName 
 	correlationId := correlation.FromContext(ctx)
 
 	basePrefix := configuration.MessageBus.GetBaseTopicPrefix()
-	publishTopic := common.BuildTopic(basePrefix, common.EventsPublishTopic, CoreDataEventTopicPrefix, serviceName, profileName, deviceName, sourceName)
+	publishTopic := common.BuildTopic(basePrefix, common.EventsPublishTopic, CoreDataEventTopicPrefix, serviceName, profileName, deviceName, url.QueryEscape(sourceName))
 	lc.Debugf("Publishing AddEventRequest to MessageBus. Topic: %s; %s: %s", publishTopic, common.CorrelationHeader, correlationId)
 
 	msgEnvelope := msgTypes.NewMessageEnvelope(data, ctx)

--- a/internal/core/data/controller/messaging/subscriber.go
+++ b/internal/core/data/controller/messaging/subscriber.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021-2022 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	cbor "github.com/fxamacker/cbor/v2"
@@ -119,7 +120,10 @@ func validateEvent(messageTopic string, e dtos.Event) errors.EdgeX {
 	len := len(fields)
 	profileName := fields[len-3]
 	deviceName := fields[len-2]
-	sourceName := fields[len-1]
+	sourceName, err := url.QueryUnescape(fields[len-1])
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
 
 	// Check whether the event fields match the message topic
 	if e.ProfileName != profileName {

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -20,6 +20,8 @@ import (
 )
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
+	// r.UseEncodedPath() tells the router to match the encoded original path to the routes
+	r.UseEncodedPath()
 	// Common
 	cc := commonController.NewCommonController(dic, serviceName)
 	r.HandleFunc(common.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
@@ -54,4 +56,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))
+	r.Use(correlation.UrlDecodeMiddleware(container.LoggingClientFrom(dic.Get)))
 }

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021-2022 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,6 +20,8 @@ import (
 )
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
+	// r.UseEncodedPath() tells the router to match the encoded original path to the routes
+	r.UseEncodedPath()
 	// Common
 	cc := commonController.NewCommonController(dic, serviceName)
 	r.HandleFunc(common.ApiPingRoute, cc.Ping).Methods(http.MethodGet)
@@ -88,4 +90,5 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.LoggingMiddleware(container.LoggingClientFrom(dic.Get)))
+	r.Use(correlation.UrlDecodeMiddleware(container.LoggingClientFrom(dic.Get)))
 }


### PR DESCRIPTION
- Use router.UseEncodedPath() to match the encoded original path to the routes
- Decode the Url path variable before passing to the controller

Close #4371

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- Run core service and device service based on the [core-contract](https://github.com/edgexfoundry/go-mod-core-contracts/pull/806) and [device-sdk](https://github.com/edgexfoundry/device-sdk-go/pull/1335) changes.
- Add a profile to the metadata service, the command name and resource name should contain special character like `:`
- Add a device to the metadata service
- Test the read command or write command
   - Verify the escape URL works, eg, escape the commandName device-a/test:value and put into the URL like /api/v2/device/name/Modbus-TCP-Device/device-a%2Ftest%3Avalue
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->