### PR TITLE
fix: Disable the default discovery scheduler

### DIFF
--- a/cmd/core-common-config-bootstrapper/res/configuration.yaml
+++ b/cmd/core-common-config-bootstrapper/res/configuration.yaml
@@ -136,4 +136,4 @@ device-services:
     Labels: []
     Discovery:
       Enabled: false
-      Interval: "30s"
+      Interval: "0s"


### PR DESCRIPTION
The default auto discovery is disabled, but the default discovery is very short (30s).  When the user enables the auto discovery, it would trigger it every 30s by default.  This value doesn't fit the most of use cases.  By modifying it to 0s, the discovery scheduler will be disabled by default.

BREAKING CHANGE: If the user develops a Device Service with the auto
discovery mechanism and enable it, the discovery won't be automatically
triggered every 30s anymore.  Users have to define this
Device_Discovery_Interval: 30s in the Device Service to keep the
original behavior.

Close https://github.com/edgexfoundry/edgex-go/issues/4859

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>
