### PR TITLE
fix: Run MessageBus command request processing in goroutines

### DIFF
--- a/internal/core/command/controller/messaging/internal.go
+++ b/internal/core/command/controller/messaging/internal.go
@@ -57,7 +57,9 @@ func SubscribeCommandRequests(ctx context.Context, requestTimeout time.Duration,
 			case err = <-messageErrors:
 				lc.Error(err.Error())
 			case requestEnvelope := <-messages:
-				processDeviceCommandRequest(messageBus, requestEnvelope, baseTopic, requestTimeout, lc, dic)
+				go func() {
+					processDeviceCommandRequest(messageBus, requestEnvelope, baseTopic, requestTimeout, lc, dic)
+				}()
 			}
 		}
 	}()
@@ -211,7 +213,9 @@ func SubscribeCommandQueryRequests(ctx context.Context, dic *di.Container) error
 			case err = <-messageErrors:
 				lc.Error(err.Error())
 			case requestEnvelope := <-messages:
-				processCommandQueryRequest(messageBus, requestEnvelope, baseTopic, lc, dic)
+				go func() {
+					processCommandQueryRequest(messageBus, requestEnvelope, baseTopic, lc, dic)
+				}()
 			}
 		}
 	}()


### PR DESCRIPTION
fix: #5152 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Deploy core services, device-modbus, and modbus-simulator.
2. Add a Modbus device to core-metadata.
3. Stop modbus-simulator.
4. While the simulator is offline, asynchronously send 100 command requests.
5. Restart modbus-simulator.
6. Verify that `core-command` service is still able to handle command requests once the simulator is back online.

