### PR TITLE
feat: refactor services to build monolithic service easily

### DIFF
--- a/cmd/core-command/main.go
+++ b/cmd/core-command/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/command"
 
@@ -25,5 +26,5 @@ import (
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	command.Main(ctx, cancel, echo.New())
+	command.Main(ctx, cancel, echo.New(), os.Args[1:])
 }

--- a/cmd/core-common-config-bootstrapper/main.go
+++ b/cmd/core-common-config-bootstrapper/main.go
@@ -15,10 +15,12 @@ package main
 
 import (
 	"context"
+	"os"
+
 	"github.com/edgexfoundry/edgex-go/internal/core/common_config"
 )
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	common_config.Main(ctx, cancel)
+	common_config.Main(ctx, cancel, os.Args[1:])
 }

--- a/cmd/core-data/main.go
+++ b/cmd/core-data/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/data"
 
@@ -25,5 +26,5 @@ import (
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	data.Main(ctx, cancel, echo.New())
+	data.Main(ctx, cancel, echo.New(), os.Args[1:])
 }

--- a/cmd/core-keeper/main.go
+++ b/cmd/core-keeper/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/keeper"
 
@@ -15,5 +16,5 @@ import (
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	keeper.Main(ctx, cancel, echo.New())
+	keeper.Main(ctx, cancel, echo.New(), os.Args[1:])
 }

--- a/cmd/core-metadata/main.go
+++ b/cmd/core-metadata/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata"
 
@@ -24,5 +25,5 @@ import (
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	metadata.Main(ctx, cancel, echo.New())
+	metadata.Main(ctx, cancel, echo.New(), os.Args[1:])
 }

--- a/cmd/secrets-config/main.go
+++ b/cmd/secrets-config/main.go
@@ -16,6 +16,6 @@ import (
 func main() {
 	os.Setenv("LOGLEVEL", "ERROR") // Workaround for https://github.com/edgexfoundry/edgex-go/issues/2922
 	ctx, cancel := context.WithCancel(context.Background())
-	exitStatusCode := config.Main(ctx, cancel)
+	exitStatusCode := config.Main(ctx, cancel, os.Args[1:])
 	os.Exit(exitStatusCode)
 }

--- a/cmd/security-bootstrapper/main.go
+++ b/cmd/security-bootstrapper/main.go
@@ -28,5 +28,5 @@ func main() {
 	_ = os.Unsetenv("EDGEX_PROFILE")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	bootstrapper.Main(ctx, cancel)
+	bootstrapper.Main(ctx, cancel, os.Args[1:])
 }

--- a/cmd/security-file-token-provider/main.go
+++ b/cmd/security-file-token-provider/main.go
@@ -17,11 +17,12 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
 )
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	fileprovider.Main(ctx, cancel)
+	fileprovider.Main(ctx, cancel, os.Args[1:])
 }

--- a/cmd/security-proxy-auth/main.go
+++ b/cmd/security-proxy-auth/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/proxyauth"
 
@@ -24,5 +25,5 @@ import (
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	proxyauth.Main(ctx, cancel, echo.New())
+	proxyauth.Main(ctx, cancel, echo.New(), os.Args[1:])
 }

--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -21,11 +21,12 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
 )
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	secretstore.Main(ctx, cancel)
+	secretstore.Main(ctx, cancel, os.Args[1:])
 }

--- a/cmd/security-spiffe-token-provider/main.go
+++ b/cmd/security-spiffe-token-provider/main.go
@@ -17,11 +17,12 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/spiffetokenprovider"
 )
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	spiffetokenprovider.Main(ctx, cancel)
+	spiffetokenprovider.Main(ctx, cancel, os.Args[1:])
 }

--- a/cmd/support-notifications/main.go
+++ b/cmd/support-notifications/main.go
@@ -23,6 +23,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/support/notifications"
 
@@ -31,5 +32,5 @@ import (
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	notifications.Main(ctx, cancel, echo.New())
+	notifications.Main(ctx, cancel, echo.New(), os.Args[1:])
 }

--- a/cmd/support-scheduler/main.go
+++ b/cmd/support-scheduler/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler"
 
@@ -24,5 +25,5 @@ import (
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	scheduler.Main(ctx, cancel, echo.New())
+	scheduler.Main(ctx, cancel, echo.New(), os.Args[1:])
 }

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -48,7 +48,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, arg
 	// Example:
 	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
 	//      ....
-	//      flags.Parse(os.Args[1:])
+	//      flags.Parse(args)
 	//
 	f := flags.New()
 	f.Parse(args)

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -18,7 +18,6 @@ package command
 
 import (
 	"context"
-	"os"
 	"sync"
 	"time"
 
@@ -41,7 +40,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
+func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.CoreCommandServiceKey)
 
 	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
@@ -52,7 +51,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
 	//      flags.Parse(os.Args[1:])
 	//
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{

--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -50,7 +50,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 	// Example:
 	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
 	//      ....
-	//      flags.Parse(os.Args[1:])
+	//      flags.Parse(args)
 	//
 
 	// TODO: figure out how to eliminate registry and profile flags

--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -42,7 +42,7 @@ const (
 	commonConfigDone = "IsCommonConfigReady"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc) {
+func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.CoreCommonConfigServiceKey)
 
 	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
@@ -55,7 +55,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 
 	// TODO: figure out how to eliminate registry and profile flags
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	var wg sync.WaitGroup
 	translateInterruptToCancel(ctx, &wg, cancel)
@@ -130,7 +130,6 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 	}
 
 	lc.Info("Core Common Config exiting")
-	os.Exit(0)
 }
 
 // translateInterruptToCancel spawns a go routine to translate the receipt of a SIGTERM signal to a call to cancel

--- a/internal/core/data/main.go
+++ b/internal/core/data/main.go
@@ -39,12 +39,12 @@ import (
 func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.CoreDataServiceKey)
 
-	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
+	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
 	// by inserting service specific flag prior to call to commonFlags.Parse().
 	// Example:
 	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
 	//      ....
-	//      flags.Parse(os.Args[1:])
+	//      flags.Parse(args)
 	//
 	f := flags.New()
 	f.Parse(args)

--- a/internal/core/data/main.go
+++ b/internal/core/data/main.go
@@ -18,8 +18,6 @@ package data
 
 import (
 	"context"
-	"os"
-
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/flags"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/handlers"
@@ -38,7 +36,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
+func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.CoreDataServiceKey)
 
 	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
@@ -49,7 +47,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
 	//      flags.Parse(os.Args[1:])
 	//
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{

--- a/internal/core/keeper/main.go
+++ b/internal/core/keeper/main.go
@@ -7,8 +7,6 @@ package keeper
 
 import (
 	"context"
-	"os"
-
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/flags"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/handlers"
@@ -28,7 +26,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
+func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(constants.CoreKeeperServiceKey)
 
 	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
@@ -39,7 +37,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
 	//      flags.Parse(os.Args[1:])
 	//
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{

--- a/internal/core/keeper/main.go
+++ b/internal/core/keeper/main.go
@@ -29,12 +29,12 @@ import (
 func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(constants.CoreKeeperServiceKey)
 
-	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
+	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
 	// by inserting service specific flag prior to call to commonFlags.Parse().
 	// Example:
 	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
 	//      ....
-	//      flags.Parse(os.Args[1:])
+	//      flags.Parse(args)
 	//
 	f := flags.New()
 	f.Parse(args)

--- a/internal/core/metadata/main.go
+++ b/internal/core/metadata/main.go
@@ -40,12 +40,12 @@ import (
 func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.CoreMetaDataServiceKey)
 
-	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
+	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
 	// by inserting service specific flag prior to call to commonFlags.Parse().
 	// Example:
 	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
 	//      ....
-	//      flags.Parse(os.Args[1:])
+	//      flags.Parse(args)
 	//
 	f := flags.New()
 	f.Parse(args)

--- a/internal/core/metadata/main.go
+++ b/internal/core/metadata/main.go
@@ -18,8 +18,6 @@ package metadata
 
 import (
 	"context"
-	"os"
-
 	"github.com/edgexfoundry/edgex-go"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/config"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/container"
@@ -39,7 +37,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
+func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.CoreMetaDataServiceKey)
 
 	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
@@ -50,7 +48,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
 	//      flags.Parse(os.Args[1:])
 	//
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{

--- a/internal/security/bootstrapper/main.go
+++ b/internal/security/bootstrapper/main.go
@@ -45,7 +45,7 @@ const (
 )
 
 // Main function is the wrapper for the security bootstrapper main
-func Main(ctx context.Context, cancel context.CancelFunc) {
+func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 	// service key for this bootstrapper service
 	startupTimer := startup.NewStartUpTimer(common.SecurityBootstrapperKey)
 
@@ -53,7 +53,7 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 	// the common flags so we are using our own implementation of the CommonFlags interface
 	f := bootstrapper.NewCommonFlags()
 
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	// find out the subcommand name before assigning the real concrete configuration
 	// bootstrapRedis has its own configuration settings

--- a/internal/security/config/main.go
+++ b/internal/security/config/main.go
@@ -16,8 +16,6 @@ package config
 
 import (
 	"context"
-	"os"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 
@@ -38,14 +36,14 @@ import (
 const securitySecretsConfigServiceKey = "secrets-config"
 
 // Main function called from cmd/secrets-config
-func Main(ctx context.Context, cancel context.CancelFunc) int {
+func Main(ctx context.Context, cancel context.CancelFunc, args []string) int {
 
 	startupTimer := startup.NewStartUpTimer(securitySecretsConfigServiceKey)
 
 	// Common Command-line flags have been moved to command.CommonFlags, but this service doesn't use all
 	// the common flags so we are using our own implementation of the CommonFlags interface
 	f := command.NewCommonFlags()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	lc := logger.NewClient(securitySecretsConfigServiceKey, models.ErrorLog)
 	configuration := &config.ConfigurationStruct{}

--- a/internal/security/fileprovider/main.go
+++ b/internal/security/fileprovider/main.go
@@ -32,19 +32,19 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc) {
+func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.SecurityFileTokenProviderServiceKey)
 
-	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
+	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
 	// by inserting service specific flag prior to call to commonFlags.Parse().
 	// Example:
 	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
 	//      ....
-	//      flags.Parse(os.Args[1:])
+	//      flags.Parse(args)
 	//
 
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{

--- a/internal/security/proxyauth/main.go
+++ b/internal/security/proxyauth/main.go
@@ -18,8 +18,6 @@ package proxyauth
 
 import (
 	"context"
-	"os"
-
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/flags"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/handlers"
@@ -39,18 +37,18 @@ import (
 
 const SecurityProxyAuthServiceKey = "security-proxy-auth"
 
-func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
+func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.CoreCommandServiceKey)
 
-	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
+	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
 	// by inserting service specific flag prior to call to commonFlags.Parse().
 	// Example:
 	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
 	//      ....
-	//      flags.Parse(os.Args[1:])
+	//      flags.Parse(args)
 	//
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{

--- a/internal/security/secretstore/main.go
+++ b/internal/security/secretstore/main.go
@@ -38,7 +38,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc) {
+func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.SecuritySecretStoreSetupServiceKey)
 
 	var insecureSkipVerify bool
@@ -52,13 +52,13 @@ func Main(ctx context.Context, cancel context.CancelFunc) {
 			"    --secretStoreInterval=<seconds>       Indicates how long the program will pause between the secret store initialization attempts until it succeeds",
 	)
 
-	if len(os.Args) < 2 {
+	if len(args) < 1 {
 		f.Help()
 	}
 
 	f.FlagSet.BoolVar(&insecureSkipVerify, "insecureSkipVerify", false, "")
 	f.FlagSet.IntVar(&secretStoreInterval, "secretStoreInterval", 30, "")
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{

--- a/internal/security/spiffetokenprovider/main.go
+++ b/internal/security/spiffetokenprovider/main.go
@@ -31,11 +31,11 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc) {
+func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.SecuritySpiffeTokenProviderKey)
 
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{

--- a/internal/support/notifications/main.go
+++ b/internal/support/notifications/main.go
@@ -24,8 +24,6 @@ package notifications
 
 import (
 	"context"
-	"os"
-
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/config"
 
 	"github.com/edgexfoundry/edgex-go"
@@ -44,18 +42,18 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
+func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.SupportNotificationsServiceKey)
 
-	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
+	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
 	// by inserting service specific flag prior to call to commonFlags.Parse().
 	// Example:
 	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
 	//      ....
-	//      flags.Parse(os.Args[1:])
+	//      flags.Parse(args)
 	//
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &notificationsConfig.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{

--- a/internal/support/scheduler/main.go
+++ b/internal/support/scheduler/main.go
@@ -16,8 +16,6 @@ package scheduler
 
 import (
 	"context"
-	"os"
-
 	"github.com/labstack/echo/v4"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap"
@@ -35,18 +33,18 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
 )
 
-func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo) {
+func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
 	startupTimer := startup.NewStartUpTimer(common.SupportSchedulerServiceKey)
 
-	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be add here,
+	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
 	// by inserting service specific flag prior to call to commonFlags.Parse().
 	// Example:
 	// 		flags.FlagSet.StringVar(&myvar, "m", "", "Specify a ....")
 	//      ....
-	//      flags.Parse(os.Args[1:])
+	//      flags.Parse(args)
 	//
 	f := flags.New()
-	f.Parse(os.Args[1:])
+	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
 	dic := di.NewContainer(di.ServiceConstructorMap{


### PR DESCRIPTION
fixes https://github.com/edgexfoundry/edgex-go/issues/5009

There is a user requirement that prefers to combine all core services into a single monolithic service. To easily achieve this based on current code structure, refactor following codes:
1. Change the signature of main function for each core services to allow pass os arguments rather than directly parse `os.Args[1:]`. With this change, the single monolithic service can alter the behavior of each individual internal services by passing different arguments.
2. Remove `os.Exit(0)` by end of a successful run of common_config_bootstrapper. This call is redundant and will force monolithic service to exit directly.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
make build
run core-keeper, core-common-config-boostrapper, core-command, core-data, core-metadata, and ensure all bootstraps as expected.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->