### PR TITLE
fix: Add create token role permission to security-spiffe-token-provider

### DIFF
--- a/cmd/security-file-token-provider/res/token-config.json
+++ b/cmd/security-file-token-provider/res/token-config.json
@@ -143,6 +143,12 @@
             "update"
           ]
         },
+        "auth/token/roles/*" : {
+          "capabilities": [
+            "create",
+            "update"
+          ]
+        },
         "sys/auth": {
           "capabilities": [
             "read"

--- a/internal/security/common/usermanager.go
+++ b/internal/security/common/usermanager.go
@@ -127,7 +127,7 @@ func (m *UserManager) CreatePasswordUserWithPolicy(username string, password str
 	}
 	err = m.secretStoreClient.CreateOrUpdateTokenRole(m.privilegedToken, username, tokenRoleParams)
 	if err != nil {
-		m.logger.Errorf("failed create/update token role '%s': %w", username, err)
+		m.logger.Errorf("failed create/update token role '%s': %v", username, err)
 		return err
 	}
 


### PR DESCRIPTION
Fixes #5089. Add create token role permission to security-spiffe-token-provider.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->