### PR TITLE
fix: Add the Database related config back to Core Keeper

### DIFF
--- a/cmd/core-keeper/res/configuration.yaml
+++ b/cmd/core-keeper/res/configuration.yaml
@@ -9,6 +9,11 @@ Writable:
         cacert: ""
         clientcert: ""
         clientkey: ""
+    DB:
+      SecretName: "postgres"
+      SecretData:
+        username: "postgres"
+        password: "postgres"
 
 Service:
   Host: localhost
@@ -29,7 +34,19 @@ Service:
     CORSExposeHeaders: "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
     CORSMaxAge: 3600
 
+Database:
+  Host: "localhost"
+  Port: 5432
+  Timeout: "5s"
+  Type: "postgres"
+
 MessageBus:
+  Protocol: "mqtt"
+  Host: "localhost"
+  Port: 1883
+  Type: "mqtt"
+  AuthMode: "none"  # required for MessageBus (secure or insecure).
+  SecretName: "mqtt-bus"
   BaseTopicPrefix: "edgex/configs" # /<key> will be added to this Base Topic prefix
   Optional:
     # Default MQTT Specific options that need to be here to enable environment variable overrides of them


### PR DESCRIPTION
Fixes #4980. Add the Database related config back to Core Keeper.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->