### PR TITLE
docs: Add onChangeThreshold in Device AutoEvent

### DIFF
--- a/openapi/core-metadata.yaml
+++ b/openapi/core-metadata.yaml
@@ -57,6 +57,9 @@ components:
         onChange:
           type: boolean
           description: OnChange indicates whether the device service will generate an event only, if the reading value is different from the previous one. If true, only generate events when readings change
+        onChangeThreshold:
+          type: number
+          description: OnChangeThreshold indicates any changed value that exceeds the threshold shall be generated new event if `onChange` is true, this feature only applies to the numeric reading. Available value types are `Uint8`, `Uint16`, `Uint32`, `Uint64`, `Int8`, `Int16`, `Int32`, `Int64`, `Float32`, `Float64`. The default value is 0.
         sourceName:
           type: string
           description: SourceName indicates the name of the resource or device command in the device profile which describes the event to generate
@@ -1315,6 +1318,7 @@ components:
             autoEvents:
               - interval: 300ms
                 onChange: true
+                onChangeThreshold: 0.01
                 sourceName: CurrentHumidity
             protocols:
               modbus-tcp:
@@ -1348,6 +1352,7 @@ components:
             autoEvents:
               - interval: "100ms"
                 onChange: true
+                onChangeThreshold: 0.01
                 sourceName: "CurrentHumidity"
         - apiVersion: v3
           device:


### PR DESCRIPTION
The onChange flag in Device AutoEvent can prevent any non changed values sent out. The onChangeThreshold could provide the advanced feature, and the default value is 0, any changed value that exceeds (>) bounds shall be published.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->