### PR TITLE
test: align min interval error expectation with parser

### DIFF
--- a/internal/pkg/utils/time_test.go
+++ b/internal/pkg/utils/time_test.go
@@ -6,11 +6,11 @@
 package utils
 
 import (
-	"errors"
 	"testing"
 	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger/mocks"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckMinInterval(t *testing.T) {
@@ -22,7 +22,8 @@ func TestCheckMinInterval(t *testing.T) {
 
 	warnMsg := "the interval value '%s' is smaller than the suggested value '%s', which might cause abnormal CPU increase"
 	errMsg := "failed to parse the interval duration string %s to a duration time value: %v"
-	expectedErr := errors.New("time: invalid duration \"" + invalidInterval + "\"")
+	_, expectedErr := time.ParseDuration(invalidInterval)
+	require.Error(t, expectedErr)
 
 	lcMock := &mocks.LoggingClient{}
 	lcMock.On("Warnf", warnMsg, validInterval, minInterval1)


### PR DESCRIPTION
## Summary
- remove the manually constructed parse-duration error from `TestCheckMinInterval`
- derive the expected error from `time.ParseDuration`, matching the production path

## Why
The test expected a generic `errors.errorString`, while `CheckMinInterval` logs the concrete error returned by `time.ParseDuration`. On current Go this is a `*time.parseDurationError`, so the mock assertion fails even though the production behavior is correct.

## Testing
- `go test ./internal/pkg/utils -run TestCheckMinInterval -count=1`
- `go test ./internal/pkg/utils -count=1`