### PR TITLE
fix(core-metadata): avoid panic when patch device with nil profileName

### DIFF
--- a/internal/core/metadata/application/device.go
+++ b/internal/core/metadata/application/device.go
@@ -244,7 +244,10 @@ func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container, 
 	}
 
 	oldProfileName := device.ProfileName
-	newProfileName := *dto.ProfileName
+	newProfileName := oldProfileName
+	if dto.ProfileName != nil {
+		newProfileName = *dto.ProfileName
+	}
 	if container.ConfigurationFrom(dic.Get).Writable.MaxResources > 0 {
 		if err = checkResourceCapacityByExistingAndNewProfile(oldProfileName, newProfileName, dic); err != nil {
 			return errors.NewCommonEdgeXWrapper(err)
@@ -252,7 +255,7 @@ func PatchDevice(dto dtos.UpdateDevice, ctx context.Context, dic *di.Container, 
 	}
 
 	requests.ReplaceDeviceModelFieldsWithDTO(&device, dto)
-	if dto.ProfileName != nil && oldProfileName != newProfileName {
+	if oldProfileName != newProfileName {
 		device, err = validateParentProfileAndAutoEventDropInvalid(dic, device)
 	} else {
 		err = validateParentProfileAndAutoEvent(dic, device)


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->