### PR TITLE
fix: Generate new action ID while updating schedule job

### DIFF
--- a/internal/support/cronscheduler/application/schedulejob.go
+++ b/internal/support/cronscheduler/application/schedulejob.go
@@ -119,6 +119,11 @@ func PatchScheduleJob(ctx context.Context, dto dtos.UpdateScheduleJob, dic *di.C
 
 	requests.ReplaceScheduleJobModelFieldsWithDTO(&job, dto)
 
+	// Add the ID for each action, the old actions will be replaced by the new actions
+	for i, action := range job.Actions {
+		job.Actions[i] = action.WithId("")
+	}
+
 	err = schedulerManager.UpdateScheduleJob(job, correlationId)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)

--- a/internal/support/cronscheduler/controller/http/schedulejob_test.go
+++ b/internal/support/cronscheduler/controller/http/schedulejob_test.go
@@ -101,7 +101,7 @@ func TestAddScheduleJob(t *testing.T) {
 
 	valid := addScheduleJobRequestData()
 	model := dtos.ToScheduleJobModel(valid.ScheduleJob)
-	dbClientMock.On("AddScheduleJob", context.Background(), mock.Anything).Return(model, nil)
+	dbClientMock.On("AddScheduleJob", context.Background(), mock.MatchedBy(func(job models.ScheduleJob) bool { return job.Name == testScheduleJobName })).Return(model, nil)
 	schedulerManagerMock.On("AddScheduleJob", mock.MatchedBy(func(job models.ScheduleJob) bool { return job.Name == testScheduleJobName }), testCorrelationID).Return(nil)
 	schedulerManagerMock.On("StartScheduleJobByName", model.Name, testCorrelationID).Return(nil)
 
@@ -410,8 +410,8 @@ func TestPatchScheduleJob(t *testing.T) {
 
 	valid := testReq
 	dbClientMock.On("ScheduleJobById", context.Background(), *valid.ScheduleJob.Id).Return(model, nil)
-	dbClientMock.On("UpdateScheduleJob", context.Background(), model).Return(nil)
-	schedulerManagerMock.On("UpdateScheduleJob", model, testCorrelationID).Return(nil)
+	dbClientMock.On("UpdateScheduleJob", context.Background(), mock.MatchedBy(func(job models.ScheduleJob) bool { return job.Name == testScheduleJobName })).Return(nil)
+	schedulerManagerMock.On("UpdateScheduleJob", mock.MatchedBy(func(job models.ScheduleJob) bool { return job.Name == testScheduleJobName }), testCorrelationID).Return(nil)
 	validWithNoReqID := testReq
 	validWithNoReqID.RequestId = ""
 	validWithNoId := testReq


### PR DESCRIPTION
fixes #4883

Fixed the potential crashed issue while updating schedule action. Since there will be new actions being created after job updated, generating new action ID for each actions.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->