### PR TITLE
fix: CoreData apply default retention policy to none autoEvent

### DIFF
--- a/internal/pkg/cache/device.go
+++ b/internal/pkg/cache/device.go
@@ -3,7 +3,6 @@
 package cache
 
 import (
-	"maps"
 	"sync"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
@@ -75,7 +74,11 @@ func (s *activeDeviceStore) Devices() map[string]models.Device {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 	// since the device map might change, return the copy of devices to prevent unexpected result
-	return maps.Clone(s.activeDeviceMap)
+	clonedDevices := make(map[string]models.Device, len(s.activeDeviceMap))
+	for deviceName, device := range s.activeDeviceMap {
+		clonedDevices[deviceName] = device.Clone()
+	}
+	return clonedDevices
 }
 
 func DeviceStore(dic *di.Container) ActiveDeviceStore {


### PR DESCRIPTION
CoreData apply default retention policy to events not coming from auto events

Close #5188

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Deploy core service and device-virtual to test the event purge.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->