### PR TITLE
core-command: prevent cascading MQTT command timeouts

### DIFF
--- a/internal/core/command/controller/messaging/external.go
+++ b/internal/core/command/controller/messaging/external.go
@@ -166,19 +166,20 @@ func commandRequestHandler(requestTimeout time.Duration, dic *di.Container) mqtt
 
 		internalMessageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
 
-		// Request waits for the response and returns it.
-		response, err := internalMessageBus.Request(requestEnvelope, deviceRequestTopic, deviceResponseTopicPrefix, requestTimeout)
-		if err != nil {
-			errorMessage := fmt.Sprintf("Failed to send DeviceCommand request with internal MessageBus: %v", err)
-			responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
-			publishMessage(client, externalResponseTopic, qos, retain, responseEnvelope, lc)
-			return
-		}
+		go func() {
+			response, err := internalMessageBus.Request(requestEnvelope, deviceRequestTopic, deviceResponseTopicPrefix, requestTimeout)
+			if err != nil {
+				errorMessage := fmt.Sprintf("Failed to send DeviceCommand request with internal MessageBus: %v", err)
+				responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
+				publishMessage(client, externalResponseTopic, qos, retain, responseEnvelope, lc)
+				return
+			}
 
-		lc.Debugf("Command response received from internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", response.ReceivedTopic, response.RequestID, response.CorrelationID)
+			lc.Debugf("Command response received from internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", response.ReceivedTopic, response.RequestID, response.CorrelationID)
 
-		response.ReceivedTopic = externalResponseTopic
-		publishMessage(client, externalResponseTopic, qos, retain, *response, lc)
+			response.ReceivedTopic = externalResponseTopic
+			publishMessage(client, externalResponseTopic, qos, retain, *response, lc)
+		}()
 	}
 }
 

--- a/internal/core/command/controller/messaging/external_test.go
+++ b/internal/core/command/controller/messaging/external_test.go
@@ -369,6 +369,9 @@ func Test_commandRequestHandler(t *testing.T) {
 
 			expectedInternalRequestTopic := common.BuildTopic(baseTopic, common.CoreCommandDeviceRequestPublishTopic, testDeviceServiceName, testDeviceName, testCommandName, testMethod)
 			expectedInternalResponseTopicPrefix := common.BuildTopic(baseTopic, common.ResponseTopic, testDeviceServiceName)
+			require.Eventually(t, func() bool {
+				return mqttClient.AssertNumberOfCalls(new(testing.T), "Publish", 1)
+			}, time.Second, time.Millisecond*10)
 			client.AssertCalled(t, "Request", tt.payload, expectedInternalRequestTopic, expectedInternalResponseTopicPrefix, mock.Anything)
 		})
 	}


### PR DESCRIPTION
The external message handler was blocking on internalMessageBus.Request() when downstream services timed out. This caused other MQTT messages to queue up and timeout as well, creating cascading failures. Moved the request handling to a goroutine so the handler returns immediately. Fixes #5394.