### PR TITLE
feat: Consume SecretProvider breaking changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.64
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.65
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.35
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.21

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.64 h1:M4pNPWfnADt2L+t/jtl7OhKmZyLuJXb6TsLhieZulX4=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.64/go.mod h1:up4e8XvmTnK6aOD8O7TQgDfjSbarCVPPJCSOpJwckDc=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.65 h1:K9IzxR9VUTPtsnT1kTAGyFsRe4bLjjrkDTnzSY64j90=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.65/go.mod h1:up4e8XvmTnK6aOD8O7TQgDfjSbarCVPPJCSOpJwckDc=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10 h1:iDuAO3vpBQnlQuFhai/NATbJkiYXxo3bPCtSnFl07Yw=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10/go.mod h1:8RlYm5CPzZgUsfXDWVP1TIeUMhsDNIdRdj1HXdomtOI=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.35 h1:XQgLXhpZ03JJAz4BvH371jQvFmiWcRI9wS90rE/PtS8=

--- a/internal/core/command/init.go
+++ b/internal/core/command/init.go
@@ -50,7 +50,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 	// DeviceServiceCommandClient is not part of the common clients handled by the NewClientsBootstrap handler
 	dic.Update(di.ServiceConstructorMap{
 		bootstrapContainer.DeviceServiceCommandClientName: func(get di.Get) interface{} { // add v2 API DeviceServiceCommandClient
-			jwtSecretProvider := secret.NewJWTSecretProvider(container.SecretProviderFrom(get))
+			jwtSecretProvider := secret.NewJWTSecretProvider(container.SecretProviderExtFrom(get))
 			return clients.NewDeviceServiceCommandClient(jwtSecretProvider)
 		},
 	})

--- a/internal/core/command/router.go
+++ b/internal/core/command/router.go
@@ -25,7 +25,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
 	r.UseEncodedPath()
 
 	lc := container.LoggingClientFrom(dic.Get)
-	secretProvider := container.SecretProviderFrom(dic.Get)
+	secretProvider := container.SecretProviderExtFrom(dic.Get)
 	authenticationHook := handlers.AutoConfigAuthenticationFunc(secretProvider, lc)
 
 	// Common

--- a/internal/core/data/router.go
+++ b/internal/core/data/router.go
@@ -26,7 +26,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
 	r.UseEncodedPath()
 
 	lc := container.LoggingClientFrom(dic.Get)
-	secretProvider := container.SecretProviderFrom(dic.Get)
+	secretProvider := container.SecretProviderExtFrom(dic.Get)
 	authenticationHook := handlers.AutoConfigAuthenticationFunc(secretProvider, lc)
 
 	// Common

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -26,7 +26,7 @@ func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
 	r.UseEncodedPath()
 
 	lc := container.LoggingClientFrom(dic.Get)
-	secretProvider := container.SecretProviderFrom(dic.Get)
+	secretProvider := container.SecretProviderExtFrom(dic.Get)
 	authenticationHook := handlers.AutoConfigAuthenticationFunc(secretProvider, lc)
 
 	// Common

--- a/internal/security/proxyauth/init.go
+++ b/internal/security/proxyauth/init.go
@@ -51,7 +51,7 @@ func NewBootstrap(router *mux.Router, serviceName string) *Bootstrap {
 // and must always authenticate even if the rest of EdgeX does not
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
 	lc := container.LoggingClientFrom(dic.Get)
-	secretProvider := container.SecretProviderFrom(dic.Get)
+	secretProvider := container.SecretProviderExtFrom(dic.Get)
 	authenticationHook := handlers.VaultAuthenticationHandlerFunc(secretProvider, lc)
 
 	// Common

--- a/internal/support/notifications/router.go
+++ b/internal/support/notifications/router.go
@@ -21,7 +21,7 @@ import (
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
 	lc := container.LoggingClientFrom(dic.Get)
-	secretProvider := container.SecretProviderFrom(dic.Get)
+	secretProvider := container.SecretProviderExtFrom(dic.Get)
 	authenticationHook := handlers.AutoConfigAuthenticationFunc(secretProvider, lc)
 
 	// Common

--- a/internal/support/scheduler/application/scheduler/manager.go
+++ b/internal/support/scheduler/application/scheduler/manager.go
@@ -35,11 +35,11 @@ type manager struct {
 	executorQueue         *queue.Queue
 	intervalToExecutorMap map[string]*Executor
 	actionToIntervalMap   map[string]string
-	secretProvider        bootstrapInterfaces.SecretProvider
+	secretProvider        bootstrapInterfaces.SecretProviderExt
 }
 
 // NewManager creates a new scheduler manager for running the interval job
-func NewManager(lc logger.LoggingClient, config *config.ConfigurationStruct, secretProvider bootstrapInterfaces.SecretProvider) interfaces.SchedulerManager {
+func NewManager(lc logger.LoggingClient, config *config.ConfigurationStruct, secretProvider bootstrapInterfaces.SecretProviderExt) interfaces.SchedulerManager {
 	return &manager{
 		ticker:                time.NewTicker(time.Duration(config.ScheduleIntervalTime) * time.Millisecond),
 		lc:                    lc,

--- a/internal/support/scheduler/init.go
+++ b/internal/support/scheduler/init.go
@@ -49,7 +49,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 	LoadRestRoutes(b.router, dic, b.serviceName)
 
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-	secretProvider := bootstrapContainer.SecretProviderFrom(dic.Get)
+	secretProvider := bootstrapContainer.SecretProviderExtFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 
 	// V2 Scheduler

--- a/internal/support/scheduler/router.go
+++ b/internal/support/scheduler/router.go
@@ -21,7 +21,7 @@ import (
 
 func LoadRestRoutes(r *mux.Router, dic *di.Container, serviceName string) {
 	lc := container.LoggingClientFrom(dic.Get)
-	secretProvider := container.SecretProviderFrom(dic.Get)
+	secretProvider := container.SecretProviderExtFrom(dic.Get)
 	authenticationHook := handlers.AutoConfigAuthenticationFunc(secretProvider, lc)
 
 	// Common


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Exiting suffice**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-docs/pull/1020

## Testing Instructions
run `make docker` from this branch
run `make run ds-virtual dev` from compose builder
Verify all services bootstrap successfully
attempt to do GET on `http://localhost:59880/api/v2/reading/all`
verify receive auth error
run `make get-token` from compose builder 
Use the token a `Bearer` in attempt to do  GET on `http://localhost:59880/api/v2/reading/all`
Verify good response with many readings.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->