### PR TITLE
fix: Fix CoreCommand GET /device/all API incorrect totalCount

### DIFF
--- a/internal/core/command/application/command.go
+++ b/internal/core/command/application/command.go
@@ -62,7 +62,7 @@ func AllCommands(offset int, limit int, dic *di.Container) (deviceCoreCommands [
 			CoreCommands: commands,
 		})
 	}
-	return deviceCoreCommands, uint32(len(deviceCoreCommands)), nil
+	return deviceCoreCommands, multiDevicesResponse.TotalCount, nil
 }
 
 // CommandsByDeviceName query coreCommands with device name

--- a/internal/core/command/application/command_test.go
+++ b/internal/core/command/application/command_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	dtosCommon "github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/responses"
 )
 
@@ -137,17 +138,23 @@ func TestAllCommands(t *testing.T) {
 	tests := []struct {
 		name                 string
 		multiDevicesResponse responses.MultiDevicesResponse
-		expectedCommandCount uint32
+		expectedTotalCount   uint32
 	}{
 		{
-			name:                 "query the commands",
-			multiDevicesResponse: responses.MultiDevicesResponse{Devices: []dtos.Device{device1, device2}},
-			expectedCommandCount: 2,
+			name: "query the commands",
+			multiDevicesResponse: responses.MultiDevicesResponse{
+				BaseWithTotalCountResponse: dtosCommon.BaseWithTotalCountResponse{TotalCount: 2},
+				Devices:                    []dtos.Device{device1, device2},
+			},
+			expectedTotalCount: 2,
 		},
 		{
-			name:                 "device has empty profile",
-			multiDevicesResponse: responses.MultiDevicesResponse{Devices: []dtos.Device{device1, device3}},
-			expectedCommandCount: 1,
+			name: "device has empty profile",
+			multiDevicesResponse: responses.MultiDevicesResponse{
+				BaseWithTotalCountResponse: dtosCommon.BaseWithTotalCountResponse{TotalCount: 2},
+				Devices:                    []dtos.Device{device1, device3},
+			},
+			expectedTotalCount: 2,
 		},
 	}
 	for _, tt := range tests {
@@ -156,7 +163,7 @@ func TestAllCommands(t *testing.T) {
 			dc.On("AllDevices", ctx, labels, 0, 0).Return(tt.multiDevicesResponse, nil).Once()
 			_, count, err := AllCommands(0, 0, dic)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedCommandCount, count)
+			assert.Equal(t, tt.expectedTotalCount, count)
 		})
 	}
 }


### PR DESCRIPTION
Fix CoreCommand GET /device/all API incorrect totalCount

Close #5172

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ]  I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->