### PR TITLE
refactor: move the validateEvent to utils package for reuse

### DIFF
--- a/internal/pkg/utils/event.go
+++ b/internal/pkg/utils/event.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2025 IOTech Ltd
+
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
+)
+
+// ValidateEvent checks if the incoming event's profileName, deviceName and sourceName match the message topic where the event received from
+func ValidateEvent(messageTopic string, e dtos.Event) errors.EdgeX {
+	// Parse messageTopic by the pattern `edgex/events/device/<device-service-name>/<device-profile-name>/<device-name>/<source-name>`
+	fields := strings.Split(messageTopic, "/")
+
+	// assumes a non-empty base topic with events/device/<device-service-name>/<device-profile-name>/<device-name>/<source-name>
+	if len(fields) < 6 {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("invalid message topic %s", messageTopic), nil)
+	}
+
+	len := len(fields)
+	profileName, err := url.PathUnescape(fields[len-3])
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	deviceName, err := url.PathUnescape(fields[len-2])
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+	sourceName, err := url.PathUnescape(fields[len-1])
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	// Check whether the event fields match the message topic
+	if e.ProfileName != profileName {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("event's profileName %s mismatches with the name %s received in topic", e.ProfileName, profileName), nil)
+	}
+	if e.DeviceName != deviceName {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("event's deviceName %s mismatches with the name %s received in topic", e.DeviceName, deviceName), nil)
+	}
+	if e.SourceName != sourceName {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("event's sourceName %s mismatches with the name %s received in topic", e.SourceName, sourceName), nil)
+	}
+	return nil
+}


### PR DESCRIPTION
fixes https://github.com/edgexfoundry/edgex-go/issues/5145

refactor the code to move the implementation of validateEvent from core-data to internal/pkg/utils for reuse.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->