### PR TITLE
fix: Fix multiline break for seed_builtin_entries.sh

### DIFF
--- a/cmd/security-spire-config/seed_builtin_entries.sh
+++ b/cmd/security-spire-config/seed_builtin_entries.sh
@@ -27,11 +27,11 @@ echo "SPIFFE_EDGEX_SVID_BASE=${SPIFFE_EDGEX_SVID_BASE}"
 
 echo "EDGEX_SPIFFE_CUSTOM_SERVICES=${EDGEX_SPIFFE_CUSTOM_SERVICES}"
 
-SPIFFE_SERVICES='security-spiffe-token-provider support-notifications support-scheduler \
+SPIFFE_SERVICES="security-spiffe-token-provider support-notifications support-scheduler \
                  device-bacnet device-camera device-grove device-modbus device-mqtt device-rest device-snmp \
                  device-virtual device-rfid-llrp device-coap device-gpio \
                  app-http-export app-mqtt-export app-sample app-rfid-llrp-inventory \
-                 app-external-mqtt-trigger'
+                 app-external-mqtt-trigger app-metrics-influxdb"
 
 SEED_SERVICES="${SPIFFE_SERVICES} ${EDGEX_SPIFFE_CUSTOM_SERVICES}"
 


### PR DESCRIPTION
Also adds a missing service, app-metrics-influxdb

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Before this change, "make run delayed-start" would show the following in the spire-config error log:

```
+ echo -n '\'
+ sed -e s/app-service-/app-/
+ service='\'
+ spire-server entry create -socketPath /tmp/edgex/secrets/spiffe/private/api.sock -parentID spiffe://edgexfoundry.org/spire/agent/x509pop/cn/agent0 -dns 'edgex-\' -spiffeID 'spiffe://edgexfoundry.org/service/\' -selector 'docker:label:com.docker.compose.service:\'
Error: path segment characters are limited to letters, numbers, dots, dashes, and underscores
+ echo -n app-external-mqtt-trigger
```



## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->