### PR TITLE
fix: Initialize interval in the local time zone

### DIFF
--- a/internal/support/scheduler/application/scheduler/executor.go
+++ b/internal/support/scheduler/application/scheduler/executor.go
@@ -32,12 +32,13 @@ type Executor struct {
 func (executor *Executor) Initialize(interval models.Interval, lc logger.LoggingClient) errors.EdgeX {
 	executor.Interval = interval
 	currentTime := time.Now()
+	loc := currentTime.Location()
 
 	// start and end time
 	if executor.Interval.Start == "" {
 		executor.StartTime = currentTime
 	} else {
-		t, err := time.Parse(SchedulerTimeFormat, executor.Interval.Start)
+		t, err := time.ParseInLocation(SchedulerTimeFormat, executor.Interval.Start, loc)
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("fail to parse the StartTime string %s", executor.Interval.End), err)
 		}
@@ -48,7 +49,7 @@ func (executor *Executor) Initialize(interval models.Interval, lc logger.Logging
 		// use max time
 		executor.EndTime = time.Unix(1<<63-62135596801, 999999999)
 	} else {
-		t, err := time.Parse(SchedulerTimeFormat, executor.Interval.End)
+		t, err := time.ParseInLocation(SchedulerTimeFormat, executor.Interval.End, loc)
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("fail to parse the EndTime string %s", executor.Interval.End), err)
 		}

--- a/internal/support/scheduler/application/scheduler/executor_test.go
+++ b/internal/support/scheduler/application/scheduler/executor_test.go
@@ -29,7 +29,7 @@ func TestInitialize(t *testing.T) {
 		expectedErrorKind errors.ErrKind
 	}{
 		{"run with interval", "midnight", "20000101T000000", "22000101T000000", "24h", ""},
-		{"run without startTime ", "midnight", "", "22000101T000000", "24h", ""},
+		{"run without startTime", "midnight", "", "22000101T000000", "24h", ""},
 		{"wrong startTime string format", "midnight", "20000101T", "", "24h", errors.KindContractInvalid},
 		{"wrong endTime string format", "midnight", "", "20000101T", "24h", errors.KindContractInvalid},
 		{"wrong frequency string format", "midnight", "", "", "24", errors.KindContractInvalid},
@@ -55,9 +55,11 @@ func TestInitialize(t *testing.T) {
 			assert.Equal(t, interval.Name, executor.Interval.Name)
 			if interval.Start != "" {
 				assert.Equal(t, interval.Start, executor.StartTime.Format("20060102T000000"))
+				assert.Equal(t, current.Location(), executor.StartTime.Location())
 			}
 			if interval.End != "" {
 				assert.Equal(t, interval.End, executor.EndTime.Format("20060102T000000"))
+				assert.Equal(t, current.Location(), executor.EndTime.Location())
 			}
 			assert.GreaterOrEqual(t, executor.NextTime.Unix(), current.Unix())
 			assert.Greater(t, executor.Frequency.Seconds(), float64(0))


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->
Fixes #4594

<!-- Add additional detailed description of need for change if no related issue -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
   As the start and end times of the input remain unchanged, there is no need to modify the docs.
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Build support-scheduler image from this branch and update the docker compose file which you want to run with to add this prop for `support-scheduler`.
```
volumes:
      - /etc/localtime:/etc/localtime:ro
```
2. Run the local support-scheduler image with other services.
3. Modify the LogLevel of support-scheduler to `DEBUG`.
4. Create a new interval with **current time** of your location as start time.
```
curl -X POST http://localhost:59861/api/v3/interval -d '[
  {
    "apiVersion": "v3",
    "interval": {
      "interval": "5s",
      "name": "test-interval",
      "start": "20230621T115000"
    }
  }
]'
```
5. Checked the logs of `support-scheduler` and verified that the new created interval has been initialized and triggered with host time zone.
```
level=DEBUG ts=2023-06-21T03:50:15.056051333Z app=support-scheduler source=manager.go:89 msg="executing interval test-interval at : 2023-06-21 11:50:15 +0800 CST"
level=DEBUG ts=2023-06-21T03:50:15.056467558Z app=support-scheduler source=manager.go:111 msg="0 action need to be executed with interval test-interval."
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->