### PR TITLE
fix: Compose env override not works in Common Config

### DIFF
--- a/internal/core/common_config/main.go
+++ b/internal/core/common_config/main.go
@@ -116,7 +116,7 @@ func Main(ctx context.Context, cancel context.CancelFunc, args []string) {
 	}
 
 	// load the yaml file and push it using the config client
-	if !hasConfig || f.OverwriteConfig() {
+	if !hasConfig || getOverwriteConfig(f, lc) {
 		lc.Info("Pushing common configuration. It doesn't exists or overwrite flag is set")
 
 		yamlFile := config.GetConfigFileLocation(lc, f)

--- a/internal/core/common_config/utils.go
+++ b/internal/core/common_config/utils.go
@@ -1,0 +1,23 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common_config
+
+import (
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/environment"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/flags"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+)
+
+// getOverwriteConfig returns a boolean value based on whether the -o flag or the EDGEX_OVERWRITE_CONFIG environment variable is set
+func getOverwriteConfig(f *flags.Default, lc logger.LoggingClient) bool {
+	overwrite := f.OverwriteConfig()
+
+	if b, ok := environment.OverwriteConfig(lc); ok {
+		overwrite = b
+	}
+
+	return overwrite
+}

--- a/internal/core/common_config/utils_test.go
+++ b/internal/core/common_config/utils_test.go
@@ -1,0 +1,52 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common_config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/flags"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetOverwriteConfig(t *testing.T) {
+	lc := logger.NewMockClient()
+
+	tests := []struct {
+		name           string
+		flags          []string
+		hasEnvVar      bool
+		envValue       string
+		expectedResult bool
+	}{
+		{"Overwrite config with -o flag", []string{"-o"}, false, "", true},
+		{"Overwrite config with EDGEX_OVERWRITE_CONFIG env variable is true", []string{}, true, "true", true},
+		{"Not overwrite config with -o flag and EDGEX_OVERWRITE_CONFIG env variable is false", []string{"-o"}, true, "false", false},
+		{"Not overwrite config no -o flag and no EDGEX_OVERWRITE_CONFIG env variable defined", []string{}, false, "", false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			f := flags.New()
+			args := testCase.flags
+			f.Parse(args)
+
+			if testCase.hasEnvVar {
+				err := os.Setenv("EDGEX_OVERWRITE_CONFIG", testCase.envValue)
+				require.NoError(t, err)
+			}
+
+			overwriteConfig := getOverwriteConfig(f, lc)
+			require.Equal(t, testCase.expectedResult, overwriteConfig)
+
+			err := os.Unsetenv("EDGEX_OVERWRITE_CONFIG")
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5086. Compose env override not works for Common Config.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->