### PR TITLE
feat: Allow Device Profile to be empty string in ProvisionWatcher

### DIFF
--- a/internal/pkg/infrastructure/redis/provisionwatcher.go
+++ b/internal/pkg/infrastructure/redis/provisionwatcher.go
@@ -72,11 +72,13 @@ func addProvisionWatcher(conn redis.Conn, pw models.ProvisionWatcher) (addedProv
 	} else if !exists {
 		return addedProvisionWatcher, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device service '%s' does not exists", pw.DiscoveredDevice.ServiceName), edgexErr)
 	}
-	exists, edgexErr = deviceProfileNameExists(conn, pw.DiscoveredDevice.ProfileName)
-	if edgexErr != nil {
-		return addedProvisionWatcher, errors.NewCommonEdgeXWrapper(edgexErr)
-	} else if !exists {
-		return addedProvisionWatcher, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exists", pw.DiscoveredDevice.ProfileName), edgexErr)
+	if pw.DiscoveredDevice.ProfileName != "" {
+		exists, edgexErr = deviceProfileNameExists(conn, pw.DiscoveredDevice.ProfileName)
+		if edgexErr != nil {
+			return addedProvisionWatcher, errors.NewCommonEdgeXWrapper(edgexErr)
+		} else if !exists {
+			return addedProvisionWatcher, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exists", pw.DiscoveredDevice.ProfileName), edgexErr)
+		}
 	}
 
 	ts := pkgCommon.MakeTimestamp()
@@ -222,11 +224,13 @@ func updateProvisionWatcher(conn redis.Conn, pw models.ProvisionWatcher) errors.
 	} else if !exists {
 		return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device service '%s' does not exist", pw.DiscoveredDevice.ServiceName), nil)
 	}
-	exists, edgeXerr = deviceProfileNameExists(conn, pw.DiscoveredDevice.ProfileName)
-	if edgeXerr != nil {
-		return errors.NewCommonEdgeX(errors.Kind(edgeXerr), fmt.Sprintf("device profile '%s' existence check failed", pw.DiscoveredDevice.ProfileName), edgeXerr)
-	} else if !exists {
-		return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exist", pw.DiscoveredDevice.ProfileName), nil)
+	if pw.DiscoveredDevice.ProfileName != "" {
+		exists, edgeXerr = deviceProfileNameExists(conn, pw.DiscoveredDevice.ProfileName)
+		if edgeXerr != nil {
+			return errors.NewCommonEdgeX(errors.Kind(edgeXerr), fmt.Sprintf("device profile '%s' existence check failed", pw.DiscoveredDevice.ProfileName), edgeXerr)
+		} else if !exists {
+			return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exist", pw.DiscoveredDevice.ProfileName), nil)
+		}
 	}
 
 	oldProvisionWatcher, edgexErr := provisionWatcherByName(conn, pw.Name)

--- a/openapi/v3/core-metadata.yaml
+++ b/openapi/v3/core-metadata.yaml
@@ -745,7 +745,6 @@ components:
           type: object
           description: A map of properties required to address the given provision watcher
       required:
-        - profileName
         - serviceName
         - adminState
     UpdateDiscoveredDevice:


### PR DESCRIPTION
Do not check the empty string profile name for adding the ProvisionWatcher

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) update the swagger file
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core service and device-simple base on the core-contracts changes and verified the provision watcher API works as expected.
https://github.com/edgexfoundry/go-mod-core-contracts/pull/834

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->