### PR TITLE
fix: added missing retention field on core-metadata API docs

### DIFF
--- a/openapi/core-metadata.yaml
+++ b/openapi/core-metadata.yaml
@@ -63,6 +63,19 @@ components:
         sourceName:
           type: string
           description: SourceName indicates the name of the resource or device command in the device profile which describes the event to generate
+        retention:
+          type: object
+          description: Retention defines policies for retaining autoevents.
+          properties:
+            maxCap:
+              type: integer
+              description: The maximum number of events to retain.
+            minCap:
+              type: integer
+              description: The minimum number of events to retain before deletion.
+            duration:
+              type: string
+              description: Duration string representing how long to retain the events, valid time units are "s", "m", "h", e.g., "1.5h" or "2h45m"
       required:
         - interval
         - resource


### PR DESCRIPTION
closes #5142 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->