### PR TITLE
fix(security): Add back missing configuration to seed message-bus secrets

### DIFF
--- a/cmd/security-secretstore-setup/res/configuration.toml
+++ b/cmd/security-secretstore-setup/res/configuration.toml
@@ -76,3 +76,21 @@ ConsulSecretsAdminTokenPath = "/tmp/edgex/secrets/edgex-consul/admin/token.json"
   [Databases.scheduler]
   Service = "support-scheduler"
   Username = "support-scheduler"
+
+
+[SecureMessageBus]
+Type = "none" # blank or none if MessageBus not secured, "redis" if secured. "mqtt" is TBD
+KuiperConfigPath = "/tmp/kuiper/edgex.yaml"
+KuiperConnectionsPath = "/tmp/kuiper-connections/connection.yaml"
+  [SecureMessageBus.Services.command]
+  Service = "core-command"
+  [SecureMessageBus.Services.metadata]
+  Service = "core-metadata"
+  [SecureMessageBus.Services.coredata]
+  Service = "core-data"
+  [SecureMessageBus.Services.rulesengine]
+  Service = "app-rules-engine"
+  [SecureMessageBus.Services.notifications]
+  Service = "support-notifications"
+  [SecureMessageBus.Services.scheduler]
+  Service = "support-scheduler"


### PR DESCRIPTION
When starting EdgeX with the mqtt-bus option, security-secretstore-setup needs information as to which services need the message-bus credential seeded.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
In edgex-compose, start services with `make run dev ds-mqtt mqtt-bus` option.  Without this fix, most of the services will fail.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->