### PR TITLE
fix: Add the /key path to API gateaway

### DIFF
--- a/cmd/security-proxy-setup/entrypoint.sh
+++ b/cmd/security-proxy-setup/entrypoint.sh
@@ -181,6 +181,18 @@ server {
       proxy_pass_request_body off;
     }
 
+    location = /key {
+    `cat "${corssnippet}"`
+      resolver           127.0.0.11 valid=30s;
+      proxy_pass         http://\$upstream_proxyauth:59842/api/v3/key;
+      proxy_method       POST;
+      proxy_redirect     off;
+      proxy_set_header   Host \$host;
+      auth_request       /auth;
+      auth_request_set   \$auth_status \$upstream_status;
+      auth_request_set   \$edgex_token \$upstream_http_authorization;
+    }
+
     # Rewriting rules (variable usage required to avoid nginx crash if host not resolveable at time of boot)
     # resolver required to enable name resolution at runtime, points at docker DNS resolver
 


### PR DESCRIPTION
Relates to #5038. Add the POST /key path to API gateaway from security-proxy-auth.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->