### PR TITLE
feat(core-metadata): filter out invalid auto events for PatchDevice

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -245,7 +245,7 @@ https://github.com/nats-io/nkeys/blob/master/LICENSE
 github.com/nats-io/nuid (Apache-2.0) https://github.com/nats-io/nuid
 https://github.com/nats-io/nuid/blob/master/LICENSE
 
-github.com/oklog/ulid (Apache 2.0) - https://github.com/oklog/ulid
+github.com/oklog/ulid/v2 (Apache 2.0) - https://github.com/oklog/ulid/v2
 https://github.com/oklog/ulid/blob/main/LICENSE
 
 github.com/opentracing/opentracing-go (Apache 2.0) - https://github.com/opentracing/opentracing-go

--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -1,5 +1,5 @@
 /********************************************************************************
- *  Copyright (C) 2020-2025 IOTech Ltd
+ *  Copyright (C) 2020-2026 IOTech Ltd
  *  Copyright 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -243,24 +243,28 @@ func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container, 
 		oldServiceName = device.ServiceName
 	}
 
+	oldProfileName := device.ProfileName
+	newProfileName := *dto.ProfileName
 	if container.ConfigurationFrom(dic.Get).Writable.MaxResources > 0 {
-		if err = checkResourceCapacityByExistingAndNewProfile(device.ProfileName, *dto.ProfileName, dic); err != nil {
+		if err = checkResourceCapacityByExistingAndNewProfile(oldProfileName, newProfileName, dic); err != nil {
 			return errors.NewCommonEdgeXWrapper(err)
 		}
 	}
 
 	requests.ReplaceDeviceModelFieldsWithDTO(&device, dto)
-
-	err = validateParentProfileAndAutoEvent(dic, device)
+	if dto.ProfileName != nil && oldProfileName != newProfileName {
+		device, err = validateParentProfileAndAutoEventDropInvalid(dic, device)
+	} else {
+		err = validateParentProfileAndAutoEvent(dic, device)
+	}
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
 	}
 
-	deviceDTO := dtos.FromDeviceModelToDTO(device)
-
 	// Execute the Device Service Validation when bypassValidation is false by default
 	// Skip the Device Service Validation if bypassValidation is true
 	if !bypassValidation {
+		deviceDTO := dtos.FromDeviceModelToDTO(device)
 		err = validateDeviceCallback(deviceDTO, dic)
 		if err != nil {
 			return errors.NewCommonEdgeXWrapper(err)
@@ -400,38 +404,86 @@ func validateParentProfileAndAutoEvent(dic *di.Container, d models.Device) error
 		// if the profile is not set, skip the validation until we have the profile
 		return nil
 	}
-	if (d.Name == d.Parent) && (d.Name != "") {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, "a device cannot be its own parent", nil)
-	}
-	dbClient := container.DBClientFrom(dic.Get)
-	dp, err := dbClient.DeviceProfileByName(d.ProfileName)
+	dp, err := validateParentAndLoadProfile(dic, d)
 	if err != nil {
-		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("device profile '%s' not found during validating device '%s'", d.ProfileName, d.Name), err)
+		return err
 	}
 	if len(d.AutoEvents) == 0 {
 		return nil
 	}
 	for _, a := range d.AutoEvents {
-		_, err := time.ParseDuration(a.Interval)
-		if err != nil {
-			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("auto event interval '%s' not valid in the device '%s'", a.Interval, d.Name), err)
+		if err := validateAutoEvent(a, d, dp); err != nil {
+			return err
 		}
+	}
+	return nil
+}
 
-		regex, regErr := regexp.CompilePOSIX(a.SourceName)
-		if regErr != nil {
-			return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to CompilePOSIX the auto event source name: "+a.SourceName, regErr)
-		}
-		hasResource := slices.ContainsFunc(dp.DeviceResources, func(r models.DeviceResource) bool {
-			matchedString := regex.FindString(r.Name)
-			return (r.Name == regex.String()) || (r.Name == matchedString)
-		})
+func validateParentProfileAndAutoEventDropInvalid(dic *di.Container, d models.Device) (models.Device, errors.EdgeX) {
+	if d.ProfileName == "" {
+		// if the profile is not set, skip the validation until we have the profile
+		return d, nil
+	}
+	dp, err := validateParentAndLoadProfile(dic, d)
+	if err != nil {
+		return d, err
+	}
+	if len(d.AutoEvents) == 0 {
+		return d, nil
+	}
 
-		hasCommand := slices.ContainsFunc(dp.DeviceCommands, func(c models.DeviceCommand) bool {
-			return c.Name == a.SourceName
-		})
-		if !hasResource && !hasCommand {
-			return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("auto event source '%s' cannot be found in the device profile '%s'", a.SourceName, dp.Name), nil)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	validAutoEvents := make([]models.AutoEvent, 0, len(d.AutoEvents))
+	for _, a := range d.AutoEvents {
+		if err := validateAutoEvent(a, d, dp); err != nil {
+			lc.Warnf("Remove auto event: %v, since it's not in Device Profile", err)
+			continue
 		}
+		validAutoEvents = append(validAutoEvents, a)
+	}
+	d.AutoEvents = validAutoEvents
+
+	return d, nil
+}
+
+func validateParentAndLoadProfile(dic *di.Container, d models.Device) (dp models.DeviceProfile, err errors.EdgeX) {
+	if d.Name != "" && d.Name == d.Parent {
+		return dp, errors.NewCommonEdgeX(errors.KindContractInvalid, "a device cannot be its own parent", nil)
+	}
+
+	dbClient := container.DBClientFrom(dic.Get)
+	dp, err = dbClient.DeviceProfileByName(d.ProfileName)
+	if err != nil {
+		return dp, errors.NewCommonEdgeX(
+			errors.KindContractInvalid,
+			fmt.Sprintf("device profile '%s' not found during validating device '%s'", d.ProfileName, d.Name),
+			err,
+		)
+	}
+
+	return dp, nil
+}
+
+func validateAutoEvent(a models.AutoEvent, d models.Device, dp models.DeviceProfile) errors.EdgeX {
+	_, err := time.ParseDuration(a.Interval)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("auto event interval '%s' not valid in the device '%s'", a.Interval, d.Name), err)
+	}
+
+	regex, regErr := regexp.CompilePOSIX(a.SourceName)
+	if regErr != nil {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to CompilePOSIX the auto event source name: "+a.SourceName, regErr)
+	}
+	hasResource := slices.ContainsFunc(dp.DeviceResources, func(r models.DeviceResource) bool {
+		matchedString := regex.FindString(r.Name)
+		return (r.Name == regex.String()) || (r.Name == matchedString)
+	})
+
+	hasCommand := slices.ContainsFunc(dp.DeviceCommands, func(c models.DeviceCommand) bool {
+		return c.Name == a.SourceName
+	})
+	if !hasResource && !hasCommand {
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("auto event source '%s' cannot be found in the device profile '%s'", a.SourceName, dp.Name), nil)
 	}
 	return nil
 }

--- a/internal/core/metadata/application/device_test.go
+++ b/internal/core/metadata/application/device_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,17 +24,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateParentProfileAndAutoEvents(t *testing.T) {
-	profile := "test-profile"
-	notFountProfileName := "notFoundProfile"
-	source1 := "source1"
-	command1 := "command1"
-	deviceProfile := models.DeviceProfile{
+var (
+	profile             = "test-profile"
+	notFountProfileName = "notFoundProfile"
+	source1             = "source1"
+	source2             = "resource2"
+	command1            = "command1"
+	command2            = "command2"
+	deviceProfile       = models.DeviceProfile{
 		Name:            profile,
-		DeviceResources: []models.DeviceResource{{Name: source1}, {Name: "resource2"}},
-		DeviceCommands:  []models.DeviceCommand{{Name: command1}, {Name: "command2"}},
+		DeviceResources: []models.DeviceResource{{Name: source1}, {Name: source2}},
+		DeviceCommands:  []models.DeviceCommand{{Name: command1}, {Name: command2}},
 	}
+)
 
+func TestValidateParentProfileAndAutoEvents(t *testing.T) {
 	dic := di.NewContainer(di.ServiceConstructorMap{})
 	dbClientMock := &mocks.DBClient{}
 	dbClientMock.On("DeviceProfileByName", profile).Return(deviceProfile, nil)
@@ -123,6 +127,99 @@ func TestValidateParentProfileAndAutoEvents(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateParentProfileAndAutoEventsDropInvalid(t *testing.T) {
+	dic := di.NewContainer(di.ServiceConstructorMap{})
+	dbClientMock := &mocks.DBClient{}
+	dbClientMock.On("DeviceProfileByName", profile).Return(deviceProfile, nil)
+	dbClientMock.On("DeviceProfileByName", notFountProfileName).Return(models.DeviceProfile{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, "not found", nil))
+	dic.Update(di.ServiceConstructorMap{
+		container.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+	})
+
+	tests := []struct {
+		name               string
+		device             models.Device
+		expectedAutoEvents int
+		errorExpected      bool
+	}{
+		{"empty profile",
+			models.Device{},
+			0,
+			false,
+		},
+		{"not found profile",
+			models.Device{
+				ProfileName: notFountProfileName,
+			},
+			0,
+			true,
+		},
+		{"no auto events",
+			models.Device{
+				ProfileName: profile,
+			},
+			0,
+			false,
+		},
+		{"is own parent",
+			models.Device{
+				ProfileName: profile,
+				Parent:      "me",
+				Name:        "me",
+				AutoEvents:  []models.AutoEvent{{SourceName: source1, Interval: "1s"}},
+			},
+			0,
+			true,
+		},
+		{"all valid",
+			models.Device{
+				ProfileName: profile,
+				AutoEvents:  []models.AutoEvent{{SourceName: source1, Interval: "1s"}},
+			},
+			1,
+			false,
+		},
+		{"one invalid",
+			models.Device{
+				ProfileName: profile,
+				AutoEvents: []models.AutoEvent{
+					{SourceName: source1, Interval: "1s"},
+					{SourceName: "invalid", Interval: "1s"},
+				},
+			},
+			1,
+			false,
+		},
+		{"all invalid",
+			models.Device{
+				ProfileName: profile,
+				AutoEvents: []models.AutoEvent{
+					{SourceName: "invalid1", Interval: "1s"},
+					{SourceName: "invalid2", Interval: "1s"},
+				},
+			},
+			0,
+			false,
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			d, err := validateParentProfileAndAutoEventDropInvalid(dic, testCase.device)
+			if testCase.errorExpected {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, testCase.expectedAutoEvents, len(d.AutoEvents))
 			}
 		})
 	}

--- a/internal/core/metadata/controller/http/device.go
+++ b/internal/core/metadata/controller/http/device.go
@@ -188,6 +188,7 @@ func (dc *DeviceController) PatchDevice(c echo.Context) error {
 	// parse URL query string for bypassValidation
 	bypassValidationParamStr := utils.ParseQueryStringToString(r, bypassValidationQueryParam, common.ValueFalse)
 	if bypassValidationParamStr == common.ValueTrue {
+		lc.Debugf("%s is true. %s=%s", bypassValidationQueryParam, common.CorrelationHeader, correlationId)
 		bypassValidation = true
 	}
 


### PR DESCRIPTION
After profile scanning, the changes in the underlying device may make some auto events invalid. This change removes those invalid auto events during validation. Also, this ensures the device profile stays consistent with the underlying device.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->