### PR TITLE
fix: Delete device profile in use should return 409

### DIFF
--- a/internal/core/metadata/application/deviceprofile.go
+++ b/internal/core/metadata/application/deviceprofile.go
@@ -112,6 +112,22 @@ func DeleteDeviceProfileByName(name string, ctx context.Context, dic *di.Contain
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+	// Check the associated Device and ProvisionWatcher existence
+	devices, edgeXErr := dbClient.DevicesByProfileName(0, 1, name)
+	if edgeXErr != nil {
+		return errors.NewCommonEdgeXWrapper(edgeXErr)
+	}
+	if len(devices) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device profile when associated device exists", nil)
+	}
+	provisionWatchers, edgeXErr := dbClient.ProvisionWatchersByProfileName(0, 1, name)
+	if edgeXErr != nil {
+		return errors.NewCommonEdgeXWrapper(edgeXErr)
+	}
+	if len(provisionWatchers) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device profile when associated provisionWatcher exists", nil)
+	}
+
 	err = dbClient.DeleteDeviceProfileByName(name)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)

--- a/internal/core/metadata/application/deviceservice.go
+++ b/internal/core/metadata/application/deviceservice.go
@@ -112,6 +112,22 @@ func DeleteDeviceServiceByName(name string, ctx context.Context, dic *di.Contain
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
+	// Check the associated Device and ProvisionWatcher existence
+	devices, edgeXErr := dbClient.DevicesByServiceName(0, 1, name)
+	if edgeXErr != nil {
+		return errors.NewCommonEdgeXWrapper(edgeXErr)
+	}
+	if len(devices) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device service when associated device exists", nil)
+	}
+	provisionWatchers, edgeXErr := dbClient.ProvisionWatchersByServiceName(0, 1, name)
+	if edgeXErr != nil {
+		return errors.NewCommonEdgeXWrapper(edgeXErr)
+	}
+	if len(provisionWatchers) > 0 {
+		return errors.NewCommonEdgeX(errors.KindStatusConflict, "fail to delete the device service when associated provisionWatcher exists", nil)
+	}
+
 	err = dbClient.DeleteDeviceServiceByName(name)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)


### PR DESCRIPTION
close #4937

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->