### PR TITLE
fix(security): Access-Control-Allow-Credentials is all CORS requests

### DIFF
--- a/cmd/security-proxy-setup/entrypoint.sh
+++ b/cmd/security-proxy-setup/entrypoint.sh
@@ -59,6 +59,8 @@ fi
 echo "$(date) CORS settings dump ..."
 ( set | grep EDGEX_SERVICE_CORSCONFIGURATION ) || true
 
+# See https://github.com/edgexfoundry/edgex-go/issues/4648 as to why CORS is implemented this way.
+# Warning: no not simplify add_header redundancy. See https://www.peterbe.com/plog/be-very-careful-with-your-add_header-in-nginx
 corssnippet=/etc/nginx/templates/cors.block.$$
 touch "${corssnippet}"
 if test "${EDGEX_SERVICE_CORSCONFIGURATION_ENABLECORS}" = "true"; then
@@ -66,7 +68,6 @@ if test "${EDGEX_SERVICE_CORSCONFIGURATION_ENABLECORS}" = "true"; then
   echo "        add_header 'Access-Control-Allow-Origin' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWEDORIGIN}';" >> "${corssnippet}"
   echo "        add_header 'Access-Control-Allow-Methods' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWEDMETHODS}';" >> "${corssnippet}"
   echo "        add_header 'Access-Control-Allow-Headers' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWEDHEADERS}';" >> "${corssnippet}"
-  # Access-Control-Expose-Headers should not be set on OPTIONS request
   if test "${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWCREDENTIALS}" = "true"; then
     # CORS specificaiton says that if not true, omit the header entirely
     echo "        add_header 'Access-Control-Allow-Credentials' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWCREDENTIALS}';" >> "${corssnippet}"
@@ -81,6 +82,10 @@ if test "${EDGEX_SERVICE_CORSCONFIGURATION_ENABLECORS}" = "true"; then
   # Always add headers regardless of response code.  Omit preflight-related headers (allow-methods, allow-headers, allow-credentials, max-age)
   echo "        add_header 'Access-Control-Allow-Origin' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWEDORIGIN}' always;" >> "${corssnippet}"
   echo "        add_header 'Access-Control-Expose-Headers' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSEXPOSEHEADERS}' always;" >> "${corssnippet}"
+  if test "${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWCREDENTIALS}" = "true"; then
+    # CORS specificaiton says that if not true, omit the header entirely
+    echo "        add_header 'Access-Control-Allow-Credentials' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWCREDENTIALS}';" >> "${corssnippet}"
+  fi
   echo "        add_header 'Vary' 'origin' always;" >> "${corssnippet}"
   echo "      }" >> "${corssnippet}"
   echo "" >> "${corssnippet}"

--- a/snap/local/runtime-helpers/bin/security-bootstrapper-nginx
+++ b/snap/local/runtime-helpers/bin/security-bootstrapper-nginx
@@ -31,6 +31,8 @@ fi
 echo "$(date) CORS settings dump ..."
 ( set | grep EDGEX_SERVICE_CORSCONFIGURATION ) || true
 
+# See https://github.com/edgexfoundry/edgex-go/issues/4648 as to why CORS is implemented this way.
+# Warning: no not simplify add_header redundancy. See https://www.peterbe.com/plog/be-very-careful-with-your-add_header-in-nginx
 corssnippet=/tmp/cors.block.$$
 touch "${corssnippet}"
 if test "${EDGEX_SERVICE_CORSCONFIGURATION_ENABLECORS}" = "true"; then
@@ -38,7 +40,6 @@ if test "${EDGEX_SERVICE_CORSCONFIGURATION_ENABLECORS}" = "true"; then
   echo "        add_header 'Access-Control-Allow-Origin' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWEDORIGIN}';" >> "${corssnippet}"
   echo "        add_header 'Access-Control-Allow-Methods' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWEDMETHODS}';" >> "${corssnippet}"
   echo "        add_header 'Access-Control-Allow-Headers' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWEDHEADERS}';" >> "${corssnippet}"
-  # Access-Control-Expose-Headers should not be set on OPTIONS request
   if test "${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWCREDENTIALS}" = "true"; then
     # CORS specificaiton says that if not true, omit the header entirely
     echo "        add_header 'Access-Control-Allow-Credentials' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWCREDENTIALS}';" >> "${corssnippet}"
@@ -53,6 +54,10 @@ if test "${EDGEX_SERVICE_CORSCONFIGURATION_ENABLECORS}" = "true"; then
   # Always add headers regardless of response code.  Omit preflight-related headers (allow-methods, allow-headers, allow-credentials, max-age)
   echo "        add_header 'Access-Control-Allow-Origin' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWEDORIGIN}' always;" >> "${corssnippet}"
   echo "        add_header 'Access-Control-Expose-Headers' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSEXPOSEHEADERS}' always;" >> "${corssnippet}"
+  if test "${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWCREDENTIALS}" = "true"; then
+    # CORS specificaiton says that if not true, omit the header entirely
+    echo "        add_header 'Access-Control-Allow-Credentials' '${EDGEX_SERVICE_CORSCONFIGURATION_CORSALLOWCREDENTIALS}';" >> "${corssnippet}"
+  fi
   echo "        add_header 'Vary' 'origin' always;" >> "${corssnippet}"
   echo "      }" >> "${corssnippet}"
   echo "" >> "${corssnippet}"


### PR DESCRIPTION
Access-Control-Allow-Credentials must be sent for non-preflight requests as well.  Note that this PR has TAF approval to send extra headers in order to avoid complicated boolean logic in the nginx rules.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
TAF team will be testing: https://github.com/edgexfoundry/edgex-go/issues/4648

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->