### PR TITLE
fix(security): core-command fuzzing test http error 500

### DIFF
--- a/internal/core/command/controller/http/command_test.go
+++ b/internal/core/command/controller/http/command_test.go
@@ -478,7 +478,7 @@ func TestIssueSetCommand(t *testing.T) {
 		{"Invalid - execute set command with invalid commandName", testDeviceName, nonExistName, testQueryStrings, testSettingsJsonStr, true, http.StatusBadRequest},
 		{"Invalid - empty device name", "", testCommandName, testQueryStrings, testSettingsJsonStr, true, http.StatusBadRequest},
 		{"Invalid - empty command name", testDeviceName, "", testQueryStrings, testSettingsJsonStr, true, http.StatusBadRequest},
-		{"Invalid - empty settings", testDeviceName, testCommandName, testQueryStrings, []byte{}, true, http.StatusInternalServerError},
+		{"Invalid - empty settings", testDeviceName, testCommandName, testQueryStrings, []byte{}, true, http.StatusBadRequest},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/pkg/utils/http.go
+++ b/internal/pkg/utils/http.go
@@ -179,7 +179,7 @@ func ParseBodyToMap(r *http.Request) (map[string]interface{}, errors.EdgeX) {
 
 	var result map[string]interface{}
 	if err = json.Unmarshal(body, &result); err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to parse request body", err)
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to parse request body", err)
 	}
 
 	return result, nil


### PR DESCRIPTION
fixed fuzzing core-command http error 500 when invalid input in body http://localhost:59882/api/v3/device/name/Random-Boolean-Device/Bool

Closes: #4639

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?) just updated the unit test
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
make docker-fuzz
make fuzz-test-command
1. after fuzz test is finished, open "/edgex-go/fuzz_test/fuzz_results/core-command/FuzzLean/RestlerResults/experiment113/bug_buckets", you should not see checker_500 error logs.
2. go back to edge-go, run `make test`, everything should pass

or you can verify it on postman:
PUT http://localhost:59882/api/v3/device/name/Random-Boolean-Device/Bool
raw JSON "false" into the body
output should not be 500 error, here is the expected output:
{
    "apiVersion": "v3",
    "message": "failed to parse request body",
    "statusCode": 400
}

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->