### PR TITLE
feat(core-data): Add message bus subscription log

### DIFF
--- a/internal/core/data/controller/messaging/subscriber.go
+++ b/internal/core/data/controller/messaging/subscriber.go
@@ -54,6 +54,11 @@ func SubscribeEvents(ctx context.Context, dic *di.Container) errors.EdgeX {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 
+	// Log the topics to which core-data is subscribing
+	for _, t := range topics {
+		lc.Infof("Subscribed to topics: %s", t.Topic)
+	}
+
 	go func() {
 		for {
 			select {


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Note

Please refer the discussion: [Subscribe/Publish Message bus topic - Need understanding on service communications #292](https://github.com/orgs/edgexfoundry/discussions/292) 
Conclusion: no logging for core-data subscription. 

## Testing Instructions

Please note that I'm using a custom Makefile from [edgex-native-build](https://github.com/M0hanrajp/edgex-native-build) (My custom configurations)
* I have gone through [Working in a Hybrid Environment](https://docs.edgexfoundry.org/3.1/getting-started/Ch-GettingStartedHybrid/) and at this time this setup is not working for me.
* So I have created a custom Makefile with configurations that help me in bringing up edgex with few commands.
* Forked & cloned the code from [edgex-go](https://github.com/edgexfoundry/edgex-go) & build and test it with my custom configurations.

Owners/maintainers can suggest me any other method of testing if it needs to be done.

And here is the result from my current configurations:
```bash
level=INFO ts=2024-07-28T06:27:08.812725069Z app=core-data source=subscriber.go:53 msg="core-data subscribing to topics: [{edgex/events/device/# 0xc0005e0180}]"
```

