### PR TITLE
fix: fix slice init length

### DIFF
--- a/internal/pkg/infrastructure/postgres/scheduleactionrecord.go
+++ b/internal/pkg/infrastructure/postgres/scheduleactionrecord.go
@@ -31,7 +31,7 @@ func (c *Client) AddScheduleActionRecord(ctx context.Context, scheduleActionReco
 
 // AddScheduleActionRecords adds multiple schedule action records to the database
 func (c *Client) AddScheduleActionRecords(ctx context.Context, scheduleActionRecords []model.ScheduleActionRecord) ([]model.ScheduleActionRecord, errors.EdgeX) {
-	records := make([]model.ScheduleActionRecord, len(scheduleActionRecords))
+	records := make([]model.ScheduleActionRecord, 0, len(scheduleActionRecords))
 	for _, record := range scheduleActionRecords {
 		r, err := c.AddScheduleActionRecord(ctx, record)
 		if err != nil {


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

The intention here should be to initialize a slice with a capacity of  `len(scheduleActionRecords)`  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW




## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->