### PR TITLE
fix(core-command): prevent HOL blocking on external MQTT command callback

### DIFF
--- a/cmd/core-command/res/configuration.yaml
+++ b/cmd/core-command/res/configuration.yaml
@@ -39,6 +39,9 @@ ExternalMQTT:
     CommandQueryRequestTopic: edgex/commandquery/request/#   # for subscribing to 3rd party command query request
     CommandQueryResponseTopic: edgex/commandquery/response   # for publishing responses back to 3rd party systems
 
+ExternalCommand:
+  MaxConcurrentRequests: 32   # cap on in-flight external MQTT commands; <=0 uses built-in default (32)
+
 MessageBus:
   Optional:
     ClientId: core-command

--- a/internal/core/command/config/config.go
+++ b/internal/core/command/config/config.go
@@ -22,13 +22,21 @@ import (
 
 // ConfigurationStruct contains the configuration properties for the core-command service.
 type ConfigurationStruct struct {
-	Writable     WritableInfo
-	Clients      bootstrapConfig.ClientsCollection
-	Databases    map[string]bootstrapConfig.Database
-	Registry     bootstrapConfig.RegistryInfo
-	Service      bootstrapConfig.ServiceInfo
-	MessageBus   bootstrapConfig.MessageBusInfo
-	ExternalMQTT bootstrapConfig.ExternalMQTTInfo
+	Writable        WritableInfo
+	Clients         bootstrapConfig.ClientsCollection
+	Databases       map[string]bootstrapConfig.Database
+	Registry        bootstrapConfig.RegistryInfo
+	Service         bootstrapConfig.ServiceInfo
+	MessageBus      bootstrapConfig.MessageBusInfo
+	ExternalMQTT    bootstrapConfig.ExternalMQTTInfo
+	ExternalCommand ExternalCommandInfo
+}
+
+// ExternalCommandInfo configures handling of inbound external (MQTT) command requests.
+type ExternalCommandInfo struct {
+	// MaxConcurrentRequests caps in-flight external MQTT command requests so a slow/offline
+	// device cannot starve the Paho callback. Values <= 0 fall back to the built-in default.
+	MaxConcurrentRequests int
 }
 
 // WritableInfo contains configuration properties that can be updated and applied without restarting the service.

--- a/internal/core/command/controller/messaging/external.go
+++ b/internal/core/command/controller/messaging/external.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022-2025 IOTech Ltd
+// Copyright (C) 2022-2026 IOTech Ltd
 // Copyright (C) 2023 Intel Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -24,7 +24,22 @@ import (
 	"github.com/edgexfoundry/edgex-go/internal/core/command/container"
 )
 
+// defaultMaxConcurrentExternalCommands caps in-flight external MQTT command requests so a single
+// slow/offline device cannot block the Paho callback goroutine and starve subsequent commands.
+// At capacity, new requests are rejected inline with a "service busy" response envelope —
+// queuing further would just delay the same failure.
+const defaultMaxConcurrentExternalCommands = 32
+
 func OnConnectHandler(requestTimeout time.Duration, dic *di.Container) mqtt.OnConnectHandler {
+	// Resolved once at service start; captured by the subscribe closure so it survives MQTT
+	// reconnects. Hot-reload is intentionally not supported — resizing the channel mid-flight
+	// would orphan in-flight work.
+	maxInFlight := container.ConfigurationFrom(dic.Get).ExternalCommand.MaxConcurrentRequests
+	if maxInFlight <= 0 {
+		maxInFlight = defaultMaxConcurrentExternalCommands
+	}
+	sem := make(chan struct{}, maxInFlight)
+
 	return func(client mqtt.Client) {
 		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 		config := container.ConfigurationFrom(dic.Get)
@@ -39,7 +54,7 @@ func OnConnectHandler(requestTimeout time.Duration, dic *di.Container) mqtt.OnCo
 		}
 
 		requestCommandTopic := externalTopics[common.CommandRequestTopicKey]
-		if token := client.Subscribe(requestCommandTopic, qos, commandRequestHandler(requestTimeout, dic)); token.Wait() && token.Error() != nil {
+		if token := client.Subscribe(requestCommandTopic, qos, commandRequestHandler(requestTimeout, sem, dic)); token.Wait() && token.Error() != nil {
 			lc.Errorf("could not subscribe to topic '%s': %s", requestCommandTopic, token.Error().Error())
 		} else {
 			lc.Debugf("Subscribed to topic '%s' on external MQTT broker", requestCommandTopic)
@@ -92,7 +107,7 @@ func commandQueryHandler(dic *di.Container) mqtt.MessageHandler {
 	}
 }
 
-func commandRequestHandler(requestTimeout time.Duration, dic *di.Container) mqtt.MessageHandler {
+func commandRequestHandler(requestTimeout time.Duration, sem chan struct{}, dic *di.Container) mqtt.MessageHandler {
 	return func(client mqtt.Client, message mqtt.Message) {
 		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 		config := container.ConfigurationFrom(dic.Get)
@@ -164,21 +179,38 @@ func commandRequestHandler(requestTimeout time.Duration, dic *di.Container) mqtt
 		lc.Debugf("Sending Command request to internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", deviceRequestTopic, requestEnvelope.RequestID, requestEnvelope.CorrelationID)
 		lc.Debugf("Expecting response on topic: %s/%s", deviceResponseTopicPrefix, requestEnvelope.RequestID)
 
-		internalMessageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
-
-		// Request waits for the response and returns it.
-		response, err := internalMessageBus.Request(requestEnvelope, deviceRequestTopic, deviceResponseTopicPrefix, requestTimeout)
-		if err != nil {
-			errorMessage := fmt.Sprintf("Failed to send DeviceCommand request with internal MessageBus: %v", err)
-			responseEnvelope := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage)
-			publishMessage(client, externalResponseTopic, qos, retain, responseEnvelope, lc)
+		// Non-blocking acquire — never block the Paho callback goroutine. At capacity we reject
+		// inline rather than queue, so a stuck device cannot cause head-of-line blocking on
+		// subsequent external command requests.
+		select {
+		case sem <- struct{}{}:
+		default:
+			lc.Warnf("external command in-flight limit (%d) reached; rejecting request for device '%s'", cap(sem), deviceName)
+			busy := types.NewMessageEnvelopeWithError(requestEnvelope.RequestID,
+				"core-command busy: too many concurrent external commands")
+			publishMessage(client, externalResponseTopic, qos, retain, busy, lc)
 			return
 		}
 
-		lc.Debugf("Command response received from internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", response.ReceivedTopic, response.RequestID, response.CorrelationID)
+		internalMessageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
 
-		response.ReceivedTopic = externalResponseTopic
-		publishMessage(client, externalResponseTopic, qos, retain, *response, lc)
+		go func() {
+			defer func() { <-sem }()
+
+			response, err := internalMessageBus.Request(requestEnvelope, deviceRequestTopic, deviceResponseTopicPrefix, requestTimeout)
+			if err != nil {
+				errorMessage := fmt.Sprintf("Failed to send DeviceCommand request with internal MessageBus: %v", err)
+				publishMessage(client, externalResponseTopic, qos, retain,
+					types.NewMessageEnvelopeWithError(requestEnvelope.RequestID, errorMessage), lc)
+				return
+			}
+
+			lc.Debugf("Command response received from internal MessageBus. Topic: %s, Request-id: %s Correlation-id: %s", response.ReceivedTopic, response.RequestID, response.CorrelationID)
+			// Copy before mutating: concurrent goroutines must not share the same *MessageEnvelope.
+			out := *response
+			out.ReceivedTopic = externalResponseTopic
+			publishMessage(client, externalResponseTopic, qos, retain, out, lc)
+		}()
 	}
 }
 

--- a/internal/core/command/controller/messaging/external_test.go
+++ b/internal/core/command/controller/messaging/external_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022-2025 IOTech Ltd
+// Copyright (C) 2022-2026 IOTech Ltd
 // Copyright (C) 2023 Intel Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -355,7 +356,8 @@ func Test_commandRequestHandler(t *testing.T) {
 			mqttClient := &mocks.Client{}
 			mqttClient.On("Publish", mock.Anything, byte(0), true, mock.Anything).Return(token)
 
-			fn := commandRequestHandler(time.Second*10, dic)
+			sem := make(chan struct{}, defaultMaxConcurrentExternalCommands)
+			fn := commandRequestHandler(time.Second*10, sem, dic)
 			fn(mqttClient, message)
 			if tt.expectedError {
 				if tt.expectedPublishError {
@@ -369,7 +371,10 @@ func Test_commandRequestHandler(t *testing.T) {
 
 			expectedInternalRequestTopic := common.BuildTopic(baseTopic, common.CoreCommandDeviceRequestPublishTopic, testDeviceServiceName, testDeviceName, testCommandName, testMethod)
 			expectedInternalResponseTopicPrefix := common.BuildTopic(baseTopic, common.ResponseTopic, testDeviceServiceName)
-			client.AssertCalled(t, "Request", tt.payload, expectedInternalRequestTopic, expectedInternalResponseTopicPrefix, mock.Anything)
+			// Request now runs in a goroutine — wait for it.
+			require.Eventually(t, func() bool {
+				return client.AssertCalled(new(testing.T), "Request", tt.payload, expectedInternalRequestTopic, expectedInternalResponseTopicPrefix, mock.Anything)
+			}, time.Second, 10*time.Millisecond)
 		})
 	}
 }
@@ -387,4 +392,171 @@ func testCommandRequestPayload() types.MessageEnvelope {
 	})
 
 	return payload
+}
+
+// newCommandRequestDIC builds a DIC and MessageClient that runs runRequest before responding to
+// Request. Shared helper for the concurrency tests below.
+func newCommandRequestDIC(t *testing.T, runRequest func(args mock.Arguments)) (*di.Container, *internalMessagingMocks.MessageClient) {
+	t.Helper()
+
+	deviceResponse := responses.DeviceResponse{
+		BaseResponse: commonDTO.NewBaseResponse("", "", http.StatusOK),
+		Device: dtos.Device{
+			Name:        testDeviceName,
+			ProfileName: testProfileName,
+			ServiceName: testDeviceServiceName,
+		},
+	}
+	deviceServiceResponse := responses.DeviceServiceResponse{
+		BaseResponse: commonDTO.NewBaseResponse("", "", http.StatusOK),
+		Service:      dtos.DeviceService{Name: testDeviceServiceName},
+	}
+
+	lc := &lcMocks.LoggingClient{}
+	lc.On("Error", mock.Anything).Return(nil)
+	lc.On("Errorf", mock.Anything, mock.Anything).Return(nil)
+	lc.On("Debugf", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	lc.On("Warn", mock.Anything).Return(nil)
+	lc.On("Warnf", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	dc := &clientMocks.DeviceClient{}
+	dc.On("DeviceByName", context.Background(), testDeviceName).Return(deviceResponse, nil)
+	dsc := &clientMocks.DeviceServiceClient{}
+	dsc.On("DeviceServiceByName", context.Background(), testDeviceServiceName).Return(deviceServiceResponse, nil)
+
+	msgClient := &internalMessagingMocks.MessageClient{}
+	call := msgClient.On("Request", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	if runRequest != nil {
+		call = call.Run(runRequest)
+	}
+	call.Return(&types.MessageEnvelope{}, nil)
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &config.ConfigurationStruct{
+				Service:    bootstrapConfig.ServiceInfo{Host: mockHost, Port: mockPort, MaxResultCount: 20},
+				MessageBus: bootstrapConfig.MessageBusInfo{BaseTopicPrefix: "edgex"},
+				ExternalMQTT: bootstrapConfig.ExternalMQTTInfo{
+					QoS: 0, Retain: true,
+					Topics: map[string]string{
+						common.CommandResponseTopicPrefixKey: testExternalCommandResponseTopicPrefix,
+					},
+				},
+			}
+		},
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} { return lc },
+		bootstrapContainer.DeviceClientName:           func(get di.Get) interface{} { return dc },
+		bootstrapContainer.DeviceServiceClientName:    func(get di.Get) interface{} { return dsc },
+		bootstrapContainer.MessagingClientName:        func(get di.Get) interface{} { return msgClient },
+	})
+
+	return dic, msgClient
+}
+
+// Test_commandRequestHandler_secondRunsWhileFirstBlocked proves the fix: a second external command
+// can complete the internal Request while the first is still blocked, i.e. no head-of-line blocking
+// on the Paho callback goroutine.
+func Test_commandRequestHandler_secondRunsWhileFirstBlocked(t *testing.T) {
+	unblockFirst := make(chan struct{})
+	var phase atomic.Int32
+
+	dic, msgClient := newCommandRequestDIC(t, func(_ mock.Arguments) {
+		if phase.Add(1) == 1 {
+			<-unblockFirst
+		}
+	})
+
+	payloadBytes, err := json.Marshal(testCommandRequestPayload())
+	require.NoError(t, err)
+
+	token := &mocks.Token{}
+	token.On("Wait").Return(true)
+	token.On("Error").Return(nil)
+	mqttClient := &mocks.Client{}
+	mqttClient.On("Publish", mock.Anything, byte(0), true, mock.Anything).Return(token)
+
+	sem := make(chan struct{}, 4)
+	handler := commandRequestHandler(10*time.Second, sem, dic)
+
+	msg := func() *mocks.Message {
+		m := &mocks.Message{}
+		m.On("Payload").Return(payloadBytes)
+		m.On("Topic").Return(testExternalCommandRequestTopicExample)
+		return m
+	}
+
+	handler(mqttClient, msg())
+	require.Eventually(t, func() bool { return phase.Load() >= 1 }, 2*time.Second, 5*time.Millisecond,
+		"first Request should have started")
+
+	done := make(chan struct{})
+	go func() {
+		handler(mqttClient, msg())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		close(unblockFirst)
+		t.Fatal("second MQTT handler invocation blocked while first Request was in flight — HOL regression")
+	}
+
+	require.Eventually(t, func() bool { return phase.Load() >= 2 }, 2*time.Second, 5*time.Millisecond,
+		"second Request should run while first is blocked")
+	close(unblockFirst)
+
+	// Drain so workers can release the semaphore before the test ends.
+	require.Eventually(t, func() bool { return len(sem) == 0 }, 2*time.Second, 5*time.Millisecond)
+	_ = msgClient
+}
+
+// Test_commandRequestHandler_busyOnOverload proves the backpressure path: when the in-flight
+// budget is exhausted, further requests are rejected inline with an error envelope and the
+// internal Request is NOT invoked again.
+func Test_commandRequestHandler_busyOnOverload(t *testing.T) {
+	blockAll := make(chan struct{})
+	var entered atomic.Int32
+
+	dic, msgClient := newCommandRequestDIC(t, func(_ mock.Arguments) {
+		entered.Add(1)
+		<-blockAll
+	})
+
+	payloadBytes, err := json.Marshal(testCommandRequestPayload())
+	require.NoError(t, err)
+
+	token := &mocks.Token{}
+	token.On("Wait").Return(true)
+	token.On("Error").Return(nil)
+	var publishCount atomic.Int32
+	mqttClient := &mocks.Client{}
+	mqttClient.On("Publish", mock.Anything, byte(0), true, mock.Anything).
+		Run(func(_ mock.Arguments) { publishCount.Add(1) }).
+		Return(token)
+
+	sem := make(chan struct{}, 1) // capacity-1 so the second request must overload
+	handler := commandRequestHandler(10*time.Second, sem, dic)
+
+	msg := func() *mocks.Message {
+		m := &mocks.Message{}
+		m.On("Payload").Return(payloadBytes)
+		m.On("Topic").Return(testExternalCommandRequestTopicExample)
+		return m
+	}
+
+	handler(mqttClient, msg())
+	require.Eventually(t, func() bool { return entered.Load() == 1 }, 2*time.Second, 5*time.Millisecond,
+		"first internal Request should have started")
+
+	handler(mqttClient, msg()) // second — should be rejected inline
+
+	// Internal Request must still have been called only once; the second was load-shed.
+	msgClient.AssertNumberOfCalls(t, "Request", 1)
+	// The rejection publishes a busy envelope on the response topic.
+	require.Eventually(t, func() bool { return publishCount.Load() >= 1 }, 2*time.Second, 5*time.Millisecond,
+		"busy response should be published for the rejected request")
+
+	close(blockAll)
+	require.Eventually(t, func() bool { return len(sem) == 0 }, 2*time.Second, 5*time.Millisecond)
 }


### PR DESCRIPTION
A slow or offline device caused internalMessageBus.Request to block the Paho callback goroutine for the full requestTimeout, which serialized all subsequent external command requests behind it and produced cascading timeouts.

Move the Request + response publish into a goroutine guarded by a bounded semaphore. At capacity, new requests are rejected inline with a "service busy" envelope on the response topic rather than queued — queuing would only defer the same failure and risks unbounded growth.

Also defensively copy the response envelope before mutating ReceivedTopic, since concurrent goroutines must not share the same *MessageEnvelope instance (caught by -race).

The concurrency limit is configurable via the new optional ExternalCommand.MaxConcurrentRequests setting; values <= 0 fall back to the built-in default of 32. Existing deployments need no YAML change.

fixes #5394

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Follow the Minimal Reproduction Steps as described in https://github.com/edgexfoundry/edgex-go/issues/5394 for verification

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->