### PR TITLE
fix(security): handle Windows file URLs in waitFor

### DIFF
--- a/internal/security/bootstrapper/command/waitfor/command.go
+++ b/internal/security/bootstrapper/command/waitfor/command.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -182,8 +183,9 @@ func (c *cmd) waitForFile(fileUri url.URL) {
 		ticker := time.NewTicker(c.retryInterval)
 		defer ticker.Stop()
 		var err error
+		filePath := filePathFromURL(uri)
 		for range ticker.C {
-			if _, err = os.Stat(uri.Path); err == nil {
+			if _, err = os.Stat(filePath); err == nil {
 				c.loggingClient.Infof("File %s had been generated", uri.String())
 				return
 			} else if os.IsNotExist(err) {
@@ -197,6 +199,44 @@ func (c *cmd) waitForFile(fileUri url.URL) {
 			}
 		}
 	}(fileUri)
+}
+
+func filePathFromURL(fileUri url.URL) string {
+	return filePathFromURLForOS(fileUri, runtime.GOOS)
+}
+
+func filePathFromURLForOS(fileUri url.URL, goos string) string {
+	filePath := fileUri.Path
+	if goos == "windows" {
+		host := fileUri.Host
+		if strings.EqualFold(host, "localhost") {
+			host = ""
+		}
+		if isWindowsDriveHost(host) {
+			filePath = host + filePath
+		} else if host != "" && filePath != "" && filePath != "/" {
+			filePath = "//" + host + filePath
+		} else if len(filePath) >= 3 && filePath[0] == '/' && filePath[2] == ':' {
+			filePath = filePath[1:]
+		}
+	}
+	return filePathFromSlashForOS(filePath, goos)
+}
+
+func filePathFromSlashForOS(filePath string, goos string) string {
+	if goos == "windows" {
+		return strings.ReplaceAll(filePath, "/", "\\")
+	}
+
+	return filePath
+}
+
+func isWindowsDriveHost(host string) bool {
+	if len(host) != 2 || host[1] != ':' {
+		return false
+	}
+
+	return (host[0] >= 'A' && host[0] <= 'Z') || (host[0] >= 'a' && host[0] <= 'z')
 }
 
 func (c *cmd) waitForSocket(scheme, addr string) {

--- a/internal/security/bootstrapper/command/waitfor/command_test.go
+++ b/internal/security/bootstrapper/command/waitfor/command_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -122,6 +123,7 @@ func TestExecute(t *testing.T) {
 	}
 
 	waitFile := filepath.Join(path, testFile)
+	waitFileURI := fileURI(waitFile)
 
 	testHttpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -140,13 +142,13 @@ func TestExecute(t *testing.T) {
 		{"Good: waitFor with existing tcp server with retryInterval", []string{"--uri=tcp://" + testSrv, "--retryInterval=2s"},
 			time.Duration(6 * time.Second), false},
 		{"Good: waitFor with existing testFile",
-			[]string{"--uri=file://" + waitFile}, defaultWaitTimeout, false},
+			[]string{"--uri=" + waitFileURI}, defaultWaitTimeout, false},
 		{"Good: waitFor with existing tcp server and testFile",
-			[]string{"--uri=tcp://" + testSrv, "--uri=file://" + waitFile}, defaultWaitTimeout, false},
+			[]string{"--uri=tcp://" + testSrv, "--uri=" + waitFileURI}, defaultWaitTimeout, false},
 		{"Good: waitFor with existing tcp server and testFile and timeout",
-			[]string{"--uri=tcp://" + testSrv, "--uri=file://" + waitFile, "--timeout=5s"}, defaultWaitTimeout, false},
+			[]string{"--uri=tcp://" + testSrv, "--uri=" + waitFileURI, "--timeout=5s"}, defaultWaitTimeout, false},
 		{"Good: waitFor with existing tcp server and testFile and retryInterval",
-			[]string{"--uri=tcp://" + testSrv, "--uri=file://" + waitFile, "--retryInterval=2s"}, defaultWaitTimeout, false},
+			[]string{"--uri=tcp://" + testSrv, "--uri=" + waitFileURI, "--retryInterval=2s"}, defaultWaitTimeout, false},
 		{"Good: waitFor with existing http server", []string{"--uri=" + testHttpSrv.URL}, defaultWaitTimeout, false},
 		{"Bad: waitFor with malformed URL", []string{"--uri=_http!@xxxxxx:1111"}, time.Duration(2 * time.Second), true},
 		{"Bad: waitFor with no tcp server response", []string{"--uri=tcp://non-existing:1111", "--timeout=3s"},
@@ -200,6 +202,56 @@ func TestExecute(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFilePathFromURLForOS(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		goos     string
+		expected string
+	}{
+		{"Windows drive file URI", "file:///C:/Program%20Files/edgex", "windows",
+			`C:\Program Files\edgex`},
+		{"Windows localhost drive file URI", "file://localhost/C:/Program%20Files/edgex", "windows",
+			`C:\Program Files\edgex`},
+		{"Windows non-RFC drive file URI", "file://C:/Program%20Files/edgex", "windows",
+			`C:\Program Files\edgex`},
+		{"Windows UNC file URI", "file://server/share/path", "windows",
+			`\\server\share\path`},
+		{"Windows host-only file URI", "file://non-existing-file", "windows", ""},
+		{"Linux file URI", "file:///var/lib/edgex", "linux", "/var/lib/edgex"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fileURL, err := url.Parse(tt.rawURL)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected, filePathFromURLForOS(*fileURL, tt.goos))
+		})
+	}
+}
+
+func TestFileURI(t *testing.T) {
+	testPath := filepath.Join(t.TempDir(), "file with space#suffix")
+
+	rawURI := fileURI(testPath)
+	require.NotContains(t, rawURI, " ")
+	require.NotContains(t, rawURI, "#")
+
+	fileURL, err := url.Parse(rawURI)
+	require.NoError(t, err)
+	require.Equal(t, "file", fileURL.Scheme)
+	require.Equal(t, filepath.Clean(testPath), filepath.Clean(filePathFromURL(*fileURL)))
+}
+
+func fileURI(path string) string {
+	slashedPath := filepath.ToSlash(path)
+	if filepath.VolumeName(path) != "" {
+		slashedPath = "/" + slashedPath
+	}
+	return (&url.URL{Scheme: "file", Path: slashedPath}).String()
 }
 
 func getTestConfig(timeout, retryInterval string) *config.ConfigurationStruct {


### PR DESCRIPTION
## Summary
- normalize `file:` URL paths before passing them to `os.Stat`
- build a valid platform file URI in the waitFor test

## Why
On Windows, a valid `file:///D:/...` URL parses to a path with a leading slash. Passing that path directly to `os.Stat` fails, so waitFor could not detect existing files by URI on Windows.

## Testing
- `go test ./internal/security/bootstrapper/command/waitfor -run TestExecute -count=1`
- `go test ./internal/security/bootstrapper/command/waitfor -count=1`
- `go test ./internal/security/bootstrapper/command -count=1`