### PR TITLE
feat: Consume new -d/--dev Dev Mode command-line flag

### DIFF
--- a/cmd/core-command/res/configuration.yaml
+++ b/cmd/core-command/res/configuration.yaml
@@ -36,12 +36,7 @@ ExternalMQTT:
     CommandQueryRequestTopic: edgex/commandquery/request/#   # for subscribing to 3rd party command query request
     CommandQueryResponseTopic: edgex/commandquery/response   # for publishing responses back to 3rd party systems
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-#Registry:
-#  Host: "localhost"
-
 MessageBus:
-#  Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: core-command
 

--- a/cmd/core-data/res/configuration.yaml
+++ b/cmd/core-data/res/configuration.yaml
@@ -13,15 +13,9 @@ Service:
   Host: "localhost"
   StartupMsg: "This is the Core Data Microservice"
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-#Registry:
-#  Host: "localhost"
-
 MessageBus:
-#  Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: "core-data"
 
 Database:
-#  Host: "localhost" # uncomment when running from command-line in hybrid mode
   Name: "coredata"

--- a/cmd/core-metadata/res/configuration.yaml
+++ b/cmd/core-metadata/res/configuration.yaml
@@ -12,16 +12,10 @@ Service:
 UoM:
   UoMFile: ./res/uom.yaml
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-#Registry:
-#  Host: "localhost"
-
 MessageBus:
-#  Host: "localhost" # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: core-metadata
 
 Database:
-#  Host: "localhost" # uncomment when running from command-line in hybrid mode
   Name: metadata
 

--- a/cmd/support-notifications/res/configuration.yaml
+++ b/cmd/support-notifications/res/configuration.yaml
@@ -24,16 +24,10 @@ Smtp:
   # AuthMode is the SMTP authentication mechanism. Currently, "usernamepassword" is the only AuthMode supported by this service, and the secret keys are "username" and "password".
   AuthMode: usernamepassword
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-#Registry:
-#  Host: "localhost"
-
 MessageBus:
-#  Host: "localhost" # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: support-notifications
 
 Database:
-#  Host: "localhost" # uncomment when running from command-line in hybrid mode
   Name: notifications
 

--- a/cmd/support-scheduler/res/configuration.yaml
+++ b/cmd/support-scheduler/res/configuration.yaml
@@ -22,16 +22,10 @@ IntervalActions:
         AdminState: UNLOCKED
         AuthMethod: JWT     # AuthMethod = JWT degrades to no auth in security-disabled EdgeX
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-#Registry:
-#  Host: "localhost"
-
 MessageBus:
-#  Host: "localhost" # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: support-scheduler
 
 Database:
-#  Host: "localhost" # uncomment when running from command-line in hybrid mode
   Name: scheduler
 

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.20
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.71
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.73
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.37
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.38
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.25
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.13
 	github.com/fxamacker/cbor/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -25,12 +25,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.71 h1:+lMhxjPuvRJ6syy1mzI1wbjfqzJPmkNMBruaiCUcEQQ=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.71/go.mod h1:GAoMAkiij8VjRAb9jRw3+skSE/VPDXBqhi5jsGSwIVM=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.73 h1:zoUJgeH2fdwWQ3qV0kiwNvYI2LMDpd6tjAjhNZyX3T8=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.73/go.mod h1:VHs/2Ri69ftKnuVw7dwNmNKOpODml90Db9e2Wcg8DPk=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10 h1:iDuAO3vpBQnlQuFhai/NATbJkiYXxo3bPCtSnFl07Yw=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10/go.mod h1:8RlYm5CPzZgUsfXDWVP1TIeUMhsDNIdRdj1HXdomtOI=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.37 h1:UTYlgeT2SxW7I/pjVcBOK0uBQGn0GAfdGJQbRU/vaoM=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.37/go.mod h1:1YS2J5NfPCd7TYBk0alu+RR5EBzBb+bnG0KF1qNRQYY=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.38 h1:FSu4b6DqviexPsS/ECBR9YgkVB76VSgyMCMDUvyGgNM=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.38/go.mod h1:1YS2J5NfPCd7TYBk0alu+RR5EBzBb+bnG0KF1qNRQYY=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.25 h1:IElkfO4qZt7+VOmQnsLNB3cDsm5Kfe6cYo/S1RU/2HA=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.25/go.mod h1:04phI5qPCFC2bfG1xZ5h6aiGH8Zp8gKDEljHjo/B+Fs=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.7 h1:sje0agoLi8ayEFxGO3xtN7P/IXwjZUUxpC8G2fCTu44=

--- a/internal/core/command/config/config.go
+++ b/internal/core/command/config/config.go
@@ -23,7 +23,7 @@ import (
 // ConfigurationStruct contains the configuration properties for the core-command service.
 type ConfigurationStruct struct {
 	Writable     WritableInfo
-	Clients      map[string]bootstrapConfig.ClientInfo
+	Clients      bootstrapConfig.ClientsCollection
 	Databases    map[string]bootstrapConfig.Database
 	Registry     bootstrapConfig.RegistryInfo
 	Service      bootstrapConfig.ServiceInfo
@@ -75,11 +75,11 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 // into an bootstrapConfig.BootstrapConfiguration struct contained within ConfigurationStruct).
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:      c.Clients,
-		Service:      c.Service,
-		Registry:     c.Registry,
-		MessageBus:   c.MessageBus,
-		ExternalMQTT: c.ExternalMQTT,
+		Clients:      &c.Clients,
+		Service:      &c.Service,
+		Registry:     &c.Registry,
+		MessageBus:   &c.MessageBus,
+		ExternalMQTT: &c.ExternalMQTT,
 	}
 }
 
@@ -94,8 +94,8 @@ func (c *ConfigurationStruct) GetRegistryInfo() bootstrapConfig.RegistryInfo {
 }
 
 // GetDatabaseInfo returns a database information map.
-func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Database {
-	return c.Databases
+func (c *ConfigurationStruct) GetDatabaseInfo() bootstrapConfig.Database {
+	return bootstrapConfig.Database{}
 }
 
 // GetInsecureSecrets returns the service's InsecureSecrets.

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -75,7 +75,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		true,
 		bootstrapConfig.ServiceTypeOther,
 		[]interfaces.BootstrapHandler{
-			handlers.NewClientsBootstrap().BootstrapHandler,
+			handlers.NewClientsBootstrap(f.InDevMode()).BootstrapHandler,
 			MessagingBootstrapHandler,
 			handlers.NewServiceMetrics(common.CoreCommandServiceKey).BootstrapHandler, // Must be after Messaging
 			NewBootstrap(router, common.CoreCommandServiceKey).BootstrapHandler,

--- a/internal/core/data/config/config.go
+++ b/internal/core/data/config/config.go
@@ -22,7 +22,6 @@ import (
 type ConfigurationStruct struct {
 	Writable     WritableInfo
 	MessageBus   bootstrapConfig.MessageBusInfo
-	Clients      map[string]bootstrapConfig.ClientInfo
 	Database     bootstrapConfig.Database
 	Registry     bootstrapConfig.RegistryInfo
 	Service      bootstrapConfig.ServiceInfo
@@ -74,10 +73,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.yaml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:    c.Clients,
-		Service:    c.Service,
-		Registry:   c.Registry,
-		MessageBus: c.MessageBus,
+		Service:    &c.Service,
+		Registry:   &c.Registry,
+		MessageBus: &c.MessageBus,
+		Database:   &c.Database,
 	}
 }
 

--- a/internal/core/metadata/config/config.go
+++ b/internal/core/metadata/config/config.go
@@ -88,9 +88,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.yaml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Service:    c.Service,
-		Registry:   c.Registry,
-		MessageBus: c.MessageBus,
+		Service:    &c.Service,
+		Registry:   &c.Registry,
+		MessageBus: &c.MessageBus,
+		Database:   &c.Database,
 	}
 }
 

--- a/internal/security/bootstrapper/command/flags_common.go
+++ b/internal/security/bootstrapper/command/flags_common.go
@@ -73,6 +73,11 @@ func (f *commonFlags) UseRegistry() bool {
 	return false
 }
 
+// InDevMode returns false since dev mode is not used
+func (f *commonFlags) InDevMode() bool {
+	return false
+}
+
 // ConfigProviderUrl returns the empty url since Configuration Provider is not used.
 func (f *commonFlags) ConfigProviderUrl() string {
 	return ""

--- a/internal/security/config/command/flags_common.go
+++ b/internal/security/config/command/flags_common.go
@@ -74,6 +74,11 @@ func (f *commonFlags) UseRegistry() bool {
 	return false
 }
 
+// InDevMode returns false since dev mode is not used
+func (f *commonFlags) InDevMode() bool {
+	return false
+}
+
 // ConfigProviderUrl returns the empty url since Configuration Provider is not used.
 func (f *commonFlags) ConfigProviderUrl() string {
 	return ""

--- a/internal/security/proxyauth/config/config.go
+++ b/internal/security/proxyauth/config/config.go
@@ -69,8 +69,8 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 // into an bootstrapConfig.BootstrapConfiguration struct contained within ConfigurationStruct).
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	return bootstrapConfig.BootstrapConfiguration{
-		Service:  c.Service,
-		Registry: c.Registry,
+		Service:  &c.Service,
+		Registry: &c.Registry,
 	}
 }
 

--- a/internal/security/proxyauth/main.go
+++ b/internal/security/proxyauth/main.go
@@ -73,7 +73,6 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 		true,
 		bootstrapConfig.ServiceTypeOther,
 		[]interfaces.BootstrapHandler{
-			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, SecurityProxyAuthServiceKey).BootstrapHandler,
 			httpServer.BootstrapHandler,
 			handlers.NewStartMessage(SecurityProxyAuthServiceKey, edgex.Version).BootstrapHandler,

--- a/internal/security/spiffetokenprovider/config/config.go
+++ b/internal/security/spiffetokenprovider/config/config.go
@@ -31,7 +31,6 @@ type SpiffeInfo struct {
 type ConfigurationStruct struct {
 	Writable    WritableInfo
 	MessageBus  bootstrapConfig.MessageBusInfo
-	Clients     map[string]bootstrapConfig.ClientInfo
 	Database    bootstrapConfig.Database
 	Registry    bootstrapConfig.RegistryInfo
 	Service     bootstrapConfig.ServiceInfo
@@ -83,9 +82,8 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.yaml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:  c.Clients,
-		Service:  c.Service,
-		Registry: c.Registry,
+		Service:  &c.Service,
+		Registry: &c.Registry,
 	}
 }
 

--- a/internal/support/notifications/config/config.go
+++ b/internal/support/notifications/config/config.go
@@ -22,7 +22,6 @@ import (
 
 type ConfigurationStruct struct {
 	Writable   WritableInfo
-	Clients    map[string]bootstrapConfig.ClientInfo
 	Database   bootstrapConfig.Database
 	Registry   bootstrapConfig.RegistryInfo
 	Service    bootstrapConfig.ServiceInfo
@@ -103,10 +102,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.yaml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:    c.Clients,
-		Service:    c.Service,
-		Registry:   c.Registry,
-		MessageBus: c.MessageBus,
+		Service:    &c.Service,
+		Registry:   &c.Registry,
+		MessageBus: &c.MessageBus,
+		Database:   &c.Database,
 	}
 }
 

--- a/internal/support/notifications/main.go
+++ b/internal/support/notifications/main.go
@@ -24,8 +24,9 @@ package notifications
 
 import (
 	"context"
-	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 	"os"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 
 	"github.com/edgexfoundry/edgex-go"
 	pkgHandlers "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/handlers"
@@ -79,7 +80,6 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
 			handlers.MessagingBootstrapHandler,
 			handlers.NewServiceMetrics(common.SupportNotificationsServiceKey).BootstrapHandler, // Must be after Messaging
-			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, common.SupportNotificationsServiceKey).BootstrapHandler,
 			httpServer.BootstrapHandler,
 			handlers.NewStartMessage(common.SupportNotificationsServiceKey, edgex.Version).BootstrapHandler,

--- a/internal/support/scheduler/config/config.go
+++ b/internal/support/scheduler/config/config.go
@@ -24,7 +24,6 @@ import (
 // Configuration V2 for the Support Scheduler Service
 type ConfigurationStruct struct {
 	Writable        WritableInfo
-	Clients         map[string]bootstrapConfig.ClientInfo
 	Database        bootstrapConfig.Database
 	Registry        bootstrapConfig.RegistryInfo
 	Service         bootstrapConfig.ServiceInfo
@@ -134,10 +133,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	// temporary until we can make backwards-breaking configuration.yaml change
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:    c.Clients,
-		Service:    c.Service,
-		Registry:   c.Registry,
-		MessageBus: c.MessageBus,
+		Service:    &c.Service,
+		Registry:   &c.Registry,
+		MessageBus: &c.MessageBus,
+		Database:   &c.Database,
 	}
 }
 

--- a/internal/support/scheduler/main.go
+++ b/internal/support/scheduler/main.go
@@ -73,7 +73,6 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 			pkgHandlers.NewDatabase(httpServer, configuration, container.DBClientInterfaceName).BootstrapHandler, // add v2 db client bootstrap handler
 			handlers.MessagingBootstrapHandler,
 			handlers.NewServiceMetrics(common.SupportSchedulerServiceKey).BootstrapHandler, // Must be after Messaging
-			handlers.NewClientsBootstrap().BootstrapHandler,
 			NewBootstrap(router, common.SupportSchedulerServiceKey).BootstrapHandler,
 			httpServer.BootstrapHandler,
 			handlers.NewStartMessage(common.SupportSchedulerServiceKey, edgex.Version).BootstrapHandler,


### PR DESCRIPTION
Dev Mode is used when running service locally with the other services running in Docker (aka hybrid mode). This causes all the `Host` settings pulled from common configuration to be overridden with the value `localhost`.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Existing suffice**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/1040

## Testing Instructions
run `make docker` using this branch
From latest Compose Builder run ` make run no-secty ds-virtual`
Verify all services have bootstrapped successfully and data is flowing from device virtual to Core Data and App Rules Engine
Verify following GET Command is successful 
```
http://localhost:59882/api/v3/device/name/Random-Float-Device/Float32
```
Stop Core Data container
Run `make data` from this branch
Run core data from command-line with just `-cp` flag
Verify the following error
```
"couldn't create database client: redis client creation failed -> could not dial Redis: dial tcp: lookup edgex-redis on 8.8.8.8:53: no such host"
```
Run core data from command-line with `-cp -d` flags
Verify no errors
Enable DEBUG logging from Consul for Core Data
Verify core data is receiving events

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->