### PR TITLE
feat: Add new bypassValidation query param to Add/Patch Device API

### DIFF
--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -144,7 +144,7 @@ func DeviceNameExists(name string, dic *di.Container) (exists bool, err errors.E
 }
 
 // PatchDevice executes the PATCH operation with the device DTO to replace the old data
-func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container) errors.EdgeX {
+func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container, bypassValidation bool) errors.EdgeX {
 	dbClient := container.DBClientFrom(dic.Get)
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 
@@ -177,9 +177,14 @@ func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container) 
 	}
 
 	deviceDTO := dtos.FromDeviceModelToDTO(device)
-	err = validateDeviceCallback(deviceDTO, dic)
-	if err != nil {
-		return errors.NewCommonEdgeXWrapper(err)
+
+	// Execute the Device Service Validation when bypassValidation is false by default
+	// Skip the Device Service Validation if bypassValidation is true
+	if !bypassValidation {
+		err = validateDeviceCallback(deviceDTO, dic)
+		if err != nil {
+			return errors.NewCommonEdgeXWrapper(err)
+		}
 	}
 
 	err = dbClient.UpdateDevice(device)

--- a/internal/core/metadata/controller/http/device.go
+++ b/internal/core/metadata/controller/http/device.go
@@ -177,6 +177,13 @@ func (dc *DeviceController) PatchDevice(c echo.Context) error {
 	ctx := r.Context()
 	correlationId := correlation.FromContext(ctx)
 
+	var bypassValidation bool
+	// parse URL query string for bypassValidation
+	bypassValidationParamStr := utils.ParseQueryStringToString(r, bypassValidationQueryParam, common.ValueFalse)
+	if bypassValidationParamStr == common.ValueTrue {
+		bypassValidation = true
+	}
+
 	var reqDTOs []requests.UpdateDeviceRequest
 	err := dc.reader.Read(r.Body, &reqDTOs)
 	if err != nil {
@@ -187,7 +194,7 @@ func (dc *DeviceController) PatchDevice(c echo.Context) error {
 	for _, dto := range reqDTOs {
 		var response interface{}
 		reqId := dto.RequestId
-		err := application.PatchDevice(dto.Device, ctx, dc.dic)
+		err := application.PatchDevice(dto.Device, ctx, dc.dic, bypassValidation)
 		if err != nil {
 			lc.Error(err.Error(), common.CorrelationHeader, correlationId)
 			lc.Debug(err.DebugMessages(), common.CorrelationHeader, correlationId)

--- a/internal/core/metadata/controller/http/device_test.go
+++ b/internal/core/metadata/controller/http/device_test.go
@@ -242,13 +242,13 @@ func TestAddDevice(t *testing.T) {
 
 			reader := strings.NewReader(string(jsonData))
 			req, err := http.NewRequest(http.MethodPost, common.ApiDeviceRoute, reader)
+			require.NoError(t, err)
 
 			if !testCase.expectedValidation {
 				query := req.URL.Query()
 				query.Add(bypassValidationQueryParam, common.ValueTrue)
 				req.URL.RawQuery = query.Encode()
 			}
-			require.NoError(t, err)
 
 			// Act
 			recorder := httptest.NewRecorder()
@@ -598,6 +598,7 @@ func TestPatchDevice(t *testing.T) {
 		{"Valid - no requestId", []requests.UpdateDeviceRequest{validWithNoReqID}, http.StatusMultiStatus, http.StatusOK, true, true},
 		{"Valid - no id", []requests.UpdateDeviceRequest{validWithNoId}, http.StatusMultiStatus, http.StatusOK, true, true},
 		{"Valid - no name", []requests.UpdateDeviceRequest{validWithNoName}, http.StatusMultiStatus, http.StatusOK, true, true},
+		{"Valid - bypassValidation", []requests.UpdateDeviceRequest{valid}, http.StatusMultiStatus, http.StatusOK, false, true},
 		{"Invalid - invalid id", []requests.UpdateDeviceRequest{invalidId}, http.StatusBadRequest, http.StatusBadRequest, false, false},
 		{"Invalid - empty id", []requests.UpdateDeviceRequest{emptyId}, http.StatusBadRequest, http.StatusBadRequest, false, false},
 		{"Invalid - empty name", []requests.UpdateDeviceRequest{emptyName}, http.StatusBadRequest, http.StatusBadRequest, false, false},
@@ -653,6 +654,12 @@ func TestPatchDevice(t *testing.T) {
 			reader := strings.NewReader(string(jsonData))
 			req, err := http.NewRequest(http.MethodPatch, common.ApiDeviceRoute, reader)
 			require.NoError(t, err)
+
+			if !testCase.expectedValidation {
+				query := req.URL.Query()
+				query.Add(bypassValidationQueryParam, common.ValueTrue)
+				req.URL.RawQuery = query.Encode()
+			}
 
 			// Act
 			recorder := httptest.NewRecorder()

--- a/internal/core/metadata/controller/http/device_test.go
+++ b/internal/core/metadata/controller/http/device_test.go
@@ -184,6 +184,7 @@ func TestAddDevice(t *testing.T) {
 		expectedSystemEvent  bool
 	}{
 		{"Valid", []requests.AddDeviceRequest{valid}, http.StatusMultiStatus, http.StatusCreated, true, true},
+		{"Valid - bypassValidation", []requests.AddDeviceRequest{valid}, http.StatusMultiStatus, http.StatusCreated, false, true},
 		{"Invalid - not found profile", []requests.AddDeviceRequest{notFoundProfile}, http.StatusMultiStatus, http.StatusNotFound, true, false},
 		{"Invalid - no name", []requests.AddDeviceRequest{noName}, http.StatusBadRequest, http.StatusBadRequest, false, false},
 		{"Invalid - no adminState", []requests.AddDeviceRequest{noAdminState}, http.StatusBadRequest, http.StatusBadRequest, false, false},
@@ -241,6 +242,12 @@ func TestAddDevice(t *testing.T) {
 
 			reader := strings.NewReader(string(jsonData))
 			req, err := http.NewRequest(http.MethodPost, common.ApiDeviceRoute, reader)
+
+			if !testCase.expectedValidation {
+				query := req.URL.Query()
+				query.Add(bypassValidationQueryParam, common.ValueTrue)
+				req.URL.RawQuery = query.Encode()
+			}
 			require.NoError(t, err)
 
 			// Act

--- a/openapi/v3/core-metadata.yaml
+++ b/openapi/v3/core-metadata.yaml
@@ -1590,10 +1590,9 @@ paths:
   /device:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
+      - $ref: '#/components/parameters/bypassValidationParam'
     post:
       summary: "Allows provisioning of a new device"
-      parameters:
-        - $ref: '#/components/parameters/bypassValidationParam'
       requestBody:
         required: true
         content:

--- a/openapi/v3/core-metadata.yaml
+++ b/openapi/v3/core-metadata.yaml
@@ -1136,6 +1136,14 @@ components:
       schema:
         type: string
       description: "Allows for querying a given object by associated user-defined label. More than one label may be specified via a comma-delimited list."
+    bypassValidationParam:
+      in: query
+      name: bypassValidation
+      required: false
+      schema:
+        type: boolean
+      description: "Indicates whether to skip the Device Service Validation API call."
+      default: false
   headers:
     correlatedResponseHeader:
       description: "A response header that returns the unique correlation ID used to initiate the request."
@@ -1584,6 +1592,8 @@ paths:
       - $ref: '#/components/parameters/correlatedRequestHeader'
     post:
       summary: "Allows provisioning of a new device"
+      parameters:
+        - $ref: '#/components/parameters/bypassValidationParam'
       requestBody:
         required: true
         content:


### PR DESCRIPTION
Fixes #4789. Add new bypassValidation query param to Add/Patch Device API.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->