### PR TITLE
feat: Consume watch for common Writable config changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/edgex-go
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.41
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.44
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.27
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.41 h1:eBWdDMOvYHiHtG/ne3caTfVawk+j4BzkU/UW6XOMqBk=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.41/go.mod h1:qiG4HABtB+mnFBOby/ZUpIWcQD0TZa8jIG7p/jeVuzc=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.44 h1:bzROMV3XZzFB5uBFTeQRuqBQyHE8DJjHSl3UWoqacds=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.44/go.mod h1:qiG4HABtB+mnFBOby/ZUpIWcQD0TZa8jIG7p/jeVuzc=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7 h1:pOH2GLDg1KB4EmAzo6IEvl4NEVFAw3ywxPUMa5Wi1Vw=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7/go.mod h1:ZZbOu7K0/P8B1VKhZygVujLQyhvWuPe0E2vC/k2yscw=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.27 h1:lKM/NwRBL/pddoSnlXbFIlpgu+XozWbqz608EeB7S94=

--- a/internal/core/command/config/config.go
+++ b/internal/core/command/config/config.go
@@ -54,6 +54,11 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return &WritableInfo{}
 }
 
+// GetWritablePtr returns pointer to the writable section
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return &c.Writable
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // which is then used to overwrite the service's existing configuration's WritableInfo struct.
 func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {

--- a/internal/core/data/config/config.go
+++ b/internal/core/data/config/config.go
@@ -52,6 +52,11 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return &WritableInfo{}
 }
 
+// GetWritablePtr returns pointer to the writable section
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return &c.Writable
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // which is then used to overwrite the service's existing configuration's WritableInfo struct.
 func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {

--- a/internal/core/metadata/config/config.go
+++ b/internal/core/metadata/config/config.go
@@ -66,6 +66,11 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return &WritableInfo{}
 }
 
+// GetWritablePtr returns pointer to the writable section
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return &c.Writable
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // which is then used to overwrite the service's existing configuration's WritableInfo struct.
 func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {

--- a/internal/security/bootstrapper/config/config.go
+++ b/internal/security/bootstrapper/config/config.go
@@ -38,6 +38,12 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return nil
 }
 
+// GetWritablePtr returns pointer to the writable section
+// Not needed for this service, so return nil
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return nil
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // which is then used to overwrite the service's existing configuration's WritableInfo struct.
 func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {

--- a/internal/security/bootstrapper/mosquitto/config/config.go
+++ b/internal/security/bootstrapper/mosquitto/config/config.go
@@ -46,6 +46,12 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return nil
 }
 
+// GetWritablePtr returns pointer to the writable section
+// Not needed for this service, so return nil
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return nil
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific
 // WritableInfo struct which is then used to overwrite the service's existing configuration's
 // WritableInfo struct.

--- a/internal/security/bootstrapper/redis/config/config.go
+++ b/internal/security/bootstrapper/redis/config/config.go
@@ -48,6 +48,12 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return nil
 }
 
+// GetWritablePtr returns pointer to the writable section
+// Not needed for this service, so return nil
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return nil
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific
 // WritableInfo struct which is then used to overwrite the service's existing configuration's
 // WritableInfo struct.

--- a/internal/security/common/tokenpolicy_test.go
+++ b/internal/security/common/tokenpolicy_test.go
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2019-2023 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -12,7 +11,6 @@
 // the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//
 package common
 
 import (

--- a/internal/security/fileprovider/config/config.go
+++ b/internal/security/fileprovider/config/config.go
@@ -56,6 +56,12 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return nil
 }
 
+// GetWritablePtr returns pointer to the writable section
+// Not needed for this service, so return nil
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return nil
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // Not needed for this service, so return false
 func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {

--- a/internal/security/fileprovider/util_test.go
+++ b/internal/security/fileprovider/util_test.go
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -12,7 +11,6 @@
 // the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-//
 package fileprovider
 
 import (

--- a/internal/security/proxyauth/config/config.go
+++ b/internal/security/proxyauth/config/config.go
@@ -48,6 +48,11 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return &WritableInfo{}
 }
 
+// GetWritablePtr returns pointer to the writable section
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return &c.Writable
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // which is then used to overwrite the service's existing configuration's WritableInfo struct.
 func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {

--- a/internal/security/secretstore/config/config.go
+++ b/internal/security/secretstore/config/config.go
@@ -86,6 +86,12 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return nil
 }
 
+// GetWritablePtr returns pointer to the writable section
+// Not needed for this service, so return nil
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return nil
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // Not needed for this service, so always return false
 func (c *ConfigurationStruct) UpdateWritableFromRaw(_ interface{}) bool {

--- a/internal/security/spiffetokenprovider/config/config.go
+++ b/internal/security/spiffetokenprovider/config/config.go
@@ -61,6 +61,11 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return &WritableInfo{}
 }
 
+// GetWritablePtr returns pointer to the writable section
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return &c.Writable
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // which is then used to overwrite the service's existing configuration's WritableInfo struct.
 func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {

--- a/internal/support/notifications/config/config.go
+++ b/internal/support/notifications/config/config.go
@@ -81,6 +81,11 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return &WritableInfo{}
 }
 
+// GetWritablePtr returns pointer to the writable section
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return &c.Writable
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // which is then used to overwrite the service's existing configuration's WritableInfo struct.
 func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {

--- a/internal/support/scheduler/config/config.go
+++ b/internal/support/scheduler/config/config.go
@@ -112,6 +112,11 @@ func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
 	return &WritableInfo{}
 }
 
+// GetWritablePtr returns pointer to the writable section
+func (c *ConfigurationStruct) GetWritablePtr() any {
+	return &c.Writable
+}
+
 // UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
 // which is then used to overwrite the service's existing configuration's WritableInfo struct.
 func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
Run `make docker` using this branch
Run non-secure EdgeX stack using compose builder `make run no-secty dev`
Verify the logs for all Core/Support services have the following:
```
"listening for private config changes"
"listening for all services common config changes"
```
In Consul change the common config all-service Writable/Telemetry/Interval to `15s`
Verify the logs for all Core/Support service should the Telemetry Interval has changed
```
"Writeable configuration has been updated from the Configuration Provider"
"Telemetry interval has been updated. Processing new value..."
"Metrics Manager report interval changed to 15s"
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->