### PR TITLE
fix: Correct error variable check

### DIFF
--- a/internal/core/command/controller/messaging/utils.go
+++ b/internal/core/command/controller/messaging/utils.go
@@ -95,7 +95,7 @@ func getCommandQueryResponseEnvelope(requestEnvelope types.MessageEnvelope, devi
 		commandsResponse = responses.NewMultiDeviceCoreCommandsResponse(requestEnvelope.RequestID, "", http.StatusOK, totalCounts, commands)
 	default:
 		commands, edgexError := application.CommandsByDeviceName(deviceName, dic)
-		if err != nil {
+		if edgexError != nil {
 			return types.MessageEnvelope{}, fmt.Errorf("failed to get commands by device name '%s': %s", deviceName, edgexError.Error())
 		}
 


### PR DESCRIPTION
fix: #5336 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Enable ExternalMQTT for core-command and query a device that doesn't exist. The `errorCode` in the response payload should be 1.

```
# Query
mosquitto_pub -t edgex/commandquery/request/test  \
  -m '{
    "apiVersion": "v3",
    "requestId": "e6e8a2f4-eb14-4649-9e2b-175247911369",
    "ContentType": "application/json",
    "queryParams": {
      "offset": "0",
      "limit": "20"
     }
  }'

# Response
edgex/commandquery/response {"apiVersion":"v3","receivedTopic":"edgex/commandquery/response","correlationID":"ccefa43c-1c27-4484-b227-b4f238b989f7","requestID":"e6e8a2f4-eb14-4649-9e2b-175247911369","errorCode":1,"payload":"failed to get commands by device name 'test': request failed, status code: 404, err: no device with name 'test' found","contentType":"text/plain"}
```