### PR TITLE
fix: Corrected NGINX forward rules for both rules engines

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/nginx_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/nginx_wait_install.sh
@@ -152,12 +152,22 @@ server {
       auth_request_set   $auth_status $upstream_status;
     }
 
-
     set $upstream_app_rules_engine edgex-app-rules-engine;
+    location /app-rules-engine {
+      rewrite            /app-rules-engine/(.*) /$1 break;
+      resolver           127.0.0.11 valid=30s;
+      proxy_pass         http://$upstream_app_rules_engine:59701;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+      auth_request       /auth;
+      auth_request_set   $auth_status $upstream_status;
+    }
+
+    set $upstream_kuiper edgex-kuiper;
     location /rules-engine {
       rewrite            /rules-engine/(.*) /$1 break;
       resolver           127.0.0.11 valid=30s;
-      proxy_pass         http://$upstream_app_rules_engine:59701;
+      proxy_pass         http://$upstream_kuiper:59720;
       proxy_redirect     off;
       proxy_set_header   Host $host;
       auth_request       /auth;

--- a/snap/local/runtime-helpers/config/nginx/edgex-default.conf
+++ b/snap/local/runtime-helpers/config/nginx/edgex-default.conf
@@ -77,10 +77,18 @@ server {
       auth_request_set   $auth_status $upstream_status;
     }
 
+    location /app-rules-engine {
+      rewrite            /app-rules-engine/(.*) /$1 break;
+      proxy_pass         http://127.0.0.1:59701;
+      proxy_redirect     off;
+      proxy_set_header   Host $host;
+      auth_request       /auth;
+      auth_request_set   $auth_status $upstream_status;
+    }
 
     location /rules-engine {
       rewrite            /rules-engine/(.*) /$1 break;
-      proxy_pass         http://127.0.0.1:59701;
+      proxy_pass         http://127.0.0.1:59720;
       proxy_redirect     off;
       proxy_set_header   Host $host;
       auth_request       /auth;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
- https://localhost:8443/app-rules-engine/api/v2/ping should get the normal EdgeX ping response
- https://localhost:8443/rules-engine/rules should get a empty Javascript array

Previously, both of these urls returned 404's

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->