### PR TITLE
build: Pull spire-server and spire-agent from prebuilt containers

### DIFF
--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -6,3 +6,5 @@ ignored:
 
 trustedRegistries:
   - docker.io
+  - ghcr.io
+

--- a/cmd/security-spire-agent/Dockerfile
+++ b/cmd/security-spire-agent/Dockerfile
@@ -1,5 +1,5 @@
 #  ----------------------------------------------------------------------------------
-#  Copyright 2022 Intel Corporation
+#  Copyright 2023 Intel Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -19,31 +19,8 @@
 ARG BUILDER_BASE=golang:1.20-alpine3.17
 FROM ${BUILDER_BASE} AS builder
 
-WORKDIR /edgex-go
-
-RUN apk add --update --no-cache make git build-base curl
-
-COPY go.mod vendor* ./
-RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
-
-COPY . .
-
-ARG SPIRE_RELEASE=1.6.3
-
-# build spire from the source in order to be compatible with arch arm64 as well
-# in CI the BUILDER_BASE will already contain a compiled spire-server/agent
-# so we check to see if the binary is already in the image before compilation
-WORKDIR /edgex-go/spire-build
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN if ! test -f /usr/local/bin/spire-server; then wget -q "https://github.com/spiffe/spire/archive/refs/tags/v${SPIRE_RELEASE}.tar.gz" && \
-    tar xv --strip-components=1 -f "v${SPIRE_RELEASE}.tar.gz" && \
-    echo "building spire from source..." && \
-    go version | sed -n -e 's/.*go\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' > .go-version && \
-    make bin/spire-server bin/spire-agent && \
-    cp bin/spire* /usr/local/bin/; \
-    fi
-
-WORKDIR /edgex-go
+FROM ghcr.io/spiffe/spire-server:1.6.3 as spire_server
+FROM ghcr.io/spiffe/spire-agent:1.6.3 as spire_agent
 
 # Deployment image
 FROM alpine:3.17
@@ -53,15 +30,15 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
 
 RUN apk update && apk --no-cache --update add dumb-init openssl gcompat
 
-COPY --from=builder /edgex-go/Attribution.txt /
-COPY --from=builder /edgex-go/security.txt /
+COPY --from=spire_agent /opt/spire/bin/spire-agent /usr/local/bin
+COPY --from=spire_server /opt/spire/bin/spire-server /usr/local/bin
 
-COPY --from=builder /usr/local/bin/spire-agent /usr/local/bin
-COPY --from=builder /usr/local/bin/spire-server /usr/local/bin
+COPY Attribution.txt /
+COPY security.txt /
 
-COPY --from=builder /edgex-go/cmd/security-spire-agent/docker-entrypoint.sh /usr/local/bin/
-COPY --from=builder /edgex-go/cmd/security-spire-agent/agent.conf /usr/local/etc/spire/agent.conf.tpl
-COPY --from=builder /edgex-go/cmd/security-spire-agent/openssl.conf /usr/local/etc/
+COPY cmd/security-spire-agent/docker-entrypoint.sh /usr/local/bin/
+COPY cmd/security-spire-agent/agent.conf /usr/local/etc/spire/agent.conf.tpl
+COPY cmd/security-spire-agent/openssl.conf /usr/local/etc/
 
 ENTRYPOINT [ "/usr/bin/dumb-init" ]
 CMD [ "--verbose", "docker-entrypoint.sh" ]

--- a/cmd/security-spire-config/Dockerfile
+++ b/cmd/security-spire-config/Dockerfile
@@ -1,5 +1,5 @@
 #  ----------------------------------------------------------------------------------
-#  Copyright 2022 Intel Corporation
+#  Copyright 2023 Intel Corporation
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -19,31 +19,7 @@
 ARG BUILDER_BASE=golang:1.20-alpine3.17
 FROM ${BUILDER_BASE} AS builder
 
-WORKDIR /edgex-go
-
-RUN apk add --update --no-cache make git build-base curl
-
-COPY go.mod vendor* ./
-RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
-
-COPY . .
-
-ARG SPIRE_RELEASE=1.6.3
-
-# build spire from the source in order to be compatible with arch arm64 as well
-# in CI the BUILDER_BASE will already contain a compiled spire-server/agent
-# so we check to see if the binary is already in the image before compilation
-WORKDIR /edgex-go/spire-build
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN if ! test -f /usr/local/bin/spire-server; then wget -q "https://github.com/spiffe/spire/archive/refs/tags/v${SPIRE_RELEASE}.tar.gz" && \
-    tar xv --strip-components=1 -f "v${SPIRE_RELEASE}.tar.gz" && \
-    echo "building spire from source..." && \
-    go version | sed -n -e 's/.*go\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' > .go-version && \
-    make bin/spire-server bin/spire-agent && \
-    cp bin/spire* /usr/local/bin/; \
-    fi
-
-WORKDIR /edgex-go
+FROM ghcr.io/spiffe/spire-server:1.6.3 as spire_server
 
 # Deployment image
 FROM alpine:3.17
@@ -53,13 +29,14 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
 
 RUN apk update && apk --no-cache --update add dumb-init gcompat
 
-COPY --from=builder /edgex-go/Attribution.txt /
-COPY --from=builder /edgex-go/security.txt /
-COPY --from=builder /usr/local/bin/spire-server /usr/local/bin
-COPY --from=builder /edgex-go/cmd/security-spire-config/docker-entrypoint.sh /usr/local/bin/
+COPY --from=spire_server /opt/spire/bin/spire-server /usr/local/bin
+
+COPY Attribution.txt /
+COPY security.txt /
+COPY cmd/security-spire-config/docker-entrypoint.sh /usr/local/bin/
 
 WORKDIR /usr/local/etc/spiffe-scripts.d
-COPY --from=builder /edgex-go/cmd/security-spire-config/seed_builtin_entries.sh /usr/local/etc/spiffe-scripts.d
+COPY cmd/security-spire-config/seed_builtin_entries.sh /usr/local/etc/spiffe-scripts.d
 
 WORKDIR /
 

--- a/cmd/security-spire-server/Dockerfile
+++ b/cmd/security-spire-server/Dockerfile
@@ -19,31 +19,7 @@
 ARG BUILDER_BASE=golang:1.20-alpine3.17
 FROM ${BUILDER_BASE} AS builder
 
-WORKDIR /edgex-go
-
-RUN apk add --update --no-cache make git build-base curl
-
-COPY go.mod vendor* ./
-RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
-
-COPY . .
-
-ARG SPIRE_RELEASE=1.6.3
-
-# build spire from the source in order to be compatible with arch arm64 as well
-# in CI the BUILDER_BASE will already contain a compiled spire-server/agent
-# so we check to see if the binary is already in the image before compilation
-WORKDIR /edgex-go/spire-build
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN if ! test -f /usr/local/bin/spire-server; then wget -q "https://github.com/spiffe/spire/archive/refs/tags/v${SPIRE_RELEASE}.tar.gz" && \
-      tar xv --strip-components=1 -f "v${SPIRE_RELEASE}.tar.gz" && \
-      echo "building spire from source..." && \
-      go version | sed -n -e 's/.*go\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' > .go-version && \
-      make bin/spire-server bin/spire-agent && \
-      cp bin/spire* /usr/local/bin/; \
-    fi
-
-WORKDIR /edgex-go
+FROM ghcr.io/spiffe/spire-server:1.6.3 as spire_server
 
 # Deployment image
 FROM alpine:3.17
@@ -53,13 +29,14 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
 
 RUN apk update && apk --no-cache --update add dumb-init openssl gcompat
 
-COPY --from=builder /edgex-go/Attribution.txt /
-COPY --from=builder /edgex-go/security.txt /
+COPY --from=spire_server /opt/spire/bin/spire-server /usr/local/bin
 
-COPY --from=builder /usr/local/bin/spire-server /usr/local/bin
-COPY --from=builder /edgex-go/cmd/security-spire-server/docker-entrypoint.sh /usr/local/bin/
-COPY --from=builder /edgex-go/cmd/security-spire-server/server.conf /usr/local/etc/spire/server.conf.tpl
-COPY --from=builder /edgex-go/cmd/security-spire-server/openssl.conf /usr/local/etc/
+COPY Attribution.txt /
+COPY security.txt /
+
+COPY cmd/security-spire-server/docker-entrypoint.sh /usr/local/bin/
+COPY cmd/security-spire-server/server.conf /usr/local/etc/spire/server.conf.tpl
+COPY cmd/security-spire-server/openssl.conf /usr/local/etc/
 
 ENTRYPOINT [ "/usr/bin/dumb-init" ]
 CMD [ "--verbose", "docker-entrypoint.sh" ]


### PR DESCRIPTION
SPIRE project is now publishing prebuilt containers for linux/amd64 and linux/arm64 on their github project that have statically-linked spire-server and spire-agent components.  Rather than building locally, we can just reference the GHCR containers in a FROM line and directly pull in the binaries, without having to waste time building them.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
"make docker" in this repo and "make run dev delayed-start ds-virtual" in edgex-compose/compose-builder and ensure all containers start properly.  This should be tested both on Intel and ARM64 architectures to be valid.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->