### PR TITLE
feat!: Switch UOM API to YAML format

### DIFF
--- a/internal/core/metadata/controller/http/uom.go
+++ b/internal/core/metadata/controller/http/uom.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 IOTech Ltd
+// Copyright (C) 2022-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -38,8 +38,8 @@ func (uc *UnitOfMeasureController) UnitsOfMeasure(w http.ResponseWriter, r *http
 	utils.WriteHttpHeader(w, ctx, http.StatusOK)
 
 	switch r.Header.Get(common.Accept) {
-	case common.ContentTypeTOML:
-		pkg.EncodeAndWriteTomlResponse(u, w, lc)
+	case common.ContentTypeYAML:
+		pkg.EncodeAndWriteYamlResponse(u, w, lc)
 	default:
 		pkg.EncodeAndWriteResponse(response, w, lc)
 	}

--- a/internal/core/metadata/controller/http/uom_test.go
+++ b/internal/core/metadata/controller/http/uom_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 IOTech Ltd
+// Copyright (C) 2022-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,6 +7,7 @@ package http
 
 import (
 	"encoding/json"
+	"gopkg.in/yaml.v3"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,7 +15,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/responses"
-	"github.com/pelletier/go-toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -48,7 +48,7 @@ func TestUnitOfMeasureController_UnitsOfMeasure(t *testing.T) {
 		expectedResponse any
 	}{
 		{"valid - json response", common.ContentTypeJSON, responses.NewUnitsOfMeasureResponse("", "", http.StatusOK, testUoM)},
-		{"valid - toml response", common.ContentTypeTOML, testUoM},
+		{"valid - yaml response", common.ContentTypeYAML, testUoM},
 	}
 
 	for _, testCase := range tests {
@@ -76,10 +76,10 @@ func TestUnitOfMeasureController_UnitsOfMeasure(t *testing.T) {
 				assert.Empty(t, actualResponse.Message, "Message should be empty when it is successful")
 			} else {
 				actualResponse := uom.UnitsOfMeasureImpl{}
-				err = toml.Unmarshal(recorder.Body.Bytes(), &actualResponse)
+				err = yaml.Unmarshal(recorder.Body.Bytes(), &actualResponse)
 				require.NoError(t, err)
 
-				assert.Equal(t, actualResponse, testCase.expectedResponse, "TOML response not as expected")
+				assert.Equal(t, actualResponse, testCase.expectedResponse, "YAML response not as expected")
 			}
 		})
 	}

--- a/internal/pkg/encoding.go
+++ b/internal/pkg/encoding.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 VMware Inc.
+ * Copyright (C) 2023 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,11 +16,11 @@ package pkg
 
 import (
 	"encoding/json"
+	"gopkg.in/yaml.v3"
 	"net/http"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
-	"github.com/pelletier/go-toml"
 )
 
 func EncodeAndWriteResponse(i interface{}, w http.ResponseWriter, LoggingClient logger.LoggingClient) {
@@ -35,10 +36,10 @@ func EncodeAndWriteResponse(i interface{}, w http.ResponseWriter, LoggingClient 
 	}
 }
 
-func EncodeAndWriteTomlResponse(i interface{}, w http.ResponseWriter, lc logger.LoggingClient) {
-	w.Header().Set(common.ContentType, common.ContentTypeTOML)
+func EncodeAndWriteYamlResponse(i interface{}, w http.ResponseWriter, lc logger.LoggingClient) {
+	w.Header().Set(common.ContentType, common.ContentTypeYAML)
 
-	enc := toml.NewEncoder(w)
+	enc := yaml.NewEncoder(w)
 	err := enc.Encode(i)
 	// Problems encoding
 	if err != nil {

--- a/openapi/v3/core-metadata.yaml
+++ b/openapi/v3/core-metadata.yaml
@@ -3808,7 +3808,7 @@ paths:
               examples:
                 UnitsOfMeasureResponse:
                   $ref: '#/components/examples/UnitsOfMeasureResponseExample'
-            application/toml:
+            application/yaml:
               schema:
                 $ref: '#/components/schemas/UnitsOfMeasure'
         '500':


### PR DESCRIPTION
BREAKING CHANGE: It was decided in Minnesota planning that all TOML files would be change to be YAML format.

Close #4441

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- Run unit test
- Test the uom API
```
curl 'http://localhost:59881/api/v2/uom' --header 'Accept: application/x-yaml'
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->