### PR TITLE
feat: Update default event retention duration

### DIFF
--- a/cmd/core-data/res/configuration.yaml
+++ b/cmd/core-data/res/configuration.yaml
@@ -32,5 +32,5 @@ Retention:
   Interval: 10m    # Purging interval defines when the database should be rid of readings above the high watermark.
   DefaultMaxCap: -1    # The maximum capacity defines where the high watermark of readings should be detected for purging the amount of the reading to the minimum capacity.
   DefaultMinCap: 1     # The minimum capacity defines where the total count of readings should be returned to during purging.
-  DefaultDuration: "720h" # The duration to keep the event, the expired events should be detected for purging, but the service will still keep the number of MinCap.
+  DefaultDuration: "168h" # The duration to keep the event, the expired events should be detected for purging, but the service will still keep the number of MinCap.
 

--- a/internal/core/data/application/reading.go
+++ b/internal/core/data/application/reading.go
@@ -339,7 +339,8 @@ func purgeEventByAutoEvents(dic *di.Container) errors.EdgeX {
 
 func purgeEvent(deviceName string, autoEvent models.AutoEvent, dic *di.Container) errors.EdgeX {
 	config := container.ConfigurationFrom(dic.Get)
-	// apply the default retention policy
+	// apply the default retention policy, when maxCap/minCap/duration are not specified or equal to zero/empty string
+	// which are mentioned in the documentation
 	if autoEvent.Retention.MaxCap == 0 {
 		autoEvent.Retention.MaxCap = config.Retention.DefaultMaxCap
 	}


### PR DESCRIPTION
Update default event retention interval to 168h.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) not impact
- [ ] I have opened a PR for the related docs change (if not, why?) https://github.com/edgexfoundry/edgex-docs/pull/1420

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->