### PR TITLE
feat: Create security-proxy-auth microservice (for proxy swapout)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ cmd/support-notifications/support-notifications
 cmd/support-scheduler/support-scheduler
 cmd/secrets-config/secrets-config
 cmd/security-bootstrapper/security-bootstrapper
+cmd/security-proxy-auth/security-proxy-auth
 cmd/security-spiffe-token-provider/security-spiffe-token-provider
 
 internal/security/bootstrapper/command/setupacl/test1/bootstrap_token.json

--- a/cmd/security-bootstrapper/res/configuration.toml
+++ b/cmd/security-bootstrapper/res/configuration.toml
@@ -53,6 +53,8 @@ LogLevel = "INFO"
           Description = "role for device virtual service"
         [StageGate.Registry.ACL.Roles.device-rest]
           Description = "role for device rest service"
+        [StageGate.Registry.ACL.Roles.security-proxy-auth]
+          Description = "role for NGINX auth proxy backend service"
         [StageGate.Registry.ACL.Roles.security-spiffe-token-provider]
           Description = "role for device security-spiffe-token-provider service"
           

--- a/cmd/security-proxy-auth/Dockerfile
+++ b/cmd/security-proxy-auth/Dockerfile
@@ -1,0 +1,51 @@
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2023 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  ----------------------------------------------------------------------------------
+
+# Docker image for Golang Core common config bootstrapper service
+ARG BUILDER_BASE=golang:1.18-alpine3.16
+FROM ${BUILDER_BASE} AS builder
+
+ARG ADD_BUILD_TAGS=""
+
+WORKDIR /edgex-go
+
+RUN apk add --update --no-cache make git
+
+COPY go.mod vendor* ./
+RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
+
+COPY . .
+RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/security-proxy-auth/security-proxy-auth
+
+#Next image - Copy built Go binary into new workspace
+FROM alpine:3.16
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2023: Intel Corporation'
+
+RUN apk add --update --no-cache dumb-init
+COPY --from=builder /edgex-go/Attribution.txt /
+COPY --from=builder /edgex-go/cmd/security-proxy-auth/security-proxy-auth /
+COPY --from=builder /edgex-go/cmd/security-proxy-auth/res/configuration.toml /res/configuration.toml
+
+COPY --from=builder /edgex-go/cmd/security-proxy-auth/entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/entrypoint.sh \
+    && ln -s /usr/local/bin/entrypoint.sh /
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["/security-proxy-auth", "-cp=consul.http://edgex-core-consul:8500"]

--- a/cmd/security-proxy-auth/entrypoint.sh
+++ b/cmd/security-proxy-auth/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/dumb-init /bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2023 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  ----------------------------------------------------------------------------------
+
+set -e
+
+"$@" && exec tail -f /dev/null

--- a/cmd/security-proxy-auth/main.go
+++ b/cmd/security-proxy-auth/main.go
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package main
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/proxyauth"
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	proxyauth.Main(ctx, cancel, mux.NewRouter())
+}

--- a/cmd/security-proxy-auth/res/configuration.toml
+++ b/cmd/security-proxy-auth/res/configuration.toml
@@ -1,0 +1,6 @@
+[Writable]
+LogLevel = "INFO"
+
+[Service]
+Port = 59842
+StartupMsg = "This is the proxy authentication microservice"

--- a/internal/security/proxyauth/config/config.go
+++ b/internal/security/proxyauth/config/config.go
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * Copyright 2018 Dell Inc.
  * Copyright 2022 IOTech Ltd.
+ * Copyright 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/internal/security/proxyauth/config/config.go
+++ b/internal/security/proxyauth/config/config.go
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright 2018 Dell Inc.
+ * Copyright 2022 IOTech Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package config
+
+import (
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v3/config"
+)
+
+// ConfigurationStruct contains the configuration properties for the core-command service.
+type ConfigurationStruct struct {
+	Writable WritableInfo
+	Registry bootstrapConfig.RegistryInfo
+	Service  bootstrapConfig.ServiceInfo
+}
+
+// WritableInfo contains configuration properties that can be updated and applied without restarting the service.
+type WritableInfo struct {
+	LogLevel string
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		*c = *configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an bootstrapConfig.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
+	return bootstrapConfig.BootstrapConfiguration{
+		Service:  c.Service,
+		Registry: c.Registry,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// GetRegistryInfo returns the RegistryInfo from the ConfigurationStruct.
+func (c *ConfigurationStruct) GetRegistryInfo() bootstrapConfig.RegistryInfo {
+	return c.Registry
+}
+
+// GetInsecureSecrets returns the service's InsecureSecrets.
+func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
+	return nil
+}
+
+// GetTelemetryInfo returns the service's Telemetry settings.
+func (c *ConfigurationStruct) GetTelemetryInfo() *bootstrapConfig.TelemetryInfo {
+	return nil
+}

--- a/internal/security/proxyauth/container/config.go
+++ b/internal/security/proxyauth/container/config.go
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package container
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/security/proxyauth/config"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+)
+
+// ConfigurationName contains the name of command's config.ConfigurationStruct implementation in the DIC.
+var ConfigurationName = di.TypeInstanceToName(config.ConfigurationStruct{})
+
+// ConfigurationFrom helper function queries the DIC and returns command's config.ConfigurationStruct implementation.
+func ConfigurationFrom(get di.Get) *config.ConfigurationStruct {
+	return get(ConfigurationName).(*config.ConfigurationStruct)
+}

--- a/internal/security/proxyauth/container/config.go
+++ b/internal/security/proxyauth/container/config.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
+ * Copyright 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/internal/security/proxyauth/init.go
+++ b/internal/security/proxyauth/init.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2017 Dell Inc.
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2023 Intel Corporation
  * Copyright (C) 2021 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -43,10 +43,13 @@ func NewBootstrap(router *mux.Router, serviceName string) *Bootstrap {
 }
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the command service.
+// Authentication is always on for this service,
+// as it is called by NGINX to authenticate requests
+// and must always authenticate even if the rest of EdgeX does not
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
 	lc := container.LoggingClientFrom(dic.Get)
 	secretProvider := container.SecretProviderFrom(dic.Get)
-	authenticationHook := handlers.VaultAuthenticationHandlerFunc(secretProvider, lc) // Auth is always on for this service!
+	authenticationHook := handlers.VaultAuthenticationHandlerFunc(secretProvider, lc)
 
 	// Run authentication hook for a nil route
 	b.router.HandleFunc("/auth", authenticationHook(emptyHandler))

--- a/internal/security/proxyauth/init.go
+++ b/internal/security/proxyauth/init.go
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright 2017 Dell Inc.
+ * Copyright (c) 2019 Intel Corporation
+ * Copyright (C) 2021 IOTech Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package proxyauth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/handlers"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	"github.com/gorilla/mux"
+)
+
+// Bootstrap contains references to dependencies required by the BootstrapHandler.
+type Bootstrap struct {
+	router      *mux.Router
+	serviceName string
+}
+
+// NewBootstrap is a factory method that returns an initialized Bootstrap receiver struct.
+func NewBootstrap(router *mux.Router, serviceName string) *Bootstrap {
+	return &Bootstrap{
+		router:      router,
+		serviceName: serviceName,
+	}
+}
+
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the command service.
+func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
+	lc := container.LoggingClientFrom(dic.Get)
+	secretProvider := container.SecretProviderFrom(dic.Get)
+	authenticationHook := handlers.VaultAuthenticationHandlerFunc(secretProvider, lc) // Auth is always on for this service!
+
+	// Run authentication hook for a nil route
+	b.router.HandleFunc("/auth", authenticationHook(emptyHandler))
+
+	return true
+}
+
+func emptyHandler(_ http.ResponseWriter, _ *http.Request) {}

--- a/internal/security/proxyauth/main.go
+++ b/internal/security/proxyauth/main.go
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ * Copyright 2022 IOTech Ltd.
+ * Copyright 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package proxyauth
+
+import (
+	"context"
+	"os"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/flags"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/handlers"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v3/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+
+	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal/security/proxyauth/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/proxyauth/container"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
+
+	"github.com/gorilla/mux"
+)
+
+const SecurityProxyAuthServiceKey = "security-proxy-auth"
+
+func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
+	startupTimer := startup.NewStartUpTimer(common.CoreCommandServiceKey)
+
+	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
+	// by inserting service specific flag prior to call to commonFlags.Parse().
+	// Example:
+	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
+	//      ....
+	//      flags.Parse(os.Args[1:])
+	//
+	f := flags.New()
+	f.Parse(os.Args[1:])
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	httpServer := handlers.NewHttpServer(router, true)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		f,
+		SecurityProxyAuthServiceKey,
+		common.ConfigStemSecurity,
+		configuration,
+		startupTimer,
+		dic,
+		true,
+		bootstrapConfig.ServiceTypeOther,
+		[]interfaces.BootstrapHandler{
+			handlers.NewClientsBootstrap().BootstrapHandler,
+			NewBootstrap(router, SecurityProxyAuthServiceKey).BootstrapHandler,
+			httpServer.BootstrapHandler,
+			handlers.NewStartMessage(SecurityProxyAuthServiceKey, edgex.Version).BootstrapHandler,
+		})
+
+	// code here!
+}


### PR DESCRIPTION
This commit introduces code for the security-proxy-auth microservice. The proxy-auth microservice will be used by the NGINX reverse proxy to perform JWT authentication of inbound requests through the proxy.

This is second in a series of commits to implement the microservice token-based authentication ADR.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?) This service only authenticates requests and has a no-op request handler.
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions

* Add the following snippet to add-security.yml to add the proxy-auth service

```
  authproxy:
    image: edgexfoundry/security-proxy-auth:0.0.0-dev
    container_name: edgex-proxy-auth
    hostname: edgex-proxy-auth
    read_only: true
    restart: always
    networks:
      - edgex-network
    ports:
      - "127.0.0.1:59842:59842" # FIXME remove localhost mount
    entrypoint: ["/bin/sh", "/edgex-init/ready_to_run_wait_install.sh"]
    command:
      - "entrypoint.sh"
      - "/security-proxy-auth"
      - "-cp=consul.http://edgex-core-consul:8500"
    env_file:
      - common-security.env
      - common-sec-stage-gate.env
    environment:
      SERVICE_HOST: edgex-proxy-auth
    volumes:
      - edgex-init:/edgex-init:ro,z
      - /tmp/edgex/secrets/security-proxy-auth:/tmp/edgex/secrets/security-proxy-auth:ro,z
    depends_on:
      - secretstore-setup
    security_opt: 
      - no-new-privileges:true
```

* Read the vault token out of /tmp/edgex/secrets/core-data/secrets-token.json

* exec into edgex-vault container and run

```
edgex-vault:/# export VAULT_TOKEN=thetoken
edgex-vault:/# vault read identity/oidc/token/core-data
```

* Exit the container and save the resulting token into a variable and call the auth method with a good and a bad token

```
export T1=(token from above)

curl -ki -H"Authorization: Bearer $T1" http://localhost:59842/auth
HTTP/1.1 200 OK

bnevis@ubu2204-edgex:~/bnevis-edgex-go$ curl -ki -H"Authorization: Bearer x$T1" http://localhost:59842/auth
HTTP/1.1 401 Unauthorized
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->