### PR TITLE
feat: Save postgres superuser password in secretstore

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/postgres_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/postgres_wait_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #  ----------------------------------------------------------------------------------
-#  Copyright (C) 2024 IOTech Ltd
+#  Copyright (C) 2024-2025 IOTech Ltd
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -98,6 +98,14 @@ fi
 
 docker_process_init_files ${DATABASECONFIG_PATH}/*
 docker_temp_server_stop
+
+# Remove the POSTGRES_PASSWORD_FILE
+rm -f "$POSTGRES_PASSWORD_FILE"
+
+# Check if the file has been removed successfully
+if [ -e "$POSTGRES_PASSWORD_FILE" ]; then
+    echo "$(date) Failed to remove the POSTGRES_PASSWORD_FILE in: $POSTGRES_PASSWORD_FILE"
+fi
 
 # starting postgres
 echo "$(date) Starting edgex-postgres ..."

--- a/internal/security/bootstrapper/helper/postgres_script.go
+++ b/internal/security/bootstrapper/helper/postgres_script.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2024 IOTech Ltd
+ * Copyright (C) 2024-2025 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ package helper
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"text/template"
@@ -72,4 +73,14 @@ func GeneratePostgresScript(confFile *os.File, credMap []map[string]any) error {
 	}
 
 	return nil
+}
+
+// GeneratePasswordFile creates a random password and writes it to the Postgres password file
+func GeneratePasswordFile(confFile *os.File, password string) error {
+	if password == "" {
+		return errors.New("failed to GeneratePasswordFile: password is empty")
+	}
+
+	_, err := confFile.WriteString(password)
+	return err
 }

--- a/internal/security/bootstrapper/helper/postgres_script_test.go
+++ b/internal/security/bootstrapper/helper/postgres_script_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -52,4 +52,27 @@ func TestGeneratePostgresScript(t *testing.T) {
 	expectedCreateScript := fmt.Sprintf("CREATE USER \"%s\" with PASSWORD '%s';", mockUsername, mockPassword)
 	require.Equal(t, 17, len(outputlines))
 	require.Equal(t, expectedCreateScript, strings.TrimSpace(outputlines[11]))
+}
+
+func TestGeneratePasswordFile(t *testing.T) {
+	fileName := "testPasswordFile"
+	testfile, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	require.NoError(t, err)
+	defer func() {
+		_ = testfile.Close()
+		_ = os.RemoveAll(fileName)
+	}()
+
+	mockPassword := "password123"
+
+	err = GeneratePasswordFile(testfile, mockPassword)
+	require.NoError(t, err)
+
+	content, readErr := os.ReadFile(testfile.Name())
+	require.NoError(t, readErr)
+	require.Equal(t, mockPassword, string(content))
+
+	// test with empty password
+	err = GeneratePasswordFile(testfile, "")
+	require.Error(t, err)
 }

--- a/internal/security/bootstrapper/postgres/configure.go
+++ b/internal/security/bootstrapper/postgres/configure.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -51,6 +51,7 @@ func Configure(ctx context.Context,
 		true,
 		bootstrapConfig.ServiceTypeOther,
 		[]interfaces.BootstrapHandler{
+			handlers.SetupPasswordFile,
 			handlers.SetupDBScriptFiles,
 		},
 	)

--- a/internal/security/bootstrapper/postgres/handlers/handlers.go
+++ b/internal/security/bootstrapper/postgres/handlers/handlers.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	postgresSecretName = "postgres" // nolint:gosec
+	postgresSecretName = "postgres"
 	passwordFileDir    = "/run/secrets"
 	passwordFileName   = "postgres_password"
 )

--- a/internal/security/bootstrapper/postgres/handlers/handlers.go
+++ b/internal/security/bootstrapper/postgres/handlers/handlers.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	postgresSecretName = "postgres"
+	postgresSecretName = "postgres" // nolint:gosec
 	passwordFileDir    = "/run/secrets"
 	passwordFileName   = "postgres_password"
 )


### PR DESCRIPTION
Resolves #5050. Save postgres superuser password in secretstore.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->