### PR TITLE
fix: Upgrade go-mod-bootstrap version

### DIFF
--- a/cmd/security-proxy-auth/Dockerfile
+++ b/cmd/security-proxy-auth/Dockerfile
@@ -45,7 +45,7 @@ RUN apk --no-cache upgrade
 COPY --from=builder /edgex-go/Attribution.txt /
 COPY --from=builder /edgex-go/security.txt /
 COPY --from=builder /edgex-go/cmd/security-proxy-auth/security-proxy-auth /
-COPY --from=builder /edgex-go/cmd/security-proxy-auth/res/configuration.yaml /res/configuration.yaml
+COPY --from=builder /edgex-go/cmd/security-proxy-auth/res /res
 
 COPY --from=builder /edgex-go/cmd/security-proxy-auth/entrypoint.sh /usr/local/bin/
 RUN chmod 755 /usr/local/bin/entrypoint.sh \

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.5.0
-	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.16
+	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.17
 	github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.10
 	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.19
 	github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.10

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
 github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
-github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.16 h1:NSEoo/YnSDNWQcZpLAtXqDKHAId5mecTVBxk9zs/ROg=
-github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.16/go.mod h1:66I+qRA22YkjA/SYw4F9R0avZ9oNYM8bg2qhwePTFkI=
+github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.17 h1:0cMD8/A1vVg2u7igPO35/spG8bZd//dHBXOlspArWyk=
+github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.17/go.mod h1:66I+qRA22YkjA/SYw4F9R0avZ9oNYM8bg2qhwePTFkI=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.10 h1:DMv5LZDxcqUeb1dREMd/vK+reXmZYlpafgtm8XhYdHQ=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.10/go.mod h1:ltUpMcOpJSzmabBtZox5qg1AK2wEikvZJyIBXtJ7mUQ=
 github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.19 h1:uXZml7n/I/+c7k3eZRuJRrlWjYx/Euk8tlnBqeitvB8=


### PR DESCRIPTION
Relates to #5038. Update go-mod-bootstrap version and proxy-auth dockerfile.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->