### PR TITLE
fix: fix error when empty scheme in Rest channel

### DIFF
--- a/internal/pkg/utils/restaddress.go
+++ b/internal/pkg/utils/restaddress.go
@@ -77,6 +77,9 @@ func ValidMethod(method string) bool {
 }
 
 func getUrlStr(address models.RESTAddress) string {
+	if address.Scheme == "" {
+		address.Scheme = common.HTTP
+	}
 	return fmt.Sprintf("%s://%s:%d%s", address.Scheme, address.Host, address.Port, address.Path)
 }
 


### PR DESCRIPTION
This is to fix an error for support-notifications with followng case: users add a subscription with Rest type channel but doesn't specify shceme will result in empty scheme when sending notifications, thus failing the sending operation.

This fix is to specify default http scheme when scheme is empty.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->