### PR TITLE
refactor(security)!: Change to camelCase args for secrets-config proxy tls

### DIFF
--- a/internal/security/config/bootstraphandler.go
+++ b/internal/security/config/bootstraphandler.go
@@ -67,7 +67,10 @@ func (b *Bootstrap) BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ sta
 	}
 
 	if err != nil {
-		lc.Error(err.Error())
+		if err != flag.ErrHelp {
+			// CLI help already printed by this point, no further output needed
+			lc.Error(err.Error())
+		}
 		b.exitStatusCode = interfaces.StatusCodeExitWithError
 		return false
 	}

--- a/internal/security/config/command/proxy/adduser/command.go
+++ b/internal/security/config/command/proxy/adduser/command.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/config/command/proxy/shared"
 	"github.com/edgexfoundry/edgex-go/internal/security/config/interfaces"
@@ -57,7 +56,7 @@ func NewCommand(
 
 	err := flagSet.Parse(args)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse command: %s: %w", strings.Join(args, " "), err)
+		return nil, err
 	}
 	if cmd.username == "" {
 		return nil, fmt.Errorf("%s vault adduser: argument --user is required", os.Args[0])

--- a/internal/security/config/command/proxy/deluser/command.go
+++ b/internal/security/config/command/proxy/deluser/command.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/config/command/proxy/shared"
 	"github.com/edgexfoundry/edgex-go/internal/security/config/interfaces"
@@ -51,7 +50,7 @@ func NewCommand(
 
 	err := flagSet.Parse(args)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse command: %s: %w", strings.Join(args, " "), err)
+		return nil, err
 	}
 	if cmd.username == "" {
 		return nil, fmt.Errorf("%s proxy deluser: argument --user is required", os.Args[0])

--- a/internal/security/config/command/proxy/tls/command.go
+++ b/internal/security/config/command/proxy/tls/command.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/security/config/interfaces"
@@ -62,21 +61,21 @@ func NewCommand(
 	flagSet := flag.NewFlagSet(CommandName, flag.ContinueOnError)
 	flagSet.StringVar(&dummy, "configDir", "", "") // handled by bootstrap; duplicated here to prevent arg parsing errors
 
-	flagSet.StringVar(&cmd.certificatePath, "incert", "", "Path to PEM-encoded leaf certificate")
-	flagSet.StringVar(&cmd.privateKeyPath, "inkey", "", "Path to PEM-encoded private key")
-	flagSet.StringVar(&cmd.targetFolder, "targetfolder", DefaultNginxTlsFolder, "Path to TLS key file")
-	flagSet.StringVar(&cmd.certFilename, "certfilename", DefaultNginxCertFile, "Filename of certificate file (on target)")
-	flagSet.StringVar(&cmd.keyFilename, "keyfilename", DefaultNginxKeyFile, "Filename of private key file (on target")
+	flagSet.StringVar(&cmd.certificatePath, "inCert", "", "Path to PEM-encoded leaf certificate")
+	flagSet.StringVar(&cmd.privateKeyPath, "inKey", "", "Path to PEM-encoded private key")
+	flagSet.StringVar(&cmd.targetFolder, "targetFolder", DefaultNginxTlsFolder, "Path to TLS key file")
+	flagSet.StringVar(&cmd.certFilename, "certFilename", DefaultNginxCertFile, "Filename of certificate file (on target)")
+	flagSet.StringVar(&cmd.keyFilename, "keyFilename", DefaultNginxKeyFile, "Filename of private key file (on target")
 
 	err := flagSet.Parse(args)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse command: %s: %w", strings.Join(args, " "), err)
+		return nil, err
 	}
 	if cmd.certificatePath == "" {
-		return nil, fmt.Errorf("%s proxy tls: argument --incert is required", os.Args[0])
+		return nil, fmt.Errorf("%s proxy tls: argument --inCert is required", os.Args[0])
 	}
 	if cmd.privateKeyPath == "" {
-		return nil, fmt.Errorf("%s proxy tls: argument --inkey is required", os.Args[0])
+		return nil, fmt.Errorf("%s proxy tls: argument --inKey is required", os.Args[0])
 	}
 
 	return &cmd, nil

--- a/internal/security/config/command/proxy/tls/command_test.go
+++ b/internal/security/config/command/proxy/tls/command_test.go
@@ -27,13 +27,13 @@ func TestTLSBagArguments(t *testing.T) {
 	badArgTestcases := [][]string{
 		{},                       // missing arg --in
 		{"-badarg"},              // invalid arg
-		{"--incert", "somefile"}, // missing --inkey
-		{"--inkey", "keyfile"},   // missing --incert
-		{"--inkey"},              // missing filename
-		{"--incert"},             // missing filename
-		{"--targetfolder"},       // missing filename
-		{"--certfilename"},       // missing filename
-		{"--keyfilename"},        // missing filename
+		{"--inCert", "somefile"}, // missing --inKey
+		{"--inKey", "keyfile"},   // missing --inCert
+		{"--inKey"},              // missing filename
+		{"--inCert"},             // missing filename
+		{"--targetFolder"},       // missing filename
+		{"--certFilename"},       // missing filename
+		{"--keyFilename"},        // missing filename
 	}
 
 	for _, args := range badArgTestcases {
@@ -51,9 +51,9 @@ func TestTLSErrorFileNotFound(t *testing.T) {
 	// Arrange
 	lc := logger.MockLogger{}
 	fileNotFoundTestcases := [][]string{
-		{"--incert", "missingcertificate", "--inkey", "missingprivatekey"},       // both files missing
-		{"--incert", "testdata/testCert.pem", "--inkey", "missingprivatekey"},    // key file missing
-		{"--incert", "missingcertificate", "--inkey", "testdata/testCert.prkey"}, // cert file missing
+		{"--inCert", "missingcertificate", "--inKey", "missingprivatekey"},       // both files missing
+		{"--inCert", "testdata/testCert.pem", "--inKey", "missingprivatekey"},    // key file missing
+		{"--inCert", "missingcertificate", "--inKey", "testdata/testCert.prkey"}, // cert file missing
 	}
 
 	for _, args := range fileNotFoundTestcases {
@@ -74,14 +74,14 @@ func TestInstallCertificate(t *testing.T) {
 	lc := logger.MockLogger{}
 	validCommandLines := [][]string{
 		{"new.crt", "new.key", "", "", "/etc/ssl/nginx/nginx.crt", "/etc/ssl/nginx/nginx.key"},
-		{"new.crt", "new.key", "--targetfolder", "/foofolder", "/foofolder/nginx.crt", "/foofolder/nginx.key"},
-		{"new.crt", "new.key", "--certfilename", "foo.crt", "/etc/ssl/nginx/foo.crt", "/etc/ssl/nginx/nginx.key"},
-		{"new.crt", "new.key", "--keyfilename", "foo.key", "/etc/ssl/nginx/nginx.crt", "/etc/ssl/nginx/foo.key"},
+		{"new.crt", "new.key", "--targetFolder", "/foofolder", "/foofolder/nginx.crt", "/foofolder/nginx.key"},
+		{"new.crt", "new.key", "--certFilename", "foo.crt", "/etc/ssl/nginx/foo.crt", "/etc/ssl/nginx/nginx.key"},
+		{"new.crt", "new.key", "--keyFilename", "foo.key", "/etc/ssl/nginx/nginx.crt", "/etc/ssl/nginx/foo.key"},
 	}
 
 	for _, args := range validCommandLines {
 		// Arrange
-		command, err := NewCommand(lc, []string{"--incert", args[0], "--inkey", args[1], args[2], args[3]})
+		command, err := NewCommand(lc, []string{"--inCert", args[0], "--inKey", args[1], args[2], args[3]})
 		require.NoError(t, err)
 		mockOpener := &mocks.FileIoPerformer{}
 		command.fileOpener = mockOpener


### PR DESCRIPTION
BREAKING CHANGE: To be consistent with other secrets-config sub-commands, the tls command will now accept camelCase command line arguments.  Also fixes issue with -h option resulting in an error in addition to printing help.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
For help, use secrets-config (command) (subcommand) -h
tls subcommand works as usual, with exception of breaking change to argument casing.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->