### PR TITLE
feat(core-metadata): Retrieve device json using its UUID.

### DIFF
--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -366,6 +366,20 @@ func DeviceByName(name string, dic *di.Container) (device dtos.Device, err error
 	return device, nil
 }
 
+// DeviceById query the device by id
+func DeviceById(id string, dic *di.Container) (device dtos.Device, err errors.EdgeX) {
+	if id == "" {
+		return device, errors.NewCommonEdgeX(errors.KindContractInvalid, "id is empty", nil)
+	}
+	dbClient := container.DBClientFrom(dic.Get)
+	d, err := dbClient.DeviceById(id)
+	if err != nil {
+		return device, errors.NewCommonEdgeXWrapper(err)
+	}
+	device = dtos.FromDeviceModelToDTO(d)
+	return device, nil
+}
+
 // DevicesByProfileName query the devices with offset, limit, and profile name
 func DevicesByProfileName(offset int, limit int, profileName string, dic *di.Container) (devices []dtos.Device, totalCount int64, err errors.EdgeX) {
 	if profileName == "" {

--- a/internal/core/metadata/application/device_test.go
+++ b/internal/core/metadata/application/device_test.go
@@ -183,3 +183,46 @@ func TestForceAddDevice(t *testing.T) {
 		})
 	}
 }
+
+func TestDeviceById(t *testing.T) {
+	validId := "82eb2e26-0f24-48aa-ae4c-de9dac3fb9bc"
+	notFoundId := "00000000-0000-0000-0000-000000000000"
+	returnedDevice := models.Device{Id: validId, Name: "testDevice"}
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+	})
+
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("DeviceById", validId).Return(returnedDevice, nil)
+	dbClientMock.On("DeviceById", notFoundId).Return(models.Device{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "device doesn't exist in the database", nil))
+	dic.Update(di.ServiceConstructorMap{
+		container.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+
+	tests := []struct {
+		name          string
+		id            string
+		errorExpected bool
+	}{
+		{"Valid - find device by id", validId, false},
+		{"Invalid - empty id", "", true},
+		{"Invalid - device not found by id", notFoundId, true},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			device, err := DeviceById(testCase.id, dic)
+			if testCase.errorExpected {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, validId, device.Id)
+				assert.Equal(t, returnedDevice.Name, device.Name)
+			}
+		})
+	}
+}

--- a/internal/core/metadata/controller/http/device.go
+++ b/internal/core/metadata/controller/http/device.go
@@ -271,6 +271,25 @@ func (dc *DeviceController) DeviceByName(c echo.Context) error {
 	return pkg.EncodeAndWriteResponse(response, w, lc)
 }
 
+func (dc *DeviceController) DeviceById(c echo.Context) error {
+	lc := container.LoggingClientFrom(dc.dic.Get)
+	r := c.Request()
+	w := c.Response()
+	ctx := r.Context()
+
+	// URL parameters
+	id := c.Param(common.Id)
+
+	device, err := application.DeviceById(id, dc.dic)
+	if err != nil {
+		return utils.WriteErrorResponse(w, ctx, lc, err, "")
+	}
+
+	response := responseDTO.NewDeviceResponse("", "", http.StatusOK, device)
+	utils.WriteHttpHeader(w, ctx, http.StatusOK)
+	return pkg.EncodeAndWriteResponse(response, w, lc)
+}
+
 func (dc *DeviceController) DevicesByProfileName(c echo.Context) error {
 	lc := container.LoggingClientFrom(dc.dic.Get)
 	r := c.Request()

--- a/internal/core/metadata/controller/http/device_test.go
+++ b/internal/core/metadata/controller/http/device_test.go
@@ -910,6 +910,73 @@ func TestDeviceByName(t *testing.T) {
 	}
 }
 
+func TestDeviceById(t *testing.T) {
+	device := dtos.ToDeviceModel(buildTestDeviceRequest().Device)
+	emptyId := ""
+	notFoundId := "00000000-0000-0000-0000-000000000000"
+
+	dic := mockDic()
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("DeviceById", device.Id).Return(device, nil)
+	dbClientMock.On("DeviceById", notFoundId).Return(models.Device{}, edgexErr.NewCommonEdgeX(edgexErr.KindEntityDoesNotExist, "device doesn't exist in the database", nil))
+	dic.Update(di.ServiceConstructorMap{
+		container.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+
+	controller := NewDeviceController(dic)
+	assert.NotNil(t, controller)
+
+	tests := []struct {
+		name               string
+		deviceId           string
+		errorExpected      bool
+		expectedStatusCode int
+	}{
+		{"Valid - find device by id", device.Id, false, http.StatusOK},
+		{"Invalid - id parameter is empty", emptyId, true, http.StatusBadRequest},
+		{"Invalid - device not found by id", notFoundId, true, http.StatusNotFound},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			e := echo.New()
+			reqPath := fmt.Sprintf("%s/%s/%s", common.ApiDeviceRoute, common.Id, testCase.deviceId)
+			req, err := http.NewRequest(http.MethodGet, reqPath, http.NoBody)
+			require.NoError(t, err)
+
+			// Act
+			recorder := httptest.NewRecorder()
+			c := e.NewContext(req, recorder)
+			c.SetParamNames(common.Id)
+			c.SetParamValues(testCase.deviceId)
+
+			err = controller.DeviceById(c)
+			require.NoError(t, err)
+
+			// Assert
+			if testCase.errorExpected {
+				var res commonDTO.BaseResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, common.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
+				assert.NotEmpty(t, res.Message, "Response message doesn't contain the error message")
+			} else {
+				var res responseDTO.DeviceResponse
+				err = json.Unmarshal(recorder.Body.Bytes(), &res)
+				require.NoError(t, err)
+				assert.Equal(t, common.ApiVersion, res.ApiVersion, "API Version not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+				assert.Equal(t, testCase.expectedStatusCode, int(res.StatusCode), "Response status code not as expected")
+				assert.Equal(t, testCase.deviceId, res.Device.Id, "Id not as expected")
+				assert.Empty(t, res.Message, "Message should be empty when it is successful")
+			}
+		})
+	}
+}
+
 func TestDevicesByProfileName(t *testing.T) {
 	device := dtos.ToDeviceModel(buildTestDeviceRequest().Device)
 	testProfileA := "testProfileA"

--- a/internal/core/metadata/router.go
+++ b/internal/core/metadata/router.go
@@ -75,6 +75,7 @@ func LoadRestRoutes(r *echo.Echo, dic *di.Container, serviceName string) {
 	r.PATCH(common.ApiDeviceRoute, d.PatchDevice, authenticationHook)
 	r.GET(common.ApiAllDeviceRoute, d.AllDevices, authenticationHook)
 	r.GET(common.ApiDeviceByNameRoute, d.DeviceByName, authenticationHook)
+	r.GET(common.ApiDeviceRoute+"/"+common.Id+"/:"+common.Id, d.DeviceById, authenticationHook)
 	r.GET(common.ApiDeviceByProfileNameRoute, d.DevicesByProfileName, authenticationHook)
 
 	// ProvisionWatcher

--- a/openapi/core-metadata.yaml
+++ b/openapi/core-metadata.yaml
@@ -2114,6 +2114,89 @@ paths:
               examples:
                 500Example:
                   $ref: '#/components/examples/500Example'
+  '/device/id/{id}':
+    parameters:
+      - $ref: '#/components/parameters/correlatedRequestHeader'
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+        description: "The universally unique identifier (UUID) of the device you wish to retrieve."
+    get:
+      summary: "Returns a device by its UUID"
+      responses:
+        '200':
+          description: "OK"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceResponse'
+              example:
+                apiVersion: "v3"
+                requestId: "75ca2b65-f8ef-44f7-a995-a29c53ce111b"
+                statusCode: 200
+                device:
+                  id: "55b68fcf-0fd2-445a-9fae-670b37fb9274"
+                  name: "Random-Boolean-Device"
+                  description: "Example of Device Virtual"
+                  created: 1600926440123
+                  modified: 1600928666321
+                  adminState: "UNLOCKED"
+                  operatingState: "UP"
+                  labels:
+                    - device-virtual-example
+                  location: ""
+                  serviceName: "device-virtual"
+                  profileName: "Random-Boolean-Device"
+                  autoEvents:
+                    - interval: "10s"
+                      onChange: false
+                      sourceName: "Bool"
+                  protocols:
+                    other:
+                      Address: "device-virtual-bool-01"
+                      Port: "300"
+        '400':
+          description: "Request is in an invalid state"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                400Example:
+                  $ref: '#/components/examples/400Example'
+        '404':
+          description: "The requested resource does not exist"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                404Example:
+                  $ref: '#/components/examples/404Example'
+        '500':
+          description: "Internal Server Error"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                500Example:
+                  $ref: '#/components/examples/500Example'
   '/device/profile/name/{name}':
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'


### PR DESCRIPTION
Core-metadata currently exposes [GET /api/v3/device/name/:name] to retrieve a single device by name, but there is no equivalent endpoint to retrieve a device by its UUID/ID. The database layer already supports [DeviceById] lookups (used internally by the [PATCH /api/v3/device] handler via [PatchDevice], but this capability is not exposed as a public REST endpoint. This creates a gap for consumers that only have a device's ID (e.g., from event data, system events, or cross-service references) and need to resolve the full device object. Currently the only workaround is to fetch all devices and filter client-side, or maintain a separate name↔ID mapping. Solution I'd like Add a new REST endpoint:
GET /api/v3/device/id/:id
The response format reuses the existing DeviceResponse DTO (same as [DeviceByName], maintaining API consistency. No new dependencies are introduced — [DeviceById] already exists in the DB client interface.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->