### PR TITLE
fix: Using current time in UTC as default in Postgresql

### DIFF
--- a/cmd/core-keeper/res/db/sql/01-tables.sql
+++ b/cmd/core-keeper/res/db/sql/01-tables.sql
@@ -8,8 +8,8 @@ CREATE TABLE IF NOT EXISTS core_keeper.config (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     key TEXT NOT NULL,
     value TEXT NOT NULL,
-    created timestamp NOT NULL DEFAULT now(),
-    modified timestamp NOT NULL DEFAULT now()
+    created timestamp NOT NULL DEFAULT (now() AT TIME ZONE 'utc'),
+    modified timestamp NOT NULL DEFAULT (now() AT TIME ZONE 'utc')
 );
 
 -- core_keeper.registry is used to store the registry information

--- a/cmd/support-scheduler/res/db/sql/01-tables.sql
+++ b/cmd/support-scheduler/res/db/sql/01-tables.sql
@@ -17,5 +17,5 @@ CREATE TABLE IF NOT EXISTS support_scheduler.record (
     action JSONB NOT NULL,
     status TEXT NOT NULL,
     scheduled_at timestamp NOT NULL,
-    created timestamp NOT NULL DEFAULT now()
+    created timestamp NOT NULL DEFAULT (now() AT TIME ZONE 'utc')
 );


### PR DESCRIPTION
Using current time in UTC as default in Postgresql for created and modified time.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Test with core service and support scheduler.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->