### PR TITLE
feat: Support ActiveYearlyTimeWindow in the scheduler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.1.0-dev.73
-	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.39
+	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.40
 	github.com/edgexfoundry/go-mod-messaging/v4 v4.1.0-dev.29
 	github.com/edgexfoundry/go-mod-secrets/v4 v4.1.0-dev.19
 	github.com/fxamacker/cbor/v2 v2.9.2

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v4 v4.1.0-dev.73 h1:C4jXnW66z/+EeWUsfZd
 github.com/edgexfoundry/go-mod-bootstrap/v4 v4.1.0-dev.73/go.mod h1:FWZT67PLsRdpoMVjtiDzXA/PZBDuRVWUujbGkw7s4HM=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.1.0-dev.22 h1:OHJyxwwlCa/AbV6EdJUZBJpcFn+4W37zHg86TrQ0g/E=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.1.0-dev.22/go.mod h1:hwwoG1IdP7lOOr0gEpBbCWo+zt15S1JNuTpwt0IQDQ0=
-github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.39 h1:jlr50ugKz0H9CkY0hIiv0X6V/Dss690wetkDMGIWLms=
-github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.39/go.mod h1:SDiRrlBMtttF3Ny8M26GNWPdMbBqhenR5pbfrCBm4zM=
+github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.40 h1:wx7B5ztxWuKFdm4ts3VCA5mn1N8mmTRniFuGHgkIri0=
+github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.40/go.mod h1:SDiRrlBMtttF3Ny8M26GNWPdMbBqhenR5pbfrCBm4zM=
 github.com/edgexfoundry/go-mod-messaging/v4 v4.1.0-dev.29 h1:+OcudoTGww3MS2fFt1nfInCgWwcZLsPbOkpFJVOGjG8=
 github.com/edgexfoundry/go-mod-messaging/v4 v4.1.0-dev.29/go.mod h1:yYeMYvFAvc156q0a+Kn4a+ibVQC2bxDUqRarty8XOYo=
 github.com/edgexfoundry/go-mod-registry/v4 v4.1.0-dev.14 h1:TszadMilOHfQACAVxpKnhLF4bNANISbagwkznTSkCwk=

--- a/internal/support/scheduler/application/action/cron.go
+++ b/internal/support/scheduler/application/action/cron.go
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package action
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// ParseCronExpression parses a crontab into a cron.Schedule. When the expression carries no TZ=/CRON_TZ=
+// prefix, it defaults the location to time.Local, so the returned schedule always has a resolved timezone.
+func ParseCronExpression(cronExpr string) (cron.Schedule, error) {
+	var withLocation string
+	if strings.HasPrefix(cronExpr, "TZ=") || strings.HasPrefix(cronExpr, "CRON_TZ=") {
+		withLocation = cronExpr
+	} else {
+		withLocation = fmt.Sprintf("CRON_TZ=%s %s", time.Local.String(), cronExpr)
+	}
+
+	// An optional 6th field is used at the beginning since withSeconds is set to true: `* * * * * *`
+	p := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+	schedule, err := p.Parse(withLocation)
+	if err != nil {
+		return nil, err
+	}
+	return schedule, nil
+}

--- a/internal/support/scheduler/application/action/cron_test.go
+++ b/internal/support/scheduler/application/action/cron_test.go
@@ -1,0 +1,53 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package action
+
+import (
+	"testing"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cronDef(crontab string) models.CronScheduleDef {
+	return models.CronScheduleDef{
+		BaseScheduleDef: models.BaseScheduleDef{Type: common.DefCron},
+		Crontab:         crontab,
+	}
+}
+
+func TestWindowLocation(t *testing.T) {
+	taipei, err := time.LoadLocation("Asia/Taipei")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		def      models.ScheduleDef
+		expected *time.Location
+	}{
+		{"CRON_TZ prefix resolves to that zone", cronDef("CRON_TZ=Asia/Taipei 0 0 * * *"), taipei},
+		{"TZ prefix resolves to that zone", cronDef("TZ=Asia/Taipei 0 0 * * *"), taipei},
+		{"CRON without prefix falls back to Local", cronDef("0 0 * * *"), time.Local},
+		{"INTERVAL falls back to Local", models.IntervalScheduleDef{
+			BaseScheduleDef: models.BaseScheduleDef{Type: common.DefInterval}, Interval: "10m"}, time.Local},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loc, err := WindowLocation(tt.def)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, loc)
+		})
+	}
+}
+
+func TestWindowLocation_InvalidCrontabReturnsError(t *testing.T) {
+	_, err := WindowLocation(cronDef("CRON_TZ=Not/A_Zone 0 0 * * *"))
+	assert.Error(t, err, "an unloadable timezone must return an error rather than silently defaulting")
+}

--- a/internal/support/scheduler/application/action/window.go
+++ b/internal/support/scheduler/application/action/window.go
@@ -8,6 +8,8 @@ package action
 import (
 	"time"
 
+	"github.com/robfig/cron/v3"
+
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
 )
 
@@ -33,4 +35,24 @@ func InWindow(now time.Time, window models.ActiveYearlyTimeWindow) bool {
 		return !less(cur, start) && !less(end, cur) // [start, end], end inclusive
 	}
 	return !less(cur, start) || !less(end, cur) // year-crossing window
+}
+
+// WindowLocation returns the timezone in which a job's window should be evaluated. For a CRON definition it
+// is the schedule's own location (a TZ=/CRON_TZ= prefix, else time.Local), so the window matches the
+// schedule's calendar day. Any non-CRON definition uses time.Local. An error is returned only when the
+// crontab fails to parse, so the caller can reject the job rather than evaluate the window in the wrong zone.
+func WindowLocation(def models.ScheduleDef) (*time.Location, error) {
+	cronDef, ok := def.(models.CronScheduleDef)
+	if !ok {
+		return time.Local, nil
+	}
+
+	schedule, err := ParseCronExpression(cronDef.Crontab)
+	if err != nil {
+		return nil, err
+	}
+	if spec, ok := schedule.(*cron.SpecSchedule); ok && spec.Location != nil {
+		return spec.Location, nil
+	}
+	return time.Local, nil
 }

--- a/internal/support/scheduler/application/action/window.go
+++ b/internal/support/scheduler/application/action/window.go
@@ -1,0 +1,36 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package action
+
+import (
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
+)
+
+// point is a (month, day) pair used to compare calendar positions within a year, ignoring the year.
+type point struct{ month, day int }
+
+// less reports whether a comes strictly before b in the calendar, comparing month first then day.
+func less(a, b point) bool {
+	if a.month != b.month {
+		return a.month < b.month
+	}
+	return a.day < b.day
+}
+
+// InWindow reports whether now falls inside the recurring month/day window. EndDay is inclusive; a start
+// after end (e.g. Nov 15 -> Feb 10) is a year-crossing window.
+func InWindow(now time.Time, window models.ActiveYearlyTimeWindow) bool {
+	cur := point{int(now.Month()), now.Day()}
+	start := point{window.StartMonth, window.StartDay}
+	end := point{window.EndMonth, window.EndDay}
+
+	if !less(end, start) { // start <= end -> same-year window
+		return !less(cur, start) && !less(end, cur) // [start, end], end inclusive
+	}
+	return !less(cur, start) || !less(end, cur) // year-crossing window
+}

--- a/internal/support/scheduler/application/action/window_test.go
+++ b/internal/support/scheduler/application/action/window_test.go
@@ -1,0 +1,70 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package action
+
+import (
+	"testing"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// date builds a time.Time at the given month/day (year and time-of-day are irrelevant to InWindow).
+func date(month, day int) time.Time {
+	return time.Date(2025, time.Month(month), day, 12, 0, 0, 0, time.Local)
+}
+
+func TestInWindow(t *testing.T) {
+	sameYear := models.ActiveYearlyTimeWindow{StartMonth: 1, StartDay: 5, EndMonth: 3, EndDay: 12}
+	yearCrossing := models.ActiveYearlyTimeWindow{StartMonth: 11, StartDay: 15, EndMonth: 2, EndDay: 10}
+	sameMonthCrossing := models.ActiveYearlyTimeWindow{StartMonth: 12, StartDay: 10, EndMonth: 12, EndDay: 1}
+	singleDay := models.ActiveYearlyTimeWindow{StartMonth: 6, StartDay: 15, EndMonth: 6, EndDay: 15}
+
+	tests := []struct {
+		name     string
+		window   models.ActiveYearlyTimeWindow
+		t        time.Time
+		expected bool
+	}{
+		// same-year window [1/5, 3/12]
+		{"same-year inside", sameYear, date(2, 20), true},
+		{"same-year on start", sameYear, date(1, 5), true},
+		{"same-year on end (inclusive)", sameYear, date(3, 12), true},
+		{"same-year day before start", sameYear, date(1, 4), false},
+		{"same-year day after end", sameYear, date(3, 13), false},
+		{"same-year far before", sameYear, date(1, 1), false},
+		{"same-year far after", sameYear, date(12, 31), false},
+
+		// year-crossing window [11/15, 2/10]
+		{"crossing inside late-year", yearCrossing, date(12, 25), true},
+		{"crossing inside early-year", yearCrossing, date(1, 20), true},
+		{"crossing on start", yearCrossing, date(11, 15), true},
+		{"crossing on end (inclusive)", yearCrossing, date(2, 10), true},
+		{"crossing day before start", yearCrossing, date(11, 14), false},
+		{"crossing day after end", yearCrossing, date(2, 11), false},
+		{"crossing between months (summer)", yearCrossing, date(7, 1), false},
+
+		// same-month year-crossing window [12/10, 12/1]: start > end within one month
+		{"same-month crossing on start", sameMonthCrossing, date(12, 10), true},
+		{"same-month crossing on end (inclusive)", sameMonthCrossing, date(12, 1), true},
+		{"same-month crossing late-year inside", sameMonthCrossing, date(12, 20), true},
+		{"same-month crossing early-year inside", sameMonthCrossing, date(1, 15), true},
+		{"same-month crossing in the gap", sameMonthCrossing, date(12, 5), false},
+
+		// single-day window [6/15, 6/15]
+		{"single-day on the day", singleDay, date(6, 15), true},
+		{"single-day day before", singleDay, date(6, 14), false},
+		{"single-day day after", singleDay, date(6, 16), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, InWindow(tt.t, tt.window))
+		})
+	}
+}

--- a/internal/support/scheduler/application/scheduleactionrecord.go
+++ b/internal/support/scheduler/application/scheduleactionrecord.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,6 +23,7 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/internal/pkg/correlation"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/utils"
+	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/application/action"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
 )
 
@@ -183,6 +184,20 @@ func GenerateMissedScheduleActionRecords(ctx context.Context, dic *di.Container,
 		if err != nil {
 			lc.Errorf("Failed to generate missed records of job: %s. Correlation-ID: %s", job.Name, correlationId)
 			return errors.NewCommonEdgeXWrapper(err), len(missedRecords) > 0
+		}
+
+		// Drop missed runs that fell outside the active yearly time window: while the service was down those
+		// ticks were never supposed to fire, so they are not "missed".
+		if window := job.Definition.GetBaseScheduleDef().ActiveYearlyTimeWindow; window != nil {
+			filtered := make([]time.Time, 0, len(missedRuns))
+			for _, run := range missedRuns {
+				if action.InWindow(run, *window) {
+					filtered = append(filtered, run)
+				}
+			}
+			lc.Debugf("job %s: %d of %d missed runs are outside the active yearly time window and were dropped. Correlation-ID: %s",
+				job.Name, len(missedRuns)-len(filtered), len(missedRuns), correlationId)
+			missedRuns = filtered
 		}
 
 		if len(missedRuns) != 0 {

--- a/internal/support/scheduler/application/scheduleactionrecord.go
+++ b/internal/support/scheduler/application/scheduleactionrecord.go
@@ -8,7 +8,6 @@ package application
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -259,7 +258,7 @@ func generateMissedRuns(def models.ScheduleDef, latestTime time.Time) (missedRun
 			return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "fail to cast ScheduleDefinition to CronScheduleDef", nil)
 		}
 
-		cronSchedule, err := parseCronExpression(cronDef.Crontab)
+		cronSchedule, err := action.ParseCronExpression(cronDef.Crontab)
 		if err != nil {
 			return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "fail to parse cron expression", err)
 		}
@@ -296,23 +295,6 @@ func findMissedCronRuns(lastRun, current time.Time, schedule cron.Schedule) (mis
 		missedRuns = append(missedRuns, t)
 	}
 	return missedRuns
-}
-
-func parseCronExpression(cronExpr string) (cron.Schedule, error) {
-	var withLocation string
-	if strings.HasPrefix(cronExpr, "TZ=") || strings.HasPrefix(cronExpr, "CRON_TZ=") {
-		withLocation = cronExpr
-	} else {
-		withLocation = fmt.Sprintf("CRON_TZ=%s %s", time.Local.String(), cronExpr)
-	}
-
-	// An optional 6th field is used at the beginning since withSeconds is set to true: `* * * * * *`
-	p := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
-	schedule, err := p.Parse(withLocation)
-	if err != nil {
-		return nil, err
-	}
-	return schedule, nil
 }
 
 func purgeRecord(ctx context.Context, dic *di.Container) errors.EdgeX {

--- a/internal/support/scheduler/application/scheduleactionrecord.go
+++ b/internal/support/scheduler/application/scheduleactionrecord.go
@@ -15,6 +15,7 @@ import (
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
@@ -185,32 +186,20 @@ func GenerateMissedScheduleActionRecords(ctx context.Context, dic *di.Container,
 			return errors.NewCommonEdgeXWrapper(err), len(missedRecords) > 0
 		}
 
-		// Drop missed runs that fell outside the active yearly time window: while the service was down those
-		// ticks were never supposed to fire, so they are not "missed".
-		if window := job.Definition.GetBaseScheduleDef().ActiveYearlyTimeWindow; window != nil {
-			filtered := make([]time.Time, 0, len(missedRuns))
-			for _, run := range missedRuns {
-				if action.InWindow(run, *window) {
-					filtered = append(filtered, run)
-				}
-			}
-			lc.Debugf("job %s: %d of %d missed runs are outside the active yearly time window and were dropped. Correlation-ID: %s",
-				job.Name, len(missedRuns)-len(filtered), len(missedRuns), correlationId)
-			missedRuns = filtered
+		// Drop missed runs that fell outside the active yearly time window; those ticks were never supposed to fire.
+		missedRuns, err = filterRunsByActiveWindow(lc, job, missedRuns, correlationId)
+		if err != nil {
+			return errors.NewCommonEdgeXWrapper(err), len(missedRecords) > 0
 		}
 
-		if len(missedRuns) != 0 {
-			for _, run := range missedRuns {
-				actionRecord := models.ScheduleActionRecord{
-					JobName:     job.Name,
-					Action:      latestRecord.Action,
-					Status:      models.Missed,
-					ScheduledAt: run.UnixMilli(),
-				}
-
-				missedRecords = append(missedRecords, actionRecord)
-				lc.Tracef("Missed schedule action record with action id: %s of job: %s have been generated successfully. Correlation-ID: %s", actionId, job.Name, correlationId)
-			}
+		for _, run := range missedRuns {
+			missedRecords = append(missedRecords, models.ScheduleActionRecord{
+				JobName:     job.Name,
+				Action:      latestRecord.Action,
+				Status:      models.Missed,
+				ScheduledAt: run.UnixMilli(),
+			})
+			lc.Tracef("Missed schedule action record with action id: %s of job: %s have been generated successfully. Correlation-ID: %s", actionId, job.Name, correlationId)
 		}
 	}
 
@@ -222,6 +211,32 @@ func GenerateMissedScheduleActionRecords(ctx context.Context, dic *di.Container,
 	lc.Debugf("Missed schedule action records for job: %s have been created successfully. Correlation-ID: %s", job.Name, correlationId)
 
 	return nil, len(missedRecords) > 0
+}
+
+// filterRunsByActiveWindow removes missed runs that fall outside the job's active yearly time window. Each run
+// is evaluated in the schedule's timezone: INTERVAL runs come from time.UnixMilli (UTC), so without this the
+// day could be off by one in non-UTC deployments. When no window is set, the runs are returned unchanged.
+func filterRunsByActiveWindow(lc logger.LoggingClient, job models.ScheduleJob, runs []time.Time, correlationId string) ([]time.Time, errors.EdgeX) {
+	window := job.Definition.GetBaseScheduleDef().ActiveYearlyTimeWindow
+	if window == nil {
+		return runs, nil
+	}
+
+	windowLoc, err := action.WindowLocation(job.Definition)
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid,
+			fmt.Sprintf("failed to resolve timezone for active yearly time window of job: %s", job.Name), err)
+	}
+
+	filtered := make([]time.Time, 0, len(runs))
+	for _, run := range runs {
+		if action.InWindow(run.In(windowLoc), *window) {
+			filtered = append(filtered, run)
+		}
+	}
+	lc.Debugf("job %s: %d of %d missed runs are outside the active yearly time window and were dropped. Correlation-ID: %s",
+		job.Name, len(runs)-len(filtered), len(runs), correlationId)
+	return filtered, nil
 }
 
 // AsyncPurgeRecord purge schedule action records according to the retention capability.

--- a/internal/support/scheduler/application/scheduleactionrecord_test.go
+++ b/internal/support/scheduler/application/scheduleactionrecord_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,6 +20,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
 
+	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/application/action"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/config"
 	"github.com/edgexfoundry/edgex-go/internal/support/scheduler/container"
 	dbMock "github.com/edgexfoundry/edgex-go/internal/support/scheduler/infrastructure/interfaces/mocks"
@@ -112,6 +113,87 @@ func TestFindMissedCronRuns(t *testing.T) {
 			got := findMissedCronRuns(tt.lastRun, tt.currentTime, tt.cronSchedule)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// captureAddedRecords runs GenerateMissedScheduleActionRecords with a mock DBClient that records the
+// missed-record slice passed to AddScheduleActionRecords, and returns that slice.
+func captureAddedRecords(t *testing.T, job models.ScheduleJob, latest []models.ScheduleActionRecord) []models.ScheduleActionRecord {
+	t.Helper()
+	ctx := context.Background()
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+	})
+
+	var added []models.ScheduleActionRecord
+	dbClientMock := &dbMock.DBClient{}
+	dbClientMock.On("AddScheduleActionRecords", ctx, mock.AnythingOfType("[]models.ScheduleActionRecord")).
+		Return([]models.ScheduleActionRecord{}, nil).
+		Run(func(args mock.Arguments) {
+			added = args.Get(1).([]models.ScheduleActionRecord)
+		})
+	dic.Update(di.ServiceConstructorMap{
+		container.DBClientInterfaceName: func(get di.Get) interface{} {
+			return dbClientMock
+		},
+	})
+
+	edgeXErr, _ := GenerateMissedScheduleActionRecords(ctx, dic, job, latest)
+	require.Nil(t, edgeXErr)
+	return added
+}
+
+func TestGenerateMissedScheduleActionRecords_ActiveYearlyTimeWindow(t *testing.T) {
+	// A daily interval whose latest run is ~120 days ago, so the missed runs span ~120 daily points
+	// crossing several months. This guarantees the set contains both in-window and out-of-window dates
+	// for any wall-clock "now", keeping the assertions below independent of time.Now().
+	latestTime := time.Now().AddDate(0, 0, -120)
+	restAction := models.RESTAction{
+		BaseScheduleAction: models.BaseScheduleAction{Id: "action-1", Type: "REST"},
+	}
+	latest := []models.ScheduleActionRecord{
+		{JobName: "job", Action: restAction, ScheduledAt: latestTime.UnixMilli()},
+	}
+	newJob := func(window *models.ActiveYearlyTimeWindow) models.ScheduleJob {
+		return models.ScheduleJob{
+			Name: "job",
+			Definition: models.IntervalScheduleDef{
+				BaseScheduleDef: models.BaseScheduleDef{Type: "INTERVAL", ActiveYearlyTimeWindow: window},
+				Interval:        "24h",
+			},
+		}
+	}
+
+	// Baseline: no window → every missed run is recorded.
+	baseline := captureAddedRecords(t, newJob(nil), latest)
+	require.NotEmpty(t, baseline, "baseline should produce missed runs to make the comparison meaningful")
+
+	// A one-month window (March). Only missed runs whose date falls in March survive the filter.
+	window := &models.ActiveYearlyTimeWindow{StartMonth: 3, StartDay: 1, EndMonth: 3, EndDay: 31}
+	filtered := captureAddedRecords(t, newJob(window), latest)
+
+	// The window must drop at least some runs (120 daily points cannot all be in March).
+	assert.Less(t, len(filtered), len(baseline), "windowed run should record fewer than the unfiltered baseline")
+
+	// Every recorded run must fall inside the window, and its status must be Missed.
+	for _, r := range filtered {
+		runTime := time.UnixMilli(r.ScheduledAt)
+		assert.True(t, action.InWindow(runTime, *window),
+			"recorded missed run %s is outside the window and should have been dropped", runTime)
+		assert.Equal(t, models.Missed, string(r.Status))
+	}
+
+	// Conversely, none of the baseline runs outside the window should appear in the filtered set.
+	inFiltered := make(map[int64]bool, len(filtered))
+	for _, r := range filtered {
+		inFiltered[r.ScheduledAt] = true
+	}
+	for _, r := range baseline {
+		if !action.InWindow(time.UnixMilli(r.ScheduledAt), *window) {
+			assert.False(t, inFiltered[r.ScheduledAt], "an out-of-window run leaked into the filtered set")
+		}
 	}
 }
 

--- a/internal/support/scheduler/application/scheduleactionrecord_test.go
+++ b/internal/support/scheduler/application/scheduleactionrecord_test.go
@@ -179,7 +179,7 @@ func TestGenerateMissedScheduleActionRecords_ActiveYearlyTimeWindow(t *testing.T
 
 	// Every recorded run must fall inside the window, and its status must be Missed.
 	for _, r := range filtered {
-		runTime := time.UnixMilli(r.ScheduledAt)
+		runTime := time.UnixMilli(r.ScheduledAt).In(time.Local)
 		assert.True(t, action.InWindow(runTime, *window),
 			"recorded missed run %s is outside the window and should have been dropped", runTime)
 		assert.Equal(t, models.Missed, string(r.Status))
@@ -191,7 +191,7 @@ func TestGenerateMissedScheduleActionRecords_ActiveYearlyTimeWindow(t *testing.T
 		inFiltered[r.ScheduledAt] = true
 	}
 	for _, r := range baseline {
-		if !action.InWindow(time.UnixMilli(r.ScheduledAt), *window) {
+		if !action.InWindow(time.UnixMilli(r.ScheduledAt).In(time.Local), *window) {
 			assert.False(t, inFiltered[r.ScheduledAt], "an out-of-window run leaked into the filtered set")
 		}
 	}

--- a/internal/support/scheduler/application/scheduleactionrecord_test.go
+++ b/internal/support/scheduler/application/scheduleactionrecord_test.go
@@ -75,7 +75,7 @@ func TestFindMissedIntervalRuns(t *testing.T) {
 
 func TestFindMissedCronRuns(t *testing.T) {
 	// Take the "0 * * * *" as an example, which means the job will run every hour
-	cronSchedule, _ := parseCronExpression("0 * * * *")
+	cronSchedule, _ := action.ParseCronExpression("0 * * * *")
 
 	tests := []struct {
 		name         string

--- a/internal/support/scheduler/infrastructure/manager.go
+++ b/internal/support/scheduler/infrastructure/manager.go
@@ -8,6 +8,7 @@ package infrastructure
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -250,86 +251,9 @@ func (m *manager) addNewJob(job models.ScheduleJob) errors.EdgeX {
 	// Add options for the scheduled job based on the startTimestamp and endTimestamp
 	toTrigger, startOption, endOption := m.arrangeScheduleJob(ctx, job)
 	if toTrigger {
-		window := job.Definition.GetBaseScheduleDef().ActiveYearlyTimeWindow
-
-		// Resolve the timezone once so the window is evaluated against the schedule's calendar day.
-		windowLoc := time.Local
-		if window != nil {
-			loc, err := action.WindowLocation(job.Definition)
-			if err != nil {
-				return errors.NewCommonEdgeX(errors.KindContractInvalid,
-					fmt.Sprintf("failed to resolve timezone for active yearly time window of job: %s", job.Name), err)
-			}
-			windowLoc = loc
+		if edgeXerr := m.startJobActions(ctx, scheduler, definition, job, startOption, endOption); edgeXerr != nil {
+			return errors.NewCommonEdgeXWrapper(edgeXerr)
 		}
-
-		// If toTrigger is true, the ScheduleAction will be added to the scheduler and ready to be triggered
-		for _, a := range job.Actions {
-			copiedAction := a
-			task, edgeXerr := action.ToGocronTask(m.lc, m.dic, m.secretProvider, a)
-			if edgeXerr != nil {
-				return errors.NewCommonEdgeXWrapper(edgeXerr)
-			}
-
-			var jobOptions []gocron.JobOption
-			if startOption != nil {
-				jobOptions = append(jobOptions, startOption)
-			}
-			if endOption != nil {
-				jobOptions = append(jobOptions, endOption)
-			}
-
-			// Capture the scheduled time in BeforeJobRuns to avoid race condition
-			// where the job may be removed from the scheduler before AfterJobRuns fires.
-			var scheduledAt atomic.Int64
-			jobOptions = append(jobOptions, gocron.WithEventListeners(
-				// Skip the run when it falls outside the active yearly time window (nil = no constraint).
-				// Returning an error makes gocron skip before the task fires and writes no record.
-				gocron.BeforeJobRunsSkipIfBeforeFuncErrors(
-					func(jobID uuid.UUID, jobName string) error {
-						now := time.Now().In(windowLoc)
-						if window != nil && !action.InWindow(now, *window) {
-							m.lc.Debugf("Skipping scheduled run of job %s on %s: current date is outside its active yearly time window (%d/%d - %d/%d)",
-								job.Name, now.Format("2006-01-02"), window.StartMonth, window.StartDay, window.EndMonth, window.EndDay)
-							return errOutsideWindow
-						}
-						return nil
-					}),
-				gocron.BeforeJobRuns(
-					func(jobID uuid.UUID, jobName string) {
-						scheduledAt.Store(time.Now().UnixMilli())
-					}),
-				gocron.AfterJobRuns(
-					func(jobID uuid.UUID, jobName string) {
-						record := models.ScheduleActionRecord{
-							JobName:     job.Name,
-							Action:      copiedAction,
-							Status:      models.Succeeded,
-							ScheduledAt: scheduledAt.Load(),
-						}
-						m.addScheduleActionRecord(ctx, record, nil)
-					}),
-				gocron.AfterJobRunsWithError(
-					func(jobID uuid.UUID, jobName string, err error) {
-						record := models.ScheduleActionRecord{
-							JobName:     job.Name,
-							Action:      copiedAction,
-							Status:      models.Failed,
-							ScheduledAt: scheduledAt.Load(),
-						}
-						m.addScheduleActionRecord(ctx, record, err)
-					}),
-			))
-
-			// A "ScheduleAction" will be treated as a "Job" in gocron scheduler
-			_, err := scheduler.NewJob(definition, task, jobOptions...)
-			if err != nil {
-				return errors.NewCommonEdgeX(errors.KindServerError,
-					fmt.Sprintf("failed to create new scheduled aciton for job: %s", job.Name), err)
-			}
-		}
-
-		scheduler.Start()
 		m.lc.Debugf("The scheduled job %s was started. Correlation-ID: %s", job.Name, correlationId)
 	}
 
@@ -339,6 +263,107 @@ func (m *manager) addNewJob(job models.ScheduleJob) errors.EdgeX {
 	m.mu.Unlock()
 
 	return nil
+}
+
+// startJobActions registers a gocron job for every action of the schedule job and starts the scheduler. It
+// resolves the window timezone once and builds the shared base options and window gate reused by each action.
+func (m *manager) startJobActions(ctx context.Context, scheduler gocron.Scheduler, definition gocron.JobDefinition,
+	job models.ScheduleJob, startOption, endOption gocron.JobOption) errors.EdgeX {
+	window := job.Definition.GetBaseScheduleDef().ActiveYearlyTimeWindow
+
+	// Resolve the timezone once so the window is evaluated against the schedule's calendar day.
+	windowLoc := time.Local
+	if window != nil {
+		loc, err := action.WindowLocation(job.Definition)
+		if err != nil {
+			return errors.NewCommonEdgeX(errors.KindContractInvalid,
+				fmt.Sprintf("failed to resolve timezone for active yearly time window of job: %s", job.Name), err)
+		}
+		windowLoc = loc
+	}
+
+	// Options shared by every action's gocron job (start/stop lifetime plus the window gate).
+	var baseOptions []gocron.JobOption
+	if startOption != nil {
+		baseOptions = append(baseOptions, startOption)
+	}
+	if endOption != nil {
+		baseOptions = append(baseOptions, endOption)
+	}
+	gate := m.windowGate(job, window, windowLoc)
+
+	for _, a := range job.Actions {
+		if edgeXerr := m.addActionJob(ctx, scheduler, definition, job, a, baseOptions, gate); edgeXerr != nil {
+			return errors.NewCommonEdgeXWrapper(edgeXerr)
+		}
+	}
+
+	scheduler.Start()
+	return nil
+}
+
+// addActionJob creates a gocron job for a single ScheduleAction with its own event listeners (window gate,
+// scheduledAt capture, and success/failure record writers) and registers it on the scheduler. baseOptions
+// holds the job-level options (lifetime start/stop) shared by every action; gate is the window gate listener.
+func (m *manager) addActionJob(ctx context.Context, scheduler gocron.Scheduler, definition gocron.JobDefinition,
+	job models.ScheduleJob, a models.ScheduleAction, baseOptions []gocron.JobOption, gate gocron.EventListener) errors.EdgeX {
+	task, edgeXerr := action.ToGocronTask(m.lc, m.dic, m.secretProvider, a)
+	if edgeXerr != nil {
+		return errors.NewCommonEdgeXWrapper(edgeXerr)
+	}
+
+	jobOptions := slices.Clone(baseOptions)
+
+	// Capture the scheduled time in BeforeJobRuns to avoid race condition
+	// where the job may be removed from the scheduler before AfterJobRuns fires.
+	var scheduledAt atomic.Int64
+	jobOptions = append(jobOptions, gocron.WithEventListeners(
+		gate,
+		gocron.BeforeJobRuns(
+			func(jobID uuid.UUID, jobName string) {
+				scheduledAt.Store(time.Now().UnixMilli())
+			}),
+		gocron.AfterJobRuns(
+			func(jobID uuid.UUID, jobName string) {
+				m.addScheduleActionRecord(ctx, models.ScheduleActionRecord{
+					JobName:     job.Name,
+					Action:      a,
+					Status:      models.Succeeded,
+					ScheduledAt: scheduledAt.Load(),
+				}, nil)
+			}),
+		gocron.AfterJobRunsWithError(
+			func(jobID uuid.UUID, jobName string, err error) {
+				m.addScheduleActionRecord(ctx, models.ScheduleActionRecord{
+					JobName:     job.Name,
+					Action:      a,
+					Status:      models.Failed,
+					ScheduledAt: scheduledAt.Load(),
+				}, err)
+			}),
+	))
+
+	// A "ScheduleAction" will be treated as a "Job" in gocron scheduler
+	if _, err := scheduler.NewJob(definition, task, jobOptions...); err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError,
+			fmt.Sprintf("failed to create new scheduled aciton for job: %s", job.Name), err)
+	}
+	return nil
+}
+
+// windowGate returns a before-run listener that skips the run (without writing a record) when the current
+// time, evaluated in windowLoc, is outside the job's active yearly time window. A nil window never skips.
+func (m *manager) windowGate(job models.ScheduleJob, window *models.ActiveYearlyTimeWindow, windowLoc *time.Location) gocron.EventListener {
+	return gocron.BeforeJobRunsSkipIfBeforeFuncErrors(
+		func(jobID uuid.UUID, jobName string) error {
+			now := time.Now().In(windowLoc)
+			if window != nil && !action.InWindow(now, *window) {
+				m.lc.Debugf("Skipping scheduled run of job %s on %s: current date is outside its active yearly time window (%d/%d - %d/%d)",
+					job.Name, now.Format("2006-01-02"), window.StartMonth, window.StartDay, window.EndMonth, window.EndDay)
+				return errOutsideWindow
+			}
+			return nil
+		})
 }
 
 func (m *manager) addScheduleActionRecord(ctx context.Context, record models.ScheduleActionRecord, err error) {

--- a/internal/support/scheduler/infrastructure/manager.go
+++ b/internal/support/scheduler/infrastructure/manager.go
@@ -346,7 +346,7 @@ func (m *manager) addActionJob(ctx context.Context, scheduler gocron.Scheduler, 
 	// A "ScheduleAction" will be treated as a "Job" in gocron scheduler
 	if _, err := scheduler.NewJob(definition, task, jobOptions...); err != nil {
 		return errors.NewCommonEdgeX(errors.KindServerError,
-			fmt.Sprintf("failed to create new scheduled aciton for job: %s", job.Name), err)
+			fmt.Sprintf("failed to create new scheduled action for job: %s", job.Name), err)
 	}
 	return nil
 }

--- a/internal/support/scheduler/infrastructure/manager.go
+++ b/internal/support/scheduler/infrastructure/manager.go
@@ -247,19 +247,21 @@ func (m *manager) addNewJob(job models.ScheduleJob) errors.EdgeX {
 		return errors.NewCommonEdgeXWrapper(edgeXerr)
 	}
 
-	var jobOptions []gocron.JobOption
-
 	// Add options for the scheduled job based on the startTimestamp and endTimestamp
 	toTrigger, startOption, endOption := m.arrangeScheduleJob(ctx, job)
 	if toTrigger {
-		if startOption != nil {
-			jobOptions = append(jobOptions, startOption)
-		}
-		if endOption != nil {
-			jobOptions = append(jobOptions, endOption)
-		}
-
 		window := job.Definition.GetBaseScheduleDef().ActiveYearlyTimeWindow
+
+		// Resolve the timezone once so the window is evaluated against the schedule's calendar day.
+		windowLoc := time.Local
+		if window != nil {
+			loc, err := action.WindowLocation(job.Definition)
+			if err != nil {
+				return errors.NewCommonEdgeX(errors.KindContractInvalid,
+					fmt.Sprintf("failed to resolve timezone for active yearly time window of job: %s", job.Name), err)
+			}
+			windowLoc = loc
+		}
 
 		// If toTrigger is true, the ScheduleAction will be added to the scheduler and ready to be triggered
 		for _, a := range job.Actions {
@@ -267,6 +269,14 @@ func (m *manager) addNewJob(job models.ScheduleJob) errors.EdgeX {
 			task, edgeXerr := action.ToGocronTask(m.lc, m.dic, m.secretProvider, a)
 			if edgeXerr != nil {
 				return errors.NewCommonEdgeXWrapper(edgeXerr)
+			}
+
+			var jobOptions []gocron.JobOption
+			if startOption != nil {
+				jobOptions = append(jobOptions, startOption)
+			}
+			if endOption != nil {
+				jobOptions = append(jobOptions, endOption)
 			}
 
 			// Capture the scheduled time in BeforeJobRuns to avoid race condition
@@ -277,7 +287,7 @@ func (m *manager) addNewJob(job models.ScheduleJob) errors.EdgeX {
 				// Returning an error makes gocron skip before the task fires and writes no record.
 				gocron.BeforeJobRunsSkipIfBeforeFuncErrors(
 					func(jobID uuid.UUID, jobName string) error {
-						now := time.Now()
+						now := time.Now().In(windowLoc)
 						if window != nil && !action.InWindow(now, *window) {
 							m.lc.Debugf("Skipping scheduled run of job %s on %s: current date is outside its active yearly time window (%d/%d - %d/%d)",
 								job.Name, now.Format("2006-01-02"), window.StartMonth, window.StartDay, window.EndMonth, window.EndDay)

--- a/internal/support/scheduler/infrastructure/manager.go
+++ b/internal/support/scheduler/infrastructure/manager.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -33,6 +33,10 @@ const (
 	// validationTag is the tag used to validate the ScheduleJob internally and then remove those jobs from the scheduler by this tag
 	validationTag = "::validation::"
 )
+
+// errOutsideWindow signals the before-run gate to skip a run outside the job's ActiveYearlyTimeWindow.
+// gocron only needs a non-nil error to skip; the value itself is never inspected.
+var errOutsideWindow = errors.NewCommonEdgeX(errors.KindStatusConflict, "skipped: outside active yearly time window", nil)
 
 type manager struct {
 	lc             logger.LoggingClient
@@ -255,6 +259,8 @@ func (m *manager) addNewJob(job models.ScheduleJob) errors.EdgeX {
 			jobOptions = append(jobOptions, endOption)
 		}
 
+		window := job.Definition.GetBaseScheduleDef().ActiveYearlyTimeWindow
+
 		// If toTrigger is true, the ScheduleAction will be added to the scheduler and ready to be triggered
 		for _, a := range job.Actions {
 			copiedAction := a
@@ -267,6 +273,18 @@ func (m *manager) addNewJob(job models.ScheduleJob) errors.EdgeX {
 			// where the job may be removed from the scheduler before AfterJobRuns fires.
 			var scheduledAt atomic.Int64
 			jobOptions = append(jobOptions, gocron.WithEventListeners(
+				// Skip the run when it falls outside the active yearly time window (nil = no constraint).
+				// Returning an error makes gocron skip before the task fires and writes no record.
+				gocron.BeforeJobRunsSkipIfBeforeFuncErrors(
+					func(jobID uuid.UUID, jobName string) error {
+						now := time.Now()
+						if window != nil && !action.InWindow(now, *window) {
+							m.lc.Debugf("Skipping scheduled run of job %s on %s: current date is outside its active yearly time window (%d/%d - %d/%d)",
+								job.Name, now.Format("2006-01-02"), window.StartMonth, window.StartDay, window.EndMonth, window.EndDay)
+							return errOutsideWindow
+						}
+						return nil
+					}),
 				gocron.BeforeJobRuns(
 					func(jobID uuid.UUID, jobName string) {
 						scheduledAt.Store(time.Now().UnixMilli())

--- a/internal/support/scheduler/infrastructure/manager_test.go
+++ b/internal/support/scheduler/infrastructure/manager_test.go
@@ -1,13 +1,14 @@
 //
-// Copyright (C) 2024 IOTech Ltd
+// Copyright (C) 2024-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package infrastructure
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v4/config"
@@ -97,6 +98,23 @@ func validScheduleJob() models.ScheduleJob {
 		AdminState: models.Unlocked,
 		Labels:     []string{testLabel},
 	}
+}
+
+// TestAddScheduleJobWithActiveYearlyTimeWindow verifies that a job carrying an ActiveYearlyTimeWindow is
+// added without error, i.e. the before-run window gate is wired into the scheduler correctly. The window
+// matching logic itself is covered by action.TestInWindow.
+func TestAddScheduleJobWithActiveYearlyTimeWindow(t *testing.T) {
+	dic := mockDic()
+	mockManager := NewManager(dic)
+
+	def := testIntervalScheduleDef
+	def.ActiveYearlyTimeWindow = &models.ActiveYearlyTimeWindow{StartMonth: 11, StartDay: 1, EndMonth: 2, EndDay: 28}
+
+	job := validScheduleJob()
+	job.Definition = def
+
+	err := mockManager.AddScheduleJob(job, testCorrelationID)
+	assert.NoError(t, err)
 }
 
 func TestValidateUpdatingScheduleJob(t *testing.T) {

--- a/openapi/support-scheduler.yaml
+++ b/openapi/support-scheduler.yaml
@@ -262,8 +262,9 @@ components:
           type: integer
           description: "The end timestamp of the schedule job, in milliseconds."
         activeYearlyTimeWindow:
+          allOf:
+            - $ref: '#/components/schemas/ActiveYearlyTimeWindow'
           description: "An optional recurring within-year active period. When omitted, the schedule has no window constraint and fires on every tick within its lifetime."
-          $ref: '#/components/schemas/ActiveYearlyTimeWindow'
       required:
         - type
     ActiveYearlyTimeWindow:

--- a/openapi/support-scheduler.yaml
+++ b/openapi/support-scheduler.yaml
@@ -261,8 +261,43 @@ components:
         endTimestamp:
           type: integer
           description: "The end timestamp of the schedule job, in milliseconds."
+        activeYearlyTimeWindow:
+          description: "An optional recurring within-year active period. When omitted, the schedule has no window constraint and fires on every tick within its lifetime."
+          $ref: '#/components/schemas/ActiveYearlyTimeWindow'
       required:
         - type
+    ActiveYearlyTimeWindow:
+      description: >-
+        An optional yearly active period for the schedule job, given as a start and end month/day.
+        The job runs only on dates within this period each year, and is skipped outside it.
+        For example, a start of Nov 15 and end of Feb 10 keeps the job active every winter.
+      type: object
+      properties:
+        startMonth:
+          type: integer
+          description: "The month the active period starts (1-12)."
+          minimum: 1
+          maximum: 12
+        startDay:
+          type: integer
+          description: "The day of the month the active period starts (1-31)."
+          minimum: 1
+          maximum: 31
+        endMonth:
+          type: integer
+          description: "The month the active period ends (1-12)."
+          minimum: 1
+          maximum: 12
+        endDay:
+          type: integer
+          description: "The last day of the month included in the active period (1-31)."
+          minimum: 1
+          maximum: 31
+      required:
+        - startMonth
+        - startDay
+        - endMonth
+        - endDay
     ScheduleJob:
       description: "Defines the job to be scheduled."
       type: object
@@ -539,6 +574,11 @@ components:
               startTimestamp: 1724331455000
               endTimestamp: 1724331555000
               crontab: "CRON_TZ=Asia/Taipei 0 0 1 1 *"
+              activeYearlyTimeWindow:
+                startMonth: 11
+                startDay: 1
+                endMonth: 2
+                endDay: 28
             actions:
               - type: "REST"
                 contentType: "application/json"
@@ -673,6 +713,11 @@ components:
               startTimestamp: 1724331455000
               endTimestamp: 1724331555000
               crontab: "CRON_TZ=Asia/Taipei 0 0 1 1 *"
+              activeYearlyTimeWindow:
+                startMonth: 11
+                startDay: 1
+                endMonth: 2
+                endDay: 28
             actions:
               - type: "REST"
                 contentType: "application/json"
@@ -720,6 +765,11 @@ components:
             definition:
               type: "CRON"
               crontab: "CRON_TZ=UTC 0 0 2 2 *"
+              activeYearlyTimeWindow:
+                startMonth: 3
+                startDay: 1
+                endMonth: 5
+                endDay: 31
             actions:
               - type: "REST"
                 contentType: "application/json"


### PR DESCRIPTION
Enforce the optional ActiveYearlyTimeWindow field on ScheduleDef (added in go-mod-core-contracts v4.1.0-dev.40) so a recurring ScheduleJob can be restricted to a date range within the year (e.g. run only during winter).

- A before-run gate skips ticks outside the window: no action runs and no record is written. Manual triggers are also subject to the window.
- GenerateMissedScheduleActionRecords drops missed runs that fell outside the window while the service was down.
- A nil/omitted window keeps the current behavior.

Closes #5449

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) updated the API doc, will open in the edgex doc
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->