### PR TITLE
feat: Add indexes on reading.device_info_id and event.device_info_id

### DIFF
--- a/internal/core/data/embed/sql/versions/4.1.0-dev/00-tables.sql
+++ b/internal/core/data/embed/sql/versions/4.1.0-dev/00-tables.sql
@@ -9,3 +9,9 @@ ALTER TABLE core_data.device_info ADD COLUMN IF NOT EXISTS mark_deleted BOOLEAN 
 CREATE INDEX IF NOT EXISTS idx_reading_event_id ON core_data.reading(event_id);
 
 ALTER TABLE core_data.reading ADD COLUMN IF NOT EXISTS numeric_value NUMERIC;
+
+-- create index on reading(device_info_id) to enhance the performance of queries that join reading with device_info on device_info_id
+CREATE INDEX IF NOT EXISTS idx_reading_device_info_id ON core_data.reading(device_info_id);
+
+-- create index on event(device_info_id) to enhance the performance of queries that join event with device_info on device_info_id
+CREATE INDEX IF NOT EXISTS idx_event_device_info_id ON core_data.event(device_info_id);


### PR DESCRIPTION
fix: #5333 

Reading and event queries often join with the device_info table by device_info_id. Adding indexes on reading.device_info_id and event.device_info_id improves query performance.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->