### PR TITLE
feat: Implement Get All DeviceProfile BasicInfo API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.4.3
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.2.0-dev.38
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.2.0-dev.7
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.26
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.27
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.2.0-dev.26
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.2.0-dev.7
 	github.com/fxamacker/cbor/v2 v2.7.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v3 v3.2.0-dev.38 h1:I6WfSLF5Xk4S/mQxrN5
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.2.0-dev.38/go.mod h1:TVhjFOP3UsYhtAOgOnORCKO6K0G6AyMpVNO0aMrtCvk=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.2.0-dev.7 h1:FTps28H9Phy/oVKJjAOdNFGVXRKXIqQo2rLQV8y5DVA=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.2.0-dev.7/go.mod h1:WX+Cqr/+nXRKxNIcvekHdf5ubbTZX0D76Rj2T0FKmtA=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.26 h1:7b7jMJcF/EEV8yf203q8WjrM5VMPY/DLxWwrKWnasQk=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.26/go.mod h1:DXNOFlESZek+NiNTSAsXTAOj/DEhpe6jMIbQ5RpnElo=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.27 h1:kocPmpfUAAhCf2cii0NVkB4gMslYRPEZYJfCLhsx5fs=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.27/go.mod h1:DXNOFlESZek+NiNTSAsXTAOj/DEhpe6jMIbQ5RpnElo=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.2.0-dev.26 h1:Fkiki07fSxofusT6vV510CdoSwE0vy91xJTdPs8bO0Q=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.2.0-dev.26/go.mod h1:PXE87Ia/lH5vVQxLMEpzb4e2UTA1e3n8tZXSwRkf0uw=
 github.com/edgexfoundry/go-mod-registry/v3 v3.2.0-dev.9 h1:pGSmX00BRUDAWuEnntqtt9E8e7Gbw5iyGG9Fdr7FK0s=

--- a/internal/core/metadata/application/deviceprofile.go
+++ b/internal/core/metadata/application/deviceprofile.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2020-2022 IOTech Ltd
+// Copyright (C) 2020-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -224,6 +224,23 @@ func PatchDeviceProfileBasicInfo(ctx context.Context, dto dtos.UpdateDeviceProfi
 	go publishUpdateDeviceProfileSystemEvent(profileDTO, ctx, dic)
 
 	return nil
+}
+
+// AllDeviceProfileBasicInfos query the device profile basic infos with offset, and limit
+func AllDeviceProfileBasicInfos(offset int, limit int, labels []string, dic *di.Container) (deviceProfileBasicInfos []dtos.DeviceProfileBasicInfo, totalCount uint32, err errors.EdgeX) {
+	dbClient := container.DBClientFrom(dic.Get)
+	dps, err := dbClient.AllDeviceProfiles(offset, limit, labels)
+	if err == nil {
+		totalCount, err = dbClient.DeviceProfileCountByLabels(labels)
+	}
+	if err != nil {
+		return deviceProfileBasicInfos, totalCount, errors.NewCommonEdgeXWrapper(err)
+	}
+	deviceProfileBasicInfos = make([]dtos.DeviceProfileBasicInfo, len(dps))
+	for i, dp := range dps {
+		deviceProfileBasicInfos[i] = dtos.FromDeviceProfileModelToBasicInfoDTO(dp)
+	}
+	return deviceProfileBasicInfos, totalCount, nil
 }
 
 func deviceProfileByDTO(dbClient interfaces.DBClient, dto dtos.UpdateDeviceProfileBasicInfo) (deviceProfile models.DeviceProfile, err errors.EdgeX) {

--- a/internal/core/metadata/controller/http/deviceprofile.go
+++ b/internal/core/metadata/controller/http/deviceprofile.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021-2023 IOTech Ltd
+// Copyright (C) 2021-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -381,4 +381,26 @@ func (dc *DeviceProfileController) PatchDeviceProfileBasicInfo(c echo.Context) e
 
 	utils.WriteHttpHeader(w, ctx, http.StatusMultiStatus)
 	return pkg.EncodeAndWriteResponse(updateResponses, w, lc)
+}
+
+func (dc *DeviceProfileController) AllDeviceProfileBasicInfos(c echo.Context) error {
+	lc := container.LoggingClientFrom(dc.dic.Get)
+	r := c.Request()
+	w := c.Response()
+	ctx := r.Context()
+	config := metadataContainer.ConfigurationFrom(dc.dic.Get)
+
+	// parse URL query string for offset, limit, and labels
+	offset, limit, labels, err := utils.ParseGetAllObjectsRequestQueryString(c, 0, math.MaxInt32, -1, config.Service.MaxResultCount)
+	if err != nil {
+		return utils.WriteErrorResponse(w, ctx, lc, err, "")
+	}
+	deviceProfileBasicInfos, totalCount, err := application.AllDeviceProfileBasicInfos(offset, limit, labels, dc.dic)
+	if err != nil {
+		return utils.WriteErrorResponse(w, ctx, lc, err, "")
+	}
+
+	response := responseDTO.NewMultiDeviceProfileBasicInfosResponse("", "", http.StatusOK, totalCount, deviceProfileBasicInfos)
+	utils.WriteHttpHeader(w, ctx, http.StatusOK)
+	return pkg.EncodeAndWriteResponse(response, w, lc)
 }

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021-2023 IOTech Ltd
+// Copyright (C) 2021-2024 IOTech Ltd
 // Copyright (C) 2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -45,6 +45,7 @@ func LoadRestRoutes(r *echo.Echo, dic *di.Container, serviceName string) {
 	r.GET(common.ApiDeviceProfileByManufacturerEchoRoute, dc.DeviceProfilesByManufacturer, authenticationHook)
 	r.GET(common.ApiDeviceProfileByManufacturerAndModelEchoRoute, dc.DeviceProfilesByManufacturerAndModel, authenticationHook)
 	r.PATCH(common.ApiDeviceProfileBasicInfoRoute, dc.PatchDeviceProfileBasicInfo, authenticationHook)
+	r.GET(common.ApiAllDeviceProfileBasicInfoRoute, dc.AllDeviceProfileBasicInfos, authenticationHook)
 
 	// Device Resource
 	dr := metadataController.NewDeviceResourceController(dic)

--- a/openapi/v3/core-metadata.yaml
+++ b/openapi/v3/core-metadata.yaml
@@ -311,6 +311,15 @@ components:
           $ref: '#/components/schemas/DeviceProfileBasicInfo'
       required:
         - profileName
+    MultiDeviceProfileBasicInfosResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseWithTotalCountResponse'
+      type: object
+      properties:
+        profiles:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeviceProfileBasicInfo'
     DeviceProfile:
       description: "A profile defining a class of device to be onboarded, including its capabilities and data format."
       type: object
@@ -1551,6 +1560,27 @@ components:
               resourceOperations:
                 - deviceResource: "1"
                   defaultValue: "false"
+    GetAllDeviceProfileBasicInfosResponse:
+      value:
+        apiVersion: "v3"
+        requestId: "bc979763-afde-492c-b0a2-79ff3025b6de"
+        statusCode: 200
+        totalCount: 3
+        profiles:
+          - id: "9d33b6fd-f38b-4f0e-aef4-0332578ff2c0"
+            name: "Device-Virtual-Profile"
+            description: "Example of Device-Virtual"
+            manufacturer: "IOTech"
+            model: "Device-Virtual-01"
+            labels:
+              - device-virtual-example
+          - id: "3edf4fe9-b3b8-4f78-bb94-ff55f7d9f316"
+            name: "Device-Modbus-Profile"
+            description: "Example of Device-Modbus"
+            manufacturer: "IOTech"
+            model: "Device-Modbus-01"
+            labels:
+              - device-modbus-example
     GetAllProvisionWatchersResponse:
       value:
         apiVersion: "v3"
@@ -2569,6 +2599,51 @@ paths:
                   $ref: '#/components/examples/400Example'
         '500':
           description: An unexpected error occurred on the server
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
+  /deviceprofile/basicinfo/all:
+    parameters:
+      - $ref: '#/components/parameters/correlatedRequestHeader'
+      - $ref: '#/components/parameters/offsetParam'
+      - $ref: '#/components/parameters/limitParam'
+      - $ref: '#/components/parameters/labelsParam'
+    get:
+      summary: "Given the entire range of device profile basic infos sorted by last modified descending, returns a portion of that range according to the offset and limit parameters. Device profiles may also be filtered by label."
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MultiDeviceProfileBasicInfosResponse'
+              examples:
+                GetAllDeviceProfilesResponse:
+                  $ref: '#/components/examples/GetAllDeviceProfileBasicInfosResponse'
+        '400':
+          description: "Request is in an invalid state"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '500':
+          description: "Internal Server Error"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'


### PR DESCRIPTION
The Device Profile sometimes is very large with lots of device resources. Device Profile query may take lots of time and cause request timeout. A new GET /deviceprofile/basicinfo/all API would be helpful for the UI integration

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- run core-metadata
- add device profile
- query the API /api/v3/deviceprofile/basicinfo/all

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->