### PR TITLE
fix: EDX-5196 Allow source name in regexp

### DIFF
--- a/internal/core/metadata/application/device_test.go
+++ b/internal/core/metadata/application/device_test.go
@@ -79,7 +79,14 @@ func TestValidateAutoEvents(t *testing.T) {
 			models.Device{
 				AutoEvents: []models.AutoEvent{{SourceName: source1, Interval: "1s"}},
 			},
-			true,
+			false,
+		},
+		{"resource match regex",
+			models.Device{
+				ProfileName: profile,
+				AutoEvents:  []models.AutoEvent{{SourceName: "res.*", Interval: "1s"}},
+			},
+			false,
 		},
 	}
 	for _, testCase := range tests {


### PR DESCRIPTION
The current auto event validation in core-metadata doesn't support regular expression, but it is supported by Device SDK. This change allow the regular expression is defined in auto event. Close https://github.com/edgexfoundry/edgex-go/issues/4865

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->