### PR TITLE
fix: CoreCommand GET /device/all API check profile is empty

### DIFF
--- a/internal/core/command/application/command.go
+++ b/internal/core/command/application/command.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -43,8 +43,11 @@ func AllCommands(offset int, limit int, dic *di.Container) (deviceCoreCommands [
 	configuration := commandContainer.ConfigurationFrom(dic.Get)
 	serviceUrl := configuration.Service.Url()
 
-	deviceCoreCommands = make([]dtos.DeviceCoreCommand, len(multiDevicesResponse.Devices))
-	for i, device := range multiDevicesResponse.Devices {
+	for _, device := range multiDevicesResponse.Devices {
+		if len(device.ProfileName) == 0 {
+			// if the profile is not set, skip the profile query
+			continue
+		}
 		deviceProfileResponse, err := dpc.DeviceProfileByName(context.Background(), device.ProfileName)
 		if err != nil {
 			return deviceCoreCommands, totalCount, errors.NewCommonEdgeXWrapper(err)
@@ -53,13 +56,13 @@ func AllCommands(offset int, limit int, dic *di.Container) (deviceCoreCommands [
 		if err != nil {
 			return nil, totalCount, errors.NewCommonEdgeXWrapper(err)
 		}
-		deviceCoreCommands[i] = dtos.DeviceCoreCommand{
+		deviceCoreCommands = append(deviceCoreCommands, dtos.DeviceCoreCommand{
 			DeviceName:   device.Name,
 			ProfileName:  device.ProfileName,
 			CoreCommands: commands,
-		}
+		})
 	}
-	return deviceCoreCommands, multiDevicesResponse.TotalCount, nil
+	return deviceCoreCommands, uint32(len(deviceCoreCommands)), nil
 }
 
 // CommandsByDeviceName query coreCommands with device name

--- a/internal/core/command/application/command_test.go
+++ b/internal/core/command/application/command_test.go
@@ -1,19 +1,27 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package application
 
 import (
+	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/command/config"
+	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v4/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/responses"
 )
 
 const (
@@ -96,4 +104,59 @@ func TestBuildCoreCommands(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, expectedCoreCommand, result)
+}
+
+func TestAllCommands(t *testing.T) {
+	ctx := context.Background()
+	device1 := dtos.Device{Name: "test-device-1", ProfileName: "test-profile-1"}
+	device2 := dtos.Device{Name: "test-device-2", ProfileName: "test-profile-2"}
+	device3 := dtos.Device{Name: "test-device-3", ProfileName: ""}
+
+	dic := di.NewContainer(di.ServiceConstructorMap{})
+	dc := &mocks.DeviceClient{}
+	dpc := &mocks.DeviceProfileClient{}
+	dpc.On("DeviceProfileByName", ctx, device1.ProfileName).Return(responses.DeviceProfileResponse{}, nil)
+	dpc.On("DeviceProfileByName", ctx, device2.ProfileName).Return(responses.DeviceProfileResponse{}, nil)
+	dic.Update(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &config.ConfigurationStruct{
+				Service: bootstrapConfig.ServiceInfo{
+					Host: "localhost",
+					Port: 59882,
+				},
+			}
+		},
+		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
+			return dc
+		},
+		bootstrapContainer.DeviceProfileClientName: func(get di.Get) interface{} {
+			return dpc
+		},
+	})
+
+	tests := []struct {
+		name                 string
+		multiDevicesResponse responses.MultiDevicesResponse
+		expectedCommandCount uint32
+	}{
+		{
+			name:                 "query the commands",
+			multiDevicesResponse: responses.MultiDevicesResponse{Devices: []dtos.Device{device1, device2}},
+			expectedCommandCount: 2,
+		},
+		{
+			name:                 "device has empty profile",
+			multiDevicesResponse: responses.MultiDevicesResponse{Devices: []dtos.Device{device1, device3}},
+			expectedCommandCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var labels []string
+			dc.On("AllDevices", ctx, labels, 0, 0).Return(tt.multiDevicesResponse, nil).Once()
+			_, count, err := AllCommands(0, 0, dic)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedCommandCount, count)
+		})
+	}
 }


### PR DESCRIPTION
CoreCommand GET /device/all API check whether device profile is empty, if empty skip the profile query for the specific device.

Close #5163

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core service and device virtual, and test the API for the device with empty profile name.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->