### PR TITLE
fix: Purge notifications properly

### DIFF
--- a/internal/pkg/infrastructure/redis/notification.go
+++ b/internal/pkg/infrastructure/redis/notification.go
@@ -381,7 +381,7 @@ func (c *Client) DeleteProcessedNotificationsByAge(age int64) (err errors.EdgeX)
 }
 
 func latestNotificationByOffset(conn redis.Conn, offset int) (notification models.Notification, edgeXerr errors.EdgeX) {
-	objects, err := getObjectsByRevRange(conn, NotificationCollectionCreated, offset, 1)
+	objects, err := getObjectsByRevRange(conn, NotificationCollection, offset, 1)
 	if err != nil {
 		return notification, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/support/notifications/application/notification.go
+++ b/internal/support/notifications/application/notification.go
@@ -235,12 +235,13 @@ func purgeNotification(dic *di.Container) errors.EdgeX {
 	}
 	if total >= config.Retention.MaxCap {
 		lc.Debugf("Purging the notification amount %d to the minimum capacity %d", total, config.Retention.MinCap)
+		// Query the latest notification and clean notifications by modified date.
 		notification, err := dbClient.LatestNotificationByOffset(config.Retention.MinCap)
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.Kind(err), fmt.Sprintf("failed to query notification with offset '%d'", config.Retention.MinCap), err)
 		}
 		now := time.Now().UnixMilli()
-		age := now - notification.Created
+		age := now - notification.Modified
 		err = dbClient.CleanupNotificationsByAge(age)
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.Kind(err), fmt.Sprintf("failed to delete notifications and transmissions by age '%d'", age), err)


### PR DESCRIPTION
Query the latest notification and clean notification by modified date.

Close #4682

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Test according to the issue description. https://github.com/edgexfoundry/edgex-go/issues/4682


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->