### PR TITLE
fix(command): reset ReceivedTopic for External MQTT response

### DIFF
--- a/internal/core/command/controller/messaging/external.go
+++ b/internal/core/command/controller/messaging/external.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 IOTech Ltd
+// Copyright (C) 2022-2023 IOTech Ltd
 // Copyright (C) 2023 Intel Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -82,6 +82,7 @@ func commandQueryHandler(dic *di.Container) mqtt.MessageHandler {
 
 		qos := externalMQTTInfo.QoS
 		retain := externalMQTTInfo.Retain
+		responseEnvelope.ReceivedTopic = responseTopic
 		publishMessage(client, responseTopic, qos, retain, responseEnvelope, lc)
 	}
 }
@@ -163,6 +164,7 @@ func commandRequestHandler(requestTimeout time.Duration, dic *di.Container) mqtt
 
 		lc.Debugf("Command response received from internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", response.ReceivedTopic, response.RequestID, response.CorrelationID)
 
+		response.ReceivedTopic = externalResponseTopic
 		publishMessage(client, externalResponseTopic, qos, retain, *response, lc)
 	}
 }


### PR DESCRIPTION
closes #4505

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-docs/pull/1017

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run `core-command` from this branch with `EXTERNALMQTT_ENABLED: true` and external mqtt broker
2. Send command request via external mqtt request topic:
```shell
$ docker exec -it mqtt-broker /bin/sh
/ $ mosquitto_pub -t 'edgex/command/request/Random-Boolean-Device/Bool/get' -m "{\"ApiVersion\":\"v2\",\"ContentType\":\"application/json\",\"C
orrelationID\":\"14a42ea6-c394-41c3-8bcd-a29b9f5e6835\",\"RequestId\":\"e6e8a2f4-eb14-4649-9e2b-175247911369\"}"
```
3. Subscribe to external command response topic and verify the ReceivedTopic field in response payload:
```shell
$ docker exec -it mqtt-broker /bin/sh
/ $ mosquitto_sub -v -t 'edgex/command/response/#'
edgex/command/response/Random-Boolean-Device/Bool/get {"ReceivedTopic":"edgex/command/response/Random-Boolean-Device/Bool/get","CorrelationID":"14a42ea6-c394-41c3-8bcd-a29b9f5e6835","ApiVersion":"v2","RequestID":"e6e8a2f4-eb14-4649-9e2b-175247911369","ErrorCode":0,"Payload":"eyJhcGlWZXJzaW9uIjoidjIiLCJyZXF1ZXN0SWQiOiJlNmU4YTJmNC1lYjE0LTQ2NDktOWUyYi0xNzUyNDc5MTEzNjkiLCJzdGF0dXNDb2RlIjoyMDAsImV2ZW50Ijp7ImFwaVZlcnNpb24iOiJ2MiIsImlkIjoiYmY2NjM0MDAtNGJlNi00ODI3LTkxMDAtMjUwNjQzMTdmMzc2IiwiZGV2aWNlTmFtZSI6IlJhbmRvbS1Cb29sZWFuLURldmljZSIsInByb2ZpbGVOYW1lIjoiUmFuZG9tLUJvb2xlYW4tRGV2aWNlIiwic291cmNlTmFtZSI6IkJvb2wiLCJvcmlnaW4iOjE2ODExODA2MzgxNTY2Nzc1MjIsInJlYWRpbmdzIjpbeyJpZCI6IjA3NzMxNDEyLTkwODctNGQ2ZC1iZjRiLWE0YTM2YmU0M2ZiMiIsIm9yaWdpbiI6MTY4MTE4MDYzODE1NjY3NzUyMiwiZGV2aWNlTmFtZSI6IlJhbmRvbS1Cb29sZWFuLURldmljZSIsInJlc291cmNlTmFtZSI6IkJvb2xBcnJheSIsInByb2ZpbGVOYW1lIjoiUmFuZG9tLUJvb2xlYW4tRGV2aWNlIiwidmFsdWVUeXBlIjoiQm9vbEFycmF5IiwidmFsdWUiOiJbZmFsc2UsIHRydWUsIHRydWUsIHRydWUsIGZhbHNlXSJ9LHsiaWQiOiI1ZmI5ZjM2ZS1iYzUzLTRkOGEtOGRlZi0xMDgyZDkwMjhjMWUiLCJvcmlnaW4iOjE2ODExODA2MzgxNTY2Nzc1MjIsImRldmljZU5hbWUiOiJSYW5kb20tQm9vbGVhbi1EZXZpY2UiLCJyZXNvdXJjZU5hbWUiOiJCb29sIiwicHJvZmlsZU5hbWUiOiJSYW5kb20tQm9vbGVhbi1EZXZpY2UiLCJ2YWx1ZVR5cGUiOiJCb29sIiwidmFsdWUiOiJmYWxzZSJ9XX19","ContentType":"application/json","QueryParams":{}}

```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->