### PR TITLE
feat: Accept Url escape in API path

### DIFF
--- a/internal/core/command/controller/messaging/internal_test.go
+++ b/internal/core/command/controller/messaging/internal_test.go
@@ -42,12 +42,12 @@ func TestSubscribeCommandRequests(t *testing.T) {
 	expectedDevice := "device1"
 	expectedResource := "resource"
 	expectedMethod := "get"
-	expectedDeviceResponseTopicPrefix := strings.Join([]string{expectedResponseTopicPrefix, expectedServiceName}, "/")
+	expectedDeviceResponseTopicPrefix := strings.Join([]string{expectedResponseTopicPrefix, common.URLEncode(expectedServiceName)}, "/")
 	expectedCommandResponseTopic := strings.Join([]string{expectedResponseTopicPrefix, common.CoreCommandServiceKey, expectedRequestId}, "/")
 	expectedCommandRequestSubscribeTopic := common.BuildTopic(baseTopic, common.CoreCommandRequestSubscribeTopic)
 	expectedCommandRequestReceivedTopic := common.BuildTopic(strings.Replace(expectedCommandRequestSubscribeTopic, "/#", "", 1),
 		expectedServiceName, expectedDevice, expectedResource, expectedMethod)
-	expectedDeviceCommandRequestRequestTopic := common.BuildTopic(baseTopic, common.CoreCommandDeviceRequestPublishTopic, expectedServiceName, expectedDevice, expectedResource, expectedMethod)
+	expectedDeviceCommandRequestRequestTopic := common.BuildTopic(baseTopic, common.CoreCommandDeviceRequestPublishTopic, common.URLEncode(expectedServiceName), common.URLEncode(expectedDevice), common.URLEncode(expectedResource), expectedMethod)
 	mockLogger := &lcMocks.LoggingClient{}
 	mockDeviceClient := &mocks2.DeviceClient{}
 	mockDeviceProfileClient := &mocks2.DeviceProfileClient{}

--- a/internal/core/command/controller/messaging/utils.go
+++ b/internal/core/command/controller/messaging/utils.go
@@ -24,32 +24,29 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/command/application"
 )
 
-// validateRequestTopic validates the request topic by checking the existence of device and device service,
-// returns the internal device request topic and service name to which the command request will be sent.
-func validateRequestTopic(prefix string, deviceName string, commandName string, method string, dic *di.Container) (string, string, error) {
+// retrieveServiceNameByDevice validates the existence of device and device service,
+// returns the service name to which the command request will be sent.
+func retrieveServiceNameByDevice(deviceName string, dic *di.Container) (string, error) {
 	// retrieve device information through Metadata DeviceClient
 	dc := bootstrapContainer.DeviceClientFrom(dic.Get)
 	if dc == nil {
-		return "", "", errors.New("nil Device Client")
+		return "", errors.New("nil Device Client")
 	}
 	deviceResponse, err := dc.DeviceByName(context.Background(), deviceName)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get Device by name %s: %v", deviceName, err)
+		return "", fmt.Errorf("failed to get Device by name %s: %v", deviceName, err)
 	}
 
 	// retrieve device service information through Metadata DeviceClient
 	dsc := bootstrapContainer.DeviceServiceClientFrom(dic.Get)
 	if dsc == nil {
-		return "", "", errors.New("nil DeviceService Client")
+		return "", errors.New("nil DeviceService Client")
 	}
 	deviceServiceResponse, err := dsc.DeviceServiceByName(context.Background(), deviceResponse.Device.ServiceName)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get DeviceService by name %s: %v", deviceResponse.Device.ServiceName, err)
+		return "", fmt.Errorf("failed to get DeviceService by name %s: %v", deviceResponse.Device.ServiceName, err)
 	}
-
-	// expected internal command request topic scheme: <prefix>/<device-service>/<device>/<command-name>/<method>
-	return deviceServiceResponse.Service.Name, common.BuildTopic(prefix, deviceServiceResponse.Service.Name, deviceName, commandName, method), nil
-
+	return deviceServiceResponse.Service.Name, nil
 }
 
 // validateGetCommandQueryParameters validates the value is valid for device service's reserved query parameters

--- a/internal/core/data/application/event.go
+++ b/internal/core/data/application/event.go
@@ -8,7 +8,6 @@ package application
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/v3/pkg/types"
@@ -83,7 +82,7 @@ func (a *CoreDataApp) PublishEvent(data []byte, serviceName string, profileName 
 	correlationId := correlation.FromContext(ctx)
 
 	basePrefix := configuration.MessageBus.GetBaseTopicPrefix()
-	publishTopic := common.BuildTopic(basePrefix, common.EventsPublishTopic, CoreDataEventTopicPrefix, serviceName, profileName, deviceName, url.QueryEscape(sourceName))
+	publishTopic := common.BuildTopic(basePrefix, common.EventsPublishTopic, CoreDataEventTopicPrefix, common.URLEncode(serviceName), common.URLEncode(profileName), common.URLEncode(deviceName), common.URLEncode(sourceName))
 	lc.Debugf("Publishing AddEventRequest to MessageBus. Topic: %s; %s: %s", publishTopic, common.CorrelationHeader, correlationId)
 
 	msgEnvelope := msgTypes.NewMessageEnvelope(data, ctx)

--- a/internal/core/data/controller/messaging/subscriber.go
+++ b/internal/core/data/controller/messaging/subscriber.go
@@ -118,8 +118,14 @@ func validateEvent(messageTopic string, e dtos.Event) errors.EdgeX {
 	}
 
 	len := len(fields)
-	profileName := fields[len-3]
-	deviceName := fields[len-2]
+	profileName, err := url.PathUnescape(fields[len-3])
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	deviceName, err := url.PathUnescape(fields[len-2])
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
 	sourceName, err := url.PathUnescape(fields[len-1])
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)

--- a/internal/core/metadata/application/notify.go
+++ b/internal/core/metadata/application/notify.go
@@ -42,8 +42,8 @@ func validateDeviceCallback(device dtos.Device, dic *di.Container) errors.EdgeX 
 	}
 
 	baseTopic := configuration.MessageBus.GetBaseTopicPrefix()
-	requestTopic := common.BuildTopic(baseTopic, device.ServiceName, common.ValidateDeviceSubscribeTopic)
-	responseTopicPrefix := common.BuildTopic(baseTopic, common.ResponseTopic, device.ServiceName)
+	requestTopic := common.BuildTopic(baseTopic, common.URLEncode(device.ServiceName), common.ValidateDeviceSubscribeTopic)
+	responseTopicPrefix := common.BuildTopic(baseTopic, common.ResponseTopic, common.URLEncode(device.ServiceName))
 	requestEnvelope := types.NewMessageEnvelopeForRequest(requestBytes, nil)
 
 	lc.Debugf("Sending Device Validation request for device=%s, CorrelationId=%s to topic: %s", device.Name, requestEnvelope.CorrelationID, requestTopic)
@@ -136,13 +136,13 @@ func publishSystemEvent(eventType, action, owner string, dto any, ctx context.Co
 		systemEvent.Source,
 		systemEvent.Type,
 		systemEvent.Action,
-		systemEvent.Owner,
+		common.URLEncode(systemEvent.Owner),
 	)
 
 	if profileName != "" {
 		publishTopic = common.BuildTopic(
 			publishTopic,
-			profileName,
+			common.URLEncode(profileName),
 		)
 	}
 

--- a/internal/core/metadata/application/notify_test.go
+++ b/internal/core/metadata/application/notify_test.go
@@ -171,8 +171,8 @@ func TestPublishSystemEvent(t *testing.T) {
 				common.CoreMetaDataServiceKey,
 				test.Type,
 				test.Action,
-				test.Owner,
-				expectedDevice.ProfileName)
+				common.URLEncode(test.Owner),
+				common.URLEncode(expectedDevice.ProfileName))
 			mockClient.AssertCalled(t, "Publish", mock.Anything, expectedTopic)
 
 			if test.PubError {


### PR DESCRIPTION
Use escaped for message bus topic
- service name
- profile name
- device name

Close #4053

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- Run unit test
- Run core service and device service to verify the API works with special char.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->