### PR TITLE
fix: remove unnecessary service name tweaks for support services

### DIFF
--- a/cmd/security-spire-config/seed_builtin_entries.sh
+++ b/cmd/security-spire-config/seed_builtin_entries.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 #
 #  ----------------------------------------------------------------------------------
-#  Copyright (c) 2022 Intel Corporation
+#  Copyright (c) 2022-2023 Intel Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -34,8 +34,6 @@ for dockerservice in security-spiffe-token-provider support-notifications suppor
     # Temporary workaround because service name in dockerfile is not consistent with service key.
     # TAF scripts depend on legacy docker-compose service name. Fix in EdgeX 3.0.
     service=`echo -n ${dockerservice} | sed -e 's/app-service-/app-/'`
-    # support- services have the opposite problem.  service key is right, service name in docker isn't
-    dockerservice=`echo -n ${dockerservice} | sed -e 's/support-//'`
     spire-server entry create -socketPath "${SPIFFE_SERVER_SOCKET}" -parentID "${local_agent_svid}" -dns "edgex-${service}" -spiffeID "${SPIFFE_EDGEX_SVID_BASE}/${service}" -selector "docker:label:com.docker.compose.service:${dockerservice}"
 done
 


### PR DESCRIPTION
  Since the docker service keys change in docker-compose file for support services (support-notifications from notifications and support-scheduler from scheduler),
  the tweaks in spire configure script for such behavior is no longer necessary and thus removed it

This should fix part of the problem in issue #4507 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
see detailed instructions in that PR: https://github.com/edgexfoundry/edgex-compose/pull/365  

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->