### PR TITLE
fix(command): enable regex for Commands via Messaging

### DIFF
--- a/internal/core/command/controller/messaging/utils.go
+++ b/internal/core/command/controller/messaging/utils.go
@@ -12,13 +12,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/responses"
+
 	"github.com/edgexfoundry/go-mod-messaging/v3/pkg/types"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/command/application"
@@ -48,7 +48,7 @@ func validateRequestTopic(prefix string, deviceName string, commandName string, 
 	}
 
 	// expected internal command request topic scheme: <prefix>/<device-service>/<device>/<command-name>/<method>
-	return deviceServiceResponse.Service.Name, common.BuildTopic(prefix, deviceServiceResponse.Service.Name, deviceName, url.QueryEscape(commandName), method), nil
+	return deviceServiceResponse.Service.Name, common.BuildTopic(prefix, deviceServiceResponse.Service.Name, deviceName, commandName, method), nil
 
 }
 


### PR DESCRIPTION
.(dot) is not escaped by QueryEscape function, check the
commandName is unescapable and use the original escaped
commandName provided by user to build MessageBus topic

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run `core-command` from this branch with `EXTERNALMQTT_ENABLED: "true"`
2. Send command request via external command request topic:
```shell
$ docker exec -it mqtt-broker /bin/sh
/ $ mosquitto_pub -t 'edgex/command/request/Simple-Device01/%2Erotation/get' -m "{\"ApiVersion\":\"v2\",\"ContentType\":\"application/json\",\"C
orrelationID\":\"14a42ea6-c394-41c3-8bcd-a29b9f5e6835\",\"RequestId\":\"e6e8a2f4-eb14-4649-9e2b-175247911369\",\"QueryParams\":{\"ds-regexcmd\":
\"true\"}}"
/ $
```
3. Subscribe to external command response topic and verify the response:
```shell
$ docker exec -it mqtt-broker /bin/sh
/ $ mosquitto_sub -v -t 'edgex/command/response/#'
edgex/command/response/Simple-Device01/%2Erotation/get {"ReceivedTopic":"edgex/response/device-simple/e6e8a2f4-eb14-4649-9e2b-175247911369","CorrelationID":"14a42ea6-c394-41c3-8bcd-a29b9f5e6835","ApiVersion":"v2","RequestID":"e6e8a2f4-eb14-4649-9e2b-175247911369","ErrorCode":0,"Payload":"eyJhcGlWZXJzaW9uIjoidjIiLCJyZXF1ZXN0SWQiOiJlNmU4YTJmNC1lYjE0LTQ2NDktOWUyYi0xNzUyNDc5MTEzNjkiLCJzdGF0dXNDb2RlIjoyMDAsImV2ZW50Ijp7ImFwaVZlcnNpb24iOiJ2MiIsImlkIjoiZjhkNGM2NTEtM2EyMS00NjYxLWE1YmYtYzYzMjNmZjA3ZGFmIiwiZGV2aWNlTmFtZSI6IlNpbXBsZS1EZXZpY2UwMSIsInByb2ZpbGVOYW1lIjoiU2ltcGxlLURldmljZSIsInNvdXJjZU5hbWUiOiIucm90YXRpb24iLCJvcmlnaW4iOjE2Nzg3OTQ0ODA0MDUzMzUwMDAsInJlYWRpbmdzIjpbeyJpZCI6IjY3OTQxMzE4LTcxOWUtNDczMi1iM2U1LWE5NzlkMTY3NzI3NiIsIm9yaWdpbiI6MTY3ODc5NDQ4MDQwNTMzNTAwMCwiZGV2aWNlTmFtZSI6IlNpbXBsZS1EZXZpY2UwMSIsInJlc291cmNlTmFtZSI6Ilhyb3RhdGlvbiIsInByb2ZpbGVOYW1lIjoiU2ltcGxlLURldmljZSIsInZhbHVlVHlwZSI6IkludDMyIiwidW5pdHMiOiJycG0iLCJ2YWx1ZSI6IjAifSx7ImlkIjoiZGFmZDhiMDYtM2UwZC00YjA4LWFmNDQtY2RkNDk4NTk0OGQxIiwib3JpZ2luIjoxNjc4Nzk0NDgwNDA1MzM1MDAwLCJkZXZpY2VOYW1lIjoiU2ltcGxlLURldmljZTAxIiwicmVzb3VyY2VOYW1lIjoiWXJvdGF0aW9uIiwicHJvZmlsZU5hbWUiOiJTaW1wbGUtRGV2aWNlIiwidmFsdWVUeXBlIjoiSW50MzIiLCJ1bml0cyI6InJwbSIsInZhbHVlIjoiMCJ9LHsiaWQiOiJkN2RjNTliOS1mNDI1LTRlYWYtOTk3ZS05NDM1ODVlOTk5M2UiLCJvcmlnaW4iOjE2Nzg3OTQ0ODA0MDUzMzUwMDAsImRldmljZU5hbWUiOiJTaW1wbGUtRGV2aWNlMDEiLCJyZXNvdXJjZU5hbWUiOiJacm90YXRpb24iLCJwcm9maWxlTmFtZSI6IlNpbXBsZS1EZXZpY2UiLCJ2YWx1ZVR5cGUiOiJJbnQzMiIsInVuaXRzIjoicnBtIiwidmFsdWUiOiIwIn1dfX0=","ContentType":"application/json","QueryParams":{}}
```
4. Check `core-command` logs has something similiar:
```shell
level=DEBUG ts=2023-03-14T11:48:00.39891988Z app=core-command source=external.go:92 msg="Received command request from external message broker on topic 'edgex/command/request/Simple-Device01/%2Erotation/get' with 195 bytes"
level=DEBUG ts=2023-03-14T11:48:00.403143148Z app=core-command source=external.go:150 msg="Sending Command request to internal MessageBus. Topic: edgex/device/command/request/device-simple/Simple-Device01/%2Erotation/get, Request-id: e6e8a2f4-eb14-4649-9e2b-175247911369 Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835"
level=DEBUG ts=2023-03-14T11:48:00.403197709Z app=core-command source=external.go:151 msg="Expecting response on topic: edgex/response/device-simple/e6e8a2f4-eb14-4649-9e2b-175247911369"
level=DEBUG ts=2023-03-14T11:48:00.407020493Z app=core-command source=external.go:164 msg="Command response received from internal MessageBus. Topic: edgex/response/device-simple/e6e8a2f4-eb14-4649-9e2b-175247911369, Request-id: e6e8a2f4-eb14-4649-9e2b-175247911369 Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835"
level=DEBUG ts=2023-03-14T11:48:00.407246695Z app=core-command source=external.go:180 msg="Published response message to external message broker on topic 'edgex/command/response/Simple-Device01/%2Erotation/get' with 1506 bytes"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->