### PR TITLE
fix(all): classify JSON decode failures as invalid contracts

### DIFF
--- a/internal/core/metadata/controller/http/devicecommand_test.go
+++ b/internal/core/metadata/controller/http/devicecommand_test.go
@@ -276,6 +276,29 @@ func TestPatchDeviceProfileDeviceCommand(t *testing.T) {
 	}
 }
 
+func TestPatchDeviceProfileDeviceCommand_BadBodyReturnsBadRequest(t *testing.T) {
+	dic := mockDic()
+	controller := NewDeviceCommandController(dic)
+	assert.NotNil(t, controller)
+
+	e := echo.New()
+	req, err := http.NewRequest(http.MethodPatch, common.ApiDeviceProfileDeviceCommandRoute, strings.NewReader("false"))
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	c := e.NewContext(req, recorder)
+	err = controller.PatchDeviceProfileDeviceCommand(c)
+	require.NoError(t, err)
+
+	var res commonDTO.BaseResponse
+	err = json.Unmarshal(recorder.Body.Bytes(), &res)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Result().StatusCode, "HTTP status code not as expected")
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode, "BaseResponse status code not as expected")
+	assert.Contains(t, res.Message, "json: cannot unmarshal bool")
+}
+
 func TestDeleteDeviceCommandByName(t *testing.T) {
 	dpModel := dtos.ToDeviceProfileModel(buildTestDeviceProfileRequest().Profile)
 	notFoundName := "notFoundName"

--- a/internal/io/reader.go
+++ b/internal/io/reader.go
@@ -42,7 +42,7 @@ func NewJsonDtoReader() DtoReader {
 func (jsonDtoReader) Read(reader io.Reader, v interface{}) errors.EdgeX {
 	err := json.NewDecoder(reader).Decode(v)
 	if err != nil {
-		return errors.NewCommonEdgeXWrapper(err)
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "", err)
 	}
 
 	return nil

--- a/internal/io/reader_test.go
+++ b/internal/io/reader_test.go
@@ -3,11 +3,13 @@ package io
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
 	dto "github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/requests"
+	edgexErrors "github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
@@ -70,6 +72,18 @@ func TestJsonReader_Read(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJsonReader_ReadInvalidBodyReturnsContractInvalid(t *testing.T) {
+	var reqDTOs []dto.AddEventRequest
+	reader := NewDtoReader(common.ContentTypeJSON)
+
+	err := reader.Read(bytes.NewReader([]byte("false")), &reqDTOs)
+
+	require.Error(t, err)
+	assert.Equal(t, edgexErrors.KindContractInvalid, edgexErrors.Kind(err))
+	assert.Equal(t, http.StatusBadRequest, err.Code())
+	assert.Contains(t, err.Message(), "json: cannot unmarshal bool")
 }
 
 func TestCborReader_Read(t *testing.T) {


### PR DESCRIPTION
## Summary
- classify JSON DTO decode failures as invalid request contracts
- keep the original JSON decoder error message in the response body
- add reader-level and metadata controller coverage for invalid JSON body shapes

## Why
Malformed JSON request bodies are client input errors. Previously the JSON reader wrapped decoder errors without an EdgeX kind, causing them to map to HTTP 500.

Fixes #4661.
Fixes #4663.

## Testing
- `go test ./internal/io -count=1`
- `go test ./internal/core/metadata/controller/http -run 'TestPatchDeviceProfileDeviceCommand' -count=1`
- `go test ./internal/io ./internal/core/metadata/controller/http ./internal/core/data/controller/http ./internal/core/command/controller/http ./internal/support/scheduler/controller/http -count=1`