### PR TITLE
fix: Windows path in db init sql

### DIFF
--- a/internal/pkg/db/postgres/utils.go
+++ b/internal/pkg/db/postgres/utils.go
@@ -91,7 +91,7 @@ func getSortedSqlFileNames(embedFiles embed.FS, sqlFilesDir string) ([]string, e
 		if err != nil {
 			continue
 		}
-		sqlFiles = append(sqlFiles, sqlFileName{order, filepath.Join(sqlFilesDir, fileName)})
+		sqlFiles = append(sqlFiles, sqlFileName{order, toEmbedPath(sqlFilesDir, fileName)})
 	}
 
 	return sqlFiles.getSortedNames(), nil
@@ -143,4 +143,9 @@ func WrapDBError(message string, err error) errors.EdgeX {
 		return errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, message, err)
 	}
 	return errors.NewCommonEdgeX(errors.KindDatabaseError, message, err)
+}
+
+// toEmbedPath converts a path to the format required for go embed by using '/' as the separator.
+func toEmbedPath(baseDir, fileName string) string {
+	return filepath.ToSlash(filepath.Join(baseDir, fileName))
 }


### PR DESCRIPTION
converts a path to the format required for go embed by using '/' as the separator. Close https://github.com/edgexfoundry/edgex-go/issues/5150

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
See https://github.com/edgexfoundry/edgex-go/pull/5151