### PR TITLE
fix: Fix the error while query reading with Postgres

### DIFF
--- a/internal/pkg/bootstrap/handlers/database.go
+++ b/internal/pkg/bootstrap/handlers/database.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	baseScriptPath = "/res/db/sql"
+	baseScriptPath = "./res/db/sql"
 	redisDBType    = "redisdb"
 	postgresDBType = "postgres"
 )

--- a/internal/pkg/infrastructure/postgres/models/reading.go
+++ b/internal/pkg/infrastructure/postgres/models/reading.go
@@ -11,6 +11,7 @@ import "github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 // which includes all the fields in BaseReading, BinaryReading, SimpleReading and ObjectReading
 type Reading struct {
 	models.BaseReading
+	EventId string `db:"event_id"` // the foreign key refers to the id column in core_data.event table
 	BinaryReading
 	SimpleReading
 	ObjectReading

--- a/internal/pkg/infrastructure/postgres/reading.go
+++ b/internal/pkg/infrastructure/postgres/reading.go
@@ -24,8 +24,6 @@ import (
 var (
 	// insertReadingCols defines the reading table columns in slice used in inserting readings
 	insertReadingCols = []string{idCol, eventIdFKCol, deviceNameCol, profileNameCol, resourceNameCol, originCol, valueTypeCol, unitsCol, tagsCol, valueCol, mediaTypeCol, binaryValueCol, objectValueCol}
-	// queryReadingCols defines the reading table columns in slice used in querying reading
-	queryReadingCols = []string{idCol, deviceNameCol, profileNameCol, resourceNameCol, originCol, valueTypeCol, unitsCol, tagsCol, valueCol, objectValueCol, mediaTypeCol, binaryValueCol}
 )
 
 func (c *Client) ReadingTotalCount() (uint32, errors.EdgeX) {
@@ -35,7 +33,8 @@ func (c *Client) ReadingTotalCount() (uint32, errors.EdgeX) {
 func (c *Client) AllReadings(offset int, limit int) ([]model.Reading, errors.EdgeX) {
 	ctx := context.Background()
 
-	readings, err := queryReadings(ctx, c.ConnPool, sqlQueryAllWithPagination(readingTableName), offset, limit)
+	// query reading by origin descending with offset & limit
+	readings, err := queryReadings(ctx, c.ConnPool, sqlQueryAllWithPaginationDescByCol(readingTableName, originCol), offset, limit)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindDatabaseError, "failed to query all readings", err)
 	}
@@ -45,7 +44,8 @@ func (c *Client) AllReadings(offset int, limit int) ([]model.Reading, errors.Edg
 
 // ReadingsByResourceName query readings by offset, limit and resource name
 func (c *Client) ReadingsByResourceName(offset int, limit int, resourceName string) ([]model.Reading, errors.EdgeX) {
-	sqlStatement := sqlQueryAllByColWithPagination(readingTableName, resourceNameCol)
+	// query reading by the resourceName and origin descending
+	sqlStatement := sqlQueryAllAndDescWithCondsAndPag(readingTableName, originCol, resourceNameCol)
 
 	readings, err := queryReadings(context.Background(), c.ConnPool, sqlStatement, resourceName, offset, limit)
 	if err != nil {
@@ -56,7 +56,8 @@ func (c *Client) ReadingsByResourceName(offset int, limit int, resourceName stri
 
 // ReadingsByDeviceName query readings by offset, limit and device name
 func (c *Client) ReadingsByDeviceName(offset int, limit int, name string) ([]model.Reading, errors.EdgeX) {
-	sqlStatement := sqlQueryAllByColWithPagination(readingTableName, deviceNameCol)
+	// query reading by the deviceName and origin descending
+	sqlStatement := sqlQueryAllAndDescWithCondsAndPag(readingTableName, originCol, deviceNameCol)
 
 	readings, err := queryReadings(context.Background(), c.ConnPool, sqlStatement, name, offset, limit)
 	if err != nil {
@@ -67,7 +68,8 @@ func (c *Client) ReadingsByDeviceName(offset int, limit int, name string) ([]mod
 
 // ReadingsByDeviceNameAndResourceName query readings by offset, limit, device name and resource name
 func (c *Client) ReadingsByDeviceNameAndResourceName(deviceName string, resourceName string, offset int, limit int) ([]model.Reading, errors.EdgeX) {
-	sqlStatement := sqlQueryAllByColWithPagination(readingTableName, deviceNameCol, resourceNameCol)
+	// query reading by the deviceName/resourceName and origin descending
+	sqlStatement := sqlQueryAllAndDescWithCondsAndPag(readingTableName, originCol, deviceNameCol, resourceNameCol)
 
 	readings, err := queryReadings(context.Background(), c.ConnPool, sqlStatement, deviceName, resourceName, offset, limit)
 	if err != nil {

--- a/internal/pkg/infrastructure/postgres/sql.go
+++ b/internal/pkg/infrastructure/postgres/sql.go
@@ -87,12 +87,20 @@ func sqlQueryAllWithPaginationDescByCol(table string, descCol string) string {
 	return fmt.Sprintf("SELECT * FROM %s ORDER BY %s DESC OFFSET $1 LIMIT $2", table, descCol)
 }
 
-// sqlQueryAllByColWithPagination returns the SQL statement for selecting all rows from the table by the given columns with pagination
-func sqlQueryAllByColWithPagination(table string, columns ...string) string {
+// sqlQueryAllAndDescWithConds returns the SQL statement for selecting all rows from the table by the given columns composed of the where condition with descending by descCol
+func sqlQueryAllAndDescWithConds(table string, descCol string, columns ...string) string {
+	whereCondition := constructWhereCondition(columns...)
+
+	return fmt.Sprintf("SELECT * FROM %s WHERE %s ORDER BY %s DESC", table, whereCondition, descCol)
+}
+
+// sqlQueryAllAndDescWithCondsAndPag returns the SQL statement for selecting all rows from the table by the given columns composed of the where condition
+// with descending by descCol and pagination
+func sqlQueryAllAndDescWithCondsAndPag(table string, descCol string, columns ...string) string {
 	columnCount := len(columns)
 	whereCondition := constructWhereCondition(columns...)
 
-	return fmt.Sprintf("SELECT * FROM %s WHERE %s OFFSET $%d LIMIT $%d", table, whereCondition, columnCount+1, columnCount+2)
+	return fmt.Sprintf("SELECT * FROM %s WHERE %s ORDER BY %s DESC OFFSET $%d LIMIT $%d", table, whereCondition, descCol, columnCount+1, columnCount+2)
 }
 
 // sqlQueryAllByLabelsWithPagination returns the SQL statement for selecting all rows from the table by the given labels from content with pagination


### PR DESCRIPTION
Fixes #4899. Fixes the struct field not found error when query reading in Postgres infra layer methods.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->