### PR TITLE
fix: Use correct service key for security proxy auth

### DIFF
--- a/internal/security/proxyauth/main.go
+++ b/internal/security/proxyauth/main.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2020 Dell Inc.
- * Copyright 2022-2023 IOTech Ltd.
+ * Copyright 2022-2024 IOTech Ltd.
  * Copyright 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -35,10 +35,8 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-const SecurityProxyAuthServiceKey = "security-proxy-auth"
-
 func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, args []string) {
-	startupTimer := startup.NewStartUpTimer(common.CoreCommandServiceKey)
+	startupTimer := startup.NewStartUpTimer(common.SecurityProxyAuthServiceKey)
 
 	// All common command-line flags have been moved to DefaultCommonFlags. Service specific flags can be added here,
 	// by inserting service specific flag prior to call to commonFlags.Parse().
@@ -63,7 +61,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, arg
 		ctx,
 		cancel,
 		f,
-		SecurityProxyAuthServiceKey,
+		common.SecurityProxyAuthServiceKey,
 		common.ConfigStemSecurity,
 		configuration,
 		startupTimer,
@@ -71,9 +69,9 @@ func Main(ctx context.Context, cancel context.CancelFunc, router *echo.Echo, arg
 		true,
 		bootstrapConfig.ServiceTypeOther,
 		[]interfaces.BootstrapHandler{
-			NewBootstrap(router, SecurityProxyAuthServiceKey).BootstrapHandler,
+			NewBootstrap(router, common.SecurityProxyAuthServiceKey).BootstrapHandler,
 			httpServer.BootstrapHandler,
-			handlers.NewStartMessage(SecurityProxyAuthServiceKey, edgex.Version).BootstrapHandler,
+			handlers.NewStartMessage(common.SecurityProxyAuthServiceKey, edgex.Version).BootstrapHandler,
 		})
 
 	// code here!


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->