### PR TITLE
fix: Don't register spiffe token provider service

### DIFF
--- a/cmd/security-spiffe-token-provider/Dockerfile
+++ b/cmd/security-spiffe-token-provider/Dockerfile
@@ -43,4 +43,4 @@ COPY --from=builder /edgex-go/cmd/security-spiffe-token-provider/security-spiffe
 COPY --from=builder /edgex-go/cmd/security-spiffe-token-provider/res/configuration.yaml /res/configuration.yaml
 
 ENTRYPOINT [ "/security-spiffe-token-provider" ]
-CMD ["-cp=consul.http://edgex-core-consul:8500", "--registry"]
+CMD ["-cp=consul.http://edgex-core-consul:8500"]


### PR DESCRIPTION
go-mod-bootstrap only allows registration of HTTP healtchecks with consul, which will not work for this service, as it requires clients have a client TLS certificate.  In any case, registration is not required for proper functioning of the service

Closes #4531

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
This service never runs in secure mode and thus embedded CMD is never exercised.
Actually fixed by edgex-compose#375, but this corresponding change is made for conistency.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->