### PR TITLE
fix: check offset, limit, totalCount before querying transmissions

### DIFF
--- a/internal/support/notifications/application/transmission.go
+++ b/internal/support/notifications/application/transmission.go
@@ -61,10 +61,17 @@ func TransmissionsByTimeRange(start int64, end int64, offset int, limit int, dic
 // AllTransmissions queries transmissions by offset and limit
 func AllTransmissions(offset, limit int, dic *di.Container) (transmissions []dtos.Transmission, totalCount uint32, err errors.EdgeX) {
 	dbClient := container.DBClientFrom(dic.Get)
-	models, err := dbClient.AllTransmissions(offset, limit)
-	if err == nil {
-		totalCount, err = dbClient.TransmissionTotalCount()
+
+	totalCount, err = dbClient.TransmissionTotalCount()
+	if err != nil {
+		return transmissions, totalCount, errors.NewCommonEdgeXWrapper(err)
 	}
+	cont, err := utils.CheckCountRange(totalCount, offset, limit)
+	if !cont {
+		return []dtos.Transmission{}, totalCount, err
+	}
+
+	models, err := dbClient.AllTransmissions(offset, limit)
 	if err != nil {
 		return transmissions, totalCount, errors.NewCommonEdgeXWrapper(err)
 	}

--- a/internal/support/notifications/controller/http/transmission_test.go
+++ b/internal/support/notifications/controller/http/transmission_test.go
@@ -193,7 +193,7 @@ func TestAllTransmissions(t *testing.T) {
 	dbClientMock.On("TransmissionTotalCount").Return(expectedTransmissionCount, nil)
 	dbClientMock.On("AllTransmissions", 0, 20).Return(transmissions, nil)
 	dbClientMock.On("AllTransmissions", 1, 2).Return([]models.Transmission{transmissions[1], transmissions[2]}, nil)
-	dbClientMock.On("AllTransmissions", 4, 1).Return([]models.Transmission{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "query objects bounds out of range.", nil))
+	dbClientMock.On("AllTransmissions", 4, 1).Return([]models.Transmission{}, errors.NewCommonEdgeX(errors.KindRangeNotSatisfiable, "query objects bounds out of range.", nil))
 	dic.Update(di.ServiceConstructorMap{
 		container.DBClientInterfaceName: func(get di.Get) interface{} {
 			return dbClientMock
@@ -213,7 +213,7 @@ func TestAllTransmissions(t *testing.T) {
 	}{
 		{"Valid - get transmissions without offset and limit", "", "", false, 3, expectedTransmissionCount, http.StatusOK},
 		{"Valid - get transmissions with offset and limit", "1", "2", false, 2, expectedTransmissionCount, http.StatusOK},
-		{"Invalid - offset out of range", "4", "1", true, 0, expectedTransmissionCount, http.StatusNotFound},
+		{"Invalid - offset out of range", "4", "1", true, 0, expectedTransmissionCount, http.StatusRequestedRangeNotSatisfiable},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
close #4988

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->