### PR TITLE
fix: Fix core-command swagger file

### DIFF
--- a/openapi/v3/core-command.yaml
+++ b/openapi/v3/core-command.yaml
@@ -461,14 +461,14 @@ paths:
           required: true
           schema:
             type: string
-          example: sensor01
+          example: Random-Boolean-Device
           description: "A name uniquely identifying a device."
         - in: path
           name: command
           required: true
           schema:
             type: string
-          example: command01
+          example: Bool
           description: "A name uniquely identifying a command."
         - in: query
           name: ds-pushevent
@@ -562,6 +562,22 @@ paths:
                   $ref: '#/components/examples/503Example'
     put:
       summary: "Issue the specified write command referenced by the command name to the device/sensor that is also referenced by name."
+      parameters:
+        - $ref: '#/components/parameters/correlatedRequestHeader'
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+          example: Random-Boolean-Device
+          description: "A name uniquely identifying a device."
+        - in: path
+          name: command
+          required: true
+          schema:
+            type: string
+          example: Bool
+          description: "A name uniquely identifying a command."
       requestBody:
         content:
           application/json:
@@ -647,6 +663,7 @@ paths:
         required: true
         schema:
           type: string
+        example: Random-Boolean-Device
         description: "A name uniquely identifying a device."
     get:
       summary: "Returns all commands associated with the specified device."


### PR DESCRIPTION
fixing core-command swagger file that has incorrect example and missing PUT parameters

Closes: #4629

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
following https://github.com/edgexfoundry/edgex-go/pull/4569 test instructions for fuzzing test, you will observe the fuzzing test coverage has increased for core-command after this fix.

## New Dependency Instructions (If applicable)
