### PR TITLE
feat: Add regen token API in secretstore-setup

### DIFF
--- a/cmd/core-common-config-bootstrapper/res/configuration.yaml
+++ b/cmd/core-common-config-bootstrapper/res/configuration.yaml
@@ -23,7 +23,7 @@ all-services:
     MaxResultCount: 1024
     MaxRequestSize: 0 # Not currently used. Defines the maximum size of http request body in bytes
     RequestTimeout: "5s"
-    EnableNameFieldEscape: false # The name field escape could allow the system to use special or Chinese characters in the different name fields, including device, profile, and so on.  If the EnableNameFieldEscape is false, some special characters might cause system error.  TODO: This is set to false by default to avoid breaking change and will be removed in EdgeX 4.0
+    EnableNameFieldEscape: true # The name field escape could allow the system to use special or Chinese characters in the different name fields, including device, profile, and so on.  If the EnableNameFieldEscape is false, some special characters might cause system error.
     CORSConfiguration:
       EnableCORS: false
       CORSAllowCredentials: false

--- a/cmd/security-secretstore-setup/entrypoint.sh
+++ b/cmd/security-secretstore-setup/entrypoint.sh
@@ -31,7 +31,7 @@ mkdir -p /openbao/config/assets
 chown -Rh 100:1000 /openbao/
 
 echo "Initializing secret store..."
-/security-secretstore-setup --secretStoreInterval=10 &
+/security-secretstore-setup --secretStoreInterval=10
 
 # default User and Group in case never set
 if [ -z "${EDGEX_USER}" ]; then
@@ -52,7 +52,10 @@ chown -Rh ${EKUIPER_UID}:${EKUIPER_GID} "${EDGEX_SECRETS_ROOT}/rules-engine"
 
 # Signal tokens ready port for other services waiting on
 exec su-exec ${EDGEX_USER} /edgex-init/security-bootstrapper --configDir=/edgex-init/res listenTcp \
-  --port="${STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT}" --host="${STAGEGATE_SECRETSTORESETUP_HOST}"
+  --port="${STAGEGATE_SECRETSTORESETUP_TOKENS_READYPORT}" --host="${STAGEGATE_SECRETSTORESETUP_HOST}" &
 if [ $? -ne 0 ]; then
   echo "$(date) failed to gating the tokens ready port"
 fi
+
+echo "Starting secret store as a long-run service listening on http service port"
+/security-secretstore-setup --secretStoreInterval=10 --longRun=true

--- a/cmd/security-secretstore-setup/entrypoint.sh
+++ b/cmd/security-secretstore-setup/entrypoint.sh
@@ -31,7 +31,7 @@ mkdir -p /openbao/config/assets
 chown -Rh 100:1000 /openbao/
 
 echo "Initializing secret store..."
-/security-secretstore-setup --secretStoreInterval=10
+/security-secretstore-setup --secretStoreInterval=10 &
 
 # default User and Group in case never set
 if [ -z "${EDGEX_USER}" ]; then

--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
+ * Copyright (c) 2025 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,9 +25,11 @@ import (
 	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
+
+	"github.com/labstack/echo/v4"
 )
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	secretstore.Main(ctx, cancel, os.Args[1:])
+	secretstore.Main(ctx, cancel, echo.New(), os.Args[1:])
 }

--- a/cmd/security-secretstore-setup/main.go
+++ b/cmd/security-secretstore-setup/main.go
@@ -25,11 +25,9 @@ import (
 	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
-
-	"github.com/labstack/echo/v4"
 )
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
-	secretstore.Main(ctx, cancel, echo.New(), os.Args[1:])
+	secretstore.Main(ctx, cancel, os.Args[1:])
 }

--- a/cmd/security-secretstore-setup/res/configuration.yaml
+++ b/cmd/security-secretstore-setup/res/configuration.yaml
@@ -1,6 +1,7 @@
 #################################################################################
 # Copyright 2019 Dell Inc.
 # Copyright 2020-2023 Intel Corp.
+# Copyright 2025 IOTech Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -80,3 +81,17 @@ SecureMessageBus:
       Service: support-notifications
     scheduler:
       Service: support-scheduler
+Service:
+  Host: localhost
+  Port: 59843
+  StartupMsg: "This is the security-secretstore-setup microservice"
+  RequestTimeout: "5s"
+  EnableNameFieldEscape: false # The name field escape could allow the system to use special or Chinese characters in the different name fields, including device, profile, and so on.  If the EnableNameFieldEscape is false, some special characters might cause system error.  TODO: This is set to false by default to avoid breaking change and will be removed in EdgeX 4.0
+  CORSConfiguration:
+    EnableCORS: false
+    CORSAllowCredentials: false
+    CORSAllowedOrigin: "https://localhost"
+    CORSAllowedMethods: "GET, POST, PUT, PATCH, DELETE"
+    CORSAllowedHeaders: "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+    CORSExposeHeaders: "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+    CORSMaxAge: 3600

--- a/cmd/security-secretstore-setup/res/configuration.yaml
+++ b/cmd/security-secretstore-setup/res/configuration.yaml
@@ -86,7 +86,7 @@ Service:
   Port: 59843
   StartupMsg: "This is the security-secretstore-setup microservice"
   RequestTimeout: "5s"
-  EnableNameFieldEscape: false # The name field escape could allow the system to use special or Chinese characters in the different name fields, including device, profile, and so on.  If the EnableNameFieldEscape is false, some special characters might cause system error.  TODO: This is set to false by default to avoid breaking change and will be removed in EdgeX 4.0
+  EnableNameFieldEscape: true # The name field escape could allow the system to use special or Chinese characters in the different name fields, including device, profile, and so on.  If the EnableNameFieldEscape is false, some special characters might cause system error.
   CORSConfiguration:
     EnableCORS: false
     CORSAllowCredentials: false

--- a/cmd/security-spire-agent/Dockerfile
+++ b/cmd/security-spire-agent/Dockerfile
@@ -19,8 +19,8 @@
 ARG BUILDER_BASE=golang:1.23-alpine3.20
 FROM ${BUILDER_BASE} AS builder
 
-FROM ghcr.io/spiffe/spire-server:1.9.6 as spire_server
-FROM ghcr.io/spiffe/spire-agent:1.9.6 as spire_agent
+FROM ghcr.io/spiffe/spire-server:1.11.1 as spire_server
+FROM ghcr.io/spiffe/spire-agent:1.11.1 as spire_agent
 
 # Deployment image
 FROM alpine:3.20

--- a/cmd/security-spire-config/Dockerfile
+++ b/cmd/security-spire-config/Dockerfile
@@ -19,7 +19,7 @@
 ARG BUILDER_BASE=golang:1.23-alpine3.20
 FROM ${BUILDER_BASE} AS builder
 
-FROM ghcr.io/spiffe/spire-server:1.9.6 as spire_server
+FROM ghcr.io/spiffe/spire-server:1.11.1 as spire_server
 
 # Deployment image
 FROM alpine:3.20

--- a/cmd/security-spire-server/Dockerfile
+++ b/cmd/security-spire-server/Dockerfile
@@ -19,7 +19,7 @@
 ARG BUILDER_BASE=golang:1.23-alpine3.20
 FROM ${BUILDER_BASE} AS builder
 
-FROM ghcr.io/spiffe/spire-server:1.9.6 as spire_server
+FROM ghcr.io/spiffe/spire-server:1.11.1 as spire_server
 
 # Deployment image
 FROM alpine:3.20

--- a/internal/security/common/usermanager.go
+++ b/internal/security/common/usermanager.go
@@ -126,7 +126,7 @@ func (m *UserManager) CreatePasswordUserWithPolicy(username string, password str
 	}
 	err = m.secretStoreClient.CreateOrUpdateTokenRole(m.privilegedToken, username, tokenRoleParams)
 	if err != nil {
-		m.logger.Errorf("failed create/update token role '%s': %v", username, err)
+		m.logger.Errorf("failed create/update token role '%s': %w", username, err)
 		return err
 	}
 

--- a/internal/security/common/usermanager.go
+++ b/internal/security/common/usermanager.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2023 Intel Corporation
+// Copyright (c) 2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -112,6 +113,20 @@ func (m *UserManager) CreatePasswordUserWithPolicy(username string, password str
 	customClaims := fmt.Sprintf(`{"name": "%s"}`, username)
 	err = m.secretStoreClient.CreateOrUpdateIdentityRole(m.privilegedToken, username, m.jwtKeyName, customClaims, m.jwtAudience, m.jwtTTL)
 	if err != nil {
+		return err
+	}
+
+	// Create the token role which will be used to associate a token with the entity alias
+	// See create token role API doc in https://openbao.org/api-docs/auth/token/#createupdate-token-role
+	tokenRoleParams := map[string]any{
+		"allowed_policies":       []string{policyName},
+		"name":                   username,
+		"renewable":              true,
+		"allowed_entity_aliases": []string{username},
+	}
+	err = m.secretStoreClient.CreateOrUpdateTokenRole(m.privilegedToken, username, tokenRoleParams)
+	if err != nil {
+		m.logger.Errorf("failed create/update token role '%s': %v", username, err)
 		return err
 	}
 

--- a/internal/security/config/command/proxy/adduser/command_test.go
+++ b/internal/security/config/command/proxy/adduser/command_test.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2020-2023 Intel Corporation
+// Copyright (c) 2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -83,6 +84,13 @@ func addUserWithArgs(t *testing.T, args []string) {
 				t.Fatalf("Unexpected call to %s %s", r.Method, r.URL.EscapedPath())
 			}
 		case "/v1/identity/entity-alias":
+			switch r.Method {
+			case "POST":
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				t.Fatalf("Unexpected call to %s %s", r.Method, r.URL.EscapedPath())
+			}
+		case "/v1/auth/token/roles/someuser":
 			switch r.Method {
 			case "POST":
 				w.WriteHeader(http.StatusNoContent)

--- a/internal/security/config/command/proxy/shared/proxyuser.go
+++ b/internal/security/config/command/proxy/shared/proxyuser.go
@@ -18,6 +18,8 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/pipedhexreader"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
 	secretStoreConfig "github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenmaintenance"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 	"github.com/edgexfoundry/go-mod-secrets/v4/pkg"
 	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/authtokenloader"
@@ -132,7 +134,7 @@ func (vb *ProxyUserCommon) LoadRootToken() (string, func(), error) {
 	}
 
 	var initResponse types.InitResponse
-	if err := secretstore.LoadInitResponse(vb.loggingClient, vb.fileOpener, vb.configuration.SecretStore, &initResponse); err != nil {
+	if err := tokenmaintenance.LoadInitResponse(vb.loggingClient, vb.fileOpener, vb.configuration.SecretStore, &initResponse); err != nil {
 		vb.loggingClient.Errorf("unable to load init response: %s", err.Error())
 		return "", nil, err
 	}

--- a/internal/security/fileprovider/command/createtoken/command.go
+++ b/internal/security/fileprovider/command/createtoken/command.go
@@ -100,7 +100,7 @@ func regenToken(entityId string, dic *di.Container) errors.EdgeX {
 	}
 	client, err := secrets.NewSecretStoreClient(clientConfig, lc, requester)
 	if err != nil {
-		lc.Errorf("error occurred creating SecretStoreClient: %v", err)
+		lc.Errorf("error occurred creating SecretStoreClient: %s", err.Error())
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 
@@ -112,7 +112,7 @@ func regenToken(entityId string, dic *di.Container) errors.EdgeX {
 
 	err = fileProvider.RegenToken(entityId)
 	if err != nil {
-		lc.Errorf("error occurred while re-generating token: %v", err)
+		lc.Errorf("error occurred while re-generating token: %s", err.Error())
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 

--- a/internal/security/fileprovider/command/createtoken/command.go
+++ b/internal/security/fileprovider/command/createtoken/command.go
@@ -1,0 +1,120 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package createtoken
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/container"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/tokenprovider"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/fileioperformer"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/types"
+	"github.com/edgexfoundry/go-mod-secrets/v4/secrets"
+)
+
+const (
+	CommandName  string = "createToken"
+	entityIdFlag string = "entityId"
+)
+
+type command struct {
+	waitGroup *sync.WaitGroup
+	dic       *di.Container
+
+	// options
+	entityId string
+}
+
+// NewCommand creates a new cmd and parses through options if any
+func NewCommand(
+	dic *di.Container,
+	args []string) (interfaces.Command, error) {
+	cmd := command{
+		waitGroup: &sync.WaitGroup{},
+		dic:       dic,
+	}
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	var entityId string
+
+	lc.Debugf("Initialize '%s' command with args: %v", CommandName, args)
+
+	flagSet := flag.NewFlagSet(CommandName, flag.ContinueOnError)
+	flagSet.StringVar(&entityId, entityIdFlag, "", "")
+
+	err := flagSet.Parse(args)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse command '%s': %v", strings.Join(args, " "), err)
+	}
+
+	if len(entityId) == 0 {
+		return nil, fmt.Errorf("%s %s: argument --entityId is required", os.Args[0], CommandName)
+	}
+	cmd.entityId = entityId
+	return &cmd, nil
+}
+
+// GetCommandName returns the name of this command
+func (c *command) GetCommandName() string {
+	return CommandName
+}
+
+// Execute implements Command and runs this command
+// command createtoken regenerate a token file for the specified entityId argument
+func (c *command) Execute() (int, error) {
+	lc := bootstrapContainer.LoggingClientFrom(c.dic.Get)
+	lc.Infof("Security file token provider - executing %s command .......", CommandName)
+
+	if err := regenToken(c.entityId, c.dic); err != nil {
+		return interfaces.StatusCodeExitWithError, err
+	}
+
+	return interfaces.StatusCodeExitNormal, nil
+}
+
+// regenToken invokes RegenToken from fileProvider to recreate the token file for the specified entity id
+func regenToken(entityId string, dic *di.Container) errors.EdgeX {
+	cfg := container.ConfigurationFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+
+	var requester internal.HttpCaller
+
+	clientConfig := types.SecretConfig{
+		Type:     secrets.DefaultSecretStore,
+		Host:     cfg.SecretStore.Host,
+		Port:     cfg.SecretStore.Port,
+		Protocol: cfg.SecretStore.Protocol,
+	}
+	client, err := secrets.NewSecretStoreClient(clientConfig, lc, requester)
+	if err != nil {
+		lc.Errorf("error occurred creating SecretStoreClient: %v", err)
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
+	tokenProvider := authtokenloader.NewAuthTokenLoader(fileOpener)
+
+	fileProvider := tokenprovider.NewTokenProvider(lc, fileOpener, tokenProvider, client)
+	fileProvider.SetConfiguration(cfg.SecretStore, cfg.TokenFileProvider)
+
+	err = fileProvider.RegenToken(entityId)
+	if err != nil {
+		lc.Errorf("error occurred while re-generating token: %v", err)
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	return nil
+}

--- a/internal/security/fileprovider/command/createtoken/command.go
+++ b/internal/security/fileprovider/command/createtoken/command.go
@@ -57,7 +57,7 @@ func NewCommand(
 
 	err := flagSet.Parse(args)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse command '%s': %v", strings.Join(args, " "), err)
+		return nil, fmt.Errorf("unable to parse command '%s': %w", strings.Join(args, " "), err)
 	}
 
 	if len(entityId) == 0 {
@@ -100,7 +100,7 @@ func regenToken(entityId string, dic *di.Container) errors.EdgeX {
 	}
 	client, err := secrets.NewSecretStoreClient(clientConfig, lc, requester)
 	if err != nil {
-		lc.Errorf("error occurred creating SecretStoreClient: %s", err.Error())
+		lc.Errorf("error occurred creating SecretStoreClient: %w", err)
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 
@@ -112,7 +112,7 @@ func regenToken(entityId string, dic *di.Container) errors.EdgeX {
 
 	err = fileProvider.RegenToken(entityId)
 	if err != nil {
-		lc.Errorf("error occurred while re-generating token: %s", err.Error())
+		lc.Errorf("error occurred while re-generating token: %w", err)
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 

--- a/internal/security/fileprovider/command/createtoken/command_test.go
+++ b/internal/security/fileprovider/command/createtoken/command_test.go
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (C) 2025 IOTech Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package createtoken
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/container"
+	secretStoreConfig "github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+
+	"github.com/stretchr/testify/require"
+)
+
+const mockEntityId = "mockId123"
+
+func mockDic() *di.Container {
+
+	return di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &config.ConfigurationStruct{
+				LogLevel:          "",
+				SecretStore:       secretStoreConfig.SecretStoreInfo{},
+				TokenFileProvider: config.TokenFileProviderInfo{},
+			}
+		},
+	})
+}
+
+func TestNewCommand(t *testing.T) {
+	// Arrange
+	dic := mockDic()
+
+	tests := []struct {
+		name        string
+		cmdArgs     []string
+		expectedErr bool
+	}{
+		{"Good: createToken required --entityId option", []string{"--entityId=" + mockEntityId}, false},
+		{"Bad: createToken empty option", []string{""}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command, err := NewCommand(dic, tt.cmdArgs)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, command)
+			}
+		})
+	}
+}

--- a/internal/security/fileprovider/command/flags_common.go
+++ b/internal/security/fileprovider/command/flags_common.go
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (C) 2025 IOTech Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package command
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/flags"
+)
+
+// commonFlags is a custom implementation of flags.Common from go-mod-bootstrap
+type commonFlags struct {
+	configDir string
+}
+
+// NewCommonFlags creates new CommonFlags and initializes it
+func NewCommonFlags() flags.Common {
+	commonFlags := commonFlags{}
+	return &commonFlags
+}
+
+// Parse parses the command-line arguments
+func (f *commonFlags) Parse(_ []string) {
+	flag.StringVar(&f.configDir, "configDir", "", "")
+	flag.Usage = HelpCallback
+
+	flag.Parse()
+
+	// Make sure Configuration Provider environment variable isn't set since this service doesn't support using it.
+	_ = os.Setenv(internal.ConfigProviderEnvVar, "")
+}
+
+// ConfigFileName returns the name of the local configuration file
+func (f *commonFlags) ConfigFileName() string {
+	return flags.DefaultConfigFile
+}
+
+// CommonConfig returns an empty string since common config is not used
+func (f *commonFlags) CommonConfig() string {
+	return ""
+}
+
+// OverwriteConfig returns false since the Configuration provider is not used
+func (f *commonFlags) OverwriteConfig() bool {
+	return false
+}
+
+// UseRegistry returns false since registry is not used
+func (f *commonFlags) UseRegistry() bool {
+	return false
+}
+
+// InDevMode returns false since dev mode is not used
+func (f *commonFlags) InDevMode() bool {
+	return false
+}
+
+// ConfigProviderUrl returns the empty url since Configuration Provider is not used.
+func (f *commonFlags) ConfigProviderUrl() string {
+	return ""
+}
+
+// Profile returns the empty name since profile is not used
+func (f *commonFlags) Profile() string {
+	return ""
+}
+
+// RemoteServiceHosts returns nil list since is not used in this service
+func (f *commonFlags) RemoteServiceHosts() []string {
+	return nil
+}
+
+// ConfigDirectory returns the directory where the config file(s) are located, if it was specified.
+func (f *commonFlags) ConfigDirectory() string {
+	return f.configDir
+}
+
+// Help displays the usage help message and exit.
+func (f *commonFlags) Help() {
+	HelpCallback()
+}
+
+// HelpCallback displays the help usage message and exits
+func HelpCallback() {
+	fmt.Printf(
+		"Usage: %s [options] <command> [arg...]\n"+
+			"Options:\n"+
+			"    -h, --help    Show this message\n"+
+			"    --configDir     Specify local configuration directory\n"+
+			"\n"+
+			"Commands:\n"+
+			"    createToken --entityId  Generate a new secret store token\n"+
+			"                            for the specified entity id",
+		os.Args[0])
+}

--- a/internal/security/fileprovider/command/handlers/init.go
+++ b/internal/security/fileprovider/command/handlers/init.go
@@ -74,7 +74,7 @@ func (b *Bootstrap) BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ sta
 
 	exitStatusCode, err := command.Execute()
 	if err != nil {
-		lc.Errorf("failed to execute command '%s': %s", err.Error())
+		lc.Errorf("failed to execute command '%s': %w", commandName, err)
 	}
 	b.exitStatusCode = exitStatusCode
 

--- a/internal/security/fileprovider/command/handlers/init.go
+++ b/internal/security/fileprovider/command/handlers/init.go
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright 2025 IOTech Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package handlers
+
+import (
+	"context"
+	"flag"
+	"sync"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/command/createtoken"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/container"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+)
+
+// Bootstrap is to implement BootstrapHandler
+type Bootstrap struct {
+	exitStatusCode int
+}
+
+// NewInitialization is to instantiate a Bootstrap instance
+func NewInitialization() *Bootstrap {
+	return &Bootstrap{}
+}
+
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed
+// for security fileprovider's command arguments
+func (b *Bootstrap) BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
+	conf := container.ConfigurationFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+
+	if flag.NArg() == 0 {
+		lc.Debug("no security-file-provider subcommand arg defined, skipping execute subcommand")
+		return true
+	}
+
+	lc.Debugf("configuration from the local file: %v", *conf)
+
+	var command interfaces.Command
+	var err error
+	commandName := flag.Arg(0)
+	subcommandArgs := flag.Args()
+
+	lc.Debugf("security-file-provider commandName: %s, subcommandArgs: %v", commandName, subcommandArgs)
+
+	switch commandName {
+	case createtoken.CommandName:
+		command, err = createtoken.NewCommand(dic, subcommandArgs[1:])
+	default:
+		return true
+	}
+
+	if err != nil {
+		lc.Error(err.Error())
+		b.exitStatusCode = interfaces.StatusCodeExitWithError
+		return false
+	}
+
+	exitStatusCode, err := command.Execute()
+	if err != nil {
+		lc.Errorf("failed to execute command '%s': %v", err)
+	}
+	b.exitStatusCode = exitStatusCode
+
+	return true
+}
+
+// GetExitStatusCode returns security fileprovider's exit code
+func (b *Bootstrap) GetExitStatusCode() int {
+	return b.exitStatusCode
+}

--- a/internal/security/fileprovider/command/handlers/init.go
+++ b/internal/security/fileprovider/command/handlers/init.go
@@ -74,7 +74,7 @@ func (b *Bootstrap) BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ sta
 
 	exitStatusCode, err := command.Execute()
 	if err != nil {
-		lc.Errorf("failed to execute command '%s': %v", err)
+		lc.Errorf("failed to execute command '%s': %s", err.Error())
 	}
 	b.exitStatusCode = exitStatusCode
 

--- a/internal/security/fileprovider/main.go
+++ b/internal/security/fileprovider/main.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2023 Intel Corporation
+ * Copyright (C) 2025 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,11 +20,12 @@ import (
 	"context"
 	"os"
 
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/command"
+	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/command/handlers"
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/container"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap"
-	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/flags"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/startup"
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v4/config"
@@ -42,8 +44,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 	//      ....
 	//      flags.Parse(args)
 	//
-
-	f := flags.New()
+	f := command.NewCommonFlags()
 	f.Parse(args)
 
 	configuration := &config.ConfigurationStruct{}
@@ -54,6 +55,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 	})
 
 	bootStrapper := NewBootstrap()
+	cmdBootStrapper := handlers.NewInitialization()
 
 	_, _, success := bootstrap.RunAndReturnWaitGroup(
 		ctx,
@@ -69,6 +71,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 		bootstrapConfig.ServiceTypeOther,
 		[]interfaces.BootstrapHandler{
 			bootStrapper.BootstrapHandler,
+			cmdBootStrapper.BootstrapHandler,
 		},
 	)
 

--- a/internal/security/fileprovider/mocks/mock.go
+++ b/internal/security/fileprovider/mocks/mock.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2019 Intel Corporation
+// Copyright (C) 2025 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -37,4 +38,10 @@ func (p *MockTokenProvider) Run() error {
 func (p *MockTokenProvider) SetConfiguration(secretConfig secretStoreConfig.SecretStoreInfo, tokenConfig config.TokenFileProviderInfo) {
 	// Boilerplate that returns whatever Mock.On().Returns() is configured for
 	p.Called(secretConfig, tokenConfig)
+}
+
+func (p *MockTokenProvider) RegenToken(entityId string) error {
+	// Boilerplate that returns whatever Mock.On().Returns() is configured for
+	p.Called(entityId)
+	return nil
 }

--- a/internal/security/fileprovider/mocks/mock_test.go
+++ b/internal/security/fileprovider/mocks/mock_test.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2019 Intel Corporation
+// Copyright (C) 2025 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -19,8 +20,8 @@ package mocks
 import (
 	"testing"
 
-	. "github.com/edgexfoundry/edgex-go/internal/security/fileprovider"
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
+	. "github.com/edgexfoundry/edgex-go/internal/security/fileprovider/tokenprovider"
 
 	secretStoreConfig "github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
 
@@ -48,6 +49,17 @@ func TestMockSetConfiguration(t *testing.T) {
 	p.On("SetConfiguration", secretStoreConfig.SecretStoreInfo{}, config.TokenFileProviderInfo{})
 
 	p.SetConfiguration(secretStoreConfig.SecretStoreInfo{}, config.TokenFileProviderInfo{})
+
+	p.AssertExpectations(t)
+}
+
+func TestMockRegenToken(t *testing.T) {
+	p := &MockTokenProvider{}
+	mockEntityId := "id123"
+	p.On("RegenToken", mockEntityId)
+
+	err := p.RegenToken(mockEntityId)
+	assert.NoError(t, err)
 
 	p.AssertExpectations(t)
 }

--- a/internal/security/fileprovider/tokenprovider/interface.go
+++ b/internal/security/fileprovider/tokenprovider/interface.go
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package fileprovider
+package tokenprovider
 
 import (
 	"github.com/edgexfoundry/edgex-go/internal/security/fileprovider/config"
@@ -28,4 +28,6 @@ type TokenProvider interface {
 	SetConfiguration(secretStore secretstoreConfig.SecretStoreInfo, tokenConfig config.TokenFileProviderInfo)
 	// Generate tokens
 	Run() error
+	// RegenToken regenerates a token for the specified entity in secret store
+	RegenToken(entityId string) error
 }

--- a/internal/security/fileprovider/tokenprovider/provider.go
+++ b/internal/security/fileprovider/tokenprovider/provider.go
@@ -248,7 +248,7 @@ func (p *fileTokenProvider) RegenToken(entityId string) error {
 	// retrieve the entity metadata that will be required while creating a token and associates with the entity
 	getEntityResp, err := p.secretStoreClient.GetIdentityByEntityId(privilegedToken, entityId)
 	if err != nil {
-		p.logger.Errorf("failed to get entity by id '%s' from secretStoreClient: %v", entityId, err)
+		p.logger.Errorf("failed to get entity by id '%s' from secretStoreClient: %w", entityId, err)
 		return err
 	}
 
@@ -279,7 +279,7 @@ func (p *fileTokenProvider) RegenToken(entityId string) error {
 	p.logger.Infof("opening token file %s", outputTokenFilename)
 	writeCloser, err := p.fileOpener.OpenFileWriter(outputTokenFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600))
 	if err != nil {
-		p.logger.Errorf("failed open token file for writing %s: %v", outputTokenFilename, err)
+		p.logger.Errorf("failed open token file for writing %s: %w", outputTokenFilename, err)
 		return err
 	}
 
@@ -296,19 +296,19 @@ func (p *fileTokenProvider) RegenToken(entityId string) error {
 	p.logger.Infof("creating token for %s ......", entityName)
 	createTokenResponse, err := p.secretStoreClient.CreateTokenByRole(privilegedToken, entityName, createTokenParameters)
 	if err != nil {
-		p.logger.Errorf("failed creation of new token for '%s': %v", entityName, err)
+		p.logger.Errorf("failed creation of new token for '%s': %w", entityName, err)
 		return err
 	}
 
 	// Write resulting token
 	if err := json.NewEncoder(writeCloser).Encode(createTokenResponse); err != nil {
 		_ = writeCloser.Close()
-		p.logger.Errorf("failed to write token file: %v", err)
+		p.logger.Errorf("failed to write token file: %w", err)
 		return err
 	}
 
 	if err := writeCloser.Close(); err != nil {
-		p.logger.Errorf("failed to close %s: %v", outputTokenFilename, err)
+		p.logger.Errorf("failed to close %s: %w", outputTokenFilename, err)
 		return err
 	}
 

--- a/internal/security/fileprovider/tokenprovider/provider.go
+++ b/internal/security/fileprovider/tokenprovider/provider.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2019-2023 Intel Corporation
+// Copyright (c) 2025 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -14,11 +15,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package fileprovider
+package tokenprovider
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -208,6 +210,106 @@ func (p *fileTokenProvider) Run() error {
 			p.logger.Errorf("failed to close %s: %s", outputTokenFilename, err.Error())
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (p *fileTokenProvider) RegenToken(entityId string) error {
+	p.logger.Infof("Generating new OpenBao token associated with the entity id '%s'", entityId)
+
+	privilegedToken, err := p.tokenProvider.Load(p.tokenConfig.PrivilegedTokenPath)
+	if err != nil {
+		p.logger.Errorf("failed to read privileged access token: %v", err)
+		return err
+	}
+
+	tokenConfEnv, err := GetTokenConfigFromEnv()
+	if err != nil {
+		p.logger.Errorf("failed to get token config from environment variable %s with error: %v", addSecretstoreTokensEnvKey, err)
+		return err
+	}
+
+	var tokenConf TokenConfFile
+	if err := LoadTokenConfig(p.fileOpener, p.tokenConfig.ConfigFile, &tokenConf); err != nil {
+		p.logger.Errorf("failed to read token configuration file %s: %v", p.tokenConfig.ConfigFile, err)
+		return err
+	}
+
+	// merge the additional token configuration list from environment variable
+	// note that the configuration file takes precedence, as the tokenConf will override
+	// the tokenConfEnv with same duplicate keys
+	// The tokenConfEnv only uses default settings.
+	tokenConf = tokenConfEnv.mergeWith(tokenConf)
+
+	var aliasName, entityName string
+	var policies []string
+
+	// retrieve the entity metadata that will be required while creating a token and associates with the entity
+	getEntityResp, err := p.secretStoreClient.GetIdentityByEntityId(privilegedToken, entityId)
+	if err != nil {
+		p.logger.Errorf("failed to get entity by id '%s' from secretStoreClient: %v", entityId, err)
+		return err
+	}
+
+	if len(getEntityResp.Aliases) == 0 {
+		err = fmt.Errorf("alias name not defined in entity resp of entity id '%s'", entityId)
+		p.logger.Error(err.Error())
+		return err
+	}
+	aliasName = getEntityResp.Aliases[0].Name
+
+	if len(getEntityResp.Name) == 0 {
+		err = fmt.Errorf("entity name not defined in entity resp of entity id '%s'", entityId)
+		p.logger.Error(err.Error())
+		return err
+	}
+	entityName = getEntityResp.Name
+
+	if len(getEntityResp.Policies) == 0 {
+		err = fmt.Errorf("policy not defined in getEntityResp of entity id '%s'", entityId)
+		p.logger.Error(err.Error())
+		return err
+	}
+	policies = getEntityResp.Policies
+
+	outputTokenDir := filepath.Join(p.tokenConfig.OutputDir, entityName)
+	outputTokenFilename := filepath.Join(outputTokenDir, p.tokenConfig.OutputFilename)
+
+	p.logger.Infof("opening token file %s", outputTokenFilename)
+	writeCloser, err := p.fileOpener.OpenFileWriter(outputTokenFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600))
+	if err != nil {
+		p.logger.Errorf("failed open token file for writing %s: %v", outputTokenFilename, err)
+		return err
+	}
+
+	createTokenParameters := make(map[string]any)
+	createTokenParameters["display_name"] = "token-" + entityName
+	createTokenParameters["role_name"] = entityName
+	createTokenParameters["entity_alias"] = aliasName
+	createTokenParameters["no_parent"] = true
+	createTokenParameters["policies"] = policies
+	createTokenParameters["meta"] = map[string]string{"user": entityName}
+	createTokenParameters["ttl"] = p.tokenConfig.DefaultTokenTTL
+	createTokenParameters["renewable"] = true
+
+	p.logger.Infof("creating token for %s ......", entityName)
+	createTokenResponse, err := p.secretStoreClient.CreateTokenByRole(privilegedToken, entityName, createTokenParameters)
+	if err != nil {
+		p.logger.Errorf("failed creation of new token for '%s': %v", entityName, err)
+		return err
+	}
+
+	// Write resulting token
+	if err := json.NewEncoder(writeCloser).Encode(createTokenResponse); err != nil {
+		_ = writeCloser.Close()
+		p.logger.Errorf("failed to write token file: %v", err)
+		return err
+	}
+
+	if err := writeCloser.Close(); err != nil {
+		p.logger.Errorf("failed to close %s: %v", outputTokenFilename, err)
+		return err
 	}
 
 	return nil

--- a/internal/security/fileprovider/tokenprovider/tokenconfig.go
+++ b/internal/security/fileprovider/tokenprovider/tokenconfig.go
@@ -50,7 +50,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/edgexfoundry/edgex-go/internal/security/secretstore"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenmaintenance"
+
 	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/fileioperformer"
 )
 
@@ -107,7 +108,7 @@ func GetTokenConfigFromEnv() (TokenConfFile, error) {
 	// the list of service names is comma-separated
 	tokenConfigFromEnv := make(TokenConfFile)
 	serviceNameList := strings.Split(addTokenList, ",")
-	serviceNameRegx := regexp.MustCompile(secretstore.ServiceNameValidationRegx)
+	serviceNameRegx := regexp.MustCompile(tokenmaintenance.ServiceNameValidationRegx)
 
 	for _, name := range serviceNameList {
 		serviceName := strings.TrimSpace(name)

--- a/internal/security/fileprovider/tokenprovider/tokenconfig.go
+++ b/internal/security/fileprovider/tokenprovider/tokenconfig.go
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package fileprovider
+package tokenprovider
 
 /*
 

--- a/internal/security/fileprovider/tokenprovider/tokenconfig_test.go
+++ b/internal/security/fileprovider/tokenprovider/tokenconfig_test.go
@@ -11,7 +11,7 @@
 // the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-package fileprovider
+package tokenprovider
 
 import (
 	"errors"

--- a/internal/security/secretstore/certs.go
+++ b/internal/security/secretstore/certs.go
@@ -28,6 +28,7 @@ import (
 	"os"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenmaintenance"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 )
@@ -97,7 +98,7 @@ func (cs *Certs) retrieve() (*CertPair, error) {
 		return nil, e
 	}
 
-	req.Header.Set(VaultToken, cs.rootToken)
+	req.Header.Set(tokenmaintenance.VaultToken, cs.rootToken)
 	resp, err := cs.client.Do(req)
 	if err != nil {
 		e := fmt.Errorf("failed to retrieve the proxy cert on path %s with error %s", cs.certPath, err.Error())
@@ -189,7 +190,7 @@ func (cs *Certs) UploadToStore(cp *CertPair) error {
 		return e
 	}
 
-	req.Header.Set(VaultToken, cs.rootToken)
+	req.Header.Set(tokenmaintenance.VaultToken, cs.rootToken)
 	resp, err := cs.client.Do(req)
 	if err != nil {
 		e := fmt.Sprintf("failed to upload the proxy cert pair on path %s with error %s", cs.certPath, err.Error())

--- a/internal/security/secretstore/certs_test.go
+++ b/internal/security/secretstore/certs_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenmaintenance"
+
 	"github.com/edgexfoundry/go-mod-secrets/v4/pkg"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
@@ -44,7 +46,7 @@ func TestRetrieve(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, fmt.Sprintf("/%s", certPath), r.URL.EscapedPath())
-		actual := r.Header.Get(VaultToken)
+		actual := r.Header.Get(tokenmaintenance.VaultToken)
 		assert.Equal(t, expected, actual)
 	}))
 	defer ts.Close()

--- a/internal/security/secretstore/config/config.go
+++ b/internal/security/secretstore/config/config.go
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
  * Copyright (C) 2023 Intel Corporation
- * Copyright (C) 2024 IOTech Ltd
+ * Copyright (C) 2024-2025 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -29,6 +29,7 @@ type ConfigurationStruct struct {
 	Database         bootstrapConfig.Database
 	Databases        map[string]Database
 	SecureMessageBus SecureMessageBusInfo
+	Service          bootstrapConfig.ServiceInfo
 }
 
 type Database struct {
@@ -102,7 +103,9 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(_ interface{}) bool {
 // GetBootstrap returns the configuration elements required by the bootstrap.
 // Not needed for this service, so return empty struct
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
-	return bootstrapConfig.BootstrapConfiguration{}
+	return bootstrapConfig.BootstrapConfiguration{
+		Service: &c.Service,
+	}
 }
 
 // GetLogLevel returns the current ConfigurationStruct's log level.

--- a/internal/security/secretstore/constants.go
+++ b/internal/security/secretstore/constants.go
@@ -47,6 +47,10 @@ path "identity/entity/name/*" {
   capabilities = ["create", "update", "read"]
 }
 
+path "identity/entity/id/*" {
+  capabilities = ["read"]
+}
+
 path "identity/entity-alias" {
   capabilities = ["create", "update"]
 }
@@ -58,11 +62,23 @@ path "identity/oidc/role" {
 path "identity/oidc/role/*" {
   capabilities = ["create", "update"]
 }
-  
+
 path "auth/userpass/users/*" {
-	capabilities = ["create", "update"]
-  }
-  
+  capabilities = ["create", "update"]
+}
+
+path "auth/token/create/*" {
+  capabilities = ["create", "update", "sudo"]
+}
+
+path "auth/token/roles" {
+  capabilities = ["list"]
+}
+
+path "auth/token/roles/*" {
+  capabilities = ["create", "update"]
+}
+
 path "sys/auth" {
   capabilities = ["read"]
 }

--- a/internal/security/secretstore/controller/token.go
+++ b/internal/security/secretstore/controller/token.go
@@ -18,8 +18,6 @@ import (
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
 	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/common"
-	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/authtokenloader"
-	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/fileioperformer"
 
 	"github.com/labstack/echo/v4"
 )
@@ -45,10 +43,6 @@ func (a *TokenController) RegenToken(c echo.Context) error {
 	entityId := c.Param("entityId")
 
 	lc := bootstrapContainer.LoggingClientFrom(a.dic.Get)
-	tokenLoader := bootstrapContainer.AuthTokenLoaderFrom(a.dic.Get)
-	if tokenLoader == nil {
-		tokenLoader = authtokenloader.NewAuthTokenLoader(fileioperformer.NewDefaultFileIoPerformer())
-	}
 	configuration := container.ConfigurationFrom(a.dic.Get)
 	secretStoreConfig := configuration.SecretStore
 	ctx := r.Context()

--- a/internal/security/secretstore/controller/token.go
+++ b/internal/security/secretstore/controller/token.go
@@ -49,20 +49,20 @@ func (a *TokenController) RegenToken(c echo.Context) error {
 
 	revokeIssuingTokenFuc, err := tokeninit.InitAdminTokens(a.dic)
 	if err != nil {
-		lc.Errorf("failed to InitAdminTokens: %s", err.Error())
+		lc.Errorf("failed to InitAdminTokens: %w", err)
 		return err
 	}
 
 	tokenProvider := tokenprovider.NewTokenProvider(ctx, lc, secretUtils.NewDefaultExecRunner())
 	if secretStoreConfig.TokenProvider != "" {
 		if err := tokenProvider.SetConfiguration(secretStoreConfig); err != nil {
-			lc.Errorf("failed to configure token provider: %s", err.Error())
+			lc.Errorf("failed to configure token provider: %w", err)
 			return err
 		}
 
 		err := tokenProvider.LaunchRegenToken(entityId)
 		if err != nil {
-			lc.Errorf("failed to call LaunchRefreshToken from token provider: %s", err.Error())
+			lc.Errorf("failed to call LaunchRefreshToken from token provider: %w", err)
 			return err
 		}
 	} else {

--- a/internal/security/secretstore/controller/token.go
+++ b/internal/security/secretstore/controller/token.go
@@ -1,0 +1,77 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"net/http"
+
+	"github.com/edgexfoundry/edgex-go/internal/pkg"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/utils"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenprovider"
+	secretUtils "github.com/edgexfoundry/edgex-go/internal/security/secretstore/utils"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/common"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/fileioperformer"
+
+	"github.com/labstack/echo/v4"
+)
+
+type TokenController struct {
+	dic *di.Container
+}
+
+func NewTokenController(dic *di.Container) *TokenController {
+	return &TokenController{
+		dic: dic,
+	}
+}
+
+func (a *TokenController) RegenToken(c echo.Context) error {
+	r := c.Request()
+	w := c.Response()
+	if r.Body != nil {
+		defer func() { _ = r.Body.Close() }()
+	}
+
+	// URL parameters
+	entityId := c.Param("entityId")
+
+	lc := bootstrapContainer.LoggingClientFrom(a.dic.Get)
+	tokenLoader := bootstrapContainer.AuthTokenLoaderFrom(a.dic.Get)
+	if tokenLoader == nil {
+		tokenLoader = authtokenloader.NewAuthTokenLoader(fileioperformer.NewDefaultFileIoPerformer())
+	}
+	configuration := container.ConfigurationFrom(a.dic.Get)
+	secretStoreConfig := configuration.SecretStore
+	ctx := r.Context()
+
+	tokenProvider := tokenprovider.NewTokenProvider(ctx, lc, secretUtils.NewDefaultExecRunner())
+	if secretStoreConfig.TokenProvider != "" {
+		if err := tokenProvider.SetConfiguration(secretStoreConfig); err != nil {
+			lc.Errorf("failed to configure token provider: %v", err)
+			return err
+		}
+
+		err := tokenProvider.LaunchRegenToken(entityId)
+		if err != nil {
+			lc.Errorf("failed to call LaunchRefreshToken from token provider: %v", err)
+			return err
+		}
+	} else {
+		lc.Info("no token provider configured")
+	}
+
+	response := commonDTO.NewBaseResponse(
+		"",
+		"",
+		http.StatusOK)
+	utils.WriteHttpHeader(w, ctx, http.StatusOK)
+	return pkg.EncodeAndWriteResponse(response, w, lc)
+}

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -39,6 +39,8 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/secretsengine"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenfilewriter"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenprovider"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/utils"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/startup"
@@ -310,17 +312,19 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 
 	// If configured to do so, create a token issuing token
 	if secretStoreConfig.TokenProviderAdminTokenPath != "" {
-		revokeIssuingTokenFuc, err := tokenfilewriter.NewWriter(lc, client, fileOpener).
+		//revokeIssuingTokenFuc, err := tokenfilewriter.NewWriter(lc, client, fileOpener).
+		//	CreateAndWrite(rootToken, secretStoreConfig.TokenProviderAdminTokenPath, tokenMaintenance.CreateTokenIssuingToken)
+		_, err := tokenfilewriter.NewWriter(lc, client, fileOpener).
 			CreateAndWrite(rootToken, secretStoreConfig.TokenProviderAdminTokenPath, tokenMaintenance.CreateTokenIssuingToken)
 		if err != nil {
 			lc.Errorf("failed to create token issuing token: %s", err.Error())
 			return false
 		}
-		if secretStoreConfig.TokenProviderType == OneShotProvider {
-			// Revoke the admin token at the end of the current function if running a one-shot provider
-			// otherwise assume the token provider will keep its token fresh after this point
-			defer revokeIssuingTokenFuc()
-		}
+		//if secretStoreConfig.TokenProviderType == OneShotProvider {
+		//	// Revoke the admin token at the end of the current function if running a one-shot provider
+		//	// otherwise assume the token provider will keep its token fresh after this point
+		//	defer revokeIssuingTokenFuc()
+		//}
 	}
 
 	// Enable userpass auth engine
@@ -351,7 +355,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	}
 
 	//Step 4: Launch token handler
-	tokenProvider := NewTokenProvider(ctx, lc, NewDefaultExecRunner())
+	tokenProvider := tokenprovider.NewTokenProvider(ctx, lc, utils.NewDefaultExecRunner())
 	if secretStoreConfig.TokenProvider != "" {
 		if err := tokenProvider.SetConfiguration(secretStoreConfig); err != nil {
 			lc.Errorf("failed to configure token provider: %s", err.Error())

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -329,7 +329,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	// Enable userpass auth engine
 	upAuthEnabled, err := client.CheckAuthMethodEnabled(rootToken, tokenmaintenance.UPAuthMountPoint, tokenmaintenance.UserPassAuthEngine)
 	if err != nil {
-		lc.Errorf("failed to check if %s auth method enabled: %s", tokenmaintenance.UserPassAuthEngine, err.Error())
+		lc.Errorf("failed to check if %s auth method enabled: %w", tokenmaintenance.UserPassAuthEngine, err)
 		return false
 	} else if !upAuthEnabled {
 		// Enable userpass engine at /v1/auth/{eng.path} path (/v1 prefix supplied by secret store)

--- a/internal/security/secretstore/init.go
+++ b/internal/security/secretstore/init.go
@@ -39,6 +39,7 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/secretsengine"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenfilewriter"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenmaintenance"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenprovider"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/utils"
 
@@ -152,7 +153,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 			switch sCode {
 			case http.StatusOK:
 				// Load the init response from disk since we need it to regenerate root token later
-				if err := LoadInitResponse(lc, fileOpener, secretStoreConfig, &initResponse); err != nil {
+				if err := tokenmaintenance.LoadInitResponse(lc, fileOpener, secretStoreConfig, &initResponse); err != nil {
 					lc.Errorf("unable to load init response: %s", err.Error())
 					return true
 				}
@@ -201,7 +202,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 
 			case http.StatusServiceUnavailable:
 				lc.Infof("%s is sealed (status code: %d). Starting unseal phase", secrets.DefaultSecretStore, sCode)
-				if err := LoadInitResponse(lc, fileOpener, secretStoreConfig, &initResponse); err != nil {
+				if err := tokenmaintenance.LoadInitResponse(lc, fileOpener, secretStoreConfig, &initResponse); err != nil {
 					lc.Errorf("unable to load init response: %s", err.Error())
 					return true
 				}
@@ -267,7 +268,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 	// spawn token provider
 	// create db credentials
 	// upload kong certificate
-	tokenMaintenance := NewTokenMaintenance(lc, client)
+	tokenMaintenance := tokenmaintenance.NewTokenMaintenance(lc, client)
 
 	// Create a transient root token from the key shares
 	var rootToken string
@@ -312,34 +313,32 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, _ *sync.WaitGroup, _ s
 
 	// If configured to do so, create a token issuing token
 	if secretStoreConfig.TokenProviderAdminTokenPath != "" {
-		//revokeIssuingTokenFuc, err := tokenfilewriter.NewWriter(lc, client, fileOpener).
-		//	CreateAndWrite(rootToken, secretStoreConfig.TokenProviderAdminTokenPath, tokenMaintenance.CreateTokenIssuingToken)
-		_, err := tokenfilewriter.NewWriter(lc, client, fileOpener).
+		revokeIssuingTokenFuc, err := tokenfilewriter.NewWriter(lc, client, fileOpener).
 			CreateAndWrite(rootToken, secretStoreConfig.TokenProviderAdminTokenPath, tokenMaintenance.CreateTokenIssuingToken)
 		if err != nil {
 			lc.Errorf("failed to create token issuing token: %s", err.Error())
 			return false
 		}
-		//if secretStoreConfig.TokenProviderType == OneShotProvider {
-		//	// Revoke the admin token at the end of the current function if running a one-shot provider
-		//	// otherwise assume the token provider will keep its token fresh after this point
-		//	defer revokeIssuingTokenFuc()
-		//}
+		if secretStoreConfig.TokenProviderType == tokenprovider.OneShotProvider {
+			// Revoke the admin token at the end of the current function if running a one-shot provider
+			// otherwise assume the token provider will keep its token fresh after this point
+			defer revokeIssuingTokenFuc()
+		}
 	}
 
 	// Enable userpass auth engine
-	upAuthEnabled, err := client.CheckAuthMethodEnabled(rootToken, UPAuthMountPoint, UserPassAuthEngine)
+	upAuthEnabled, err := client.CheckAuthMethodEnabled(rootToken, tokenmaintenance.UPAuthMountPoint, tokenmaintenance.UserPassAuthEngine)
 	if err != nil {
-		lc.Errorf("failed to check if %s auth method enabled: %s", UserPassAuthEngine, err.Error())
+		lc.Errorf("failed to check if %s auth method enabled: %s", tokenmaintenance.UserPassAuthEngine, err.Error())
 		return false
 	} else if !upAuthEnabled {
 		// Enable userpass engine at /v1/auth/{eng.path} path (/v1 prefix supplied by secret store)
 		lc.Infof("Enabling userpass authentication for the first time...")
-		if err := client.EnablePasswordAuth(rootToken, UPAuthMountPoint); err != nil {
+		if err := client.EnablePasswordAuth(rootToken, tokenmaintenance.UPAuthMountPoint); err != nil {
 			lc.Errorf("failed to enable userpass secrets engine: %s", err.Error())
 			return false
 		}
-		lc.Infof("Userpass authentication engine enabled at path %s", UPAuthMountPoint)
+		lc.Infof("Userpass authentication engine enabled at path %s", tokenmaintenance.UPAuthMountPoint)
 	}
 
 	// Create a key for issuing JWTs
@@ -610,7 +609,7 @@ func (b *Bootstrap) getKnownSecretsToAdd() (map[string][]string, error) {
 		return knownSecretsToAdd, nil
 	}
 
-	serviceNameRegx := regexp.MustCompile(ServiceNameValidationRegx)
+	serviceNameRegx := regexp.MustCompile(tokenmaintenance.ServiceNameValidationRegx)
 	knownSecrets := strings.Split(addKnownSecretsValue, knownSecretSeparator)
 	for _, secretSpec := range knownSecrets {
 		// each secretSpec has format of "<secretName>[<serviceName>;<serviceName>; ...]"
@@ -722,36 +721,6 @@ func storeCredential(lc logger.LoggingClient, credBootstrapStem string, cred Cre
 	}
 
 	return err
-}
-
-func LoadInitResponse(
-	lc logger.LoggingClient,
-	fileOpener fileioperformer.FileIoPerformer,
-	secretConfig config.SecretStoreInfo,
-	initResponse *types.InitResponse) error {
-
-	absPath := filepath.Join(secretConfig.TokenFolderPath, secretConfig.TokenFile)
-
-	tokenFile, err := fileOpener.OpenFileReader(absPath, os.O_RDONLY, 0400)
-	if err != nil {
-		lc.Errorf("could not read master key shares file %s: %s", absPath, err.Error())
-		return err
-	}
-	tokenFileCloseable := fileioperformer.MakeReadCloser(tokenFile)
-	defer func() { _ = tokenFileCloseable.Close() }()
-
-	decoder := json.NewDecoder(tokenFileCloseable)
-	if decoder == nil {
-		err := errors.New("Failed to create JSON decoder")
-		lc.Error(err.Error())
-		return err
-	}
-	if err := decoder.Decode(initResponse); err != nil {
-		lc.Errorf("unable to read token file at %s with error: %s", absPath, err.Error())
-		return err
-	}
-
-	return nil
 }
 
 func saveInitResponse(

--- a/internal/security/secretstore/init_test.go
+++ b/internal/security/secretstore/init_test.go
@@ -9,7 +9,6 @@ package secretstore
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
@@ -22,39 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const sampleJSON = `
-{
-	"keys": [
-		"test-keys"
-	],
-	"keys_base64": [
-		"test-keys-base64"
-	],
-	"root_token": "test-root-token"
-}`
-
 var expectedFolder = "/foo"
 var expectedFile = "bar.baz"
-
-func TestLoadInitResponse(t *testing.T) {
-	// Arrange
-	mockLogger := logger.MockLogger{}
-	fileOpener := &mocks.FileIoPerformer{}
-	stringReader := strings.NewReader(sampleJSON)
-	fileOpener.On("OpenFileReader", filepath.Join(expectedFolder, expectedFile), os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
-	secretConfig := config.SecretStoreInfo{
-		TokenFolderPath: expectedFolder,
-		TokenFile:       expectedFile,
-	}
-	initResponse := types.InitResponse{}
-
-	// Act
-	err := LoadInitResponse(mockLogger, fileOpener, secretConfig, &initResponse)
-
-	// Assert
-	assert.NoError(t, err)
-	fileOpener.AssertExpectations(t)
-}
 
 func TestSaveInitResponse(t *testing.T) {
 

--- a/internal/security/secretstore/initserver.go
+++ b/internal/security/secretstore/initserver.go
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (C) 2025 IOTech Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package secretstore
+
+import (
+	"context"
+	"sync"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Bootstrap contains references to dependencies required by the BootstrapHandler.
+type BootstrapServer struct {
+	router      *echo.Echo
+	serviceName string
+}
+
+// NewBootstrap is a factory method that returns an initialized Bootstrap receiver struct.
+func NewBootstrapServer(router *echo.Echo, serviceName string) *BootstrapServer {
+	return &BootstrapServer{
+		router:      router,
+		serviceName: serviceName,
+	}
+}
+
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the security-secretstore-setup service to declare the rest routes
+func (b *BootstrapServer) BootstrapServerHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
+	LoadRestRoutes(b.router, dic, b.serviceName)
+
+	return true
+}

--- a/internal/security/secretstore/password.go
+++ b/internal/security/secretstore/password.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenmaintenance"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/utils"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
@@ -128,7 +129,7 @@ func (cr *Cred) retrieve(path string) (*UserPasswordPair, error) {
 		return nil, e
 	}
 
-	req.Header.Set(VaultToken, cr.rootToken)
+	req.Header.Set(tokenmaintenance.VaultToken, cr.rootToken)
 	resp, err := cr.client.Do(req)
 	if err != nil {
 		e := fmt.Errorf("failed to retrieve the credential pair on path %s with error %s", path, err.Error())
@@ -201,7 +202,7 @@ func (cr *Cred) UploadToStore(pair *UserPasswordPair, path string) error {
 		return e
 	}
 
-	req.Header.Set(VaultToken, cr.rootToken)
+	req.Header.Set(tokenmaintenance.VaultToken, cr.rootToken)
 	resp, err := cr.client.Do(req)
 	if err != nil {
 		e := fmt.Sprintf("failed to upload the credential pair on path %s: %s", path, err.Error())

--- a/internal/security/secretstore/password.go
+++ b/internal/security/secretstore/password.go
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
  * Copyright 2021 Intel Inc.
+ * Copyright 2025 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,6 +27,7 @@ import (
 	"net/url"
 
 	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/utils"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 )
@@ -42,7 +44,7 @@ func NewPasswordGenerator(lc logger.LoggingClient, passwordProvider string, pass
 		generatorImplementation: NewDefaultCredentialGenerator(),
 	}
 	if passwordProvider != "" {
-		pp := NewPasswordProvider(lc, NewDefaultExecRunner())
+		pp := NewPasswordProvider(lc, utils.NewDefaultExecRunner())
 		err := pp.SetConfiguration(passwordProvider, passwordProviderArgs)
 		if err != nil {
 			lc.Warnf("Could not configure password generator %s: error: %s", passwordProvider, err.Error())

--- a/internal/security/secretstore/password_test.go
+++ b/internal/security/secretstore/password_test.go
@@ -25,9 +25,10 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
-	"github.com/edgexfoundry/go-mod-secrets/v4/pkg"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenmaintenance"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,7 +58,7 @@ func TestRetrieveCred(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, fmt.Sprintf("/%s", credPath), r.URL.EscapedPath())
-		actual := r.Header.Get(VaultToken)
+		actual := r.Header.Get(tokenmaintenance.VaultToken)
 		assert.Equal(t, expected, actual)
 	}))
 	defer ts.Close()

--- a/internal/security/secretstore/passwordprovider.go
+++ b/internal/security/secretstore/passwordprovider.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2021 Intel Corporation
+// Copyright 2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -14,12 +15,14 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/utils"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 )
 
 type PasswordProvider struct {
 	loggingClient        logger.LoggingClient
-	execRunner           ExecRunner
+	execRunner           utils.ExecRunner
 	initialized          bool
 	passwordProvider     string
 	passwordProviderArgs []string
@@ -27,7 +30,7 @@ type PasswordProvider struct {
 }
 
 // NewPasswordProvider creates a new PasswordProvider
-func NewPasswordProvider(lc logger.LoggingClient, execRunner ExecRunner) *PasswordProvider {
+func NewPasswordProvider(lc logger.LoggingClient, execRunner utils.ExecRunner) *PasswordProvider {
 	return &PasswordProvider{
 		loggingClient: lc,
 		execRunner:    execRunner,

--- a/internal/security/secretstore/passwordprovider_test.go
+++ b/internal/security/secretstore/passwordprovider_test.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2021 Intel Corporation
+// Copyright 2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,13 +19,14 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/utils"
 )
 
 func TestInvalidPasswordProvider(t *testing.T) {
 	serviceInfo := config.SecretStoreInfo{
 		PasswordProvider: "does-not-exist",
 	}
-	mockExecRunner := &mockExecRunner{}
+	mockExecRunner := &utils.MockExecRunner{}
 	mockExecRunner.On("LookPath", serviceInfo.PasswordProvider).
 		Return("", errors.New("fake file does not exist"))
 	_, cancel := context.WithCancel(context.Background())
@@ -36,7 +38,7 @@ func TestInvalidPasswordProvider(t *testing.T) {
 }
 
 func TestPasswordConfigNotInitialized(t *testing.T) {
-	mockExecRunner := &mockExecRunner{}
+	mockExecRunner := &utils.MockExecRunner{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	p := NewPasswordProvider(logger.MockLogger{}, mockExecRunner)
@@ -51,8 +53,8 @@ func TestPasswordProviderFailsToStart(t *testing.T) {
 		PasswordProvider:     "failing-executable",
 		PasswordProviderArgs: []string{"arg1", "arg2"},
 	}
-	mockExecRunner := &mockExecRunner{}
-	mockCmd := mockCmd{}
+	mockExecRunner := &utils.MockExecRunner{}
+	mockCmd := utils.MockCmd{}
 	mockExecRunner.On("LookPath", serviceInfo.PasswordProvider).
 		Return(serviceInfo.PasswordProvider, nil)
 	mockExecRunner.On("SetStdout", mock.Anything).Once()
@@ -76,8 +78,8 @@ func TestPasswordProviderFailsAtRuntime(t *testing.T) {
 		PasswordProvider:     "failing-executable",
 		PasswordProviderArgs: []string{"arg1", "arg2"},
 	}
-	mockExecRunner := &mockExecRunner{}
-	mockCmd := mockCmd{}
+	mockExecRunner := &utils.MockExecRunner{}
+	mockCmd := utils.MockCmd{}
 	mockExecRunner.On("LookPath", serviceInfo.PasswordProvider).
 		Return(serviceInfo.PasswordProvider, nil)
 	mockExecRunner.On("SetStdout", mock.Anything).Once()

--- a/internal/security/secretstore/router.go
+++ b/internal/security/secretstore/router.go
@@ -1,0 +1,29 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secretstore
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/controller"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/handlers"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+
+	"github.com/labstack/echo/v4"
+)
+
+// TODO: this will be declared in go-mod-core-contracts after the review
+const regenTokenRoute = "/api/v3/token/entityId/:entityId"
+
+// LoadRestRoutes generates the routing for API requests
+// Authentication is always on for this service,
+// as it is called by NGINX to authenticate requests
+// and must always authenticate even if the rest of EdgeX does not
+func LoadRestRoutes(r *echo.Echo, dic *di.Container, serviceName string) {
+	authenticationHook := handlers.AutoConfigAuthenticationFunc(dic)
+
+	ac := controller.NewTokenController(dic)
+	r.PUT(regenTokenRoute, ac.RegenToken, authenticationHook)
+}

--- a/internal/security/secretstore/server/configure.go
+++ b/internal/security/secretstore/server/configure.go
@@ -1,0 +1,60 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"github.com/edgexfoundry/edgex-go"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/server/handlers"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/flags"
+	bootstrapHandlers "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/handlers"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/startup"
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v4/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Configure is the main entry point for configuring the Postgres database before startup
+func Configure(ctx context.Context,
+	cancel context.CancelFunc,
+	flags flags.Common,
+	router *echo.Echo) {
+	startupTimer := startup.NewStartUpTimer(common.SecuritySecretStoreSetupServiceKey)
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	httpServer := bootstrapHandlers.NewHttpServer(router, true, common.SecuritySecretStoreSetupServiceKey)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		flags,
+		common.SecuritySecretStoreSetupServiceKey,
+		common.ConfigStemSecurity,
+		configuration,
+		startupTimer,
+		dic,
+		false,
+		bootstrapConfig.ServiceTypeOther,
+		[]interfaces.BootstrapHandler{
+			handlers.NewBootstrapServer(router).BootstrapServerHandler,
+			httpServer.BootstrapHandler,
+			bootstrapHandlers.NewStartMessage(common.SecuritySecretStoreSetupServiceKey, edgex.Version).BootstrapHandler,
+		},
+	)
+}

--- a/internal/security/secretstore/server/handlers/initserver.go
+++ b/internal/security/secretstore/server/handlers/initserver.go
@@ -12,7 +12,7 @@
  * the License.
  *******************************************************************************/
 
-package secretstore
+package handlers
 
 import (
 	"context"
@@ -26,21 +26,19 @@ import (
 
 // Bootstrap contains references to dependencies required by the BootstrapHandler.
 type BootstrapServer struct {
-	router      *echo.Echo
-	serviceName string
+	router *echo.Echo
 }
 
 // NewBootstrap is a factory method that returns an initialized Bootstrap receiver struct.
-func NewBootstrapServer(router *echo.Echo, serviceName string) *BootstrapServer {
+func NewBootstrapServer(router *echo.Echo) *BootstrapServer {
 	return &BootstrapServer{
-		router:      router,
-		serviceName: serviceName,
+		router: router,
 	}
 }
 
 // BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the security-secretstore-setup service to declare the rest routes
 func (b *BootstrapServer) BootstrapServerHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
-	LoadRestRoutes(b.router, dic, b.serviceName)
+	LoadRestRoutes(b.router, dic)
 
 	return true
 }

--- a/internal/security/secretstore/server/handlers/router.go
+++ b/internal/security/secretstore/server/handlers/router.go
@@ -14,7 +14,7 @@ import (
 )
 
 // TODO: this will be declared in go-mod-core-contracts after the review
-const regenTokenRoute = "/api/v3/token/entityId/:entityId"
+const regenTokenRoute = "/api/v3/token/entityId/:entityId" // nolint:gosec
 
 // LoadRestRoutes generates the routing for API requests
 // Authentication is always on for this service,

--- a/internal/security/secretstore/server/handlers/router.go
+++ b/internal/security/secretstore/server/handlers/router.go
@@ -3,12 +3,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package secretstore
+package handlers
 
 import (
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/controller"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/handlers"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
 
 	"github.com/labstack/echo/v4"
@@ -21,9 +20,7 @@ const regenTokenRoute = "/api/v3/token/entityId/:entityId"
 // Authentication is always on for this service,
 // as it is called by NGINX to authenticate requests
 // and must always authenticate even if the rest of EdgeX does not
-func LoadRestRoutes(r *echo.Echo, dic *di.Container, serviceName string) {
-	authenticationHook := handlers.AutoConfigAuthenticationFunc(dic)
-
+func LoadRestRoutes(r *echo.Echo, dic *di.Container) {
 	ac := controller.NewTokenController(dic)
-	r.PUT(regenTokenRoute, ac.RegenToken, authenticationHook)
+	r.PUT(regenTokenRoute, ac.RegenToken)
 }

--- a/internal/security/secretstore/tokeninit/secretstore.go
+++ b/internal/security/secretstore/tokeninit/secretstore.go
@@ -14,7 +14,6 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokencreatable"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenfilewriter"
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenmaintenance"
-	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenprovider"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
@@ -89,11 +88,7 @@ func InitAdminTokens(dic *di.Container) (tokencreatable.RevokeFunc, error) {
 		if err != nil {
 			lc.Errorf("failed to create token issuing token: %s", err.Error())
 		}
-		if secretStoreConfig.TokenProviderType == tokenprovider.OneShotProvider {
-			// Revoke the admin token at the end of the current function if running a one-shot provider
-			// otherwise assume the token provider will keep its token fresh after this point
-			//defer revokeIssuingTokenFuc()
-		}
+
 		return revokeIssuingTokenFuc, nil
 	}
 	return nil, errors.New("no TokenProviderAdminTokenPath defined in secretStoreConfig")

--- a/internal/security/secretstore/tokeninit/secretstore.go
+++ b/internal/security/secretstore/tokeninit/secretstore.go
@@ -1,0 +1,100 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tokeninit
+
+import (
+	"errors"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/container"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokencreatable"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenfilewriter"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenmaintenance"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/tokenprovider"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/fileioperformer"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/types"
+	"github.com/edgexfoundry/go-mod-secrets/v4/secrets"
+)
+
+// InitAdminTokens reads the resp-init.json file and recreate root tokens and admin token for controller API usage
+func InitAdminTokens(dic *di.Container) (tokencreatable.RevokeFunc, error) {
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	configuration := container.ConfigurationFrom(dic.Get)
+	secretStoreConfig := configuration.SecretStore
+
+	fileOpener := fileioperformer.NewDefaultFileIoPerformer()
+
+	var httpCaller internal.HttpCaller
+	if caFilePath := secretStoreConfig.CaFilePath; caFilePath != "" {
+		lc.Info("using certificate verification for secret store connection")
+		caReader, err := fileOpener.OpenFileReader(caFilePath, os.O_RDONLY, 0400)
+		if err != nil {
+			lc.Errorf("failed to load CA certificate: %s", err.Error())
+		}
+		httpCaller = pkg.NewRequester(lc).WithTLS(caReader, secretStoreConfig.ServerName)
+	} else {
+		lc.Info("bypassing certificate verification for secret store connection")
+		httpCaller = pkg.NewRequester(lc).Insecure()
+	}
+
+	clientConfig := types.SecretConfig{
+		Type:     secretStoreConfig.Type,
+		Protocol: secretStoreConfig.Protocol,
+		Host:     secretStoreConfig.Host,
+		Port:     secretStoreConfig.Port,
+	}
+	secretStoreClient, err := secrets.NewSecretStoreClient(clientConfig, lc, httpCaller)
+	if err != nil {
+		lc.Errorf("failed to create SecretStoreClient: %s", err.Error())
+	}
+
+	var initResponse types.InitResponse // reused many places in below flow
+
+	// Load the init response from disk since we need it to regenerate root token later
+	if err := tokenmaintenance.LoadInitResponse(lc, fileOpener, secretStoreConfig, &initResponse); err != nil {
+		lc.Errorf("unable to load init response: %s", err.Error())
+
+	}
+
+	tokenMaintenance := tokenmaintenance.NewTokenMaintenance(lc, secretStoreClient)
+	// Create a transient root token from the key shares
+	var rootToken string
+	rootToken, err = secretStoreClient.RegenRootToken(initResponse.Keys)
+	if err != nil {
+		lc.Errorf("could not regenerate root token %s", err.Error())
+
+	}
+	defer func() {
+		// Revoke transient root token at the end of this function
+		lc.Info("revoking temporary root token")
+		err := secretStoreClient.RevokeToken(rootToken)
+		if err != nil {
+			lc.Errorf("could not revoke temporary root token %s", err.Error())
+		}
+	}()
+	lc.Info("generated transient root token")
+
+	// If configured to do so, create a token issuing token
+	if secretStoreConfig.TokenProviderAdminTokenPath != "" {
+		revokeIssuingTokenFuc, err := tokenfilewriter.NewWriter(lc, secretStoreClient, fileOpener).
+			CreateAndWrite(rootToken, secretStoreConfig.TokenProviderAdminTokenPath, tokenMaintenance.CreateTokenIssuingToken)
+		if err != nil {
+			lc.Errorf("failed to create token issuing token: %s", err.Error())
+		}
+		if secretStoreConfig.TokenProviderType == tokenprovider.OneShotProvider {
+			// Revoke the admin token at the end of the current function if running a one-shot provider
+			// otherwise assume the token provider will keep its token fresh after this point
+			//defer revokeIssuingTokenFuc()
+		}
+		return revokeIssuingTokenFuc, nil
+	}
+	return nil, errors.New("no TokenProviderAdminTokenPath defined in secretStoreConfig")
+}

--- a/internal/security/secretstore/tokenmaintenance/constants.go
+++ b/internal/security/secretstore/tokenmaintenance/constants.go
@@ -16,7 +16,7 @@
  * @author: Tingyu Zeng, Dell
  *******************************************************************************/
 
-package secretstore
+package tokenmaintenance
 
 const (
 	// ServiceNameValidationRegx is regex string for valid service name as key

--- a/internal/security/secretstore/tokenmaintenance/initresp.go
+++ b/internal/security/secretstore/tokenmaintenance/initresp.go
@@ -39,7 +39,7 @@ func LoadInitResponse(
 
 	tokenFile, err := fileOpener.OpenFileReader(absPath, os.O_RDONLY, 0400)
 	if err != nil {
-		lc.Errorf("could not read master key shares file %s: %s", absPath, err.Error())
+		lc.Errorf("could not read master key shares file %s: %w", absPath, err)
 		return err
 	}
 	tokenFileCloseable := fileioperformer.MakeReadCloser(tokenFile)
@@ -52,7 +52,7 @@ func LoadInitResponse(
 		return err
 	}
 	if err := decoder.Decode(initResponse); err != nil {
-		lc.Errorf("unable to read token file at %s with error: %s", absPath, err.Error())
+		lc.Errorf("unable to read token file at %s with error: %w", absPath, err)
 		return err
 	}
 

--- a/internal/security/secretstore/tokenmaintenance/initresp.go
+++ b/internal/security/secretstore/tokenmaintenance/initresp.go
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright 2025 IOTech Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package tokenmaintenance
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/fileioperformer"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/types"
+)
+
+// LoadInitResponse load the resp-init.json file content from secret store
+func LoadInitResponse(
+	lc logger.LoggingClient,
+	fileOpener fileioperformer.FileIoPerformer,
+	secretConfig config.SecretStoreInfo,
+	initResponse *types.InitResponse) error {
+
+	absPath := filepath.Join(secretConfig.TokenFolderPath, secretConfig.TokenFile)
+
+	tokenFile, err := fileOpener.OpenFileReader(absPath, os.O_RDONLY, 0400)
+	if err != nil {
+		lc.Errorf("could not read master key shares file %s: %s", absPath, err.Error())
+		return err
+	}
+	tokenFileCloseable := fileioperformer.MakeReadCloser(tokenFile)
+	defer func() { _ = tokenFileCloseable.Close() }()
+
+	decoder := json.NewDecoder(tokenFileCloseable)
+	if decoder == nil {
+		err := errors.New("Failed to create JSON decoder")
+		lc.Error(err.Error())
+		return err
+	}
+	if err := decoder.Decode(initResponse); err != nil {
+		lc.Errorf("unable to read token file at %s with error: %s", absPath, err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/internal/security/secretstore/tokenmaintenance/initresp_test.go
+++ b/internal/security/secretstore/tokenmaintenance/initresp_test.go
@@ -1,0 +1,56 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tokenmaintenance
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/token/fileioperformer/mocks"
+	"github.com/edgexfoundry/go-mod-secrets/v4/pkg/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	sampleJSON = `
+{
+	"keys": [
+		"test-keys"
+	],
+	"keys_base64": [
+		"test-keys-base64"
+	],
+	"root_token": "test-root-token"
+}`
+	expectedFolder = "/foo"
+	expectedFile   = "bar.baz"
+)
+
+func TestLoadInitResponse(t *testing.T) {
+	// Arrange
+	mockLogger := logger.MockLogger{}
+	fileOpener := &mocks.FileIoPerformer{}
+	stringReader := strings.NewReader(sampleJSON)
+	fileOpener.On("OpenFileReader", filepath.Join(expectedFolder, expectedFile), os.O_RDONLY, os.FileMode(0400)).Return(stringReader, nil)
+	secretConfig := config.SecretStoreInfo{
+		TokenFolderPath: expectedFolder,
+		TokenFile:       expectedFile,
+	}
+	initResponse := types.InitResponse{}
+
+	// Act
+	err := LoadInitResponse(mockLogger, fileOpener, secretConfig, &initResponse)
+
+	// Assert
+	assert.NoError(t, err)
+	fileOpener.AssertExpectations(t)
+}

--- a/internal/security/secretstore/tokenmaintenance/tokenmaintenance.go
+++ b/internal/security/secretstore/tokenmaintenance/tokenmaintenance.go
@@ -12,7 +12,7 @@
 // the License.
 //
 
-package secretstore
+package tokenmaintenance
 
 /*
 

--- a/internal/security/secretstore/tokenmaintenance/tokenmaintenance_test.go
+++ b/internal/security/secretstore/tokenmaintenance/tokenmaintenance_test.go
@@ -12,7 +12,7 @@
 // the License.
 //
 
-package secretstore
+package tokenmaintenance
 
 import (
 	"testing"

--- a/internal/security/secretstore/tokenprovider/tokenprovider.go
+++ b/internal/security/secretstore/tokenprovider/tokenprovider.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2021 Intel Corporation
+// Copyright (C) 2025 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -12,16 +13,18 @@
 // the License.
 //
 
-package secretstore
+package tokenprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
 	"syscall"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/utils"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 )
@@ -31,14 +34,14 @@ const OneShotProvider = "oneshot"
 type TokenProvider struct {
 	loggingClient logger.LoggingClient
 	ctx           context.Context
-	execRunner    ExecRunner
+	execRunner    utils.ExecRunner
 	initialized   bool
 	secretStore   config.SecretStoreInfo
 	resolvedPath  string
 }
 
 // NewTokenProvider creates a new TokenProvider
-func NewTokenProvider(ctx context.Context, lc logger.LoggingClient, execRunner ExecRunner) *TokenProvider {
+func NewTokenProvider(ctx context.Context, lc logger.LoggingClient, execRunner utils.ExecRunner) *TokenProvider {
 	return &TokenProvider{
 		loggingClient: lc,
 		ctx:           ctx,
@@ -91,6 +94,39 @@ func (p *TokenProvider) Launch() error {
 	}
 	if err != nil {
 		err = fmt.Errorf("%s failed with unexpected error: %s", p.resolvedPath, err.Error())
+		return err
+	}
+
+	p.loggingClient.Info("token provider exited successfully")
+	return nil
+}
+
+func (p *TokenProvider) LaunchRegenToken(entityId string) error {
+	if !p.initialized {
+		err := fmt.Errorf("TokenProvider object not initialized; call SetConfiguration() first")
+		return err
+	}
+
+	p.loggingClient.Infof(
+		"Launching token provider %s with arguments %s",
+		p.resolvedPath,
+		strings.Join(p.secretStore.TokenProviderArgs, " "))
+
+	cmd := p.execRunner.CommandContext(p.ctx, p.resolvedPath, "-configDir", "res-file-token-provider", "createToken", "-entityId", entityId)
+	if err := cmd.Start(); err != nil {
+		err = fmt.Errorf("%s failed to launch: %v", p.resolvedPath, err)
+		return err
+	}
+
+	err := cmd.Wait()
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		waitStatus := exitError.Sys().(syscall.WaitStatus)
+		err = fmt.Errorf("%s terminated with non-zero exit code %d", p.resolvedPath, waitStatus.ExitStatus())
+		return err
+	}
+	if err != nil {
+		err = fmt.Errorf("%s failed with unexpected error: %v", p.resolvedPath, err)
 		return err
 	}
 

--- a/internal/security/secretstore/tokenprovider/tokenprovider_linux_test.go
+++ b/internal/security/secretstore/tokenprovider/tokenprovider_linux_test.go
@@ -3,6 +3,7 @@
 
 //
 // Copyright (c) 2021 Intel Corporation
+// Copyright (C) 2025 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +18,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package secretstore
+package tokenprovider
 
 import (
 	"context"
@@ -25,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/utils"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 
@@ -46,7 +48,7 @@ func TestCreatesFile(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = os.RemoveAll(testfile) }() // cleanup
 
-	p := NewTokenProvider(ctx, logger.MockLogger{}, NewDefaultExecRunner())
+	p := NewTokenProvider(ctx, logger.MockLogger{}, utils.NewDefaultExecRunner())
 	err = p.SetConfiguration(configuration)
 	assert.NoError(t, err)
 

--- a/internal/security/secretstore/utils/execrunner-mock.go
+++ b/internal/security/secretstore/utils/execrunner-mock.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package secretstore
+package utils
 
 import (
 	"context"
@@ -13,35 +13,35 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type mockExecRunner struct {
+type MockExecRunner struct {
 	mock.Mock
 }
 
-func (m *mockExecRunner) SetStdout(stdout io.Writer) {
+func (m *MockExecRunner) SetStdout(stdout io.Writer) {
 	m.Called(stdout)
 }
 
-func (m *mockExecRunner) LookPath(file string) (string, error) {
+func (m *MockExecRunner) LookPath(file string) (string, error) {
 	arguments := m.Called(file)
 	return arguments.String(0), arguments.Error(1)
 }
 
-func (m *mockExecRunner) CommandContext(ctx context.Context,
+func (m *MockExecRunner) CommandContext(ctx context.Context,
 	name string, arg ...string) CmdRunner {
 	arguments := m.Called(ctx, name, arg)
 	return arguments.Get(0).(CmdRunner)
 }
 
-type mockCmd struct {
+type MockCmd struct {
 	mock.Mock
 }
 
-func (m *mockCmd) Start() error {
+func (m *MockCmd) Start() error {
 	arguments := m.Called()
 	return arguments.Error(0)
 }
 
-func (m *mockCmd) Wait() error {
+func (m *MockCmd) Wait() error {
 	arguments := m.Called()
 	return arguments.Error(0)
 }

--- a/internal/security/secretstore/utils/execrunner.go
+++ b/internal/security/secretstore/utils/execrunner.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package secretstore
+package utils
 
 import (
 	"context"

--- a/openapi/security-secretstore-setup.yaml
+++ b/openapi/security-secretstore-setup.yaml
@@ -1,0 +1,124 @@
+openapi: 3.1.0
+info:
+  title: Edge Foundry - Secret store Setup API
+  description: This is the definition of the API for the Security Store Setup service in the EdgeX Foundry IOT microservice platform.
+  version: 4.0.0
+
+servers:
+  - url: http://localhost:59843/api/v3
+    description: URL for local development and testing
+
+components:
+  schemas:
+    BaseResponse:
+      description: "Defines basic properties which all use-case specific response DTO instances should support"
+      type: object
+      properties:
+        apiVersion:
+          description: "A version number shows the API version in DTOs."
+          type: string
+          example: v3
+        requestId:
+          description: "Uniquely identifies the request that resulted in this response."
+          type: string
+          format: uuid
+          example: "e6e8a2f4-eb14-4649-9e2b-175247911369"
+        message:
+          description: "A field that can contain a free-form message, such as an error message."
+          type: string
+        statusCode:
+          description: "A numeric code signifying the operational status of the response."
+          type: integer
+    ErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/BaseResponse'
+      description: "A response type for returning a generic error to the caller."
+      type: object
+
+  headers:
+    correlatedResponseHeader:
+      description: "A response header that returns the unique correlation ID used to initiate the request."
+      schema:
+        type: string
+        format: uuid
+      example: "14a42ea6-c394-41c3-8bcd-a29b9f5e6835"
+  examples:
+    400Example:
+      value:
+        apiVersion: "v3"
+        requestId: "73f0932c-0148-11eb-adc1-0242ac120002"
+        statusCode: 400
+        message: "Bad Request"
+    401Example:
+      value:
+        apiVersion: "v3"
+        requestId: "73f0932c-0148-11eb-adc1-0242ac120002"
+        statusCode: 401
+        message: "Unauthorized"
+    403Example:
+      value:
+        apiVersion: "v3"
+        requestId: "73f0932c-0148-11eb-adc1-0242ac120002"
+        statusCode: 403
+        message: "Forbidden"
+    404Example:
+      value:
+        apiVersion: "v3"
+        requestId: "84c9489c-0148-11eb-adc1-0242ac120002"
+        statusCode: 404
+        message: "Not Found"
+    500Example:
+      value:
+        apiVersion: "v3"
+        statusCode: 500
+        message: "Interval Server Error"
+
+
+paths:
+  /token/entityId/{entityId}:
+    parameters:
+      - name: entityId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: "Specifies the id of the secret store entity"
+    put:
+      summary: Create a new secret store client token for the specified entity id and saved in the token file
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
+        '400':
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '403':
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/403Example'
+        '500':
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'

--- a/openapi/security-secretstore-setup.yaml
+++ b/openapi/security-secretstore-setup.yaml
@@ -105,7 +105,7 @@ paths:
                 400Example:
                   $ref: '#/components/examples/400Example'
         '403':
-          description: "Bad Request"
+          description: "Forbidden"
           content:
             application/json:
               schema:


### PR DESCRIPTION
Resolves #5065. Add regen token API in secretstore-setup.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->