### PR TITLE
fix: Enable delayed-start services to get message-bus credential

### DIFF
--- a/cmd/security-file-token-provider/res/token-config.json
+++ b/cmd/security-file-token-provider/res/token-config.json
@@ -160,6 +160,11 @@
             "read"
           ]
         },
+        "secret/edgex/security-bootstrapper-messagebus/message-bus": {
+          "capabilities": [
+            "read"
+          ]
+        },
         "secret/edgex/*": {
           "capabilities": [
             "list",

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -614,7 +614,7 @@ func (b *Bootstrap) getKnownSecretsToAdd() (map[string][]string, error) {
 		secretItems := strings.Split(secretSpec, serviceListBegin)
 		if len(secretItems) != 2 {
 			return nil, fmt.Errorf(
-				"invalid specification for %s environment vaiable: Format of value '%s' is invalid. Missing or too many '%s'",
+				"invalid specification for %s environment variable: Format of value '%s' is invalid. Missing or too many '%s'",
 				addKnownSecretsEnv,
 				secretSpec,
 				serviceListBegin)
@@ -625,7 +625,7 @@ func (b *Bootstrap) getKnownSecretsToAdd() (map[string][]string, error) {
 		_, valid := b.validKnownSecrets[secretName]
 		if !valid {
 			return nil, fmt.Errorf(
-				"invalid specification for %s environment vaiable: '%s' is not a known secret",
+				"invalid specification for %s environment variable: '%s' is not a known secret",
 				addKnownSecretsEnv,
 				secretName)
 		}
@@ -633,7 +633,7 @@ func (b *Bootstrap) getKnownSecretsToAdd() (map[string][]string, error) {
 		serviceNameList := secretItems[1]
 		if !strings.Contains(serviceNameList, serviceListEnd) {
 			return nil, fmt.Errorf(
-				"invalid specification for %s environment vaiable: Service list for '%s' missing closing '%s'",
+				"invalid specification for %s environment variable: Service list for '%s' missing closing '%s'",
 				addKnownSecretsEnv,
 				secretName,
 				serviceListEnd)
@@ -642,7 +642,7 @@ func (b *Bootstrap) getKnownSecretsToAdd() (map[string][]string, error) {
 		serviceNameList = strings.TrimSpace(strings.Replace(serviceNameList, serviceListEnd, "", 1))
 		if len(serviceNameList) == 0 {
 			return nil, fmt.Errorf(
-				"invalid specification for %s environment vaiable: Service name list for '%s' is empty.",
+				"invalid specification for %s environment variable: Service name list for '%s' is empty.",
 				addKnownSecretsEnv,
 				secretName)
 		}
@@ -653,7 +653,7 @@ func (b *Bootstrap) getKnownSecretsToAdd() (map[string][]string, error) {
 
 			if !serviceNameRegx.MatchString(serviceNames[index]) {
 				return nil, fmt.Errorf(
-					"invalid specification for %s environment vaiable: Service name '%s' has invalid characters.",
+					"invalid specification for %s environment variable: Service name '%s' has invalid characters.",
 					addKnownSecretsEnv, serviceNames[index])
 			}
 		}

--- a/internal/security/spiffetokenprovider/init.go
+++ b/internal/security/spiffetokenprovider/init.go
@@ -56,19 +56,17 @@ import (
 
 const (
 	redisSecretName                  = "redisdb"
+	messageBusSecretName             = "message-bus"
 	secretBasePath                   = "/v1/secret/edgex" // nolint:gosec
 	edgexRedisBootstrapperServiceKey = "security-bootstrapper-redis"
 )
 
 type Bootstrap struct {
-	validKnownSecrets map[string]bool
 	secretStoreConfig *bootstrapConfig.SecretStoreInfo
 }
 
 func NewBootstrap() *Bootstrap {
-	return &Bootstrap{
-		validKnownSecrets: map[string]bool{redisSecretName: true},
-	}
+	return &Bootstrap{}
 }
 
 func (b *Bootstrap) getSecretStoreClient(dic *di.Container) (secrets.SecretStoreClient, error) {
@@ -353,19 +351,6 @@ func (b *Bootstrap) seedKnownSecrets(ctx context.Context, lc logger.LoggingClien
 	ssConfig *bootstrapConfig.SecretStoreInfo,
 	knownSecretNames []string, serviceKey string, privilegedToken string) error {
 
-	// to see if we can find redisdb as part of known secret name since that is the known secret we can support now
-	found := false
-	for _, secretName := range knownSecretNames {
-		_, valid := b.validKnownSecrets[secretName]
-		if valid {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return fmt.Errorf("cannot find secret name from validKnownSecrets")
-	}
-
 	// copy from security-bootstrapper-redis: /v1/secret/edgex/security-bootstrapper-redis/redisdb
 	// to /v1/secret/edgex/<service_key>/redisdb using secret client's APIs
 
@@ -391,15 +376,35 @@ func (b *Bootstrap) seedKnownSecrets(ctx context.Context, lc logger.LoggingClien
 		return fmt.Errorf("found error on getting secretClient: %v", err)
 	}
 
-	// copy known secrets redisdb from redis-bootstrapper to the requested service with serviceKey
-	secrets, err := secretClient.GetSecret(fmt.Sprintf("%s/%s", edgexRedisBootstrapperServiceKey, redisSecretName))
-	if err != nil {
-		return fmt.Errorf("found error on getting secrets: %v", err)
-	}
+	// Copy requested known secrets
+	for _, secretName := range knownSecretNames {
+		switch secretName {
+		case redisSecretName:
+			// copy known secrets redisdb from redis-bootstrapper to the requested service with serviceKey
+			secrets, err := secretClient.GetSecret(fmt.Sprintf("%s/%s", edgexRedisBootstrapperServiceKey, redisSecretName))
+			if err != nil {
+				return fmt.Errorf("found error on getting secret %s/%s: %v", edgexRedisBootstrapperServiceKey, secretName, err)
+			}
 
-	err = secretClient.StoreSecret(fmt.Sprintf("%s/%s", serviceKey, redisSecretName), secrets)
-	if err != nil {
-		return fmt.Errorf("found error on storing secrets: %v", err)
+			err = secretClient.StoreSecret(fmt.Sprintf("%s/%s", serviceKey, redisSecretName), secrets)
+			if err != nil {
+				return fmt.Errorf("found error on storing secret %s/%s: %v", serviceKey, secretName, err)
+			}
+
+		case messageBusSecretName:
+			// copy known secrets redisdb from redis-bootstrapper to the requested service with serviceKey
+			secrets, err := secretClient.GetSecret(fmt.Sprintf("%s/%s", internal.BootstrapMessageBusServiceKey, messageBusSecretName))
+			if err != nil {
+				return fmt.Errorf("found error on getting secret %s/%s: %v", internal.BootstrapMessageBusServiceKey, secretName, err)
+			}
+
+			err = secretClient.StoreSecret(fmt.Sprintf("%s/%s", serviceKey, messageBusSecretName), secrets)
+			if err != nil {
+				return fmt.Errorf("found error on storing secret %s/%s: %v", serviceKey, secretName, err)
+			}
+		default:
+			lc.Warnf("unrecognized known secret requested: %s", secretName)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Closes #4540

security-spiffe-token-provider allows delayed start services to request known secrets. Prior to this commit, it didn't know about the message-bus known secret.  Also is now just a warning to the log if a service requests a nonexistent secret.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Suggested testing instructions:
modify add-runtime-token-config-template.yml and add SECRETSTORE_RUNTIMETOKENPROVIDER_REQUIREDSECRETS: foo,message-bus,redisdb,bar

make run dev delayed-start ds-virtual

docker logs -f edgex-security-spiffe-token-provider

you will notice that there are errors thrown when it tries to request the message-bus known secret, which doesn't exists, because make run didn't have the mqtt-bus option provided.  Also foo and bar secrets will be ignored.  Basically, this proves the code is trying to copy those known secrets.

Success case achieved by make run dev mqtt-bus delayed-start ds-virtual.



## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->