### PR TITLE
feat: Add the Keeper registry db methods for Postgres

### DIFF
--- a/cmd/core-keeper/res/db/sql/00-utils.sql
+++ b/cmd/core-keeper/res/db/sql/00-utils.sql
@@ -3,5 +3,8 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+-- uuid-ossp extension is used for generating UUID automatically
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
 -- schema for core-keeper related tables
 CREATE SCHEMA IF NOT EXISTS core_keeper;

--- a/cmd/core-keeper/res/db/sql/01-tables.sql
+++ b/cmd/core-keeper/res/db/sql/01-tables.sql
@@ -11,3 +11,9 @@ CREATE TABLE IF NOT EXISTS core_keeper.config (
     created timestamp NOT NULL DEFAULT now(),
     modified timestamp NOT NULL DEFAULT now()
 );
+
+-- core_keeper.registry is used to store the registry information
+CREATE TABLE IF NOT EXISTS core_keeper.registry (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    content jsonb NOT NULL
+);

--- a/internal/core/keeper/controller/http/registry.go
+++ b/internal/core/keeper/controller/http/registry.go
@@ -6,6 +6,7 @@
 package http
 
 import (
+	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
 	"net/http"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
@@ -67,7 +68,11 @@ func (rc *RegistryController) Register(c echo.Context) error {
 	}
 
 	utils.WriteHttpHeader(w, ctx, http.StatusCreated)
-	return nil
+	response := commonDTO.BaseWithServiceNameResponse{
+		BaseResponse: commonDTO.NewBaseResponse("", "", http.StatusCreated),
+		ServiceName:  registry.ServiceId,
+	}
+	return pkg.EncodeAndWriteResponse(response, w, lc)
 }
 
 func (rc *RegistryController) UpdateRegister(c echo.Context) error {

--- a/internal/pkg/infrastructure/postgres/consts.go
+++ b/internal/pkg/infrastructure/postgres/consts.go
@@ -13,9 +13,10 @@ const (
 
 // constants relate to the postgres db table names
 const (
-	eventTableName   = coreDataSchema + ".event"
-	readingTableName = coreDataSchema + ".reading"
-	configTableName  = coreKeeperSchema + ".config"
+	eventTableName    = coreDataSchema + ".event"
+	readingTableName  = coreDataSchema + ".reading"
+	configTableName   = coreKeeperSchema + ".config"
+	registryTableName = coreKeeperSchema + ".registry"
 )
 
 // constants relate to the event/reading postgres db table column names

--- a/internal/pkg/infrastructure/postgres/registry.go
+++ b/internal/pkg/infrastructure/postgres/registry.go
@@ -6,20 +6,157 @@
 package postgres
 
 import (
+	"context"
+	"encoding/json"
+	goErrors "errors"
+	"fmt"
+	"time"
+
+	pgClient "github.com/edgexfoundry/edgex-go/internal/pkg/db/postgres"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+const serviceIdField = "ServiceId"
+
 func (c *Client) AddRegistration(r models.Registration) (models.Registration, errors.EdgeX) {
-	return models.Registration{}, nil
+	ctx := context.Background()
+	exists, edgexErr := checkRegistrationExists(c.ConnPool, ctx, r.ServiceId)
+	if edgexErr != nil {
+		return models.Registration{}, errors.NewCommonEdgeXWrapper(edgexErr)
+	}
+	if exists {
+		return models.Registration{}, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("registry with service id '%s' already exists", r.ServiceId), nil)
+	}
+
+	timestamp := time.Now().UTC().UnixMilli()
+	r.Created = timestamp
+	r.Modified = timestamp
+	dataBytes, err := json.Marshal(r)
+	if err != nil {
+		return models.Registration{}, errors.NewCommonEdgeX(errors.KindServerError, "failed to marshal registration model", err)
+	}
+
+	_, err = c.ConnPool.Exec(context.Background(),
+		sqlInsert(registryTableName, contentCol),
+		dataBytes,
+	)
+	if err != nil {
+		return models.Registration{}, pgClient.WrapDBError("failed to insert row to registry table", err)
+	}
+
+	return r, nil
 }
 
-func (c *Client) DeleteRegistrationByServiceId(id string) errors.EdgeX { return nil }
+// Registrations retrieves all the registry information from database
+func (c *Client) Registrations() ([]models.Registration, errors.EdgeX) {
+	rows, err := c.ConnPool.Query(context.Background(), sqlQueryContent(registryTableName))
+	if err != nil {
+		return nil, pgClient.WrapDBError("failed to query rows from registry table", err)
+	}
 
-func (c *Client) Registrations() ([]models.Registration, errors.EdgeX) { return nil, nil }
+	registrations, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (models.Registration, error) {
+		var r models.Registration
+		scanErr := row.Scan(&r)
+		return r, scanErr
+	})
+	if err != nil {
+		return nil, pgClient.WrapDBError("failed to collect rows to Registration model", err)
+	}
 
-func (c *Client) RegistrationByServiceId(id string) (models.Registration, errors.EdgeX) {
-	return models.Registration{}, nil
+	return registrations, nil
 }
 
-func (c *Client) UpdateRegistration(r models.Registration) errors.EdgeX { return nil }
+// RegistrationByServiceId queries the registry by service id from database
+func (c *Client) RegistrationByServiceId(serviceId string) (models.Registration, errors.EdgeX) {
+	return queryRegistryByServiceId(c.ConnPool, serviceId)
+}
+
+// UpdateRegistration updates the registry information by service id from database
+func (c *Client) UpdateRegistration(r models.Registration) errors.EdgeX {
+	ctx := context.Background()
+
+	oldRegistry, edgexErr := queryRegistryByServiceId(c.ConnPool, r.ServiceId)
+	if edgexErr != nil {
+		return errors.NewCommonEdgeXWrapper(edgexErr)
+	}
+
+	if r.Created == 0 {
+		r.Created = oldRegistry.Created
+	}
+	r.Modified = time.Now().UTC().UnixMilli()
+
+	dataBytes, err := json.Marshal(r)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "failed to marshal registration model", err)
+	}
+
+	queryObj := map[string]any{serviceIdField: r.ServiceId}
+	_, err = c.ConnPool.Exec(ctx,
+		sqlUpdateColsByJSONCondCol(registryTableName, contentCol),
+		dataBytes,
+		queryObj,
+	)
+	if err != nil {
+		return pgClient.WrapDBError(fmt.Sprintf("failed to update row by service id '%s' from registry table", r.ServiceId), err)
+	}
+
+	return nil
+}
+
+// DeleteRegistrationByServiceId deletes the registry by service id from database
+func (c *Client) DeleteRegistrationByServiceId(serviceId string) errors.EdgeX {
+	ctx := context.Background()
+
+	exists, edgexErr := checkRegistrationExists(c.ConnPool, ctx, serviceId)
+	if edgexErr != nil {
+		return errors.NewCommonEdgeXWrapper(edgexErr)
+	}
+	if !exists {
+		return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("service id '%s' not found from registry table", serviceId), nil)
+	}
+
+	queryObj := map[string]any{serviceIdField: serviceId}
+
+	_, err := c.ConnPool.Exec(context.Background(), sqlDeleteByJSONField(registryTableName), queryObj)
+	if err != nil {
+		return pgClient.WrapDBError(fmt.Sprintf("failed to delete row with service id '%s' from registry table", serviceId), err)
+	}
+
+	return nil
+}
+
+// checkRegistrationExists checks if registration exists by service id
+func checkRegistrationExists(connPool *pgxpool.Pool, ctx context.Context, serviceId string) (bool, errors.EdgeX) {
+	var exists bool
+
+	queryObj := map[string]any{serviceIdField: serviceId}
+	err := connPool.QueryRow(ctx, sqlCheckExistsByJSONField(registryTableName), queryObj).Scan(&exists)
+	if err != nil {
+		return exists, pgClient.WrapDBError(fmt.Sprintf("failed to query row by service id '%s' from registry table", serviceId), err)
+	}
+
+	return exists, nil
+}
+
+// queryRegistryByServiceId queries the registry by service id
+func queryRegistryByServiceId(connPool *pgxpool.Pool, serviceId string) (models.Registration, errors.EdgeX) {
+	var registry models.Registration
+	sqlStmt := sqlQueryContentByJSONField(registryTableName)
+	queryObj := map[string]any{serviceIdField: serviceId}
+
+	row := connPool.QueryRow(context.Background(), sqlStmt, queryObj)
+
+	err := row.Scan(&registry)
+	if err != nil {
+		if goErrors.Is(err, pgx.ErrNoRows) {
+			return models.Registration{}, pgClient.WrapDBError(fmt.Sprintf("service id '%s' not found from registry table", serviceId), err)
+		}
+		return models.Registration{}, pgClient.WrapDBError(fmt.Sprintf("failed to query row by serviceId '%s' from registry table", serviceId), err)
+	}
+	return registry, nil
+}

--- a/internal/pkg/infrastructure/postgres/sql.go
+++ b/internal/pkg/infrastructure/postgres/sql.go
@@ -170,10 +170,15 @@ func sqlQueryAllById(table string) string {
 //	return fmt.Sprintf("SELECT content FROM %s ORDER BY created OFFSET $1 LIMIT $2", table)
 //}
 
+// sqlQueryContent returns the SQL statement for selecting content column in the table for all entries
+func sqlQueryContent(table string) string {
+	return fmt.Sprintf("SELECT content FROM %s", table)
+}
+
 // sqlQueryCountByJSONField returns the SQL statement for selecting content column in the table by the given JSON query string
-//func sqlQueryContentByJSONField(table string) (string, errors.EdgeX) {
-//	return fmt.Sprintf("SELECT content FROM %s WHERE content @> $1::jsonb ORDER BY %s OFFSET $2 LIMIT $3", table, createdCol), nil
-//}
+func sqlQueryContentByJSONField(table string) string {
+	return fmt.Sprintf("SELECT content FROM %s WHERE content @> $1::jsonb", table)
+}
 
 // sqlQueryCountByJSONField returns the SQL statement for selecting content column by the given time range of the JSON field name
 //func sqlQueryContentByJSONFieldTimeRange(table string, field string) string {
@@ -194,6 +199,11 @@ func sqlCheckExistsByName(table string) string {
 func sqlCheckExistsByCol(table string, columns ...string) string {
 	whereCondition := constructWhereCondition(columns...)
 	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM %s WHERE %s)", table, whereCondition)
+}
+
+// sqlCheckExistsByJSONField returns the SQL statement for checking if a row exists by query the JSON field in content column.
+func sqlCheckExistsByJSONField(table string) string {
+	return fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM %s WHERE content @> $1::jsonb)", table)
 }
 
 // sqlQueryCount returns the SQL statement for counting the number of rows in the table.
@@ -259,6 +269,13 @@ func sqlUpdateColsByCondCol(table string, condCol string, cols ...string) string
 	return fmt.Sprintf("UPDATE %s SET %s WHERE %s = $%d", table, updatedValues, condCol, columnCount+1)
 }
 
+// sqlUpdateColsByJSONCondCol returns the SQL statement for updating the passed columns of a row in the table by JSON field condition of content column.
+func sqlUpdateColsByJSONCondCol(table string, cols ...string) string {
+	columnCount := len(cols)
+	updatedValues := constructUpdatedValues(cols...)
+	return fmt.Sprintf("UPDATE %s SET %s WHERE content@>$%d::jsonb", table, updatedValues, columnCount+1)
+}
+
 // sqlUpdateContentById returns the SQL statement for updating the content and modified timestamp of a row in the table by id.
 //func sqlUpdateContentById(table string) string {
 //	return fmt.Sprintf("UPDATE %s SET %s = $1 , %s = $2 WHERE %s = $3", table, contentCol, modifiedCol, idCol)
@@ -306,9 +323,9 @@ func sqlDeleteByColAndLikePat(table string, column string, returnCol ...string) 
 }
 
 // sqlDeleteByJSONField returns the SQL statement for deleting rows from the table by the given JSON query string
-//func sqlDeleteByJSONField(table string) (string, errors.EdgeX) {
-//	return fmt.Sprintf("DELETE FROM %s WHERE content @> $1::jsonb", table), nil
-//}
+func sqlDeleteByJSONField(table string) string {
+	return fmt.Sprintf("DELETE FROM %s WHERE content @> $1::jsonb", table)
+}
 
 // ----------------------------------------------------------------------------------
 // Utils


### PR DESCRIPTION
Resolves #4877. Add the Keeper registry db methods for Postgres.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->