### PR TITLE
fix(security): Fix crash in entrypoint.sh due to exit code

### DIFF
--- a/cmd/security-proxy-setup/entrypoint.sh
+++ b/cmd/security-proxy-setup/entrypoint.sh
@@ -57,7 +57,7 @@ fi
 : ${EDGEX_SERVICE_CORSCONFIGURATION_CORSMAXAGE:=`yq -r .all-services.Service.CORSConfiguration.CORSMaxAge /edgex/res/common_configuration.yaml`}
 
 echo "$(date) CORS settings dump ..."
-env | grep EDGEX_SERVICE_CORSCONFIGURATION
+( env | grep EDGEX_SERVICE_CORSCONFIGURATION ) || true
 
 corssnippet=/etc/nginx/templates/cors.block.$$
 touch "${corssnippet}"


### PR DESCRIPTION
Closes #4641

Fix crash caused by grep returning nonzero exit code during CORS configuration dump

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
"make docker" in edgex-go then "make run dev" in edgex-compose/compose-builder

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->