### PR TITLE
feat: Introduce external command queue configuration for MQTT commands

### DIFF
--- a/cmd/core-command/res/configuration.yaml
+++ b/cmd/core-command/res/configuration.yaml
@@ -39,6 +39,13 @@ ExternalMQTT:
     CommandQueryRequestTopic: edgex/commandquery/request/#   # for subscribing to 3rd party command query request
     CommandQueryResponseTopic: edgex/commandquery/response   # for publishing responses back to 3rd party systems
 
+# Bounded concurrency for external MQTT command callbacks (non-blocking enqueue; no blocking-on-full-queue mode).
+ExternalCommandQueue:
+  MaxConcurrentExternalCommands: 32
+  MaxQueuedExternalCommands: 64
+  OverloadPublishChannelCapacity: 16
+  ShutdownTimeout: 30s
+
 MessageBus:
   Optional:
     ClientId: core-command

--- a/internal/core/command/config/config.go
+++ b/internal/core/command/config/config.go
@@ -22,13 +22,26 @@ import (
 
 // ConfigurationStruct contains the configuration properties for the core-command service.
 type ConfigurationStruct struct {
-	Writable     WritableInfo
-	Clients      bootstrapConfig.ClientsCollection
-	Databases    map[string]bootstrapConfig.Database
-	Registry     bootstrapConfig.RegistryInfo
-	Service      bootstrapConfig.ServiceInfo
-	MessageBus   bootstrapConfig.MessageBusInfo
-	ExternalMQTT bootstrapConfig.ExternalMQTTInfo
+	Writable             WritableInfo
+	Clients              bootstrapConfig.ClientsCollection
+	Databases            map[string]bootstrapConfig.Database
+	Registry             bootstrapConfig.RegistryInfo
+	Service              bootstrapConfig.ServiceInfo
+	MessageBus           bootstrapConfig.MessageBusInfo
+	ExternalMQTT         bootstrapConfig.ExternalMQTTInfo
+	ExternalCommandQueue ExternalCommandQueue
+}
+
+// ExternalCommandQueue bounds concurrency and queuing for external MQTT command requests (see messaging.OnConnectHandler).
+type ExternalCommandQueue struct {
+	// MaxConcurrentExternalCommands is the number of worker goroutines processing external command requests.
+	MaxConcurrentExternalCommands int `yaml:"MaxConcurrentExternalCommands,omitempty"`
+	// MaxQueuedExternalCommands is the capacity of the buffered jobs channel (pending work not yet assigned to a worker).
+	MaxQueuedExternalCommands int `yaml:"MaxQueuedExternalCommands,omitempty"`
+	// OverloadPublishChannelCapacity is the capacity of the channel to the dedicated overload/error MQTT publisher goroutine.
+	OverloadPublishChannelCapacity int `yaml:"OverloadPublishChannelCapacity,omitempty"`
+	// ShutdownTimeout is the maximum duration to wait for workers when the service context is cancelled (e.g. "30s").
+	ShutdownTimeout string `yaml:"ShutdownTimeout,omitempty"`
 }
 
 // WritableInfo contains configuration properties that can be updated and applied without restarting the service.

--- a/internal/core/command/controller/messaging/external.go
+++ b/internal/core/command/controller/messaging/external.go
@@ -7,10 +7,12 @@
 package messaging
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -21,11 +23,238 @@ import (
 
 	"github.com/edgexfoundry/go-mod-messaging/v4/pkg/types"
 
+	"github.com/edgexfoundry/edgex-go/internal/core/command/config"
 	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
 )
 
-func OnConnectHandler(requestTimeout time.Duration, dic *di.Container) mqtt.OnConnectHandler {
+// Defaults for ExternalCommandQueue when configuration omits zero values.
+const (
+	defaultMaxConcurrentExternalCommands  = 32
+	defaultMaxQueuedExternalCommands      = 64
+	defaultOverloadPublishChannelCapacity = 16
+	defaultShutdownTimeoutString          = "30s"
+)
+
+var defaultExternalMQTTShutdownTimeout time.Duration
+
+func init() {
+	var err error
+	defaultExternalMQTTShutdownTimeout, err = time.ParseDuration(defaultShutdownTimeoutString)
+	if err != nil {
+		defaultExternalMQTTShutdownTimeout = 30 * time.Second
+	}
+}
+
+type externalCommandLimits struct {
+	maxWorkers     int
+	maxQueued      int
+	errPubCapacity int
+	shutdown       time.Duration
+}
+
+func externalCommandLimitsFromConfig(q config.ExternalCommandQueue) externalCommandLimits {
+	w := q.MaxConcurrentExternalCommands
+	if w <= 0 {
+		w = defaultMaxConcurrentExternalCommands
+	}
+	queueCap := q.MaxQueuedExternalCommands
+	if queueCap <= 0 {
+		queueCap = defaultMaxQueuedExternalCommands
+	}
+	e := q.OverloadPublishChannelCapacity
+	if e <= 0 {
+		e = defaultOverloadPublishChannelCapacity
+	}
+	st := q.ShutdownTimeout
+	if st == "" {
+		st = defaultShutdownTimeoutString
+	}
+	d, err := time.ParseDuration(st)
+	if err != nil || d <= 0 {
+		d = defaultExternalMQTTShutdownTimeout
+	}
+	return externalCommandLimits{
+		maxWorkers:     w,
+		maxQueued:      queueCap,
+		errPubCapacity: e,
+		shutdown:       d,
+	}
+}
+
+// externalCommandWork is dispatched to workers; payload is not used after enqueue (envelope carries content).
+type externalCommandWork struct {
+	envelope              types.MessageEnvelope
+	mqttTopic             string
+	externalResponseTopic string
+}
+
+type overloadPublishWork struct {
+	topic   string
+	payload []byte
+	qos     byte
+	retain  bool
+}
+
+// Blocking enqueue on a full jobs channel was considered and rejected: it would only move head-of-line
+// blocking from internal Request to queue admission and can stall other MQTT handlers on the same client
+// (see design doc / plan §2). Only non-blocking send with overload response is supported.
+
+// externalCommandProcessor owns the worker pool and overload publisher for external MQTT commands.
+type externalCommandProcessor struct {
+	ctx            context.Context
+	requestTimeout time.Duration
+	dic            *di.Container
+	limits         externalCommandLimits
+
+	clientMu sync.RWMutex
+	client   mqtt.Client
+
+	jobs       chan externalCommandWork
+	errPubCh   chan overloadPublishWork
+	enqueueMu  sync.Mutex
+	jobsClosed bool
+
+	workerWg      sync.WaitGroup
+	overloadPubWg sync.WaitGroup
+	startOnce     sync.Once
+}
+
+func newExternalCommandProcessor(ctx context.Context, requestTimeout time.Duration, dic *di.Container, limits externalCommandLimits) *externalCommandProcessor {
+	return &externalCommandProcessor{
+		ctx:            ctx,
+		requestTimeout: requestTimeout,
+		dic:            dic,
+		limits:         limits,
+	}
+}
+
+func (p *externalCommandProcessor) setMQTTClient(c mqtt.Client) {
+	p.clientMu.Lock()
+	defer p.clientMu.Unlock()
+	p.client = c
+}
+
+func (p *externalCommandProcessor) getMQTTClient() mqtt.Client {
+	p.clientMu.RLock()
+	defer p.clientMu.RUnlock()
+	return p.client
+}
+
+func (p *externalCommandProcessor) ensureStarted() {
+	p.startOnce.Do(func() {
+		p.jobs = make(chan externalCommandWork, p.limits.maxQueued)
+		p.errPubCh = make(chan overloadPublishWork, p.limits.errPubCapacity)
+		p.workerWg.Add(p.limits.maxWorkers)
+		for i := 0; i < p.limits.maxWorkers; i++ {
+			go p.workerLoop()
+		}
+		p.overloadPubWg.Add(1)
+		go p.overloadPublisherLoop()
+		go p.runShutdownWatcher()
+	})
+}
+
+func (p *externalCommandProcessor) runShutdownWatcher() {
+	<-p.ctx.Done()
+	done := make(chan struct{})
+	go func() {
+		p.shutdownWorkerPool()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(p.limits.shutdown):
+		lc := bootstrapContainer.LoggingClientFrom(p.dic.Get)
+		lc.Warnf("external MQTT command worker shutdown exceeded ShutdownTimeout (%v)", p.limits.shutdown)
+	}
+}
+
+func (p *externalCommandProcessor) shutdownWorkerPool() {
+	p.enqueueMu.Lock()
+	if p.jobsClosed {
+		p.enqueueMu.Unlock()
+		return
+	}
+	p.jobsClosed = true
+	close(p.jobs)
+	p.enqueueMu.Unlock()
+
+	p.workerWg.Wait()
+	close(p.errPubCh)
+	p.overloadPubWg.Wait()
+}
+
+func (p *externalCommandProcessor) tryEnqueue(w externalCommandWork) bool {
+	p.enqueueMu.Lock()
+	defer p.enqueueMu.Unlock()
+	if p.jobsClosed {
+		return false
+	}
+	// Non-blocking enqueue only: blocking send would reintroduce head-of-line blocking on the Paho callback
+	// when the buffer is full (see package comment near commandRequestMQTTHandler).
+	select {
+	case p.jobs <- w:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *externalCommandProcessor) workerLoop() {
+	defer p.workerWg.Done()
+	lc := bootstrapContainer.LoggingClientFrom(p.dic.Get)
+	for w := range p.jobs {
+		func(work externalCommandWork) {
+			defer func() {
+				if r := recover(); r != nil {
+					lc.Errorf("recovered panic in external MQTT command worker: %v", r)
+				}
+			}()
+			p.processExternalMQTTCommand(work)
+		}(w)
+	}
+}
+
+func (p *externalCommandProcessor) overloadPublisherLoop() {
+	defer p.overloadPubWg.Done()
+	lc := bootstrapContainer.LoggingClientFrom(p.dic.Get)
+	for item := range p.errPubCh {
+		client := p.getMQTTClient()
+		if client == nil {
+			continue
+		}
+		token := client.Publish(item.topic, item.qos, item.retain, item.payload)
+		if token.Wait() && token.Error() != nil {
+			lc.Errorf("Could not publish overload response to external message broker on topic '%s': %s",
+				item.topic, token.Error().Error())
+		}
+	}
+}
+
+func (p *externalCommandProcessor) enqueueOverloadPublish(externalResponseTopic string, qos byte, retain bool, envelope types.MessageEnvelope, lc logger.LoggingClient) {
+	payload, err := json.Marshal(&envelope)
+	if err != nil {
+		lc.Errorf("Failed to marshal overload MessageEnvelope: %s", err.Error())
+		return
+	}
+	item := overloadPublishWork{topic: externalResponseTopic, payload: payload, qos: qos, retain: retain}
+	select {
+	case p.errPubCh <- item:
+	default:
+		lc.Warn("overload response channel full; dropping overload notification for external MQTT command load shed")
+	}
+}
+
+// OnConnectHandler returns an MQTT OnConnectHandler that subscribes to external command and query topics.
+func OnConnectHandler(ctx context.Context, requestTimeout time.Duration, dic *di.Container) mqtt.OnConnectHandler {
+	cfg := container.ConfigurationFrom(dic.Get)
+	limits := externalCommandLimitsFromConfig(cfg.ExternalCommandQueue)
+	proc := newExternalCommandProcessor(ctx, requestTimeout, dic, limits)
+
 	return func(client mqtt.Client) {
+		proc.setMQTTClient(client)
+		proc.ensureStarted()
+
 		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 		config := container.ConfigurationFrom(dic.Get)
 		externalTopics := config.ExternalMQTT.Topics
@@ -39,7 +268,7 @@ func OnConnectHandler(requestTimeout time.Duration, dic *di.Container) mqtt.OnCo
 		}
 
 		requestCommandTopic := externalTopics[common.CommandRequestTopicKey]
-		if token := client.Subscribe(requestCommandTopic, qos, commandRequestHandler(requestTimeout, dic)); token.Wait() && token.Error() != nil {
+		if token := client.Subscribe(requestCommandTopic, qos, proc.commandRequestMQTTHandler()); token.Wait() && token.Error() != nil {
 			lc.Errorf("could not subscribe to topic '%s': %s", requestCommandTopic, token.Error().Error())
 		} else {
 			lc.Debugf("Subscribed to topic '%s' on external MQTT broker", requestCommandTopic)
@@ -92,24 +321,27 @@ func commandQueryHandler(dic *di.Container) mqtt.MessageHandler {
 	}
 }
 
-func commandRequestHandler(requestTimeout time.Duration, dic *di.Container) mqtt.MessageHandler {
+func (p *externalCommandProcessor) commandRequestMQTTHandler() mqtt.MessageHandler {
 	return func(client mqtt.Client, message mqtt.Message) {
-		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-		config := container.ConfigurationFrom(dic.Get)
+		lc := bootstrapContainer.LoggingClientFrom(p.dic.Get)
+		cfg := container.ConfigurationFrom(p.dic.Get)
 		lc.Debugf("Received command request from external message broker on topic '%s' with %d bytes", message.Topic(), len(message.Payload()))
 
-		externalMQTTInfo := container.ConfigurationFrom(dic.Get).ExternalMQTT
+		externalMQTTInfo := cfg.ExternalMQTT
 		qos := externalMQTTInfo.QoS
 		retain := externalMQTTInfo.Retain
 
-		requestEnvelope, err := types.NewMessageEnvelopeFromJSON(message.Payload())
+		payload := append([]byte(nil), message.Payload()...)
+		mqttTopic := strings.Clone(message.Topic())
+
+		requestEnvelope, err := types.NewMessageEnvelopeFromJSON(payload)
 		if err != nil {
 			lc.Errorf("Failed to decode request MessageEnvelope: %s", err.Error())
 			lc.Warn("Not publishing error message back due to insufficient information on response topic")
 			return
 		}
 
-		topicLevels := strings.Split(message.Topic(), "/")
+		topicLevels := strings.Split(mqttTopic, "/")
 		length := len(topicLevels)
 		if length < 3 {
 			lc.Error("Failed to parse and construct response topic scheme, expected request topic scheme: '#/<device-name>/<command-name>/<method>")
@@ -117,7 +349,6 @@ func commandRequestHandler(requestTimeout time.Duration, dic *di.Container) mqtt
 			return
 		}
 
-		// expected external command request/response topic scheme: #/<device-name>/<command-name>/<method>
 		deviceName, err := url.PathUnescape(topicLevels[length-3])
 		if err != nil {
 			lc.Errorf("Failed to unescape device name from '%s': %s", topicLevels[length-3], err.Error())
@@ -139,10 +370,7 @@ func commandRequestHandler(requestTimeout time.Duration, dic *di.Container) mqtt
 
 		externalResponseTopic := common.BuildTopic(externalMQTTInfo.Topics[common.CommandResponseTopicPrefixKey], deviceName, commandName, method)
 
-		internalBaseTopic := config.MessageBus.GetBaseTopicPrefix()
-		topicPrefix := common.BuildTopic(internalBaseTopic, common.CoreCommandDeviceRequestPublishTopic)
-
-		deviceServiceName, err := retrieveServiceNameByDevice(deviceName, dic)
+		_, err = retrieveServiceNameByDevice(deviceName, p.dic)
 		if err != nil {
 			responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, err.Error())
 			publishMessage(client, externalResponseTopic, qos, retain, responseEnvelope, lc)
@@ -156,30 +384,94 @@ func commandRequestHandler(requestTimeout time.Duration, dic *di.Container) mqtt
 			return
 		}
 
-		deviceRequestTopic := common.NewPathBuilder().EnableNameFieldEscape(config.Service.EnableNameFieldEscape).
-			SetPath(topicPrefix).SetNameFieldPath(deviceServiceName).SetNameFieldPath(deviceName).SetNameFieldPath(commandName).SetPath(method).BuildPath()
-		deviceResponseTopicPrefix := common.NewPathBuilder().EnableNameFieldEscape(config.Service.EnableNameFieldEscape).
-			SetPath(internalBaseTopic).SetPath(common.ResponseTopic).SetNameFieldPath(deviceServiceName).BuildPath()
+		select {
+		case <-p.ctx.Done():
+			return
+		default:
+		}
 
-		lc.Debugf("Sending Command request to internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", deviceRequestTopic, requestEnvelope.RequestID, requestEnvelope.CorrelationID)
-		lc.Debugf("Expecting response on topic: %s/%s", deviceResponseTopicPrefix, requestEnvelope.RequestID)
-
-		internalMessageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
-
-		// Request waits for the response and returns it.
-		response, err := internalMessageBus.Request(requestEnvelope, deviceRequestTopic, deviceResponseTopicPrefix, requestTimeout)
-		if err != nil {
-			errorMessage := fmt.Sprintf("Failed to send DeviceCommand request with internal MessageBus: %v", err)
-			responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
-			publishMessage(client, externalResponseTopic, qos, retain, responseEnvelope, lc)
+		work := externalCommandWork{
+			envelope:              requestEnvelope,
+			mqttTopic:             mqttTopic,
+			externalResponseTopic: externalResponseTopic,
+		}
+		if p.tryEnqueue(work) {
 			return
 		}
 
-		lc.Debugf("Command response received from internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", response.ReceivedTopic, response.RequestID, response.CorrelationID)
-
-		response.ReceivedTopic = externalResponseTopic
-		publishMessage(client, externalResponseTopic, qos, retain, *response, lc)
+		// Service busy — non-blocking policy only; blocking enqueue would reintroduce callback HOL (see tryEnqueue).
+		busyMsg := "service busy: external command queue is full"
+		responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, busyMsg)
+		p.enqueueOverloadPublish(externalResponseTopic, qos, retain, responseEnvelope, lc)
 	}
+}
+
+func (p *externalCommandProcessor) processExternalMQTTCommand(work externalCommandWork) {
+	lc := bootstrapContainer.LoggingClientFrom(p.dic.Get)
+	cfg := container.ConfigurationFrom(p.dic.Get)
+	externalMQTTInfo := cfg.ExternalMQTT
+	qos := externalMQTTInfo.QoS
+	retain := externalMQTTInfo.Retain
+	requestEnvelope := work.envelope
+	externalResponseTopic := work.externalResponseTopic
+
+	topicLevels := strings.Split(work.mqttTopic, "/")
+	length := len(topicLevels)
+	deviceName, err := url.PathUnescape(topicLevels[length-3])
+	if err != nil {
+		lc.Errorf("Failed to unescape device name from '%s': %s", topicLevels[length-3], err.Error())
+		return
+	}
+	commandName, err := url.PathUnescape(topicLevels[length-2])
+	if err != nil {
+		lc.Errorf("Failed to unescape command name from '%s': %s", topicLevels[length-2], err.Error())
+		return
+	}
+	method := topicLevels[length-1]
+
+	internalBaseTopic := cfg.MessageBus.GetBaseTopicPrefix()
+	topicPrefix := common.BuildTopic(internalBaseTopic, common.CoreCommandDeviceRequestPublishTopic)
+
+	deviceServiceName, err := retrieveServiceNameByDevice(deviceName, p.dic)
+	if err != nil {
+		responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, err.Error())
+		publishMessage(p.getMQTTClient(), externalResponseTopic, qos, retain, responseEnvelope, lc)
+		return
+	}
+
+	err = validateGetCommandQueryParameters(requestEnvelope.QueryParams)
+	if err != nil {
+		responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, err.Error())
+		publishMessage(p.getMQTTClient(), externalResponseTopic, qos, retain, responseEnvelope, lc)
+		return
+	}
+
+	deviceRequestTopic := common.NewPathBuilder().EnableNameFieldEscape(cfg.Service.EnableNameFieldEscape).
+		SetPath(topicPrefix).SetNameFieldPath(deviceServiceName).SetNameFieldPath(deviceName).SetNameFieldPath(commandName).SetPath(method).BuildPath()
+	deviceResponseTopicPrefix := common.NewPathBuilder().EnableNameFieldEscape(cfg.Service.EnableNameFieldEscape).
+		SetPath(internalBaseTopic).SetPath(common.ResponseTopic).SetNameFieldPath(deviceServiceName).BuildPath()
+
+	lc.Debugf("Sending Command request to internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", deviceRequestTopic, requestEnvelope.RequestID, requestEnvelope.CorrelationID)
+	lc.Debugf("Expecting response on topic: %s/%s", deviceResponseTopicPrefix, requestEnvelope.RequestID)
+
+	internalMessageBus := bootstrapContainer.MessagingClientFrom(p.dic.Get)
+	// go-mod-messaging/v4 MessageClient.Request has no context parameter; cancellation is only via timeout.
+	// Service shutdown closes the jobs channel so workers exit without relying on context cancellation here.
+	response, err := internalMessageBus.Request(requestEnvelope, deviceRequestTopic, deviceResponseTopicPrefix, p.requestTimeout)
+	if err != nil {
+		errorMessage := fmt.Sprintf("Failed to send DeviceCommand request with internal MessageBus: %v", err)
+		responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
+		publishMessage(p.getMQTTClient(), externalResponseTopic, qos, retain, responseEnvelope, lc)
+		return
+	}
+
+	lc.Debugf("Command response received from internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", response.ReceivedTopic, response.RequestID, response.CorrelationID)
+
+	// Copy before mutating ReceivedTopic: concurrent workers must not share the same *MessageEnvelope instance
+	// if the messaging mock returns a reused pointer (tests) or the stack ever does.
+	out := *response
+	out.ReceivedTopic = externalResponseTopic
+	publishMessage(p.getMQTTClient(), externalResponseTopic, qos, retain, out, lc)
 }
 
 func publishMessage(client mqtt.Client, responseTopic string, qos byte, retain bool, message types.MessageEnvelope, lc logger.LoggingClient) {

--- a/internal/core/command/controller/messaging/external_test.go
+++ b/internal/core/command/controller/messaging/external_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,6 +74,12 @@ func TestOnConnectHandler(t *testing.T) {
 					QoS:    0,
 					Retain: true,
 				},
+				ExternalCommandQueue: config.ExternalCommandQueue{
+					MaxConcurrentExternalCommands:  4,
+					MaxQueuedExternalCommands:      8,
+					OverloadPublishChannelCapacity: 4,
+					ShutdownTimeout:                "30s",
+				},
 			}
 		},
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
@@ -101,7 +108,7 @@ func TestOnConnectHandler(t *testing.T) {
 			client.On("Subscribe", testQueryRequestTopic, byte(0), mock.Anything).Return(token)
 			client.On("Subscribe", testExternalCommandRequestTopic, byte(0), mock.Anything).Return(token)
 
-			fn := OnConnectHandler(time.Second*10, dic)
+			fn := OnConnectHandler(context.Background(), time.Second*10, dic)
 			fn(client)
 
 			if tt.expectedSucceed {
@@ -268,6 +275,7 @@ func Test_commandRequestHandler(t *testing.T) {
 	}
 
 	expectedResponse := &types.MessageEnvelope{}
+	baseTopic := "edgex"
 
 	lc := &lcMocks.LoggingClient{}
 	lc.On("Error", mock.Anything).Return(nil)
@@ -282,7 +290,6 @@ func Test_commandRequestHandler(t *testing.T) {
 	dsc.On("DeviceServiceByName", context.Background(), testDeviceServiceName).Return(deviceServiceResponse, nil)
 	dsc.On("DeviceServiceByName", context.Background(), unknownService).Return(responses.DeviceServiceResponse{}, edgexErr.NewCommonEdgeX(edgexErr.KindEntityDoesNotExist, "unknown device service", nil))
 	client := &internalMessagingMocks.MessageClient{}
-	client.On("Request", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedResponse, nil)
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return &config.ConfigurationStruct{
@@ -300,6 +307,12 @@ func Test_commandRequestHandler(t *testing.T) {
 					Topics: map[string]string{
 						common.CommandResponseTopicPrefixKey: testExternalCommandResponseTopicPrefix,
 					},
+				},
+				ExternalCommandQueue: config.ExternalCommandQueue{
+					MaxConcurrentExternalCommands:  8,
+					MaxQueuedExternalCommands:      16,
+					OverloadPublishChannelCapacity: 4,
+					ShutdownTimeout:                "30s",
 				},
 			}
 		},
@@ -355,7 +368,17 @@ func Test_commandRequestHandler(t *testing.T) {
 			mqttClient := &mocks.Client{}
 			mqttClient.On("Publish", mock.Anything, byte(0), true, mock.Anything).Return(token)
 
-			fn := commandRequestHandler(time.Second*10, dic)
+			requestDone := make(chan struct{}, 1)
+			if !tt.expectedError {
+				client.On("Request", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) { requestDone <- struct{}{} }).
+					Return(expectedResponse, nil).Once()
+			}
+
+			proc := newExternalCommandProcessor(context.Background(), time.Second*10, dic, externalCommandLimitsFromConfig(container.ConfigurationFrom(dic.Get).ExternalCommandQueue))
+			proc.setMQTTClient(mqttClient)
+			proc.ensureStarted()
+			fn := proc.commandRequestMQTTHandler()
 			fn(mqttClient, message)
 			if tt.expectedError {
 				if tt.expectedPublishError {
@@ -365,6 +388,12 @@ func Test_commandRequestHandler(t *testing.T) {
 				}
 				lc.AssertCalled(t, "Warn", mock.Anything)
 				return
+			}
+
+			select {
+			case <-requestDone:
+			case <-time.After(3 * time.Second):
+				t.Fatal("timed out waiting for internal MessageBus Request")
 			}
 
 			expectedInternalRequestTopic := common.BuildTopic(baseTopic, common.CoreCommandDeviceRequestPublishTopic, testDeviceServiceName, testDeviceName, testCommandName, testMethod)
@@ -387,4 +416,224 @@ func testCommandRequestPayload() types.MessageEnvelope {
 	})
 
 	return payload
+}
+
+// Test_externalCommand_secondRequestWhileFirstBlocked ensures a second external command can complete
+// internal Request while the first Request is still blocked (no MQTT callback head-of-line blocking).
+func Test_externalCommand_secondRequestWhileFirstBlocked(t *testing.T) {
+	deviceResponse := responses.DeviceResponse{
+		BaseResponse: commonDTO.NewBaseResponse("", "", http.StatusOK),
+		Device: dtos.Device{
+			Name:        testDeviceName,
+			ProfileName: testProfileName,
+			ServiceName: testDeviceServiceName,
+		},
+	}
+	deviceServiceResponse := responses.DeviceServiceResponse{
+		BaseResponse: commonDTO.NewBaseResponse("", "", http.StatusOK),
+		Service: dtos.DeviceService{
+			Name: testDeviceServiceName,
+		},
+	}
+	expectedResponse := &types.MessageEnvelope{}
+
+	lc := &lcMocks.LoggingClient{}
+	lc.On("Error", mock.Anything).Return(nil)
+	lc.On("Errorf", mock.Anything, mock.Anything).Return(nil)
+	lc.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	dc := &clientMocks.DeviceClient{}
+	dc.On("DeviceByName", context.Background(), testDeviceName).Return(deviceResponse, nil)
+	dsc := &clientMocks.DeviceServiceClient{}
+	dsc.On("DeviceServiceByName", context.Background(), testDeviceServiceName).Return(deviceServiceResponse, nil)
+
+	unblockFirst := make(chan struct{})
+	var requestPhase atomic.Int32
+
+	msgClient := &internalMessagingMocks.MessageClient{}
+	msgClient.On("Request", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			n := requestPhase.Add(1)
+			if n == 1 {
+				<-unblockFirst
+			}
+		}).Return(expectedResponse, nil)
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &config.ConfigurationStruct{
+				Service: bootstrapConfig.ServiceInfo{
+					Host: mockHost, Port: mockPort, MaxResultCount: 20,
+				},
+				MessageBus: bootstrapConfig.MessageBusInfo{BaseTopicPrefix: "edgex"},
+				ExternalMQTT: bootstrapConfig.ExternalMQTTInfo{
+					QoS: 0, Retain: true,
+					Topics: map[string]string{
+						common.CommandResponseTopicPrefixKey: testExternalCommandResponseTopicPrefix,
+					},
+				},
+				ExternalCommandQueue: config.ExternalCommandQueue{
+					MaxConcurrentExternalCommands:  4,
+					MaxQueuedExternalCommands:      8,
+					OverloadPublishChannelCapacity: 4,
+					ShutdownTimeout:                "30s",
+				},
+			}
+		},
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} { return lc },
+		bootstrapContainer.DeviceClientName:           func(get di.Get) interface{} { return dc },
+		bootstrapContainer.DeviceServiceClientName:    func(get di.Get) interface{} { return dsc },
+		bootstrapContainer.MessagingClientName:        func(get di.Get) interface{} { return msgClient },
+	})
+
+	payload := testCommandRequestPayload()
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	token := &mocks.Token{}
+	token.On("Wait").Return(true)
+	token.On("Error").Return(nil)
+	mqttClient := &mocks.Client{}
+	mqttClient.On("Publish", mock.Anything, byte(0), true, mock.Anything).Return(token)
+
+	proc := newExternalCommandProcessor(context.Background(), time.Second*10, dic,
+		externalCommandLimitsFromConfig(container.ConfigurationFrom(dic.Get).ExternalCommandQueue))
+	proc.setMQTTClient(mqttClient)
+	proc.ensureStarted()
+	handler := proc.commandRequestMQTTHandler()
+
+	message1 := &mocks.Message{}
+	message1.On("Payload").Return(append([]byte(nil), payloadBytes...))
+	message1.On("Topic").Return(testExternalCommandRequestTopicExample)
+	handler(mqttClient, message1)
+
+	require.Eventually(t, func() bool { return requestPhase.Load() >= 1 }, 2*time.Second, 5*time.Millisecond,
+		"first Request should have started")
+
+	message2 := &mocks.Message{}
+	message2.On("Payload").Return(append([]byte(nil), payloadBytes...))
+	message2.On("Topic").Return(testExternalCommandRequestTopicExample)
+
+	done2 := make(chan struct{})
+	go func() {
+		handler(mqttClient, message2)
+		close(done2)
+	}()
+
+	select {
+	case <-done2:
+	case <-time.After(3 * time.Second):
+		close(unblockFirst)
+		t.Fatal("second MQTT handler invocation did not return")
+	}
+
+	require.Eventually(t, func() bool { return requestPhase.Load() >= 2 }, 2*time.Second, 5*time.Millisecond,
+		"second Request should run while first is blocked")
+	close(unblockFirst)
+	time.Sleep(100 * time.Millisecond)
+}
+
+// Test_externalCommand_queueFullOverload exercises non-blocking enqueue when the jobs channel is full.
+func Test_externalCommand_queueFullOverload(t *testing.T) {
+	deviceResponse := responses.DeviceResponse{
+		BaseResponse: commonDTO.NewBaseResponse("", "", http.StatusOK),
+		Device: dtos.Device{
+			Name:        testDeviceName,
+			ProfileName: testProfileName,
+			ServiceName: testDeviceServiceName,
+		},
+	}
+	deviceServiceResponse := responses.DeviceServiceResponse{
+		BaseResponse: commonDTO.NewBaseResponse("", "", http.StatusOK),
+		Service: dtos.DeviceService{
+			Name: testDeviceServiceName,
+		},
+	}
+	expectedResponse := &types.MessageEnvelope{}
+
+	lc := &lcMocks.LoggingClient{}
+	lc.On("Error", mock.Anything).Return(nil)
+	lc.On("Errorf", mock.Anything, mock.Anything).Return(nil)
+	lc.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	lc.On("Warn", mock.Anything).Return(nil)
+	dc := &clientMocks.DeviceClient{}
+	dc.On("DeviceByName", context.Background(), testDeviceName).Return(deviceResponse, nil)
+	dsc := &clientMocks.DeviceServiceClient{}
+	dsc.On("DeviceServiceByName", context.Background(), testDeviceServiceName).Return(deviceServiceResponse, nil)
+
+	blockAll := make(chan struct{})
+	var requestEntered atomic.Int32
+	msgClient := &internalMessagingMocks.MessageClient{}
+	msgClient.On("Request", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			requestEntered.Add(1)
+			<-blockAll
+		}).Return(expectedResponse, nil)
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &config.ConfigurationStruct{
+				Service: bootstrapConfig.ServiceInfo{
+					Host: mockHost, Port: mockPort, MaxResultCount: 20,
+				},
+				MessageBus: bootstrapConfig.MessageBusInfo{BaseTopicPrefix: "edgex"},
+				ExternalMQTT: bootstrapConfig.ExternalMQTTInfo{
+					QoS: 0, Retain: true,
+					Topics: map[string]string{
+						common.CommandResponseTopicPrefixKey: testExternalCommandResponseTopicPrefix,
+					},
+				},
+				ExternalCommandQueue: config.ExternalCommandQueue{
+					MaxConcurrentExternalCommands:  1,
+					MaxQueuedExternalCommands:      1,
+					OverloadPublishChannelCapacity: 4,
+					ShutdownTimeout:                "30s",
+				},
+			}
+		},
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} { return lc },
+		bootstrapContainer.DeviceClientName:           func(get di.Get) interface{} { return dc },
+		bootstrapContainer.DeviceServiceClientName:    func(get di.Get) interface{} { return dsc },
+		bootstrapContainer.MessagingClientName:        func(get di.Get) interface{} { return msgClient },
+	})
+
+	payload := testCommandRequestPayload()
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	token := &mocks.Token{}
+	token.On("Wait").Return(true)
+	token.On("Error").Return(nil)
+	var publishCount atomic.Int32
+	mqttClient := &mocks.Client{}
+	mqttClient.On("Publish", mock.Anything, byte(0), true, mock.Anything).
+		Run(func(args mock.Arguments) { publishCount.Add(1) }).
+		Return(token)
+
+	proc := newExternalCommandProcessor(context.Background(), time.Second*10, dic,
+		externalCommandLimitsFromConfig(container.ConfigurationFrom(dic.Get).ExternalCommandQueue))
+	proc.setMQTTClient(mqttClient)
+	proc.ensureStarted()
+	handler := proc.commandRequestMQTTHandler()
+
+	send := func() {
+		message := &mocks.Message{}
+		message.On("Payload").Return(append([]byte(nil), payloadBytes...))
+		message.On("Topic").Return(testExternalCommandRequestTopicExample)
+		handler(mqttClient, message)
+	}
+
+	send()
+	require.Eventually(t, func() bool { return requestEntered.Load() >= 1 },
+		2*time.Second, 5*time.Millisecond, "first internal Request should start")
+	send()
+	time.Sleep(20 * time.Millisecond)
+	send()
+
+	msgClient.AssertNumberOfCalls(t, "Request", 1)
+	// Third message was load-shed; overload response is published via the dedicated publisher.
+	require.Eventually(t, func() bool { return publishCount.Load() >= 1 },
+		2*time.Second, 10*time.Millisecond, "overload response publish")
+
+	close(blockAll)
+	time.Sleep(50 * time.Millisecond)
 }

--- a/internal/core/command/main.go
+++ b/internal/core/command/main.go
@@ -102,7 +102,7 @@ func MessagingBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupT
 	}
 
 	if configuration.ExternalMQTT.Enabled {
-		if !handlers.NewExternalMQTT(messaging.OnConnectHandler(requestTimeout, dic)).BootstrapHandler(ctx, wg, startupTimer, dic) {
+		if !handlers.NewExternalMQTT(messaging.OnConnectHandler(ctx, requestTimeout, dic)).BootstrapHandler(ctx, wg, startupTimer, dic) {
 			return false
 		}
 	}


### PR DESCRIPTION
Added a new configuration section for managing external command queue parameters, including maximum concurrent commands, queued commands, overload publish channel capacity, and shutdown timeout. Updated related code to utilize these settings in the MQTT command processing workflow.

- Updated configuration structure to include ExternalCommandQueue.
- Modified OnConnectHandler to initialize the external command processor with new limits.
- Enhanced command request handling to support non-blocking enqueueing of external commands.

This change aims to improve the handling of external MQTT commands by allowing better concurrency management and reducing potential blocking issues.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested this new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)

## Testing Instructions
1. Configure small `ExternalCommandQueue` limits.
2. Send external MQTT command bursts above capacity.
3. Verify concurrency/queue stay within configured bounds.
4. Verify enqueue remains non-blocking when saturated.
5. Verify shutdown completes within configured timeout.

Closes #5394