### PR TITLE
fix: Check profile existence before adding device/provision watcher

### DIFF
--- a/internal/core/metadata/application/provisionwatcher.go
+++ b/internal/core/metadata/application/provisionwatcher.go
@@ -29,6 +29,16 @@ func AddProvisionWatcher(pw models.ProvisionWatcher, ctx context.Context, dic *d
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	correlationId := correlation.FromContext(ctx)
 
+	// check the associated ProfileName existence
+	if pw.DiscoveredDevice.ProfileName != "" {
+		exists, err := dbClient.DeviceProfileNameExists(pw.DiscoveredDevice.ProfileName)
+		if err != nil {
+			return "", errors.NewCommonEdgeXWrapper(err)
+		} else if !exists {
+			return "", errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, fmt.Sprintf("device profile '%s' does not exists", pw.DiscoveredDevice.ProfileName), err)
+		}
+	}
+
 	addProvisionWatcher, err := dbClient.AddProvisionWatcher(pw)
 	if err != nil {
 		return "", errors.NewCommonEdgeXWrapper(err)


### PR DESCRIPTION
close #4957

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->