### PR TITLE
feat: Add the force query param to add device metadata API

### DIFF
--- a/internal/core/metadata/application/device_test.go
+++ b/internal/core/metadata/application/device_test.go
@@ -6,15 +6,23 @@
 package application
 
 import (
-	"github.com/edgexfoundry/edgex-go/internal/core/metadata/container"
+	"context"
 	"testing"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/config"
+	"github.com/edgexfoundry/edgex-go/internal/core/metadata/container"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/infrastructure/interfaces/mocks"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateAutoEvents(t *testing.T) {
@@ -96,6 +104,62 @@ func TestValidateAutoEvents(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestForceAddDevice(t *testing.T) {
+	invalidDeviceName := "invalidDevice"
+	validDeviceName := "validDevice"
+	invalidDeviceName2 := "invalidDevice2"
+	invalidDevice := models.Device{Name: invalidDeviceName}
+	invalidDevice2 := models.Device{Name: invalidDeviceName2}
+	returnedDevice := models.Device{Name: validDeviceName}
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &config.ConfigurationStruct{
+				Writable: config.WritableInfo{
+					LogLevel: "DEBUG",
+				},
+			}
+		},
+	})
+
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("DeviceByName", invalidDeviceName).Return(models.Device{}, errors.NewCommonEdgeX(errors.KindDatabaseError, "failed to query", nil))
+	dbClientMock.On("DeviceByName", validDeviceName).Return(returnedDevice, nil)
+	dbClientMock.On("DeviceByName", invalidDeviceName2).Return(invalidDevice2, nil)
+	dbClientMock.On("UpdateDevice", returnedDevice).Return(nil)
+	dbClientMock.On("UpdateDevice", invalidDevice2).Return(errors.NewCommonEdgeX(errors.KindDatabaseError, "failed to update", nil))
+	dic.Update(di.ServiceConstructorMap{
+		container.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+
+	tests := []struct {
+		name          string
+		device        models.Device
+		errorExpected bool
+	}{
+		{"invalid - DeviceByName error", invalidDevice, true},
+		{"valid", returnedDevice, false},
+		{"invalid - UpdateDevice error", invalidDevice2, true},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx, _ := correlation.FromContextOrNew(context.Background())
+			result, err := forceAddDevice(testCase.device, ctx, dic)
+			if testCase.errorExpected {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, returnedDevice.Id, result)
 			}
 		})
 	}

--- a/internal/core/metadata/controller/http/device_test.go
+++ b/internal/core/metadata/controller/http/device_test.go
@@ -130,8 +130,16 @@ func TestAddDevice(t *testing.T) {
 
 	valid := testDevice
 	dbClientMock.On("DeviceServiceNameExists", deviceModel.ServiceName).Return(true, nil)
+	dbClientMock.On("DeviceNameExists", deviceModel.Name).Return(false, nil)
 	dbClientMock.On("AddDevice", deviceModel).Return(deviceModel, nil)
 	dbClientMock.On("DeviceProfileByName", mock.Anything).Return(models.DeviceProfile{Name: "test-profile", DeviceResources: []models.DeviceResource{{Name: "TestResource"}}}, nil)
+
+	validForceAdd := testDevice
+	validForceAdd.Device.Name = "forceAdd"
+	forceAddDm := dtos.ToDeviceModel(validForceAdd.Device)
+	dbClientMock.On("DeviceNameExists", validForceAdd.Device.Name).Return(true, nil)
+	dbClientMock.On("DeviceByName", validForceAdd.Device.Name).Return(forceAddDm, nil)
+	dbClientMock.On("UpdateDevice", forceAddDm).Return(nil)
 
 	notFoundProfile := testDevice
 	notFoundProfile.Device.ProfileName = "notFoundProfile"
@@ -190,23 +198,25 @@ func TestAddDevice(t *testing.T) {
 		expectedResponseCode int
 		expectedValidation   bool
 		expectedSystemEvent  bool
+		forceAdd             bool
 	}{
-		{"Valid", []requests.AddDeviceRequest{valid}, http.StatusMultiStatus, http.StatusCreated, true, true},
-		{"Valid - bypassValidation", []requests.AddDeviceRequest{valid}, http.StatusMultiStatus, http.StatusCreated, false, true},
-		{"Valid - no profile name and no auto events", []requests.AddDeviceRequest{noProfileAndAutoEvents}, http.StatusMultiStatus, http.StatusCreated, true, true},
-		{"Invalid - not found profile", []requests.AddDeviceRequest{notFoundProfile}, http.StatusMultiStatus, http.StatusNotFound, true, false},
-		{"Invalid - no name", []requests.AddDeviceRequest{noName}, http.StatusBadRequest, http.StatusBadRequest, false, false},
-		{"Invalid - no adminState", []requests.AddDeviceRequest{noAdminState}, http.StatusBadRequest, http.StatusBadRequest, false, false},
-		{"Invalid - no operatingState", []requests.AddDeviceRequest{noOperatingState}, http.StatusBadRequest, http.StatusBadRequest, false, false},
-		{"Invalid - invalid adminState", []requests.AddDeviceRequest{invalidAdminState}, http.StatusBadRequest, http.StatusBadRequest, false, false},
-		{"Invalid - invalid operatingState", []requests.AddDeviceRequest{invalidOperatingState}, http.StatusBadRequest, http.StatusBadRequest, false, false},
-		{"Invalid - no service name", []requests.AddDeviceRequest{noServiceName}, http.StatusBadRequest, http.StatusBadRequest, false, false},
-		{"Valid - no profile name", []requests.AddDeviceRequest{noProfileName}, http.StatusMultiStatus, http.StatusCreated, true, true},
-		{"Invalid - no protocols", []requests.AddDeviceRequest{noProtocols}, http.StatusBadRequest, http.StatusBadRequest, false, false},
-		{"Valid - empty protocols", []requests.AddDeviceRequest{emptyProtocols}, http.StatusMultiStatus, http.StatusCreated, true, true},
-		{"Invalid - invalid protocols", []requests.AddDeviceRequest{invalidProtocols}, http.StatusMultiStatus, http.StatusInternalServerError, true, false},
-		{"Invalid - not found device service", []requests.AddDeviceRequest{notFoundService}, http.StatusMultiStatus, http.StatusBadRequest, false, false},
-		{"Invalid - device service unavailable", []requests.AddDeviceRequest{valid}, http.StatusMultiStatus, http.StatusServiceUnavailable, true, false},
+		{"Valid", []requests.AddDeviceRequest{valid}, http.StatusMultiStatus, http.StatusCreated, true, true, false},
+		{"Valid - bypassValidation", []requests.AddDeviceRequest{valid}, http.StatusMultiStatus, http.StatusCreated, false, true, false},
+		{"Valid - no profile name and no auto events", []requests.AddDeviceRequest{noProfileAndAutoEvents}, http.StatusMultiStatus, http.StatusCreated, true, true, false},
+		{"Invalid - not found profile", []requests.AddDeviceRequest{notFoundProfile}, http.StatusMultiStatus, http.StatusNotFound, true, false, false},
+		{"Invalid - no name", []requests.AddDeviceRequest{noName}, http.StatusBadRequest, http.StatusBadRequest, false, false, false},
+		{"Invalid - no adminState", []requests.AddDeviceRequest{noAdminState}, http.StatusBadRequest, http.StatusBadRequest, false, false, false},
+		{"Invalid - no operatingState", []requests.AddDeviceRequest{noOperatingState}, http.StatusBadRequest, http.StatusBadRequest, false, false, false},
+		{"Invalid - invalid adminState", []requests.AddDeviceRequest{invalidAdminState}, http.StatusBadRequest, http.StatusBadRequest, false, false, false},
+		{"Invalid - invalid operatingState", []requests.AddDeviceRequest{invalidOperatingState}, http.StatusBadRequest, http.StatusBadRequest, false, false, false},
+		{"Invalid - no service name", []requests.AddDeviceRequest{noServiceName}, http.StatusBadRequest, http.StatusBadRequest, false, false, false},
+		{"Valid - no profile name", []requests.AddDeviceRequest{noProfileName}, http.StatusMultiStatus, http.StatusCreated, true, true, false},
+		{"Invalid - no protocols", []requests.AddDeviceRequest{noProtocols}, http.StatusBadRequest, http.StatusBadRequest, false, false, false},
+		{"Valid - empty protocols", []requests.AddDeviceRequest{emptyProtocols}, http.StatusMultiStatus, http.StatusCreated, true, true, false},
+		{"Invalid - invalid protocols", []requests.AddDeviceRequest{invalidProtocols}, http.StatusMultiStatus, http.StatusInternalServerError, true, false, false},
+		{"Invalid - not found device service", []requests.AddDeviceRequest{notFoundService}, http.StatusMultiStatus, http.StatusBadRequest, false, false, false},
+		{"Invalid - device service unavailable", []requests.AddDeviceRequest{valid}, http.StatusMultiStatus, http.StatusServiceUnavailable, true, false, false},
+		{"Valid - force add device", []requests.AddDeviceRequest{validForceAdd}, http.StatusMultiStatus, http.StatusCreated, false, true, true},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -241,6 +251,14 @@ func TestAddDevice(t *testing.T) {
 				mockMessaging.On("Publish", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 					wg.Done()
 				}).Return(nil)
+
+				// if forceAdd flag is enabled, add the second publish event
+				if testCase.forceAdd {
+					wg.Add(1)
+					mockMessaging.On("Publish", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+						wg.Done()
+					}).Return(nil)
+				}
 			}
 
 			dic.Update(di.ServiceConstructorMap{
@@ -256,6 +274,12 @@ func TestAddDevice(t *testing.T) {
 			if !testCase.expectedValidation {
 				query := req.URL.Query()
 				query.Add(bypassValidationQueryParam, common.ValueTrue)
+				req.URL.RawQuery = query.Encode()
+			}
+
+			if testCase.forceAdd {
+				query := req.URL.Query()
+				query.Add(forceQueryParam, common.ValueTrue)
 				req.URL.RawQuery = query.Encode()
 			}
 

--- a/internal/pkg/infrastructure/postgres/device.go
+++ b/internal/pkg/infrastructure/postgres/device.go
@@ -29,11 +29,6 @@ func (c *Client) AddDevice(d model.Device) (model.Device, errors.EdgeX) {
 		d.Id = uuid.New().String()
 	}
 
-	exists, _ := deviceNameExists(ctx, c.ConnPool, d.Name)
-	if exists {
-		return model.Device{}, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("device name %s already exists", d.Name), nil)
-	}
-
 	timestamp := pkgCommon.MakeTimestamp()
 	d.Created = timestamp
 	d.Modified = timestamp

--- a/internal/pkg/infrastructure/redis/device.go
+++ b/internal/pkg/infrastructure/redis/device.go
@@ -87,13 +87,6 @@ func addDevice(conn redis.Conn, d models.Device) (models.Device, errors.EdgeX) {
 		return d, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("device id %s already exists", d.Id), edgeXerr)
 	}
 
-	exists, edgeXerr = deviceNameExists(conn, d.Name)
-	if edgeXerr != nil {
-		return d, errors.NewCommonEdgeXWrapper(edgeXerr)
-	} else if exists {
-		return d, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("device name %s already exists", d.Name), edgeXerr)
-	}
-
 	ts := pkgCommon.MakeTimestamp()
 	if d.Created == 0 {
 		d.Created = ts

--- a/openapi/v3/core-metadata.yaml
+++ b/openapi/v3/core-metadata.yaml
@@ -1152,6 +1152,14 @@ components:
         type: boolean
       description: "Indicates whether to skip the Device Service Validation API call."
       default: false
+    forceParam:
+      in: query
+      name: force
+      required: false
+      schema:
+        type: boolean
+      description: "Indicates whether to force add the device if device name already exists."
+      default: false
   headers:
     correlatedResponseHeader:
       description: "A response header that returns the unique correlation ID used to initiate the request."
@@ -1661,6 +1669,8 @@ paths:
       - $ref: '#/components/parameters/bypassValidationParam'
     post:
       summary: "Allows provisioning of a new device"
+      parameters:
+        - $ref: '#/components/parameters/forceParam'
       requestBody:
         required: true
         content:


### PR DESCRIPTION
Resolves #4694. Add the force query param to add device metadata API.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->