### PR TITLE
fix: Return 404 response for Keeper GET key API with Postgres

### DIFF
--- a/cmd/core-keeper/Dockerfile
+++ b/cmd/core-keeper/Dockerfile
@@ -52,5 +52,6 @@ RUN apk add --update --no-cache dumb-init
 COPY --from=builder /edgex-go/Attribution.txt /
 COPY --from=builder /edgex-go/cmd/core-keeper/core-keeper /
 COPY --from=builder /edgex-go/cmd/core-keeper/res/configuration.yaml /res/configuration.yaml
+COPY --from=builder /edgex-go/cmd/core-keeper/res/db/ /res/db/
 
 ENTRYPOINT ["/core-keeper"]

--- a/cmd/core-keeper/res/db/sql/01-tables.sql
+++ b/cmd/core-keeper/res/db/sql/01-tables.sql
@@ -5,7 +5,7 @@
 
 -- core_keeper.config is used to store the config information
 CREATE TABLE IF NOT EXISTS core_keeper.config (
-    id UUID PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     key TEXT NOT NULL,
     value TEXT NOT NULL,
     created timestamp NOT NULL DEFAULT now(),

--- a/internal/pkg/infrastructure/postgres/kv.go
+++ b/internal/pkg/infrastructure/postgres/kv.go
@@ -75,6 +75,10 @@ func (c *Client) KeeperKeys(key string, keyOnly bool, isRaw bool) ([]models.KVRe
 		return nil, pgClient.WrapDBError("failed to scan row to models.KVResponse", err)
 	}
 
+	if rows.CommandTag().RowsAffected() == 0 {
+		return nil, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("no key starting with '%s' found", key), nil)
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
Relates to #4877. Return 404 response for Keeper GET key API with Postgres. Copy res/db dir in Keeper Docker file.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->