### PR TITLE
fix(security): make openbao log level configurable

### DIFF
--- a/cmd/security-bootstrapper/entrypoint-scripts/secretstore_wait_install.sh
+++ b/cmd/security-bootstrapper/entrypoint-scripts/secretstore_wait_install.sh
@@ -42,6 +42,9 @@ listener "tcp" {
 
 BAO_LOCAL_CONFIG=${BAO_LOCAL_CONFIG:-$DEFAULT_BAO_LOCAL_CONFIG}
 
+DEFAULT_BAO_LOG_LEVEL='info'
+BAO_LOG_LEVEL=${BAO_LOG_LEVEL:-$DEFAULT_BAO_LOG_LEVEL}
+
 export BAO_LOCAL_CONFIG
 
 echo "$(date) BAO_LOCAL_CONFIG: ${BAO_LOCAL_CONFIG}"
@@ -54,5 +57,5 @@ if [ "$1" = 'server' ]; then
     -timeout "${STAGEGATE_WAITFOR_TIMEOUT}"
 
   echo "$(date) Starting edgex-secret-store..."
-  exec /usr/local/bin/docker-entrypoint.sh server -log-level=info
+  exec /usr/local/bin/docker-entrypoint.sh server -log-level=${BAO_LOG_LEVEL}
 fi


### PR DESCRIPTION
fixes: #5264

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) No unit tests for startup scripts.
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) The docs contain links to OpenBao documentation
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Generate a docker compose file with security enabled 
2. Modify the `secret-store` service environment variable, `BAO_LOG_LEVEL`, to change the log level of OpenBao. The default is `info` if no variable is set.

```yaml
secret-store:
    command:
      - server
    container_name: edgex-secret-store
    depends_on:
      security-bootstrapper:
        condition: service_started
        required: true
    entrypoint:
      - /edgex-init/secretstore_wait_install.sh
    environment:
      # ... other configurations ...
      BAO_LOG_LEVEL: "debug"
# ...
```
3. See that the log level changes
`docker logs edgex-secret-store`
<img width="645" height="141" alt="image" src="https://github.com/user-attachments/assets/870e9516-f246-41c3-8aee-1238e50f5d63" />



## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->