### PR TITLE
fix: newline interpretation in docker_base target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,10 +203,10 @@ docker_base:
 	if [ "$${response}" = "200" ]; then \
 		echo "Found base Dockerfile"; \
 		curl -s "$(BASE_DOCKERFILE)" | docker build -t $(LOCAL_CACHE_IMAGE_BASE) -f - .; \
-		echo "FROM $(LOCAL_CACHE_IMAGE_BASE)\nWORKDIR /edgex-go\nCOPY go.mod .\nRUN go mod download" | docker build -t $(LOCAL_CACHE_IMAGE) -f - .; \
+		printf "FROM $(LOCAL_CACHE_IMAGE_BASE)\nWORKDIR /edgex-go\nCOPY go.mod .\nRUN go mod download" | docker build -t $(LOCAL_CACHE_IMAGE) -f - .; \
 	else \
 		echo "No base Dockerfile found. Using golang:$(GO_VERSION)-alpine"; \
-		echo "FROM golang:$(GO_VERSION)-alpine\nRUN apk add --update make git\nWORKDIR /edgex-go\nCOPY go.mod .\nRUN go mod download" | docker build -t $(LOCAL_CACHE_IMAGE) -f - .; \
+		printf "FROM golang:$(GO_VERSION)-alpine\nRUN apk add --update make git\nWORKDIR /edgex-go\nCOPY go.mod .\nRUN go mod download" | docker build -t $(LOCAL_CACHE_IMAGE) -f - .; \
 	fi
 
 dcore: dmetadata ddata dcommand


### PR DESCRIPTION
When executing docker-based Makefile targets the target `docker_base` executes a docker command with an inline Dockerfile piped to its input containing uninterpreted `\n` chars, causing a failure during parseing. To create multi-line inlined Dockerfiles the `-e` option must be used with `echo`, however to prevent incompatibility issues with other shells, like Ubuntu's dash, using `printf` is the best option.

Closes #5340

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

## Testing Instructions

Running the reproducer instructions stated in the issue does not hit the issue after this patch.