### PR TITLE
fix: Fix the incorrect reading value with trailing zero

### DIFF
--- a/internal/pkg/infrastructure/postgres/reading.go
+++ b/internal/pkg/infrastructure/postgres/reading.go
@@ -319,9 +319,17 @@ func numericReadingVal(valueType string, numericValue *pgtype.Numeric) (any, err
 		}
 		return val.Float64, nil
 	case common.ValueTypeUint8, common.ValueTypeUint16, common.ValueTypeUint32, common.ValueTypeUint64:
-		return numericValue.Int.Uint64(), nil
+		parsedUint, err := numericToUint64(numericValue)
+		if err != nil {
+			return nil, pgClient.WrapDBError("failed to parse numeric reading value to uint", err)
+		}
+		return parsedUint, nil
 	case common.ValueTypeInt8, common.ValueTypeInt16, common.ValueTypeInt32, common.ValueTypeInt64:
-		return numericValue.Int.Int64(), nil
+		pgIntNum, err := numericValue.Int64Value()
+		if err != nil || !pgIntNum.Valid {
+			return nil, pgClient.WrapDBError("failed to parse numeric value to int64", err)
+		}
+		return pgIntNum.Int64, nil
 	default:
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("unexpected value type '%s", valueType), nil)
 	}

--- a/internal/pkg/infrastructure/postgres/reading_test.go
+++ b/internal/pkg/infrastructure/postgres/reading_test.go
@@ -1,0 +1,193 @@
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNumericReadingVal(t *testing.T) {
+	testInt64Power10 := pgtype.Numeric{
+		Int:   big.NewInt(1),
+		Exp:   18,
+		Valid: true,
+	}
+	testInt64 := pgtype.Numeric{
+		Int:   big.NewInt(9223372036854775807),
+		Exp:   0,
+		Valid: true,
+	}
+	testUint64Power := pgtype.Numeric{
+		Int:   big.NewInt(1),
+		Exp:   19,
+		Valid: true,
+	}
+	testUint64 := pgtype.Numeric{
+		Int:   new(big.Int).SetUint64(^uint64(0)), //  ^uint64(0) represents the max uint 64 value 18446744073709551615
+		Exp:   0,
+		Valid: true,
+	}
+
+	testInt32 := pgtype.Numeric{
+		Int:   big.NewInt(-2147483648),
+		Exp:   0,
+		Valid: true,
+	}
+	testUint32 := pgtype.Numeric{
+		Int:   big.NewInt(4294967295),
+		Exp:   0,
+		Valid: true,
+	}
+	testInt16 := pgtype.Numeric{
+		Int:   big.NewInt(-32768),
+		Exp:   0,
+		Valid: true,
+	}
+	testUint16 := pgtype.Numeric{
+		Int:   big.NewInt(65535),
+		Exp:   0,
+		Valid: true,
+	}
+	testInt8 := pgtype.Numeric{
+		Int:   big.NewInt(-128),
+		Exp:   0,
+		Valid: true,
+	}
+	testUint8 := pgtype.Numeric{
+		Int:   big.NewInt(255),
+		Exp:   0,
+		Valid: true,
+	}
+	testFloat64 := pgtype.Numeric{
+		Int:   big.NewInt(1), // approximately equals to 2^53
+		Exp:   -16383,
+		Valid: true,
+	}
+	testFloat32 := pgtype.Numeric{
+		Int:   big.NewInt(14), // approximately equals to 2^53
+		Exp:   -46,
+		Valid: true,
+	}
+
+	tests := []struct {
+		name          string
+		valueType     string
+		numericValue  *pgtype.Numeric
+		expectedValue any
+		expectError   bool
+	}{
+		{
+			name:          "Valid - Test number is power of 10 to int64",
+			valueType:     common.ValueTypeInt64,
+			numericValue:  &testInt64Power10,
+			expectedValue: int64(1e18),
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number to int64",
+			valueType:     common.ValueTypeInt64,
+			numericValue:  &testInt64,
+			expectedValue: int64(9223372036854775807),
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number is power of 10 to Uint64",
+			valueType:     common.ValueTypeUint64,
+			numericValue:  &testUint64Power,
+			expectedValue: uint64(1e19),
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number to Uint64",
+			valueType:     common.ValueTypeUint64,
+			numericValue:  &testUint64,
+			expectedValue: ^uint64(0),
+			expectError:   false,
+		},
+
+		{
+			name:          "Valid - Test number to Int32",
+			valueType:     common.ValueTypeInt32,
+			numericValue:  &testInt32,
+			expectedValue: int64(-2147483648),
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number to Uint32",
+			valueType:     common.ValueTypeUint32,
+			numericValue:  &testUint32,
+			expectedValue: uint64(4294967295),
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number to Int16",
+			valueType:     common.ValueTypeInt16,
+			numericValue:  &testInt16,
+			expectedValue: int64(-32768),
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number to Uint16",
+			valueType:     common.ValueTypeUint16,
+			numericValue:  &testUint16,
+			expectedValue: uint64(65535),
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number to Int8",
+			valueType:     common.ValueTypeInt8,
+			numericValue:  &testInt8,
+			expectedValue: int64(-128),
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number to Uint8",
+			valueType:     common.ValueTypeUint8,
+			numericValue:  &testUint8,
+			expectedValue: uint64(255),
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number to Float64",
+			valueType:     common.ValueTypeFloat64,
+			numericValue:  &testFloat64,
+			expectedValue: 1e-16383,
+			expectError:   false,
+		},
+		{
+			name:          "Valid - Test number to Float32",
+			valueType:     common.ValueTypeFloat32,
+			numericValue:  &testFloat32,
+			expectedValue: 1.4e-45,
+			expectError:   false,
+		},
+		{
+			name:          "Invalid - Unknown value type",
+			valueType:     "UNKNOWN",
+			numericValue:  &testFloat32,
+			expectedValue: "",
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := numericReadingVal(tt.valueType, tt.numericValue)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, result, "Returned value is not as expected")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5251. Fix the incorrect reading value with trailing zero.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->