### PR TITLE
feat: Add ability to customize spiffe services

### DIFF
--- a/cmd/security-spire-config/seed_builtin_entries.sh
+++ b/cmd/security-spire-config/seed_builtin_entries.sh
@@ -25,12 +25,18 @@ echo "local_agent_svid=${local_agent_svid}"
 echo "SPIFFE_SERVER_SOCKET=${SPIFFE_SERVER_SOCKET}"
 echo "SPIFFE_EDGEX_SVID_BASE=${SPIFFE_EDGEX_SVID_BASE}"
 
+echo "SPIFFE_CUSTOM_SERVICES=${SPIFFE_CUSTOM_SERVICES}"
+
+SPIFFE_SERVICES='security-spiffe-token-provider support-notifications support-scheduler \
+                 device-bacnet device-camera device-grove device-modbus device-mqtt device-rest device-snmp \
+                 device-virtual device-rfid-llrp device-coap device-gpio \
+                 app-http-export app-mqtt-export app-sample app-rfid-llrp-inventory \
+                 app-external-mqtt-trigger'
+
+SEED_SERVICES="${SPIFFE_SERVICES} ${SPIFFE_CUSTOM_SERVICES}"
+
 # add pre-authorized services into spire server entry
-for dockerservice in security-spiffe-token-provider support-notifications support-scheduler \
-    device-bacnet device-camera device-grove device-modbus device-mqtt device-rest device-snmp \
-    device-virtual device-rfid-llrp device-coap device-gpio \
-    app-http-export app-mqtt-export app-sample app-rfid-llrp-inventory \
-    app-external-mqtt-trigger; do
+for dockerservice in $SEED_SERVICES; do
     # Temporary workaround because service name in dockerfile is not consistent with service key.
     # TAF scripts depend on legacy docker-compose service name. Fix in EdgeX 3.0.
     service=`echo -n ${dockerservice} | sed -e 's/app-service-/app-/'`

--- a/cmd/security-spire-config/seed_builtin_entries.sh
+++ b/cmd/security-spire-config/seed_builtin_entries.sh
@@ -25,7 +25,7 @@ echo "local_agent_svid=${local_agent_svid}"
 echo "SPIFFE_SERVER_SOCKET=${SPIFFE_SERVER_SOCKET}"
 echo "SPIFFE_EDGEX_SVID_BASE=${SPIFFE_EDGEX_SVID_BASE}"
 
-echo "SPIFFE_CUSTOM_SERVICES=${SPIFFE_CUSTOM_SERVICES}"
+echo "EDGEX_SPIFFE_CUSTOM_SERVICES=${EDGEX_SPIFFE_CUSTOM_SERVICES}"
 
 SPIFFE_SERVICES='security-spiffe-token-provider support-notifications support-scheduler \
                  device-bacnet device-camera device-grove device-modbus device-mqtt device-rest device-snmp \
@@ -33,7 +33,7 @@ SPIFFE_SERVICES='security-spiffe-token-provider support-notifications support-sc
                  app-http-export app-mqtt-export app-sample app-rfid-llrp-inventory \
                  app-external-mqtt-trigger'
 
-SEED_SERVICES="${SPIFFE_SERVICES} ${SPIFFE_CUSTOM_SERVICES}"
+SEED_SERVICES="${SPIFFE_SERVICES} ${EDGEX_SPIFFE_CUSTOM_SERVICES}"
 
 # add pre-authorized services into spire server entry
 for dockerservice in $SEED_SERVICES; do


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  [docs PR](https://github.com/edgexfoundry/edgex-docs/pull/1041)

## Testing Instructions
**Testing without setting SPIFFE_CUSTOM_SERVICES**
1. pull the current PR branch
2. build all the edgex-go services `make docker` in edgex-go
3. pull the latest images from edgex-compose compose-builder directory `make pull delayed-start ds-virtual ds-modbus`
4. in edgex-compose compose-builder directory, run `make run dev delayed-start ds-virtual ds-modbus`
5. Wait for all security services to start up. Ensure that edgex-security-spire-config container has run the seed_builtin_entries script properly. Last log chunk should be:
```
...
+ echo -n app-external-mqtt-trigger
+ sed -e s/app-service-/app-/
+ service=app-external-mqtt-trigger
+ spire-server entry create -socketPath /tmp/edgex/secrets/spiffe/private/api.sock -parentID spiffe://edgexfoundry.org/spire/agent/x509pop/cn/agent0 -dns edgex-app-external-mqtt-trigger -spiffeID spiffe://edgexfoundry.org/service/app-external-mqtt-trigger -selector docker:label:com.docker.compose.service:app-external-mqtt-trigger
Entry ID         : cfee5346-947e-4a2c-aba4-912d5f7a205f
SPIFFE ID        : spiffe://edgexfoundry.org/service/app-external-mqtt-trigger
Parent ID        : spiffe://edgexfoundry.org/spire/agent/x509pop/cn/agent0
Revision         : 0
X509-SVID TTL    : default
JWT-SVID TTL     : default
Selector         : docker:label:com.docker.compose.service:app-external-mqtt-trigger
DNS name         : edgex-app-external-mqtt-trigger
+ exit 0
+ exec tail -f /dev/null
```

**Testing with setting SPIFFE_CUSTOM_SERVICES**

1. pull the current PR branch
2. Modify the `cmd/security-spire-config/seed_builtin_entries.sh` so the service list is:
    ```
    SPIFFE_SERVICES='security-spiffe-token-provider support-notifications support-scheduler \
                 device-bacnet device-camera device-grove device-modbus device-mqtt device-rest device-snmp \
                 device-virtual device-rfid-llrp device-coap device-gpio \
                 app-http-export app-mqtt-export app-sample'
    ```
5. build all the edgex-go services `make docker` in edgex-go
7. pull the latest images from edgex-compose compose-builder directory `make pull delayed-start ds-virtual ds-modbus`
8. In edgex-compose change compose-builder/common-sec-stage-gate.env to add the following env variable:
    ```
    SPIFFE_CUSTOM_SERVICES='app-external-mqtt-trigger app-rfid-llrp-inventory'
    ```
10. in edgex-compose compose-builder directory, run `make run dev delayed-start ds-virtual ds-modbus`
11. Wait for all security services to start up. Ensure that edgex-security-spire-config container has run the seed_builtin_entries script properly. Last log chunk should look something like this:
```
...
+ echo -n app-rfid-llrp-inventory
+ sed -e s/app-service-/app-/
+ service=app-rfid-llrp-inventory
+ spire-server entry create -socketPath /tmp/edgex/secrets/spiffe/private/api.sock -parentID spiffe://edgexfoundry.org/spire/agent/x509pop/cn/agent0 -dns edgex-app-external-mqtt-trigger -spiffeID spiffe://edgexfoundry.org/service/app-rfid-llrp-inventory -selector docker:label:com.docker.compose.service:app-rfid-llrp-inventory
Entry ID         : cfee5346-947e-4a2c-aba4-912d5f7a205f
SPIFFE ID        : spiffe://edgexfoundry.org/service/app-rfid-llrp-inventory
Parent ID        : spiffe://edgexfoundry.org/spire/agent/x509pop/cn/agent0
Revision         : 0
X509-SVID TTL    : default
JWT-SVID TTL     : default
Selector         : docker:label:com.docker.compose.service:app-rfid-llrp-inventory
DNS name         : edgex-app-rfid-llrp-inventory
+ exit 0
+ exec tail -f /dev/null
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->