### PR TITLE
docs: update core-metadata API doc with correct sample

### DIFF
--- a/openapi/core-metadata.yaml
+++ b/openapi/core-metadata.yaml
@@ -1347,8 +1347,8 @@ components:
             protocols:
               modbus-tcp:
                 Address: "localhost"
-                Port: "502"
-                UnitID: "1"
+                Port: 502
+                UnitID: 1
             tags:
               tag1:
                 field1: "field1Value"


### PR DESCRIPTION
The sample for POST new device specifies string for both Port and UnitID, which are incorrect and should be corrected to use numbers.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->