### PR TITLE
fix: Add more db config in service private configuration

### DIFF
--- a/cmd/core-data/res/configuration.yaml
+++ b/cmd/core-data/res/configuration.yaml
@@ -8,6 +8,13 @@ Writable:
       ReadingsPersisted: false
 #    Tags: # Contains the service level tags to be attached to all the service's metrics
     ##    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only change existing value, not added new ones.
+  InsecureSecrets:
+    DB:
+      SecretName: "redisdb"
+      SecretData:
+        username: ""
+        password: ""
+
 Service:
   Port: 59880
   Host: "localhost"
@@ -19,6 +26,10 @@ MessageBus:
 
 Database:
   Name: "coredata"
+  Host: "localhost"
+  Port: 6379
+  Timeout: "5s"
+  Type: "redisdb"
 
 Retention:
   Enabled: false

--- a/cmd/core-metadata/res/configuration.yaml
+++ b/cmd/core-metadata/res/configuration.yaml
@@ -5,6 +5,13 @@ Writable:
     StrictDeviceProfileDeletes: false
   UoM:
     Validation: false
+  InsecureSecrets:
+    DB:
+      SecretName: "redisdb"
+      SecretData:
+        username: ""
+        password: ""
+
 Service:
   Host: localhost
   Port: 59881
@@ -18,4 +25,7 @@ MessageBus:
 
 Database:
   Name: metadata
-
+  Host: "localhost"
+  Port: 6379
+  Timeout: "5s"
+  Type: "redisdb"

--- a/cmd/support-notifications/res/configuration.yaml
+++ b/cmd/support-notifications/res/configuration.yaml
@@ -8,6 +8,12 @@ Writable:
       SecretData:
         username: username@mail.example.com
         password: ''
+    DB:
+      SecretName: "redisdb"
+      SecretData:
+        username: ""
+        password: ""
+
 Service:
   Host: localhost
   Port: 59860
@@ -30,6 +36,10 @@ MessageBus:
 
 Database:
   Name: notifications
+  Host: "localhost"
+  Port: 6379
+  Timeout: "5s"
+  Type: "redisdb"
 
 Retention:
   Enabled: false

--- a/cmd/support-scheduler/res/configuration.yaml
+++ b/cmd/support-scheduler/res/configuration.yaml
@@ -1,6 +1,13 @@
 ScheduleIntervalTime: 500
 Writable:
     LogLevel: INFO
+    InsecureSecrets:
+      DB:
+        SecretName: "redisdb"
+        SecretData:
+          username: ""
+          password: ""
+
 Service:
     Host: localhost
     Port: 59861
@@ -28,4 +35,7 @@ MessageBus:
 
 Database:
   Name: scheduler
-
+  Host: "localhost"
+  Port: 6379
+  Timeout: "5s"
+  Type: "redisdb"


### PR DESCRIPTION
Relates to #4847. Add more db config in service private config in order to use env variable overwrite to support Postgres in some services.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->