### PR TITLE
feat: revise DB schema initialVersion to 4.0.0-dev

### DIFF
--- a/internal/pkg/db/postgres/migration.go
+++ b/internal/pkg/db/postgres/migration.go
@@ -28,8 +28,8 @@ const (
 	statusFailure = "FAILURE"
 
 	// initialVersion specifies the version when the service introduced schema_migrations table to handle migration
-	// as we introduced the schema_migration in the release of 4.0.0, the initial version is set to 4.0.0
-	initialVersion = "4.0.0"
+	// as we introduced the schema_migration in the release of 4.0.0-dev, the initial version is set to 4.0.0-dev
+	initialVersion = "4.0.0-dev"
 )
 
 // TableManager defines the interface for the table manager


### PR DESCRIPTION
related to https://github.com/edgexfoundry/edgex-go/issues/5072

The orignal initialVersion is specified as 4.0.0, which will cause services with version 4.0.0-dev.XX below the db schema version and fails to initialize the postgreSQL client.

Specify the initialVersion to 4.0.0-dev to avoid this.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Add a `VERSION` file with following content in the repository:
```
4.0.0-dev.22
```
2. Build docker images for core-data, core-keeper, core-metadata, support-notifications, support-scheduler, security-proxy-auth:
```
make ddata
make dkeeper
make dmetadata
make dproxya
make dnotifications
make dscheduler
```
3. Clone https://github.com/edgexfoundry/edgex-compose.git and revise https://github.com/edgexfoundry/edgex-compose/blob/main/compose-builder/docker-compose-base.yml and https://github.com/edgexfoundry/edgex-compose/blob/main/compose-builder/add-security-proxy.yml with proper docker images built in previous step.
4. `make run ds-virtual`
5. check logs for `edgex-core-data`, `edgex-core-keeper`, `edgex-core-metadata`, `edgex-support-notifications`, `edgex-support-scheduler`, `edgex-proxy-auth`, and verify if their logging contains migration successfully applied information:
```
level=INFO ts=2025-02-10T17:22:19.848211375+08:00 app=security-proxy-auth source=migration.go:135 msg="db schema version: 4.0.0-dev, service version: 4.0.0-dev.22, security-proxy-auth preparing to apply schema migration scripts if any"
level=INFO ts=2025-02-10T17:22:19.848260588+08:00 app=security-proxy-auth source=migration.go:141 msg="security-proxy-auth successfully applied SQL scripts"
level=INFO ts=2025-02-10T17:22:19.848813356+08:00 app=security-proxy-auth source=database.go:155 msg="postgres database connected"
```
6. obtain the client token from openbao: `sudo cat /tmp/edgex/secrets/security-bootstrapper-postgres/secrets-token.json`
7. use the client token to retrieve the random generated password for postgres: `curl -s -H 'X-Vault-Token: <BAO_TOKEN>' http://localhost:8200/v1/secret/edgex/security-bootstrapper-postgres/postgres`
8. use the password to access into postgres DB using psql: `psql -h localhost -U postgres -W -d edgex_db`
9. check if all schema_migrations tables have proper records:
```
edgex_db=# select * from core_data.schema_migrations;
 id |  version  | status  |            created            
----+-----------+---------+-------------------------------
  1 | 4.0.0-dev | SUCCESS | 2025-02-10 17:22:19.211259+08
(1 row)

edgex_db=# select * from core_keeper.schema_migrations;
 id |  version  | status  |            created            
----+-----------+---------+-------------------------------
  1 | 4.0.0-dev | SUCCESS | 2025-02-10 17:22:17.900764+08
(1 row)

edgex_db=# select * from core_metadata.schema_migrations;
 id |  version  | status  |            created            
----+-----------+---------+-------------------------------
  1 | 4.0.0-dev | SUCCESS | 2025-02-10 17:22:19.416201+08
(1 row)

edgex_db=# select * from security_proxy_auth.schema_migrations;
 id |  version  | status  |            created            
----+-----------+---------+-------------------------------
  1 | 4.0.0-dev | SUCCESS | 2025-02-10 17:22:19.847124+08
(1 row)

edgex_db=# select * from support_notifications.schema_migrations;
 id |  version  | status  |            created            
----+-----------+---------+-------------------------------
  1 | 4.0.0-dev | SUCCESS | 2025-02-10 17:22:19.383451+08
(1 row)

edgex_db=# select * from support_scheduler.schema_migrations;
 id |  version  | status  |            created            
----+-----------+---------+-------------------------------
  1 | 4.0.0-dev | SUCCESS | 2025-02-10 17:22:19.259743+08
(1 row)
```
10.  verify if all tables for each individual services are properly created


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->