### PR TITLE
fix: Remove forced chown of ngnix tls for snap compatibility

### DIFF
--- a/internal/security/config/command/proxy/tls/command.go
+++ b/internal/security/config/command/proxy/tls/command.go
@@ -30,12 +30,6 @@ const (
 	DefaultNginxKeyFile   = "nginx.key"
 )
 
-// permissionable is the subset of the File API that allows setting file permissions
-type permissionable interface {
-	Chown(uid int, gid int) error
-	Chmod(mode os.FileMode) error
-}
-
 type cmd struct {
 	loggingClient   logger.LoggingClient
 	client          internal.HttpCaller
@@ -115,11 +109,6 @@ func (c *cmd) copyFile(destPath string, srcPath string, perm os.FileMode, uid in
 	destCloser, _ := dest.(io.Closer)
 	if destCloser != nil {
 		defer func() { _ = destCloser.Close() }()
-	}
-
-	permissionable := destCloser.(permissionable)
-	if err := permissionable.Chown(uid, gid); err != nil {
-		return err
 	}
 
 	_, err = io.Copy(dest, src)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
See https://docs.edgexfoundry.org/3.0/security/Ch-APIGateway/#using-a-bring-your-own-external-tls-certificate-for-api-gateway

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->