### PR TITLE
refactor(snap)!: Disable and stop services by default

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download and test snap
-        uses: canonical/edgex-snap-testing/test@autostart-refactor
+        uses: canonical/edgex-snap-testing/test@v3
         with:
           name: edgexfoundry
           snap: ${{needs.build.outputs.snap}}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download and test snap
-        uses: canonical/edgex-snap-testing/test@v3
+        uses: canonical/edgex-snap-testing/test@autostart-refactor
         with:
           name: edgexfoundry
           snap: ${{needs.build.outputs.snap}}

--- a/snap/local/helper-go/common.go
+++ b/snap/local/helper-go/common.go
@@ -36,6 +36,7 @@ const (
 var (
 	securityServices = []string{
 		vault,
+		securityNginx,
 	}
 	securitySetupServices = []string{
 		securitySecretStoreSetup,
@@ -43,7 +44,6 @@ var (
 		securityBootstrapperNginx,
 		securityProxyAuth,
 		securityBootstrapperRedis,
-		securityNginx,
 	}
 	coreSetupServices = []string{
 		coreCommonConfigBootstrapper,

--- a/snap/local/helper-go/common.go
+++ b/snap/local/helper-go/common.go
@@ -66,10 +66,11 @@ func allOneshotServices() (s []string) {
 }
 
 func allServices() (s []string) {
-	s = make([]string, len(coreServices)+len(supportServices)+len(securityServices)+len(allOneshotServices()))
+	allOneshotServices := allOneshotServices()
+	s = make([]string, 0, len(coreServices)+len(supportServices)+len(securityServices)+len(allOneshotServices))
 	s = append(s, coreServices...)
 	s = append(s, supportServices...)
 	s = append(s, securityServices...)
-	s = append(s, allOneshotServices()...)
+	s = append(s, allOneshotServices...)
 	return s
 }

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -160,13 +160,20 @@ func configure() {
 		log.Fatalf("Error processing autostart options: %v", err)
 	}
 
-	// Unset autostart for oneshot services so they don't start again
-	var oneshotAutostart []string
+	// Disable autostart for oneshot services so they don't start again
+	var oneshotAutostartFalse []string
 	for _, s := range allOneshotServices() {
-		oneshotAutostart = append(oneshotAutostart, "apps."+s+".autostart")
+		oneshotAutostartFalse = append(oneshotAutostartFalse,
+			"apps."+s+".autostart", "false")
 	}
-	if err = snapctl.Unset(oneshotAutostart...).Run(); err != nil {
-		log.Fatalf("Error unsetting snap option: %v", err)
+	if err = snapctl.Set(oneshotAutostartFalse...).Run(); err != nil {
+		log.Fatalf("Error setting snap option: %v", err)
+	}
+
+	// Process autostart to schedule the disabling of oneshot services configured above
+	err = opt.ProcessAutostart(allServices()...)
+	if err != nil {
+		log.Fatalf("Error processing autostart options: %v", err)
 	}
 
 	log.Debug("End")

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -160,21 +160,5 @@ func configure() {
 		log.Fatalf("Error processing autostart options: %v", err)
 	}
 
-	// Disable autostart for oneshot services so they don't start again
-	var oneshotAutostartFalse []string
-	for _, s := range allOneshotServices() {
-		oneshotAutostartFalse = append(oneshotAutostartFalse,
-			"apps."+s+".autostart", "false")
-	}
-	if err = snapctl.Set(oneshotAutostartFalse...).Run(); err != nil {
-		log.Fatalf("Error setting snap option: %v", err)
-	}
-
-	// Process autostart to schedule the disabling of oneshot services configured above
-	err = opt.ProcessAutostart(allServices()...)
-	if err != nil {
-		log.Fatalf("Error processing autostart options: %v", err)
-	}
-
 	log.Debug("End")
 }

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -303,15 +303,4 @@ func install() {
 		log.Fatalf("Error installing redis: %v", err)
 	}
 
-	// Enable autostart so that services start by default after seeding configuration
-	// Set the option for each app instead of globally (i.e. autostart=true), so
-	// that the option can be selectively changed for oneshot services after starting
-	// them once!
-	var autostartKeyValues []string
-	for _, s := range allServices() {
-		autostartKeyValues = append(autostartKeyValues, "apps."+s+".autostart", "true")
-	}
-	if err = snapctl.Set(autostartKeyValues...).Run(); err != nil {
-		log.Fatalf("Error setting snap option: %v", err)
-	}
 }

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -305,7 +305,7 @@ func install() {
 
 	// Enable autostart so that services start by default after seeding configuration
 	// Set the option for each app instead of globally (i.e. autostart=true), so
-	// that the option can be selectively unset for oneshot services after starting
+	// that the option can be selectively changed for oneshot services after starting
 	// them once!
 	var autostartKeyValues []string
 	for _, s := range allServices() {


### PR DESCRIPTION
Prior to https://github.com/edgexfoundry/edgex-go/issues/4448, it was possible to override configuration coming from the Config Provider via environment variables. This is no longer possible. As a result, the environment variables need to be set before initial startup. This PR changes the services startup to have them disabled and stopped by default, instead of enabled and started. This is to allow changing configurations via environment variables in this Snap (via snap options) when installing the snap manually. 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix - https://github.com/canonical/edgex-snap-testing/pull/195
- [x] I have fully tested (add details below) this the new feature or bug fix
- [ ] I have opened a PR for the related docs change - TBA

## Testing Instructions
<!-- How can the reviewers test your change? -->
```bash
snapcraft -v
sudo snap install --dangerous <snap> 
# or
sudo snap install edgexfoundry --channel=latest/edge/pr-4552

sudo snap services edgexfoundry # all services should be disabled and inactive

# smoke testing
sudo snap start --enable edgexfoundry
sudo snap stop --disable edgexfoundry
sudo snap set edgexfoundry autostart=true
sudo snap set edgexfoundry apps.core-data.autostart=false
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->