### PR TITLE
feat: use a better error handling logic and messages when run in hybrid mode with no common config

### DIFF
--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -91,6 +91,11 @@ func MessagingBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupT
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
 
+	if len(configuration.Service.RequestTimeout) == 0 {
+		lc.Error("Service.RequestTimeout found empty in service's configuration, missing common config? Use -cp or -cc flags for common config")
+		return false
+	}
+
 	requestTimeout, err := time.ParseDuration(configuration.Service.RequestTimeout)
 	if err != nil {
 		lc.Errorf("Failed to parse Service.RequestTimeout configuration value: %v", err)


### PR DESCRIPTION
  Closes: #4615

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- git clone this PR
- build all services: `make build` 
- make sure your EdgeX stack is running insecure mode from edgex-compose/compose-builder: `make run no-secty`
- and then you would need to stop the service to test from the stack, like for example `docker stop edgex-core-data`
- to see the better error message and handling, you can start with `core-data`: change directory to `cmd/core-data`
- run the core-data in hybrid mode without any common config: `./core-data`, and you should see some better error messages with suggestion like `missing common conifg? Use -cc or -cp flags from the command line.`
- add the missing elements or properties in configuration.yaml /res to observe it going through the next issue and better error messages.   You would need to repeat this process until the service is starting up and running.
- the services been tested are:
  1. all the EdgeX core services: `core-command, core-data, core-metadata`
  2. EdgeX support services: `support-scheduler, support-notifications`
  3. security services: `security-proxy-auth, security-spiffe-token-provider`
  
changed configuration yaml example for core-data:
```yaml
MaxEventSize: 25000 # Defines the maximum event size in kilobytes
Writable:
  InsecureSecrets:
    DB:
      path: "redisdb"
      Secrets:
        username: ""
        password: ""
      SecretName: "redisdb"
      SecretData:
        username: ""
        password: ""
  LogLevel: "INFO"
  PersistData: true
  Telemetry:
    Metrics: # All service's metric names must be present in this list.
      EventsPersisted: false
      ReadingsPersisted: false
#    Tags: # Contains the service level tags to be attached to all the service's metrics
    ##    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only change existing value, not added new ones.
Service:
  Port: 59880
  Host: "localhost"
  StartupMsg: "This is the Core Data Microservice"
  RequestTimeout: "5s"

MessageBus:
  Optional:
    ClientId: "core-data"
  Protocol: "redis"
  Host: "localhost"
  Port: 6379
  Type: "redis"

Database:
  Name: "coredata"
  Host: "localhost"
  Port: 6379
  Timeout: "10s"
  Type: "redisdb"

```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->