### PR TITLE
feat: Update reading table schema

### DIFF
--- a/cmd/core-data/res/db/sql/01-tables.sql
+++ b/cmd/core-data/res/db/sql/01-tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS core_data.event (
 
 -- core_data.reading is used to store the reading information
 CREATE TABLE IF NOT EXISTS core_data.reading (
-    id UUID PRIMARY KEY,
+    id UUID,
     event_id UUID,
     devicename TEXT,
     profilename TEXT,
@@ -32,3 +32,6 @@ CREATE TABLE IF NOT EXISTS core_data.reading (
         FOREIGN KEY(event_id)
           REFERENCES core_data.event(id)
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reading_id_origin
+    ON core_data.reading(id, origin) -- Using id and origin as index for TimescaleDB integration


### PR DESCRIPTION
Using id and origin as the index for TimescaleDB integration.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Since we try to integrate the TimescaleDB as the time series db, we combine `id` and `origin` as the index. 
- replace postgres with timescaleDB
- run SQL to create the hypertable: `SELECT create_hypertable('reding', by_range('origin')); `
- run SQL to set the chunk interval: `SELECT set_chunk_time_interval('reading', 604800000000000);` -- 604800000000000 nanoseconds is for a chunk is 7 days
- check whether the chunk is created `select * from timescaledb_information.chunks;` and the interval is applied `select * from timescaledb_information.dimensions;`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->