### PR TITLE
fix: Fix the wrong behavior when querying schedule action records

### DIFF
--- a/internal/pkg/infrastructure/postgres/scheduleactionrecord.go
+++ b/internal/pkg/infrastructure/postgres/scheduleactionrecord.go
@@ -58,7 +58,8 @@ func (c *Client) AllScheduleActionRecords(ctx context.Context, start, end int64,
 		return nil, errors.NewCommonEdgeXWrapper(err)
 	}
 
-	records, err := queryScheduleActionRecords(ctx, c.ConnPool, sqlQueryAllWithPaginationAndTimeRange(scheduleActionRecordTable), time.UnixMilli(start), time.UnixMilli(end), offset, limit)
+	startTime, endTime := getUTCStartAndEndTime(start, end)
+	records, err := queryScheduleActionRecords(ctx, c.ConnPool, sqlQueryAllWithPaginationAndTimeRange(scheduleActionRecordTable), startTime, endTime, offset, limit)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.Kind(err), "failed to query all schedule action records", err)
 	}
@@ -99,7 +100,8 @@ func (c *Client) ScheduleActionRecordsByStatus(ctx context.Context, status strin
 		return nil, errors.NewCommonEdgeXWrapper(err)
 	}
 
-	records, err := queryScheduleActionRecords(ctx, c.ConnPool, sqlQueryAllByStatusWithPaginationAndTimeRange(scheduleActionRecordTable), status, time.UnixMilli(start), time.UnixMilli(end), offset, limit)
+	startTime, endTime := getUTCStartAndEndTime(start, end)
+	records, err := queryScheduleActionRecords(ctx, c.ConnPool, sqlQueryAllByStatusWithPaginationAndTimeRange(scheduleActionRecordTable), status, startTime, endTime, offset, limit)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.Kind(err), fmt.Sprintf("failed to query schedule action records by status %s", status), err)
 	}
@@ -115,7 +117,8 @@ func (c *Client) ScheduleActionRecordsByJobName(ctx context.Context, jobName str
 		return nil, errors.NewCommonEdgeXWrapper(err)
 	}
 
-	records, err := queryScheduleActionRecords(ctx, c.ConnPool, sqlQueryAllByColWithPaginationAndTimeRange(scheduleActionRecordTable, jobNameCol), jobName, time.UnixMilli(start), time.UnixMilli(end), offset, limit)
+	startTime, endTime := getUTCStartAndEndTime(start, end)
+	records, err := queryScheduleActionRecords(ctx, c.ConnPool, sqlQueryAllByColWithPaginationAndTimeRange(scheduleActionRecordTable, jobNameCol), jobName, startTime, endTime, offset, limit)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.Kind(err), fmt.Sprintf("failed to query schedule action records by job name %s", jobName), err)
 	}
@@ -131,7 +134,8 @@ func (c *Client) ScheduleActionRecordsByJobNameAndStatus(ctx context.Context, jo
 		return nil, errors.NewCommonEdgeXWrapper(err)
 	}
 
-	records, err := queryScheduleActionRecords(ctx, c.ConnPool, sqlQueryAllByColWithPaginationAndTimeRange(scheduleActionRecordTable, jobNameCol, statusCol), jobName, status, time.UnixMilli(start), time.UnixMilli(end), offset, limit)
+	startTime, endTime := getUTCStartAndEndTime(start, end)
+	records, err := queryScheduleActionRecords(ctx, c.ConnPool, sqlQueryAllByColWithPaginationAndTimeRange(scheduleActionRecordTable, jobNameCol, statusCol), jobName, status, startTime, endTime, offset, limit)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.Kind(err), fmt.Sprintf("failed to query schedule action records by job name %s and status %s", jobName, status), err)
 	}
@@ -140,23 +144,27 @@ func (c *Client) ScheduleActionRecordsByJobNameAndStatus(ctx context.Context, jo
 }
 
 // ScheduleActionRecordTotalCount returns the total count of all the schedule action records
-func (c *Client) ScheduleActionRecordTotalCount(ctx context.Context) (uint32, errors.EdgeX) {
-	return getTotalRowsCount(ctx, c.ConnPool, sqlQueryCount(scheduleActionRecordTable))
+func (c *Client) ScheduleActionRecordTotalCount(ctx context.Context, start, end int64) (uint32, errors.EdgeX) {
+	startTime, endTime := getUTCStartAndEndTime(start, end)
+	return getTotalRowsCount(ctx, c.ConnPool, sqlQueryCountByTimeRangeCol(scheduleActionRecordTable, createdCol, nil), startTime, endTime)
 }
 
 // ScheduleActionRecordCountByStatus returns the total count of the schedule action records by status
-func (c *Client) ScheduleActionRecordCountByStatus(ctx context.Context, status string) (uint32, errors.EdgeX) {
-	return getTotalRowsCount(ctx, c.ConnPool, sqlQueryCountByCol(scheduleActionRecordTable, statusCol), status)
+func (c *Client) ScheduleActionRecordCountByStatus(ctx context.Context, status string, start, end int64) (uint32, errors.EdgeX) {
+	startTime, endTime := getUTCStartAndEndTime(start, end)
+	return getTotalRowsCount(ctx, c.ConnPool, sqlQueryCountByTimeRangeCol(scheduleActionRecordTable, createdCol, nil, statusCol), startTime, endTime, status)
 }
 
 // ScheduleActionRecordCountByJobName returns the total count of the schedule action records by job name
-func (c *Client) ScheduleActionRecordCountByJobName(ctx context.Context, jobName string) (uint32, errors.EdgeX) {
-	return getTotalRowsCount(ctx, c.ConnPool, sqlQueryCountByCol(scheduleActionRecordTable, jobNameCol), jobName)
+func (c *Client) ScheduleActionRecordCountByJobName(ctx context.Context, jobName string, start, end int64) (uint32, errors.EdgeX) {
+	startTime, endTime := getUTCStartAndEndTime(start, end)
+	return getTotalRowsCount(ctx, c.ConnPool, sqlQueryCountByTimeRangeCol(scheduleActionRecordTable, createdCol, nil, jobNameCol), startTime, endTime, jobName)
 }
 
 // ScheduleActionRecordCountByJobNameAndStatus returns the total count of the schedule action records by job name and status
-func (c *Client) ScheduleActionRecordCountByJobNameAndStatus(ctx context.Context, jobName, status string) (uint32, errors.EdgeX) {
-	return getTotalRowsCount(ctx, c.ConnPool, sqlQueryCountByCol(scheduleActionRecordTable, jobNameCol, statusCol), jobName, status)
+func (c *Client) ScheduleActionRecordCountByJobNameAndStatus(ctx context.Context, jobName, status string, start, end int64) (uint32, errors.EdgeX) {
+	startTime, endTime := getUTCStartAndEndTime(start, end)
+	return getTotalRowsCount(ctx, c.ConnPool, sqlQueryCountByTimeRangeCol(scheduleActionRecordTable, createdCol, nil, jobNameCol, statusCol), startTime, endTime, jobName, status)
 }
 
 // DeleteScheduleActionRecordByAge deletes the schedule action records by age

--- a/internal/pkg/infrastructure/postgres/utils.go
+++ b/internal/pkg/infrastructure/postgres/utils.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -52,4 +53,13 @@ func getTotalRowsCount(ctx context.Context, connPool *pgxpool.Pool, sql string, 
 	}
 
 	return uint32(rowCount), nil
+}
+
+// getUTCStartAndEndTime returns the UTC start and end time from the given start and end timestamp
+func getUTCStartAndEndTime(start, end int64) (time.Time, time.Time) {
+	return getUTCTime(start), getUTCTime(end)
+}
+
+func getUTCTime(timestamp int64) time.Time {
+	return time.UnixMilli(timestamp).UTC()
 }

--- a/internal/support/cronscheduler/application/scheduleactionrecord.go
+++ b/internal/support/cronscheduler/application/scheduleactionrecord.go
@@ -29,7 +29,7 @@ func AllScheduleActionRecords(ctx context.Context, start, end int64, offset, lim
 	dbClient := container.DBClientFrom(dic.Get)
 	records, err := dbClient.AllScheduleActionRecords(ctx, start, end, offset, limit)
 	if err == nil {
-		totalCount, err = dbClient.ScheduleActionRecordTotalCount(ctx)
+		totalCount, err = dbClient.ScheduleActionRecordTotalCount(ctx, start, end)
 	}
 	if err != nil {
 		return scheduleActionRecordDTOs, totalCount, errors.NewCommonEdgeXWrapper(err)
@@ -44,7 +44,7 @@ func ScheduleActionRecordsByStatus(ctx context.Context, status string, start, en
 	dbClient := container.DBClientFrom(dic.Get)
 	records, err := dbClient.ScheduleActionRecordsByStatus(ctx, status, start, end, offset, limit)
 	if err == nil {
-		totalCount, err = dbClient.ScheduleActionRecordCountByStatus(ctx, status)
+		totalCount, err = dbClient.ScheduleActionRecordCountByStatus(ctx, status, start, end)
 	}
 	if err != nil {
 		return scheduleActionRecordDTOs, totalCount, errors.NewCommonEdgeXWrapper(err)
@@ -59,7 +59,7 @@ func ScheduleActionRecordsByJobName(ctx context.Context, jobName string, start, 
 	dbClient := container.DBClientFrom(dic.Get)
 	records, err := dbClient.ScheduleActionRecordsByJobName(ctx, jobName, start, end, offset, limit)
 	if err == nil {
-		totalCount, err = dbClient.ScheduleActionRecordCountByJobName(ctx, jobName)
+		totalCount, err = dbClient.ScheduleActionRecordCountByJobName(ctx, jobName, start, end)
 	}
 	if err != nil {
 		return scheduleActionRecordDTOs, totalCount, errors.NewCommonEdgeXWrapper(err)
@@ -74,7 +74,7 @@ func ScheduleActionRecordsByJobNameAndStatus(ctx context.Context, jobName, statu
 	dbClient := container.DBClientFrom(dic.Get)
 	records, err := dbClient.ScheduleActionRecordsByJobNameAndStatus(ctx, jobName, status, start, end, offset, limit)
 	if err == nil {
-		totalCount, err = dbClient.ScheduleActionRecordCountByJobNameAndStatus(ctx, jobName, status)
+		totalCount, err = dbClient.ScheduleActionRecordCountByJobNameAndStatus(ctx, jobName, status, start, end)
 	}
 	if err != nil {
 		return scheduleActionRecordDTOs, totalCount, errors.NewCommonEdgeXWrapper(err)

--- a/internal/support/cronscheduler/controller/http/scheduleactionrecord_test.go
+++ b/internal/support/cronscheduler/controller/http/scheduleactionrecord_test.go
@@ -55,11 +55,12 @@ func TestAllScheduleActionRecords(t *testing.T) {
 	expectedTotalScheduleActionRecordCount := uint32(0)
 	dic := mockDic()
 	dbClientMock := &csMock.DBClient{}
-	dbClientMock.On("ScheduleActionRecordTotalCount", context.Background()).Return(expectedTotalScheduleActionRecordCount, nil)
+	dbClientMock.On("ScheduleActionRecordTotalCount", context.Background(), int64(0), mock.AnythingOfType("int64")).Return(expectedTotalScheduleActionRecordCount, nil)
 	dbClientMock.On("AllScheduleActionRecords", context.Background(), int64(0), mock.AnythingOfType("int64"), 0, 20).Return([]models.ScheduleActionRecord{}, nil)
 	dbClientMock.On("AllScheduleActionRecords", context.Background(), int64(0), mock.AnythingOfType("int64"), 0, 1).Return([]models.ScheduleActionRecord{}, nil)
 	dbClientMock.On("AllScheduleActionRecords", context.Background(), int64(0), int64(1723642440000), 0, 1).Return([]models.ScheduleActionRecord{}, nil)
 	dbClientMock.On("AllScheduleActionRecords", context.Background(), int64(1723642430000), int64(1723642440000), 0, 1).Return([]models.ScheduleActionRecord{}, nil)
+	dbClientMock.On("ScheduleActionRecordTotalCount", context.Background(), int64(1723642430000), int64(1723642440000)).Return(expectedTotalScheduleActionRecordCount, nil)
 	dic.Update(di.ServiceConstructorMap{
 		container.DBClientInterfaceName: func(get di.Get) any {
 			return dbClientMock
@@ -217,7 +218,7 @@ func TestScheduleActionRecordsByStatus(t *testing.T) {
 
 	dic := mockDic()
 	dbClientMock := &csMock.DBClient{}
-	dbClientMock.On("ScheduleActionRecordCountByStatus", context.Background(), testStatus).Return(expectedTotalScheduleActionRecordCount, nil)
+	dbClientMock.On("ScheduleActionRecordCountByStatus", context.Background(), testStatus, int64(0), mock.AnythingOfType("int64")).Return(expectedTotalScheduleActionRecordCount, nil)
 	dbClientMock.On("ScheduleActionRecordsByStatus", context.Background(), testStatus, int64(0), mock.AnythingOfType("int64"), 0, 20).Return(records, nil)
 	dbClientMock.On("ScheduleActionRecordsByStatus", context.Background(), emptyStatus, int64(0), mock.AnythingOfType("int64"), 0, 20).Return([]models.ScheduleActionRecord{}, errors.NewCommonEdgeX(errors.KindContractInvalid, "the status is required", nil))
 	dbClientMock.On("ScheduleActionRecordsByStatus", context.Background(), notFoundStatus, int64(0), mock.AnythingOfType("int64"), 0, 20).Return([]models.ScheduleActionRecord{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "schedule action records with given status doesn't exist in the database", nil))
@@ -296,7 +297,7 @@ func TestScheduleActionRecordsByJobName(t *testing.T) {
 
 	dic := mockDic()
 	dbClientMock := &csMock.DBClient{}
-	dbClientMock.On("ScheduleActionRecordCountByJobName", context.Background(), testScheduleJobName).Return(expectedTotalScheduleActionRecordCount, nil)
+	dbClientMock.On("ScheduleActionRecordCountByJobName", context.Background(), testScheduleJobName, int64(0), mock.AnythingOfType("int64")).Return(expectedTotalScheduleActionRecordCount, nil)
 	dbClientMock.On("ScheduleActionRecordsByJobName", context.Background(), testScheduleJobName, int64(0), mock.AnythingOfType("int64"), 0, 20).Return(records, nil)
 	dbClientMock.On("ScheduleActionRecordsByJobName", context.Background(), emptyJobName, int64(0), mock.AnythingOfType("int64"), 0, 20).Return([]models.ScheduleActionRecord{}, errors.NewCommonEdgeX(errors.KindContractInvalid, "the job name is required", nil))
 	dbClientMock.On("ScheduleActionRecordsByJobName", context.Background(), notFoundJobName, int64(0), mock.AnythingOfType("int64"), 0, 20).Return([]models.ScheduleActionRecord{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "schedule action records with given job name doesn't exist in the database", nil))
@@ -377,7 +378,7 @@ func TestScheduleActionRecordsByJobNameAndStatus(t *testing.T) {
 
 	dic := mockDic()
 	dbClientMock := &csMock.DBClient{}
-	dbClientMock.On("ScheduleActionRecordCountByJobNameAndStatus", context.Background(), testScheduleJobName, testStatus).Return(expectedTotalScheduleActionRecordCount, nil)
+	dbClientMock.On("ScheduleActionRecordCountByJobNameAndStatus", context.Background(), testScheduleJobName, testStatus, int64(0), mock.AnythingOfType("int64")).Return(expectedTotalScheduleActionRecordCount, nil)
 	dbClientMock.On("ScheduleActionRecordsByJobNameAndStatus", context.Background(), testScheduleJobName, testStatus, int64(0), mock.AnythingOfType("int64"), 0, 20).Return(records, nil)
 	dbClientMock.On("ScheduleActionRecordsByJobNameAndStatus", context.Background(), emptyJobName, emptyStatus, int64(0), mock.AnythingOfType("int64"), 0, 20).Return([]models.ScheduleActionRecord{}, errors.NewCommonEdgeX(errors.KindContractInvalid, "the job name and status are required", nil))
 	dbClientMock.On("ScheduleActionRecordsByJobNameAndStatus", context.Background(), notFoundJobName, notFoundStatus, int64(0), mock.AnythingOfType("int64"), 0, 20).Return([]models.ScheduleActionRecord{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "schedule action records with given job name and status doesn't exist in the database", nil))

--- a/internal/support/cronscheduler/infrastructure/interfaces/db.go
+++ b/internal/support/cronscheduler/infrastructure/interfaces/db.go
@@ -30,9 +30,9 @@ type DBClient interface {
 	ScheduleActionRecordsByStatus(ctx context.Context, status string, start, end int64, offset, limit int) ([]model.ScheduleActionRecord, errors.EdgeX)
 	ScheduleActionRecordsByJobName(ctx context.Context, jobName string, start, end int64, offset, limit int) ([]model.ScheduleActionRecord, errors.EdgeX)
 	ScheduleActionRecordsByJobNameAndStatus(ctx context.Context, jobName, status string, start, end int64, offset, limit int) ([]model.ScheduleActionRecord, errors.EdgeX)
-	ScheduleActionRecordTotalCount(ctx context.Context) (uint32, errors.EdgeX)
-	ScheduleActionRecordCountByStatus(ctx context.Context, status string) (uint32, errors.EdgeX)
-	ScheduleActionRecordCountByJobName(ctx context.Context, jobName string) (uint32, errors.EdgeX)
-	ScheduleActionRecordCountByJobNameAndStatus(ctx context.Context, jobName, status string) (uint32, errors.EdgeX)
+	ScheduleActionRecordTotalCount(ctx context.Context, start, end int64) (uint32, errors.EdgeX)
+	ScheduleActionRecordCountByStatus(ctx context.Context, status string, start, end int64) (uint32, errors.EdgeX)
+	ScheduleActionRecordCountByJobName(ctx context.Context, jobName string, start, end int64) (uint32, errors.EdgeX)
+	ScheduleActionRecordCountByJobNameAndStatus(ctx context.Context, jobName, status string, start, end int64) (uint32, errors.EdgeX)
 	DeleteScheduleActionRecordByAge(ctx context.Context, age int64) errors.EdgeX
 }

--- a/internal/support/cronscheduler/infrastructure/interfaces/mocks/DBClient.go
+++ b/internal/support/cronscheduler/infrastructure/interfaces/mocks/DBClient.go
@@ -250,9 +250,9 @@ func (_m *DBClient) LatestScheduleActionRecordsByJobName(ctx context.Context, jo
 	return r0, r1
 }
 
-// ScheduleActionRecordCountByJobName provides a mock function with given fields: ctx, jobName
-func (_m *DBClient) ScheduleActionRecordCountByJobName(ctx context.Context, jobName string) (uint32, errors.EdgeX) {
-	ret := _m.Called(ctx, jobName)
+// ScheduleActionRecordCountByJobName provides a mock function with given fields: ctx, jobName, start, end
+func (_m *DBClient) ScheduleActionRecordCountByJobName(ctx context.Context, jobName string, start int64, end int64) (uint32, errors.EdgeX) {
+	ret := _m.Called(ctx, jobName, start, end)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ScheduleActionRecordCountByJobName")
@@ -260,17 +260,17 @@ func (_m *DBClient) ScheduleActionRecordCountByJobName(ctx context.Context, jobN
 
 	var r0 uint32
 	var r1 errors.EdgeX
-	if rf, ok := ret.Get(0).(func(context.Context, string) (uint32, errors.EdgeX)); ok {
-		return rf(ctx, jobName)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, int64) (uint32, errors.EdgeX)); ok {
+		return rf(ctx, jobName, start, end)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) uint32); ok {
-		r0 = rf(ctx, jobName)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, int64) uint32); ok {
+		r0 = rf(ctx, jobName, start, end)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) errors.EdgeX); ok {
-		r1 = rf(ctx, jobName)
+	if rf, ok := ret.Get(1).(func(context.Context, string, int64, int64) errors.EdgeX); ok {
+		r1 = rf(ctx, jobName, start, end)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)
@@ -280,9 +280,9 @@ func (_m *DBClient) ScheduleActionRecordCountByJobName(ctx context.Context, jobN
 	return r0, r1
 }
 
-// ScheduleActionRecordCountByJobNameAndStatus provides a mock function with given fields: ctx, jobName, status
-func (_m *DBClient) ScheduleActionRecordCountByJobNameAndStatus(ctx context.Context, jobName string, status string) (uint32, errors.EdgeX) {
-	ret := _m.Called(ctx, jobName, status)
+// ScheduleActionRecordCountByJobNameAndStatus provides a mock function with given fields: ctx, jobName, status, start, end
+func (_m *DBClient) ScheduleActionRecordCountByJobNameAndStatus(ctx context.Context, jobName string, status string, start int64, end int64) (uint32, errors.EdgeX) {
+	ret := _m.Called(ctx, jobName, status, start, end)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ScheduleActionRecordCountByJobNameAndStatus")
@@ -290,17 +290,17 @@ func (_m *DBClient) ScheduleActionRecordCountByJobNameAndStatus(ctx context.Cont
 
 	var r0 uint32
 	var r1 errors.EdgeX
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (uint32, errors.EdgeX)); ok {
-		return rf(ctx, jobName, status)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64, int64) (uint32, errors.EdgeX)); ok {
+		return rf(ctx, jobName, status, start, end)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) uint32); ok {
-		r0 = rf(ctx, jobName, status)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64, int64) uint32); ok {
+		r0 = rf(ctx, jobName, status, start, end)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) errors.EdgeX); ok {
-		r1 = rf(ctx, jobName, status)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int64, int64) errors.EdgeX); ok {
+		r1 = rf(ctx, jobName, status, start, end)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)
@@ -310,9 +310,9 @@ func (_m *DBClient) ScheduleActionRecordCountByJobNameAndStatus(ctx context.Cont
 	return r0, r1
 }
 
-// ScheduleActionRecordCountByStatus provides a mock function with given fields: ctx, status
-func (_m *DBClient) ScheduleActionRecordCountByStatus(ctx context.Context, status string) (uint32, errors.EdgeX) {
-	ret := _m.Called(ctx, status)
+// ScheduleActionRecordCountByStatus provides a mock function with given fields: ctx, status, start, end
+func (_m *DBClient) ScheduleActionRecordCountByStatus(ctx context.Context, status string, start int64, end int64) (uint32, errors.EdgeX) {
+	ret := _m.Called(ctx, status, start, end)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ScheduleActionRecordCountByStatus")
@@ -320,17 +320,17 @@ func (_m *DBClient) ScheduleActionRecordCountByStatus(ctx context.Context, statu
 
 	var r0 uint32
 	var r1 errors.EdgeX
-	if rf, ok := ret.Get(0).(func(context.Context, string) (uint32, errors.EdgeX)); ok {
-		return rf(ctx, status)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, int64) (uint32, errors.EdgeX)); ok {
+		return rf(ctx, status, start, end)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) uint32); ok {
-		r0 = rf(ctx, status)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, int64) uint32); ok {
+		r0 = rf(ctx, status, start, end)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) errors.EdgeX); ok {
-		r1 = rf(ctx, status)
+	if rf, ok := ret.Get(1).(func(context.Context, string, int64, int64) errors.EdgeX); ok {
+		r1 = rf(ctx, status, start, end)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)
@@ -340,9 +340,9 @@ func (_m *DBClient) ScheduleActionRecordCountByStatus(ctx context.Context, statu
 	return r0, r1
 }
 
-// ScheduleActionRecordTotalCount provides a mock function with given fields: ctx
-func (_m *DBClient) ScheduleActionRecordTotalCount(ctx context.Context) (uint32, errors.EdgeX) {
-	ret := _m.Called(ctx)
+// ScheduleActionRecordTotalCount provides a mock function with given fields: ctx, start, end
+func (_m *DBClient) ScheduleActionRecordTotalCount(ctx context.Context, start int64, end int64) (uint32, errors.EdgeX) {
+	ret := _m.Called(ctx, start, end)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ScheduleActionRecordTotalCount")
@@ -350,17 +350,17 @@ func (_m *DBClient) ScheduleActionRecordTotalCount(ctx context.Context) (uint32,
 
 	var r0 uint32
 	var r1 errors.EdgeX
-	if rf, ok := ret.Get(0).(func(context.Context) (uint32, errors.EdgeX)); ok {
-		return rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int64) (uint32, errors.EdgeX)); ok {
+		return rf(ctx, start, end)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context) uint32); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int64) uint32); ok {
+		r0 = rf(ctx, start, end)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) errors.EdgeX); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, int64, int64) errors.EdgeX); ok {
+		r1 = rf(ctx, start, end)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(errors.EdgeX)


### PR DESCRIPTION
fixes #4889

Fixed the mismatch timezone of start and end time parameters for querying schedule action records.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->