### PR TITLE
fix: Add /support-cron-scheduler path in API gateway

### DIFF
--- a/cmd/security-proxy-setup/entrypoint.sh
+++ b/cmd/security-proxy-setup/entrypoint.sh
@@ -259,6 +259,18 @@ server {
       auth_request_set   \$auth_status \$upstream_status;
     }
 
+    set \$upstream_support_cron_scheduler edgex-support-cron-scheduler;
+    location /support-cron-scheduler {
+`cat "${corssnippet}"`
+      rewrite            /support-cron-scheduler/(.*) /\$1 break;
+      resolver           127.0.0.11 valid=30s;
+      proxy_pass         http://\$upstream_support_cron_scheduler:59863;
+      proxy_redirect     off;
+      proxy_set_header   Host \$host;
+      auth_request       /auth;
+      auth_request_set   \$auth_status \$upstream_status;
+    }
+
     set \$upstream_app_rules_engine edgex-app-rules-engine;
     location /app-rules-engine {
 `cat "${corssnippet}"`

--- a/cmd/support-cron-scheduler/res/db/sql/00-utils.sql
+++ b/cmd/support-cron-scheduler/res/db/sql/00-utils.sql
@@ -4,4 +4,4 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- schema for support_scheduler related tables
-CREATE SCHEMA IF NOT EXISTS support_scheduler;
+CREATE SCHEMA IF NOT EXISTS support_cron_scheduler;

--- a/cmd/support-cron-scheduler/res/db/sql/01-tables.sql
+++ b/cmd/support-cron-scheduler/res/db/sql/01-tables.sql
@@ -4,13 +4,13 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- support_scheduler.job is used to store the schedule job information
-CREATE TABLE IF NOT EXISTS support_scheduler.job (
+CREATE TABLE IF NOT EXISTS support_cron_scheduler.job (
     id UUID PRIMARY KEY,
     content JSONB NOT NULL
 );
 
 -- support_scheduler.record is used to store the schedule action record
-CREATE TABLE IF NOT EXISTS support_scheduler.record (
+CREATE TABLE IF NOT EXISTS support_cron_scheduler.record (
     id UUID PRIMARY KEY,
     action_id UUID NOT NULL,
     job_name TEXT NOT NULL,

--- a/internal/pkg/infrastructure/postgres/consts.go
+++ b/internal/pkg/infrastructure/postgres/consts.go
@@ -11,7 +11,7 @@ const (
 	coreKeeperSchema           = "core_keeper"
 	coreMetaDataSchema         = "core_metadata"
 	supportNotificationsSchema = "support_notifications"
-	supportSchedulerSchema     = "support_scheduler"
+	supportSchedulerSchema     = "support_cron_scheduler"
 )
 
 // constants relate to the postgres db table names


### PR DESCRIPTION
Resolves #4930.
- Add /support-cron-scheduler path in API gateway
- Rename support_scheduler schema to support_cron_scheduler

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->