### PR TITLE
fix: Add warn log for create/update interval

### DIFF
--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	goErrors "errors"
 	"fmt"
+	"time"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
@@ -34,8 +35,8 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/pkg/utils"
 )
 
-// the suggested minimum duration string for auto event interval
-const minAutoEventInterval = "1ms"
+// the suggested minimum duration for auto event interval
+const minAutoEventInterval = 1 * time.Millisecond
 
 // The AddDevice function accepts the new device model from the controller function
 // and then invokes AddDevice function of infrastructure layer to add new device

--- a/internal/pkg/utils/time.go
+++ b/internal/pkg/utils/time.go
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+)
+
+// CheckMinInterval parses the ISO 8601 time duration string to Duration type
+// and evaluates if the duration value is smaller than the suggested minimum duration string
+func CheckMinInterval(value string, min string, lc logger.LoggingClient) bool {
+	valueDuration, err := time.ParseDuration(value)
+	if err != nil {
+		lc.Errorf("failed to parse the interval duration string %s to a duration time value: %v", value, err)
+		return false
+	}
+	minDuration, err := time.ParseDuration(min)
+	if err != nil {
+		lc.Errorf("failed to parse the  minimum duration string %s to a duration time value: %v", value, err)
+		return false
+	}
+
+	if valueDuration < minDuration {
+		// the duration value is smaller than the min
+		lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", valueDuration, minDuration)
+		return false
+	}
+	return true
+}

--- a/internal/pkg/utils/time.go
+++ b/internal/pkg/utils/time.go
@@ -13,17 +13,15 @@ import (
 
 // CheckMinInterval parses the ISO 8601 time duration string to Duration type
 // and evaluates if the duration value is smaller than the suggested minimum duration
-func CheckMinInterval(value string, minDuration time.Duration, lc logger.LoggingClient) bool {
+func CheckMinInterval(value string, minDuration time.Duration, lc logger.LoggingClient) {
 	valueDuration, err := time.ParseDuration(value)
 	if err != nil {
 		lc.Errorf("failed to parse the interval duration string %s to a duration time value: %v", value, err)
-		return false
+		return
 	}
 
 	if valueDuration < minDuration {
 		// the duration value is smaller than the min
-		lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", valueDuration, minDuration)
-		return false
+		lc.Warnf("the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase", value, minDuration)
 	}
-	return true
 }

--- a/internal/pkg/utils/time.go
+++ b/internal/pkg/utils/time.go
@@ -12,16 +12,11 @@ import (
 )
 
 // CheckMinInterval parses the ISO 8601 time duration string to Duration type
-// and evaluates if the duration value is smaller than the suggested minimum duration string
-func CheckMinInterval(value string, min string, lc logger.LoggingClient) bool {
+// and evaluates if the duration value is smaller than the suggested minimum duration
+func CheckMinInterval(value string, minDuration time.Duration, lc logger.LoggingClient) bool {
 	valueDuration, err := time.ParseDuration(value)
 	if err != nil {
 		lc.Errorf("failed to parse the interval duration string %s to a duration time value: %v", value, err)
-		return false
-	}
-	minDuration, err := time.ParseDuration(min)
-	if err != nil {
-		lc.Errorf("failed to parse the  minimum duration string %s to a duration time value: %v", value, err)
 		return false
 	}
 

--- a/internal/pkg/utils/time_test.go
+++ b/internal/pkg/utils/time_test.go
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2023 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckMinInterval(t *testing.T) {
+	lc := logger.NewMockClient()
+
+	tests := []struct {
+		name     string
+		interval string
+		min      string
+		result   bool
+	}{
+		{"valid - interval is bigger than the minimum value", "1s", "10ms", true},
+		{"invalid - interval is smaller than the minimum value", "100us", "1ms", false},
+		{"invalid - parsing duration string failed", "INVALID", "1ms", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckMinInterval(tt.interval, tt.min, lc)
+			assert.Equal(t, tt.result, result)
+		})
+	}
+}

--- a/internal/pkg/utils/time_test.go
+++ b/internal/pkg/utils/time_test.go
@@ -6,31 +6,54 @@
 package utils
 
 import (
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger/mocks"
 )
 
 func TestCheckMinInterval(t *testing.T) {
-	lc := logger.NewMockClient()
+	validInterval := "1s"
+	lessThanMinInterval := "100us"
+	invalidInterval := "INVALID"
+	minInterval1 := 10 * time.Millisecond
+	minInterval2 := 1 * time.Millisecond
+
+	warnMsg := "the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase"
+	errMsg := "failed to parse the interval duration string %s to a duration time value: %v"
+	expectedErr := errors.New("time: invalid duration \"" + invalidInterval + "\"")
+
+	lcMock := &mocks.LoggingClient{}
+	lcMock.On("Warnf", warnMsg, validInterval, minInterval1)
+	lcMock.On("Warnf", warnMsg, lessThanMinInterval, minInterval2)
+	lcMock.On("Errorf", errMsg, invalidInterval, expectedErr)
 
 	tests := []struct {
-		name     string
-		interval string
-		min      time.Duration
-		result   bool
+		name        string
+		interval    string
+		min         time.Duration
+		logExpected bool
+		logLevel    string
+		logMsg      string
+		err         error
 	}{
-		{"valid - interval is bigger than the minimum value", "1s", 10 * time.Millisecond, true},
-		{"invalid - interval is smaller than the minimum value", "100us", 1 * time.Millisecond, false},
-		{"invalid - parsing duration string failed", "INVALID", 1 * time.Millisecond, false},
+		{"valid - interval is bigger than the minimum value", validInterval, minInterval1, false, "", "", nil},
+		{"invalid - interval is smaller than the minimum value", lessThanMinInterval, minInterval2, true, "Warnf", warnMsg, nil},
+		{"invalid - parsing duration string failed", invalidInterval, minInterval2, true, "Errorf", errMsg, expectedErr},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := CheckMinInterval(tt.interval, tt.min, lc)
-			assert.Equal(t, tt.result, result)
+			CheckMinInterval(tt.interval, tt.min, lcMock)
+			if tt.logExpected {
+				if tt.logLevel == "Warnf" {
+					lcMock.AssertCalled(t, tt.logLevel, tt.logMsg, tt.interval, tt.min)
+				} else {
+					lcMock.AssertCalled(t, tt.logLevel, tt.logMsg, tt.interval, tt.err)
+				}
+			} else {
+				lcMock.AssertNotCalled(t, tt.logLevel, tt.logMsg, tt.interval, tt.min)
+			}
 		})
 	}
 }

--- a/internal/pkg/utils/time_test.go
+++ b/internal/pkg/utils/time_test.go
@@ -7,6 +7,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 
@@ -19,12 +20,12 @@ func TestCheckMinInterval(t *testing.T) {
 	tests := []struct {
 		name     string
 		interval string
-		min      string
+		min      time.Duration
 		result   bool
 	}{
-		{"valid - interval is bigger than the minimum value", "1s", "10ms", true},
-		{"invalid - interval is smaller than the minimum value", "100us", "1ms", false},
-		{"invalid - parsing duration string failed", "INVALID", "1ms", false},
+		{"valid - interval is bigger than the minimum value", "1s", 10 * time.Millisecond, true},
+		{"invalid - interval is smaller than the minimum value", "100us", 1 * time.Millisecond, false},
+		{"invalid - parsing duration string failed", "INVALID", 1 * time.Millisecond, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/support/scheduler/application/interval.go
+++ b/internal/support/scheduler/application/interval.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/utils"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/infrastructure/interfaces"
 
@@ -21,6 +22,9 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 )
+
+// the suggested minimum duration string for scheduler interval
+const minSchedulerInterval = "10ms"
 
 // The AddInterval function accepts the new Interval model from the controller function
 // and then invokes AddInterval function of infrastructure layer to add new Interval
@@ -40,6 +44,9 @@ func AddInterval(interval models.Interval, ctx context.Context, dic *di.Containe
 	lc.Debugf("Interval created on DB successfully. Interval ID: %s, Correlation-ID: %s ",
 		addedInterval.Id,
 		correlation.FromContext(ctx))
+
+	// If interval is successfully created, check the interval value and display a warning if it's smaller than the suggested 10ms value
+	utils.CheckMinInterval(interval.Interval, minSchedulerInterval, lc)
 
 	return addedInterval.Id, nil
 }
@@ -115,6 +122,9 @@ func PatchInterval(dto dtos.UpdateInterval, ctx context.Context, dic *di.Contain
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+
+	// If interval is successfully updated, check the interval value and display a warning if it's smaller than the suggested 10ms value
+	utils.CheckMinInterval(interval.Interval, minSchedulerInterval, lc)
 
 	lc.Debugf(
 		"Interval patched on DB successfully. Correlation-ID: %s ",

--- a/internal/support/scheduler/application/interval.go
+++ b/internal/support/scheduler/application/interval.go
@@ -8,6 +8,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/utils"
@@ -23,8 +24,8 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 )
 
-// the suggested minimum duration string for scheduler interval
-const minSchedulerInterval = "10ms"
+// the suggested minimum duration for scheduler interval
+const minSchedulerInterval = 10 * time.Millisecond
 
 // The AddInterval function accepts the new Interval model from the controller function
 // and then invokes AddInterval function of infrastructure layer to add new Interval


### PR DESCRIPTION
Add warn log for interval value from Interval and AutoEvent if the value is less than the suggested value.

Closes #4586.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) - _no doc change needed as the change only shows the warning logs when the interval value is less than the suggested value._
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Invoke the POST interval API with the following command:
```
curl --location 'http://localhost:59861/api/v3/interval' \
--header 'Content-Type: application/json' \
--data '  [ 
    {
      "apiVersion":"v3",
      "interval":{
         "name":"test",
         "start":"20230707T094508",
         "interval":"599us"
      }
   }
  ]'
```
The following warning log should be displayed in the support-scheduler log:
```
level=WARN ts=2023-07-05T07:27:29.922821Z app=support-scheduler source=time.go:30 msg="the interval value '599µs' is smaller than the suggested value '10ms', which might cause abnormal CPU increase"
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->