### PR TITLE
fix: allow multiple tags to be selected during a docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ dcore: dmetadata ddata dcommand
 dmetadata: docker_core_metadata
 docker_core_metadata: docker_base
 	docker build \
-		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
+		--build-arg ADD_BUILD_TAGS="$(ADD_BUILD_TAGS)" \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -227,7 +227,7 @@ docker_core_metadata: docker_base
 ddata: docker_core_data
 docker_core_data: docker_base
 	docker build \
-		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
+		--build-arg ADD_BUILD_TAGS="$(ADD_BUILD_TAGS)" \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -240,7 +240,7 @@ docker_core_data: docker_base
 dcommand: docker_core_command
 docker_core_command: docker_base
 	docker build \
-		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
+		--build-arg ADD_BUILD_TAGS="$(ADD_BUILD_TAGS)" \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -253,7 +253,7 @@ docker_core_command: docker_base
 dcommon-config: docker_core_common_config
 docker_core_common_config: docker_base
 	docker build \
-		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
+		--build-arg ADD_BUILD_TAGS="$(ADD_BUILD_TAGS)" \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -266,7 +266,7 @@ docker_core_common_config: docker_base
 dkeeper: docker_core_keeper
 docker_core_keeper: docker_base
 	docker build \
-		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
+		--build-arg ADD_BUILD_TAGS="$(ADD_BUILD_TAGS)" \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -281,7 +281,7 @@ dsupport: dnotifications dscheduler dscheduler
 dnotifications: docker_support_notifications
 docker_support_notifications: docker_base
 	docker build \
-		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
+		--build-arg ADD_BUILD_TAGS="$(ADD_BUILD_TAGS)" \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \
@@ -294,7 +294,7 @@ docker_support_notifications: docker_base
 dscheduler: docker_support_scheduler
 docker_support_scheduler: docker_base
 	docker build \
-		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
+		--build-arg ADD_BUILD_TAGS="$(ADD_BUILD_TAGS)" \
 		--build-arg http_proxy \
 		--build-arg https_proxy \
 		--build-arg BUILDER_BASE=$(LOCAL_CACHE_IMAGE) \

--- a/cmd/core-command/Dockerfile
+++ b/cmd/core-command/Dockerfile
@@ -30,7 +30,7 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
-RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS  cmd/core-command/core-command
+RUN make -e ADD_BUILD_TAGS="$ADD_BUILD_TAGS"  cmd/core-command/core-command
 
 FROM alpine:3.20
 

--- a/cmd/core-common-config-bootstrapper/Dockerfile
+++ b/cmd/core-common-config-bootstrapper/Dockerfile
@@ -30,7 +30,7 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
-RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/core-common-config-bootstrapper/core-common-config-bootstrapper
+RUN make -e ADD_BUILD_TAGS="$ADD_BUILD_TAGS" cmd/core-common-config-bootstrapper/core-common-config-bootstrapper
 
 #Next image - Copy built Go binary into new workspace
 FROM alpine:3.20

--- a/cmd/core-data/Dockerfile
+++ b/cmd/core-data/Dockerfile
@@ -32,7 +32,7 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
-RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/core-data/core-data
+RUN make -e ADD_BUILD_TAGS="$ADD_BUILD_TAGS" cmd/core-data/core-data
 
 #Next image - Copy built Go binary into new workspace
 FROM alpine:3.20

--- a/cmd/core-metadata/Dockerfile
+++ b/cmd/core-metadata/Dockerfile
@@ -31,7 +31,7 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
-RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/core-metadata/core-metadata
+RUN make -e ADD_BUILD_TAGS="$ADD_BUILD_TAGS" cmd/core-metadata/core-metadata
 
 #Next image - Copy built Go binary into new workspace
 FROM alpine:3.20

--- a/cmd/security-proxy-auth/Dockerfile
+++ b/cmd/security-proxy-auth/Dockerfile
@@ -31,7 +31,7 @@ COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
 
 COPY . .
-RUN make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS cmd/security-proxy-auth/security-proxy-auth
+RUN make -e ADD_BUILD_TAGS="$ADD_BUILD_TAGS" cmd/security-proxy-auth/security-proxy-auth
 
 #Next image - Copy built Go binary into new workspace
 FROM alpine:3.20


### PR DESCRIPTION
The ADD_BUILD_TAGS argument is used recursively in the makefile and docker build structure.
