### PR TITLE
build: Update .gitignore and vendor debug pkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ docker/docker-compose.yml
 .project
 .vscode/
 coverage.out
-debug
+/debug/
 *.dll
 VERSION
 __debug_bin

--- a/vendor/github.com/go-openapi/analysis/internal/debug/debug.go
+++ b/vendor/github.com/go-openapi/analysis/internal/debug/debug.go
@@ -1,0 +1,41 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var (
+	output = os.Stdout
+)
+
+// GetLogger provides a prefix debug logger
+func GetLogger(prefix string, debug bool) func(string, ...interface{}) {
+	if debug {
+		logger := log.New(output, prefix+":", log.LstdFlags)
+
+		return func(msg string, args ...interface{}) {
+			_, file1, pos1, _ := runtime.Caller(1)
+			logger.Printf("%s:%d: %s", filepath.Base(file1), pos1, fmt.Sprintf(msg, args...))
+		}
+	}
+
+	return func(_ string, _ ...interface{}) {}
+}


### PR DESCRIPTION
The original `.gitignore` contain debug, which will ignore `vendor/github.com/go-openapi/analysis/internal/debug/debug.go` and fails the `make test` during build. Update .gitignore to only ignore the debug folder in the top level.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->