### PR TITLE
fix: Escape dash in Postgres init db script

### DIFF
--- a/internal/security/bootstrapper/helper/postgres_script.go
+++ b/internal/security/bootstrapper/helper/postgres_script.go
@@ -40,11 +40,11 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -q <<-'EOSQL'
   DO $$
   BEGIN
     {{range .Services}} 
-        CREATE SCHEMA IF NOT EXISTS {{.Username}};
+        CREATE SCHEMA IF NOT EXISTS "{{.Username}}";
         IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '{{.Username}}') THEN
-            CREATE USER {{.Username}} with PASSWORD '{{.Password}}';
-            GRANT ALL ON SCHEMA {{.Username}} TO {{.Username}};
-            ALTER GROUP edgex_user ADD USER {{.Username}};
+            CREATE USER "{{.Username}}" with PASSWORD '{{.Password}}';
+            GRANT ALL ON SCHEMA "{{.Username}}" TO "{{.Username}}";
+            ALTER GROUP edgex_user ADD USER "{{.Username}}";
         END IF;
 	{{end}}
   END $$;

--- a/internal/security/bootstrapper/helper/postgres_script_test.go
+++ b/internal/security/bootstrapper/helper/postgres_script_test.go
@@ -49,7 +49,7 @@ func TestGeneratePostgresScript(t *testing.T) {
 		}
 	}
 
-	expectedCreateScript := fmt.Sprintf("CREATE USER %s with PASSWORD '%s';", mockUsername, mockPassword)
+	expectedCreateScript := fmt.Sprintf("CREATE USER \"%s\" with PASSWORD '%s';", mockUsername, mockPassword)
 	require.Equal(t, 17, len(outputlines))
 	require.Equal(t, expectedCreateScript, strings.TrimSpace(outputlines[11]))
 }


### PR DESCRIPTION
Resolves #4945. Escape dash in Postgres init db script for schema and username of Security Bootstrapper.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->