### PR TITLE
refactor(snap): Remove explicit config provider addresses

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -284,7 +284,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/core-metadata --configDir $SNAP_DATA/config/core-metadata/res --configProvider consul.http://localhost:8500 --registry
+    command: bin/core-metadata --configDir $SNAP_DATA/config/core-metadata/res --configProvider --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -302,7 +302,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/core-command --configDir $SNAP_DATA/config/core-command/res --configProvider consul.http://localhost:8500 --registry
+    command: bin/core-command --configDir $SNAP_DATA/config/core-command/res --configProvider --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -319,7 +319,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/support-notifications --configDir $SNAP_DATA/config/support-notifications/res --configProvider consul.http://localhost:8500 --registry
+    command: bin/support-notifications --configDir $SNAP_DATA/config/support-notifications/res --configProvider --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -336,7 +336,7 @@ apps:
       # This generates the consul role for this service before the service starts
       - security-consul-bootstrapper
       - security-proxy-setup
-    command: bin/support-scheduler --configDir $SNAP_DATA/config/support-scheduler/res --configProvider consul.http://localhost:8500 --registry
+    command: bin/support-scheduler --configDir $SNAP_DATA/config/support-scheduler/res --configProvider --registry
     command-chain:
       - bin/service-config-overrides.sh
     environment:
@@ -358,7 +358,7 @@ apps:
   core-common-config-bootstrapper:
     after:
       - security-consul-bootstrapper
-    command: bin/core-common-config-bootstrapper --configDir $SNAP_DATA/config/core-common-config-bootstrapper/res --configFile configuration.yaml --configProvider consul.http://localhost:8500 --registry 
+    command: bin/core-common-config-bootstrapper --configDir $SNAP_DATA/config/core-common-config-bootstrapper/res --configFile configuration.yaml --configProvider --registry 
     environment:
       SECRETSTORE_TOKENFILE: $SNAP_DATA/secrets/core-common-config-bootstrapper/secrets-token.json
     daemon: oneshot


### PR DESCRIPTION
Given the current flags, the services (core-metadata, core-command, support-scheduler, support-notifications) don't get registered in Consul and don't produce any errors either.

There appear to be a bug either in the command processing of snapcraft or the EdgeX services. It appear that the `--registry` flag isn't processed at all. This PR is set as a refactoring type because the removed flag values are the defaults and theoretically equivalent. 

Another working solution was to change the order from `--configProvider consul.http://localhost:8500/ --registry` to `--registry --configProvider consul.http://localhost:8500/`.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Before:
```
$ snap logs -f edgexfoundry
...
2023-02-28T17:10:09+01:00 edgexfoundry.consul[210169]: 2023-02-28T17:10:09.531+0100 [INFO]  agent: Synced node info
2023-02-28T17:10:17+01:00 edgexfoundry.consul[210169]: 2023-02-28T17:10:17.581+0100 [INFO]  agent: Synced check: check=core-data
^C
```

After:
```
$ snap logs -f edgexfoundry
...
2023-02-28T17:13:34+01:00 edgexfoundry.consul[212989]: 2023-02-28T17:13:34.017+0100 [INFO]  agent: Synced check: check=support-scheduler
2023-02-28T17:13:35+01:00 edgexfoundry.consul[212989]: 2023-02-28T17:13:35.079+0100 [INFO]  agent: Synced check: check=core-data
2023-02-28T17:13:35+01:00 edgexfoundry.consul[212989]: 2023-02-28T17:13:35.698+0100 [INFO]  agent: Synced check: check=core-command
2023-02-28T17:13:38+01:00 edgexfoundry.consul[212989]: 2023-02-28T17:13:38.687+0100 [INFO]  agent: Synced check: check=support-notifications
2023-02-28T17:13:41+01:00 edgexfoundry.consul[212989]: 2023-02-28T17:13:41.448+0100 [INFO]  agent: Synced check: check=core-metadata
^C
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->