### PR TITLE
fix(security): Restore ADD_PROXY_ROUTE functionality for docker NGINX

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/nginx_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/nginx_wait_install.sh
@@ -32,6 +32,11 @@ echo "$(date) Executing waitFor with waiting on tcp://${STAGEGATE_BOOTSTRAPPER_H
 
 echo "$(date) Generating default config ..."
 
+# Ensure this file exists since reference below; proxy-setup will regenerate it
+touch /etc/nginx/templates/generated-routes.inc.template
+
+# This file can be modified by the user; deleted when docker volumes are pruned;
+# but preserved across start/up and stop/down actions
 if test -f /etc/nginx/templates/edgex-custom-rewrites.inc.template; then
   echo "Using existing custom-rewrites."
 else
@@ -197,6 +202,7 @@ server {
       proxy_set_header   Host $host;
     }
 
+    include /etc/nginx/conf.d/generated-routes.inc;
     include /etc/nginx/conf.d/edgex-custom-rewrites.inc;
 
 }


### PR DESCRIPTION
This functionality was dropped in the Kong to NGINX change, and is being restored in order to make it easy to permanently add a custom route that survives "make clean" operations in Docker.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A already documented as POR


## Testing Instructions
As per existing documentation, use ADD_PROXY_ROUTE on proxy-setup to add custom routes.
Verify changes to /etc/nginx/conf.d/custom-routes.inc and /etc/nginx/templates/custom-routes.inc.template

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->