### PR TITLE
feat: Make secrets base directory configurable

### DIFF
--- a/cmd/security-secretstore-setup/Dockerfile
+++ b/cmd/security-secretstore-setup/Dockerfile
@@ -32,7 +32,7 @@ RUN make cmd/security-file-token-provider/security-file-token-provider \
 
 FROM alpine:3.17
 
-RUN apk add --update --no-cache ca-certificates dumb-init su-exec
+RUN apk add --update --no-cache ca-certificates dumb-init su-exec yq
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
       copyright='Copyright (c) 2019: Dell Technologies, Inc.; Copyright (C) 2023 Intel Corporation'

--- a/cmd/security-secretstore-setup/entrypoint.sh
+++ b/cmd/security-secretstore-setup/entrypoint.sh
@@ -19,7 +19,12 @@
 
 set -e
 
-# env settings are populated from env files of docker-compose
+# EDGEX_SECRETS_ROOT should default to /tmp/edgex/secrets
+# unless changed in configuration.yaml or overridden by environment variable
+EDGEX_SECRETS_ROOT=`yq -r .TokenFileProvider.OutputDir /res-file-token-provider/configuration.yaml`
+if [ ! -z "${TOKENFILEPROVIDER_OUTPUTDIR}" ]; then
+  EDGEX_SECRETS_ROOT="${TOKENFILEPROVIDER_OUTPUTDIR}"
+fi
 
 # create token dir, and assign perms
 mkdir -p /vault/config/assets
@@ -36,8 +41,8 @@ fi
 
 # /tmp/edgex/secrets need to be shared with all other services that need secrets and
 # thus change the ownership to EDGEX_USER:EDGEX_GROUP
-echo "$(date) Changing ownership of secrets to ${EDGEX_USER}:${EDGEX_GROUP}"
-chown -Rh ${EDGEX_USER}:${EDGEX_GROUP} /tmp/edgex/secrets
+echo "$(date) Changing ownership of ${EDGEX_SECRETS_ROOT} to ${EDGEX_USER}:${EDGEX_GROUP}"
+chown -Rh ${EDGEX_USER}:${EDGEX_GROUP} "${EDGEX_SECRETS_ROOT}"
 
 # Signal tokens ready port for other services waiting on
 exec su-exec ${EDGEX_USER} /edgex-init/security-bootstrapper --configDir=/edgex-init/res listenTcp \


### PR DESCRIPTION
Closes #4570

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
"make docker" on in this repo.  In edgex-compose, modify add-security.yaml set EDGEX_SECRETS_ROOT to some other value.  Make run dev and verify that the chmod applies to the new directory path, and defaults to /tmp/edgex/secrets if unset.


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->