### PR TITLE
fix: Update create token params for regenToken API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.5.0
 	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.27
 	github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.14
-	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.27
+	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.28
 	github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.18
 	github.com/edgexfoundry/go-mod-secrets/v4 v4.0.0-dev.9
 	github.com/fxamacker/cbor/v2 v2.7.0

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.27 h1:d1JiYIoFHMHkCeHoYTx
 github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.27/go.mod h1:JY9Def/1rzes+aBwmI3ge9z+gnPyJdWTP+o+76IrBkg=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.14 h1:A2LI3YVXGqZS0myTiBrNMFIqIWbH0rNNmLsDPHeI1RM=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.14/go.mod h1:Sj4PTuZJI5bjQvFh8rz0U1egEu+jkEnlWoHXXUYjgXs=
-github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.27 h1:H8L6yV4K71qreDzWM8gOiZHA49J/hnwB8qCLgnfZwYs=
-github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.27/go.mod h1:D35HIMZkFFy82shKtPYaEL3Nn+ZNEjUjZI1RLn1j23E=
+github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.28 h1:eli2uheGD7d5qMDFPzNhm3fAEyoDLTgqKWQoDacaF8A=
+github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.28/go.mod h1:D35HIMZkFFy82shKtPYaEL3Nn+ZNEjUjZI1RLn1j23E=
 github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.18 h1:gTaPm8iwdVO0vi8TLuNRYaeNno46Nm6+S04OpubBLlk=
 github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.18/go.mod h1:h7it/lhC7QhcLKW+KA+D9mCd8Ng3GxT8kSegZMrdEFM=
 github.com/edgexfoundry/go-mod-registry/v4 v4.0.0-dev.4 h1:/IZtXURVZXSKaxHEWVSYHXrNJqoVk2n6OcUR+GmPbgw=

--- a/internal/security/common/usermanager.go
+++ b/internal/security/common/usermanager.go
@@ -123,6 +123,7 @@ func (m *UserManager) CreatePasswordUserWithPolicy(username string, password str
 		"name":                   username,
 		"renewable":              true,
 		"allowed_entity_aliases": []string{username},
+		"orphan":                 true,
 	}
 	err = m.secretStoreClient.CreateOrUpdateTokenRole(m.privilegedToken, username, tokenRoleParams)
 	if err != nil {

--- a/internal/security/fileprovider/command/createtoken/command.go
+++ b/internal/security/fileprovider/command/createtoken/command.go
@@ -100,7 +100,7 @@ func regenToken(entityId string, dic *di.Container) errors.EdgeX {
 	}
 	client, err := secrets.NewSecretStoreClient(clientConfig, lc, requester)
 	if err != nil {
-		lc.Errorf("error occurred creating SecretStoreClient: %w", err)
+		lc.Errorf("error occurred creating SecretStoreClient: %v", err)
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 
@@ -112,7 +112,7 @@ func regenToken(entityId string, dic *di.Container) errors.EdgeX {
 
 	err = fileProvider.RegenToken(entityId)
 	if err != nil {
-		lc.Errorf("error occurred while re-generating token: %w", err)
+		lc.Errorf("error occurred while re-generating token: %v", err)
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 

--- a/internal/security/fileprovider/command/handlers/init.go
+++ b/internal/security/fileprovider/command/handlers/init.go
@@ -74,7 +74,7 @@ func (b *Bootstrap) BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ sta
 
 	exitStatusCode, err := command.Execute()
 	if err != nil {
-		lc.Errorf("failed to execute command '%s': %w", commandName, err)
+		lc.Errorf("failed to execute command '%s': %v", commandName, err)
 	}
 	b.exitStatusCode = exitStatusCode
 

--- a/internal/security/fileprovider/tokenprovider/provider_test.go
+++ b/internal/security/fileprovider/tokenprovider/provider_test.go
@@ -77,8 +77,8 @@ func TestMultipleTokensWithNoDefaults(t *testing.T) {
 
 	expectedService1Policy := "{}"
 	expectedService2Policy := "{}"
-	expectedSvc1TokenRoleParam := map[string]any{"allowed_entity_aliases": []string{"service1"}, "allowed_policies": []string{"edgex-service-service1"}, "name": "service1", "renewable": true}
-	expectedSvc2TokenRoleParam := map[string]any{"allowed_entity_aliases": []string{"service2"}, "allowed_policies": []string{"edgex-service-service2"}, "name": "service2", "renewable": true}
+	expectedSvc1TokenRoleParam := map[string]any{"allowed_entity_aliases": []string{"service1"}, "allowed_policies": []string{"edgex-service-service1"}, "name": "service1", "orphan": true, "renewable": true}
+	expectedSvc2TokenRoleParam := map[string]any{"allowed_entity_aliases": []string{"service2"}, "allowed_policies": []string{"edgex-service-service2"}, "name": "service2", "orphan": true, "renewable": true}
 
 	mockSecretStoreClient := &mocks.SecretStoreClient{}
 	mockSecretStoreClient.On("InstallPolicy", "fake-priv-token", "edgex-service-service1", expectedService1Policy).Return(nil)
@@ -162,7 +162,7 @@ func TestNoDefaultsCustomPolicy(t *testing.T) {
 	mockAuthTokenLoader.On("Load", privilegedTokenPath).Return("fake-priv-token", nil)
 
 	expectedService1Policy := `{"path":{"secret/non/standard/location/*":{"capabilities":["list","read"]}}}`
-	expectedSvcTokenRoleParam := map[string]any{"allowed_entity_aliases": []string{"myservice"}, "allowed_policies": []string{"edgex-service-myservice"}, "name": "myservice", "renewable": true}
+	expectedSvcTokenRoleParam := map[string]any{"allowed_entity_aliases": []string{"myservice"}, "allowed_policies": []string{"edgex-service-myservice"}, "name": "myservice", "orphan": true, "renewable": true}
 	mockSecretStoreClient := &mocks.SecretStoreClient{}
 	mockSecretStoreClient.On("InstallPolicy", "fake-priv-token", "edgex-service-myservice", expectedService1Policy).Return(nil)
 	mockSecretStoreClient.On("CreateOrUpdateIdentity", "fake-priv-token", "myservice", map[string]string{"name": "myservice"}, []string{"edgex-service-myservice"}).Return("myserviceid", nil)
@@ -237,7 +237,7 @@ func TestTokenFilePermissions(t *testing.T) {
 	mockFileIoPerformer := &fileMock.FileIoPerformer{}
 	expectedService1Dir := filepath.Join(outputDir, "myservice")
 	expectedService1File := filepath.Join(expectedService1Dir, outputFilename)
-	expectedSvcTokenRoleParam := map[string]any{"allowed_entity_aliases": []string{"myservice"}, "allowed_policies": []string{"edgex-service-myservice"}, "name": "myservice", "renewable": true}
+	expectedSvcTokenRoleParam := map[string]any{"allowed_entity_aliases": []string{"myservice"}, "allowed_policies": []string{"edgex-service-myservice"}, "name": "myservice", "orphan": true, "renewable": true}
 	service1Buffer := new(bytes.Buffer)
 	mockFileIoPerformer.On("MkdirAll", expectedService1Dir, os.FileMode(0700)).Return(nil)
 	mockFileIoPerformer.On("OpenFileReader", configFile, os.O_RDONLY, os.FileMode(0400)).Return(strings.NewReader(`{"myservice":{"file_permissions":{"uid":0,"gid":0,"mode_octal":"0664"}}}`), nil)
@@ -408,7 +408,7 @@ func runTokensWithDefault(serviceName string, additionalKeysEnv string, t *testi
 	}
 	expectedService1Policy, err := json.Marshal(&policy)
 	require.NoError(t, err)
-	expectedSvcTokenRoleParam1 := map[string]any{"allowed_entity_aliases": []string{serviceName}, "allowed_policies": []string{"edgex-service-" + serviceName}, "name": serviceName, "renewable": true}
+	expectedSvcTokenRoleParam1 := map[string]any{"allowed_entity_aliases": []string{serviceName}, "allowed_policies": []string{"edgex-service-" + serviceName}, "name": serviceName, "orphan": true, "renewable": true}
 	mockSecretStoreClient := &mocks.SecretStoreClient{}
 	mockSecretStoreClient.On("InstallPolicy", "fake-priv-token", "edgex-service-"+serviceName, string(expectedService1Policy)).Return(nil)
 	mockSecretStoreClient.On("CreateOrUpdateIdentity", "fake-priv-token", serviceName, map[string]string{"name": serviceName}, []string{"edgex-service-" + serviceName}).Return("myserviceid", nil)
@@ -437,7 +437,7 @@ func runTokensWithDefault(serviceName string, additionalKeysEnv string, t *testi
 		}
 		expectedServicePolicy, err := json.Marshal(&policy)
 		require.NoError(t, err)
-		expectedSvcTokenRoleParam2 := map[string]any{"allowed_entity_aliases": []string{service}, "allowed_policies": []string{"edgex-service-" + service}, "name": service, "renewable": true}
+		expectedSvcTokenRoleParam2 := map[string]any{"allowed_entity_aliases": []string{service}, "allowed_policies": []string{"edgex-service-" + service}, "name": service, "orphan": true, "renewable": true}
 
 		mockSecretStoreClient.On("InstallPolicy", "fake-priv-token", "edgex-service-"+service, string(expectedServicePolicy)).Return(nil)
 		mockSecretStoreClient.On("CreateOrUpdateIdentity", "fake-priv-token", service, map[string]string{"name": service}, []string{"edgex-service-" + service}).Return("myserviceid", nil)

--- a/internal/security/secretstore/controller/token.go
+++ b/internal/security/secretstore/controller/token.go
@@ -17,6 +17,7 @@ import (
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/common"
 
 	"github.com/labstack/echo/v4"
@@ -40,7 +41,7 @@ func (a *TokenController) RegenToken(c echo.Context) error {
 	}
 
 	// URL parameters
-	entityId := c.Param("entityId")
+	entityId := c.Param(common.EntityId)
 
 	lc := bootstrapContainer.LoggingClientFrom(a.dic.Get)
 	configuration := container.ConfigurationFrom(a.dic.Get)

--- a/internal/security/secretstore/server/handlers/router.go
+++ b/internal/security/secretstore/server/handlers/router.go
@@ -9,12 +9,10 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/security/secretstore/controller"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 
 	"github.com/labstack/echo/v4"
 )
-
-// TODO: this will be declared in go-mod-core-contracts after the review
-const regenTokenRoute = "/api/v3/token/entityId/:entityId" // nolint:gosec
 
 // LoadRestRoutes generates the routing for API requests
 // Authentication is always on for this service,
@@ -22,5 +20,5 @@ const regenTokenRoute = "/api/v3/token/entityId/:entityId" // nolint:gosec
 // and must always authenticate even if the rest of EdgeX does not
 func LoadRestRoutes(r *echo.Echo, dic *di.Container) {
 	ac := controller.NewTokenController(dic)
-	r.PUT(regenTokenRoute, ac.RegenToken)
+	r.PUT(common.ApiRegenTokenRoute, ac.RegenToken)
 }


### PR DESCRIPTION
Relates to #5065. Update create token params while invoking the secretstore-setup regenToken API.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->