### PR TITLE
fix: Add authentication to support-scheduler actions

### DIFF
--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -26,6 +26,8 @@ Name = "scheduler"
     Path = "/api/v2/event/age/604800000000000" # Remove events older than 7 days
     Interval = "midnight"
     AdminState = "UNLOCKED"
+    # AuthMethod = JWT degrades to no auth in security-disabled EdgeX
+    AuthMethod = "JWT"
 
 [MessageBus]
   [MessageBus.Optional]

--- a/internal/support/notifications/application/channel/sender.go
+++ b/internal/support/notifications/application/channel/sender.go
@@ -39,7 +39,9 @@ func (sender *RESTSender) Send(notification models.Notification, address models.
 	if !ok {
 		return "", errors.NewCommonEdgeX(errors.KindContractInvalid, "fail to cast Address to RESTAddress", nil)
 	}
-	return utils.SendRequestWithRESTAddress(lc, notification.Content, notification.ContentType, restAddress)
+	// NOTE: Not currently passing an AuthenticationInjector here;
+	// no current notifications are calling EdgeX services
+	return utils.SendRequestWithRESTAddress(lc, notification.Content, notification.ContentType, restAddress, nil)
 }
 
 // EmailSender is the implementation of the interfaces.ChannelSender, which is used to send the notifications via email

--- a/internal/support/scheduler/application/intervalaction.go
+++ b/internal/support/scheduler/application/intervalaction.go
@@ -164,6 +164,7 @@ func LoadIntervalActionToSchedulerManager(dic *di.Container) errors.EdgeX {
 			Content:     configuration.IntervalActions[i].Content,
 			ContentType: configuration.IntervalActions[i].ContentType,
 			AdminState:  configuration.IntervalActions[i].AdminState,
+			AuthMethod:  configuration.IntervalActions[i].AuthMethod,
 		}
 		validateErr := common.Validate(dto)
 		if validateErr != nil {

--- a/internal/support/scheduler/application/scheduler/manager.go
+++ b/internal/support/scheduler/application/scheduler/manager.go
@@ -143,7 +143,6 @@ func (m *manager) executeAction(action models.IntervalAction) errors.EdgeX {
 		}
 
 		var jwtSecretProvider clientInterfaces.AuthenticationInjector
-		// Awaiting change to go-mod-core-contracts
 		if action.AuthMethod == config.AuthMethodJWT {
 			jwtSecretProvider = secret.NewJWTSecretProvider(m.secretProvider)
 		} else {

--- a/internal/support/scheduler/application/scheduler/manager_test.go
+++ b/internal/support/scheduler/application/scheduler/manager_test.go
@@ -25,6 +25,6 @@ func TestNewManager(t *testing.T) {
 		IntervalActions:      nil,
 		ScheduleIntervalTime: 500,
 	}
-	manager := NewManager(lc, config)
+	manager := NewManager(lc, config, nil)
 	require.NotNil(t, manager)
 }

--- a/internal/support/scheduler/config/config.go
+++ b/internal/support/scheduler/config/config.go
@@ -82,7 +82,14 @@ type IntervalActionInfo struct {
 	ContentType string
 	// Administrative state (LOCKED/UNLOCKED)
 	AdminState string
+	// AuthMethod indicates how to authenticate the outbound URL -- "none" (default) or "jwt"
+	AuthMethod string
 }
+
+const (
+	AuthMethodNone = "NONE"
+	AuthMethodJWT  = "JWT"
+)
 
 // URI constructs a URI from the protocol, host and port and returns that as a string.
 func (e IntervalActionInfo) URL() string {

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -49,10 +49,11 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 	LoadRestRoutes(b.router, dic, b.serviceName)
 
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	secretProvider := bootstrapContainer.SecretProviderFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 
 	// V2 Scheduler
-	schedulerManager := scheduler.NewManager(lc, configuration)
+	schedulerManager := scheduler.NewManager(lc, configuration, secretProvider)
 	dic.Update(di.ServiceConstructorMap{
 		container.SchedulerManagerName: func(get di.Get) interface{} {
 			return schedulerManager


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
The easiest way to test this change is to modify support-scheduler configuration.toml and set the Midnight interval to a period of "5m" (five minutes).  Then make docker (make clean_docker_base docker_base docker), then from edgex-compose/compose-builder run make run dev.   Then do docker logs -f edgex-core-data and wait for the following log message to appear:

```
level=INFO ts=2023-03-08T00:45:00.109776605Z app=core-data source=auth_middleware.go:50 msg="Authorizing incoming call to '/api/v2/event/age/604800000000000' via JWT (Authorization len=467)"
level=INFO ts=2023-03-08T00:45:00.124832092Z app=core-data source=auth_middleware.go:64 msg="Request to '/api/v2/event/age/604800000000000' authorized"
```
If the incoming JWT length == 0, then this fix didn't catch and try again.  Otherwise, the request will be authorized after this fix.


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->