### PR TITLE
fix: Generate reading id if it's empty for postgres reading table

### DIFF
--- a/internal/pkg/infrastructure/postgres/reading.go
+++ b/internal/pkg/infrastructure/postgres/reading.go
@@ -17,6 +17,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	model "github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -318,8 +319,16 @@ func addReadingsInTx(tx pgx.Tx, readings []model.Reading, eventId string) error 
 
 	for _, r := range readings {
 		baseReading := r.GetBaseReading()
-		var readingDBModel dbModels.Reading
+		if baseReading.Id == "" {
+			baseReading.Id = uuid.New().String()
+		} else {
+			_, err := uuid.Parse(baseReading.Id)
+			if err != nil {
+				return errors.NewCommonEdgeX(errors.KindInvalidId, "uuid parsing failed", err)
+			}
+		}
 
+		var readingDBModel dbModels.Reading
 		switch contractReadingModel := r.(type) {
 		case model.BinaryReading:
 			// convert BinaryReading struct to Reading DB model


### PR DESCRIPTION
close #4935

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->