### PR TITLE
feat: Add Postgres ConnPool Config

### DIFF
--- a/cmd/core-common-config-bootstrapper/res/configuration.yaml
+++ b/cmd/core-common-config-bootstrapper/res/configuration.yaml
@@ -46,6 +46,9 @@ all-services:
     Port: 5432
     Timeout: "5s"
     Type: "postgres"
+    MaxConns: 4
+    MaxConnIdleTime: "30m"
+    MaxConnLifetime: "1h"
   
   MessageBus:
     Protocol: "mqtt"

--- a/cmd/core-data/res/configuration.yaml
+++ b/cmd/core-data/res/configuration.yaml
@@ -15,6 +15,11 @@ Service:
   Host: "localhost"
   StartupMsg: "This is the Core Data Microservice"
 
+Database:
+  MaxConns: 4
+  MaxConnIdleTime: "30m"
+  MaxConnLifetime: "1h"
+
 Clients:
   core-metadata:
     Protocol: http

--- a/cmd/core-keeper/res/configuration.yaml
+++ b/cmd/core-keeper/res/configuration.yaml
@@ -39,6 +39,9 @@ Database:
   Port: 5432
   Timeout: "5s"
   Type: "postgres"
+  MaxConns: 4
+  MaxConnIdleTime: "30m"
+  MaxConnLifetime: "1h"
 
 MessageBus:
   Protocol: "mqtt"

--- a/internal/pkg/bootstrap/handlers/database.go
+++ b/internal/pkg/bootstrap/handlers/database.go
@@ -67,10 +67,13 @@ func (d Database) newDBClient(
 	databaseInfo := d.database.GetDatabaseInfo()
 
 	databaseConfig := db.Configuration{
-		Host:     databaseInfo.Host,
-		Port:     databaseInfo.Port,
-		Password: credentials.Password,
-		Timeout:  databaseInfo.Timeout,
+		Host:            databaseInfo.Host,
+		Port:            databaseInfo.Port,
+		Password:        credentials.Password,
+		Timeout:         databaseInfo.Timeout,
+		MaxConns:        databaseInfo.MaxConns,
+		MaxConnIdleTime: databaseInfo.MaxConnIdleTime,
+		MaxConnLifetime: databaseInfo.MaxConnLifetime,
 	}
 
 	switch databaseInfo.Type {

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -29,12 +29,15 @@ var (
 )
 
 type Configuration struct {
-	DbType       string
-	Host         string
-	Port         int
-	Timeout      string
-	DatabaseName string
-	Username     string
-	Password     string
-	BatchSize    int
+	DbType          string
+	Host            string
+	Port            int
+	Timeout         string
+	DatabaseName    string
+	Username        string
+	Password        string
+	BatchSize       int
+	MaxConns        int
+	MaxConnIdleTime string
+	MaxConnLifetime string
 }

--- a/internal/pkg/db/postgres/client.go
+++ b/internal/pkg/db/postgres/client.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -22,6 +23,9 @@ import (
 )
 
 const defaultDBName = "edgex_db"
+const defaultMaxConns = int32(4)
+const defaultMaxConnIdleTime = time.Minute * 30
+const defaultMaxConnLifetime = time.Hour
 
 var once sync.Once
 var dc *Client
@@ -35,17 +39,15 @@ type Client struct {
 
 // NewClient returns a pointer to the Postgres client
 func NewClient(ctx context.Context, config db.Configuration, lc logger.LoggingClient, schemaName, serviceKey, serviceVersion string, sqlFiles embed.FS) (*Client, errors.EdgeX) {
-	// Get the database name from the environment variable
-	databaseName := os.Getenv("EDGEX_DBNAME")
-	if databaseName == "" {
-		databaseName = defaultDBName
-	}
-
 	var edgeXerr errors.EdgeX
 	once.Do(func() {
-		// use url encode to prevent special characters in the connection string
-		connectionStr := "postgres://" + fmt.Sprintf("%s:%s@%s:%d/%s", url.PathEscape(config.Username), url.PathEscape(config.Password), url.PathEscape(config.Host), config.Port, url.PathEscape(databaseName))
-		dbPool, err := pgxpool.New(ctx, connectionStr)
+		connPoolConfig, err := connPoolConConfig(config, lc)
+		if err != nil {
+			edgeXerr = WrapDBError("fail to parse pg conn pool config", err)
+			return
+		}
+
+		dbPool, err := pgxpool.NewWithConfig(ctx, connPoolConfig)
 		if err != nil {
 			edgeXerr = WrapDBError("fail to create pg connection pool", err)
 		}
@@ -76,6 +78,35 @@ func NewClient(ctx context.Context, config db.Configuration, lc logger.LoggingCl
 	}
 
 	return dc, nil
+}
+
+func connPoolConConfig(config db.Configuration, lc logger.LoggingClient) (*pgxpool.Config, error) {
+	// Get the database name from the environment variable
+	databaseName := os.Getenv("EDGEX_DBNAME")
+	if databaseName == "" {
+		databaseName = defaultDBName
+	}
+
+	// use url encode to prevent special characters in the connection string
+	connectionStr := "postgres://" + fmt.Sprintf("%s:%s@%s:%d/%s", url.PathEscape(config.Username), url.PathEscape(config.Password), url.PathEscape(config.Host), config.Port, url.PathEscape(databaseName))
+	connPoolConfig, err := pgxpool.ParseConfig(connectionStr)
+	if err != nil {
+		return nil, WrapDBError("fail to parse pg connection string", err)
+	}
+	connPoolConfig.MaxConns = int32(config.MaxConns)
+	if connPoolConfig.MaxConns <= 0 {
+		lc.Errorf("The MaxConns too small, use default '%d'", defaultMaxConns)
+		connPoolConfig.MaxConns = defaultMaxConns
+	}
+	if connPoolConfig.MaxConnIdleTime, err = time.ParseDuration(config.MaxConnIdleTime); err != nil {
+		connPoolConfig.MaxConnIdleTime = defaultMaxConnIdleTime
+		lc.Errorf("Fail to parse pg conn pool MaxConnIdleTime config, use default '%v', err: %v", defaultMaxConnIdleTime, err)
+	}
+	if connPoolConfig.MaxConnLifetime, err = time.ParseDuration(config.MaxConnLifetime); err != nil {
+		connPoolConfig.MaxConnLifetime = defaultMaxConnLifetime
+		lc.Errorf("Fail to parse pg conn pool MaxConnLifetime config, use default '%v', err: %v", defaultMaxConnLifetime, err)
+	}
+	return connPoolConfig, nil
 }
 
 // CloseSession closes the connections to postgres


### PR DESCRIPTION
Add Postgres ConnPool Config for user to tune the ConnPool.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

This PR is based on the go-mod-bootstrap config changes https://github.com/edgexfoundry/go-mod-bootstrap/pull/892

- Change the config 
- Deploy core service, device service
- Execute the event or reading REST API
- Verify the conn stats by the command
  ```
  docker exec edgex-postgres psql -U postgres -d edgex_db -a -c "select pid, state, query from pg_stat_activity WHERE datname='edgex_db'"
  ```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->