### PR TITLE
feat: Add env override capability for common configuration

### DIFF
--- a/cmd/core-command/res/configuration.toml
+++ b/cmd/core-command/res/configuration.toml
@@ -11,6 +11,7 @@
       clientkey = ""
 
 [Service]
+Host = "localhost"
 Port = 59882
 StartupMsg = "This is the Core Command Microservice"
 

--- a/cmd/core-common-config-bootstrapper/res/configuration.yaml
+++ b/cmd/core-common-config-bootstrapper/res/configuration.yaml
@@ -19,7 +19,7 @@ all-services:
         SecuritySecretsStored: false
         SecurityConsulTokensRequested: false
         SecurityConsulTokenDuration: false
-      Tags: # Contains the service level tags to be attached to all the service's metrics
+#     Tags: # Contains the service level tags to be attached to all the service's metrics
       #  Gateway: "my-iot-gateway" # Tag must be added here or via Consul Env Override can only change existing value, not added new ones.
       
   Service:

--- a/cmd/core-data/res/configuration.toml
+++ b/cmd/core-data/res/configuration.toml
@@ -11,6 +11,7 @@ PersistData = true
 #    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only change existing value, not added new ones.
 
 [Service]
+Host = "localhost"
 Port = 59880
 StartupMsg = "This is the Core Data Microservice"
 

--- a/cmd/core-metadata/res/configuration.toml
+++ b/cmd/core-metadata/res/configuration.toml
@@ -7,6 +7,7 @@ LogLevel = "INFO"
   Validation = false
 
 [Service]
+Host = "localhost"
 Port = 59881
 StartupMsg = "This is the EdgeX Core Metadata Microservice"
 

--- a/cmd/security-proxy-auth/res/configuration.toml
+++ b/cmd/security-proxy-auth/res/configuration.toml
@@ -2,5 +2,6 @@
 LogLevel = "INFO"
 
 [Service]
+Host = "localhost"
 Port = 59842
 StartupMsg = "This is the proxy authentication microservice"

--- a/cmd/security-spiffe-token-provider/res/configuration.toml
+++ b/cmd/security-spiffe-token-provider/res/configuration.toml
@@ -2,6 +2,7 @@
 LogLevel = "DEBUG"
 
 [Service]
+Host = "localhost"
 Port = 59841
 StartupMsg = "This is the SPIFFE token provider microservice"
 

--- a/cmd/support-notifications/res/configuration.toml
+++ b/cmd/support-notifications/res/configuration.toml
@@ -10,6 +10,7 @@ ResendInterval = "5s"
       password = ""
 
 [Service]
+Host = "localhost"
 Port = 59860
 StartupMsg = "This is the Support Notifications Microservice"
 

--- a/cmd/support-scheduler/res/configuration.toml
+++ b/cmd/support-scheduler/res/configuration.toml
@@ -4,6 +4,7 @@ ScheduleIntervalTime = 500
 LogLevel = "INFO"
 
 [Service]
+Host = "localhost"
 Port = 59861
 StartupMsg = "This is the Support Scheduler Microservice"
 

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,11 @@ module github.com/edgexfoundry/edgex-go
 
 go 1.20
 
-replace github.com/edgexfoundry/go-mod-bootstrap/v3 => ../MODS/go-mod-bootstrap
-
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.46
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.50
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.27
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.30
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.18
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.9
 	github.com/fxamacker/cbor/v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/edgexfoundry/edgex-go
 
 go 1.20
 
+replace github.com/edgexfoundry/go-mod-bootstrap/v3 => ../MODS/go-mod-bootstrap
+
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.46
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.27
-	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16
+	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.18
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.9
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/gomodule/redigo v1.8.9

--- a/go.sum
+++ b/go.sum
@@ -25,14 +25,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.46 h1:A15UzeUgFfQM+R27LvXeoUJAbVFgY41NEhMcDF8XOQU=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.46/go.mod h1:nweayvPW3G+nBZwwdRB6lWq3u0e1rWGvReEWEjDQjFE=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7 h1:pOH2GLDg1KB4EmAzo6IEvl4NEVFAw3ywxPUMa5Wi1Vw=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7/go.mod h1:ZZbOu7K0/P8B1VKhZygVujLQyhvWuPe0E2vC/k2yscw=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.27 h1:lKM/NwRBL/pddoSnlXbFIlpgu+XozWbqz608EeB7S94=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.27/go.mod h1:QBzXOAoyLzBm5k9CshgH9CR9nWMNXxZjknBFMnGJN/A=
-github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16 h1:JdZiqZ6CAboZ3+GuWZLyXc42y8HfsH1CmsIKNPY+0PY=
-github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16/go.mod h1:3q+Ys51HwpR9/kOv6sT7+EwAANgOfFWi509sEP5iPEo=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.18 h1:8empqTOIVhKzebC3gnP9C0LGQvwXtHLJF8x8AqlTGLM=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.18/go.mod h1:Sf7lvKtICWRy0Tmvw+bV6L1wdXKRaTSmKmJKw4Caxe4=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.5 h1:FUUfsQUKHJqSwOXEj0j/qAn+uoWzM8nV7IOapGf7D80=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.5/go.mod h1:MroNeX/i6ymRu8cyuRB4U5zdBusyUpFhUphko6pInTQ=
 github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.9 h1:12UHZG/Nl+dfFOaNnC87ANP/FQ3rOXe0Z6NVlYdmYgU=

--- a/go.sum
+++ b/go.sum
@@ -25,10 +25,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.50 h1:iP/2tKszlM6Ud1El3kY9wdB7lnsvuIHWquYNLDXwvQw=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.50/go.mod h1:oz5+G3SImWqKvRIcKrh/ErXae9nNapmDNnlXsdykpGg=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7 h1:pOH2GLDg1KB4EmAzo6IEvl4NEVFAw3ywxPUMa5Wi1Vw=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7/go.mod h1:ZZbOu7K0/P8B1VKhZygVujLQyhvWuPe0E2vC/k2yscw=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.27 h1:lKM/NwRBL/pddoSnlXbFIlpgu+XozWbqz608EeB7S94=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.27/go.mod h1:QBzXOAoyLzBm5k9CshgH9CR9nWMNXxZjknBFMnGJN/A=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.30 h1:diarfNbfUeSYD7Hq8pOqHzxMtIbaPO6W8nWq34W8X6g=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.30/go.mod h1:SYoD+tmUP/zwWuuIySmsQSjPx6MHP+2w9FsLgm0IR7A=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.18 h1:8empqTOIVhKzebC3gnP9C0LGQvwXtHLJF8x8AqlTGLM=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.18/go.mod h1:Sf7lvKtICWRy0Tmvw+bV6L1wdXKRaTSmKmJKw4Caxe4=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.5 h1:FUUfsQUKHJqSwOXEj0j/qAn+uoWzM8nV7IOapGf7D80=

--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -118,10 +118,10 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 		os.Exit(1)
 	}
 
-	lc.Infof("Common configuration exists in Config Provider is %v and overwrite flag is %v", hasConfig, f.OverwriteConfig())
-
 	// load the yaml file and push it using the config client
 	if !hasConfig || f.OverwriteConfig() {
+		lc.Info("Pushing common configuration. It doesn't exists or overwrite flag is set")
+
 		yamlFile := config.GetConfigLocation(lc, f)
 		err = pushConfiguration(lc, yamlFile, configClient)
 		if err != nil {
@@ -129,7 +129,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 			os.Exit(1)
 		}
 	} else {
-		lc.Infof("Skipped pushing common configuration")
+		lc.Info("Skipped pushing common configuration. It already exists and overwrite flag not set")
 	}
 
 	lc.Info("Core Common Config exiting")


### PR DESCRIPTION
closes #4448

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) 
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  TBD

## Testing Instructions
Run non-secure EdgeX stack
Build core-common-config from this branch
Set the following
- export ALL_SERVICES_WRITABLE_TELEMETRY_INTERVAL=50s
- export APP_SERVICES_WRITABLE_TELEMETRY_METRICS_MESSAGESRECEIVED=true
- export DEVICE_SERVICES_WRITABLE_TELEMETRY_METRICS_EVENTSSENT=true
 
run common config from command line
- `./core-common-config-bootstrapper -cp -cf configuration.yaml -o`

verify consul has the appropriate overridden values
verify logs contain the following:
```
"Variables override of 'app-services/Writable/Telemetry/Metrics/MessagesReceived' by environment variable: APP_SERVICES_WRITABLE_TELEMETRY_METRICS_MESSAGESRECEIVED=true"
"Variables override of 'all-services/Writable/Telemetry/Interval' by environment variable: ALL_SERVICES_WRITABLE_TELEMETRY_INTERVAL=50s"
"Variables override of 'device-services/Writable/Telemetry/Metrics/EventsSent' by environment variable: DEVICE_SERVICES_WRITABLE_TELEMETRY_METRICS_EVENTSSENT=false"
"Common configuration loaded from file with 3 overrides applied"
"Common configuration has been pushed to into Configuration Provider with overrides applied"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->