### PR TITLE
fix: Fix event query incorrect return data when enabling EventPurge

### DIFF
--- a/internal/core/data/embed/sql/versions/4.1.0-dev/00-tables.sql
+++ b/internal/core/data/embed/sql/versions/4.1.0-dev/00-tables.sql
@@ -1,0 +1,6 @@
+--
+-- Copyright (C) 2025 IOTech Ltd
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+ALTER TABLE core_data.device_info ADD COLUMN IF NOT EXISTS mark_deleted BOOLEAN DEFAULT false;

--- a/internal/pkg/infrastructure/postgres/consts.go
+++ b/internal/pkg/infrastructure/postgres/consts.go
@@ -59,6 +59,7 @@ const (
 	binaryValueCol    = "binaryvalue"
 	mediaTypeCol      = "mediatype"
 	objectValueCol    = "objectvalue"
+	markDeletedCol    = "mark_deleted"
 )
 
 // constants relate to the keeper postgres db table column names

--- a/internal/pkg/infrastructure/postgres/deviceinfo.go
+++ b/internal/pkg/infrastructure/postgres/deviceinfo.go
@@ -144,3 +144,12 @@ func deleteDeviceInfoById(ctx context.Context, tx pgx.Tx, id int) errors.EdgeX {
 	}
 	return nil
 }
+
+// updateDeviceInfosDeletableByDeviceName updates deviceInfos by deviceName as deletable
+func (c *Client) updateDeviceInfosDeletableByDeviceName(deviceName string) errors.EdgeX {
+	_, err := c.ConnPool.Exec(context.Background(), fmt.Sprintf("UPDATE %s SET %s = true WHERE %s=$1", deviceInfoTableName, markDeletedCol, deviceNameCol), deviceName)
+	if err != nil {
+		return pgClient.WrapDBError(fmt.Sprintf("update %s to deletable by devicename '%s'", deviceInfoTableName, deviceName), err)
+	}
+	return nil
+}

--- a/internal/pkg/infrastructure/postgres/models/deviceinfo.go
+++ b/internal/pkg/infrastructure/postgres/models/deviceinfo.go
@@ -15,4 +15,5 @@ type DeviceInfo struct {
 	ValueType    string
 	Units        string
 	MediaType    string
+	MarkDeleted  bool
 }

--- a/internal/pkg/infrastructure/postgres/reading.go
+++ b/internal/pkg/infrastructure/postgres/reading.go
@@ -27,7 +27,7 @@ var (
 )
 
 func (c *Client) ReadingTotalCount() (uint32, errors.EdgeX) {
-	return getTotalRowsCount(context.Background(), c.ConnPool, sqlQueryCount(readingTableName))
+	return getTotalRowsCount(context.Background(), c.ConnPool, sqlQueryCountReading())
 }
 
 func (c *Client) AllReadings(offset int, limit int) ([]model.Reading, errors.EdgeX) {


### PR DESCRIPTION
CoreData should not return the events when enabling EventPurge and removing device from metadata. This issue occurs when user want to purge large amount of event data.

- Adds mark_deleted field to CoreData deviceInfo table
- Marks deviceInfo as deletable before deleting events adn readings
- Add mark_deleted

Close #5175

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

- Deploy core service and device-virtual
- Insert million of events readings data
- Remove a device
- Query the event by the deleted device from the DB
- Check whether the related events do not exist

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->