### PR TITLE
refactor: Remove unused MaxCmdValueLen from device common config

### DIFF
--- a/cmd/core-common-config-bootstrapper/res/configuration.yaml
+++ b/cmd/core-common-config-bootstrapper/res/configuration.yaml
@@ -132,8 +132,7 @@ device-services:
         OpenZitiController: "openziti:1280"
   Device:
     DataTransform: true
-    MaxCmdOps: 128
-    MaxCmdValueLen: 256
+    MaxCmdOps: 12800
     ProfilesDir: "./res/profiles"
     DevicesDir: "./res/devices"
     # ProvisionWatchersDir is omitted here since most Device Services don't use it.


### PR DESCRIPTION
Relates to https://github.com/edgexfoundry/device-sdk-go/issues/1843

Also increase default MaxCmdOps to 12800

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->