### PR TITLE
fix: report FuzzLean result to fuzz_results folder

### DIFF
--- a/fuzz_test/fuzzing_docker.sh
+++ b/fuzz_test/fuzzing_docker.sh
@@ -44,7 +44,7 @@ runFuzzLeanPerSwagger() {
 
     echo "--copy result logs into $1"
     mkdir -p /fuzz_results/"$1"
-    cp -r ./Test/ /fuzz_results/"$1"/
+    cp -r ./FuzzLean/ /fuzz_results/"$1"/
 }
 
 if [ "$EDGEX_PROJECT_NAME" == "" ]


### PR DESCRIPTION
the FuzzLean test result is inside the FuzzLean folder and that needs to be copied into fuzz_results

Closes: #4636

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
make docker-fuzz
make fuzz-test-command
You should see "fuzz_test/fuzz_results/core-command/FuzzLean" folder not Test folder

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->